### PR TITLE
feat(mobile): read-only RPC proxy + EIP-5792 wallet-control methods

### DIFF
--- a/apps/mobile/src/features/ConfirmTx/ConfirmTx.container.tsx
+++ b/apps/mobile/src/features/ConfirmTx/ConfirmTx.container.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { ScrollView, View } from 'tamagui'
 import { RefreshControl } from 'react-native'
 import { useScrollableHeader } from '@/src/navigation/useScrollableHeader'
@@ -62,8 +62,12 @@ function ConfirmTxContainer() {
 
   // When the tx originates from a WalletConnect dApp, surface its logo + name in the
   // on-screen TransactionHeader (provided via context, consumed by TransactionHeader).
+  // Memoized so context consumers don't re-render on every unrelated parent render.
   const dappMetadata = useAppSelector((state) => selectDappMetadataByTxHash(state, txId))
-  const dappOrigin = dappMetadata ? { name: dappMetadata.name, logoUri: dappMetadata.icons?.[0] } : null
+  const dappOrigin = useMemo(
+    () => (dappMetadata ? { name: dappMetadata.name, logoUri: dappMetadata.icons?.[0] } : null),
+    [dappMetadata],
+  )
 
   const { handleScroll } = useScrollableHeader({
     children: <NavBarTitle paddingRight={5}>{headerText}</NavBarTitle>,

--- a/apps/mobile/src/features/ConfirmTx/ConfirmTx.container.tsx
+++ b/apps/mobile/src/features/ConfirmTx/ConfirmTx.container.tsx
@@ -16,6 +16,8 @@ import { PendingStatus, selectPendingTxById } from '@/src/store/pendingTxsSlice'
 import { useTransactionProcessingState } from '@/src/hooks/useTransactionProcessingState'
 import { useFocusEffect, useRouter } from 'expo-router'
 import { Severity } from '@safe-global/utils/features/safe-shield/types'
+import { selectDappMetadataByTxHash } from '@/src/features/WalletConnect/Wallet/store/walletKitSlice'
+import { DappOriginProvider } from './components/DappOriginContext'
 
 const getHeaderText = (isExecuting: boolean, isSigning: boolean): string => {
   if (isExecuting) {
@@ -57,6 +59,11 @@ function ConfirmTxContainer() {
   useFocusEffect(handleHistoryNavigation)
   const headerText = getHeaderText(isExecuting, isSigning)
 
+  // When the tx originates from a WalletConnect dApp, surface its logo + name in the
+  // on-screen TransactionHeader (provided via context, consumed by TransactionHeader).
+  const dappMetadata = useAppSelector((state) => selectDappMetadataByTxHash(state, txId))
+  const dappOrigin = dappMetadata ? { name: dappMetadata.name, logoUri: dappMetadata.icons?.[0] } : null
+
   const { handleScroll } = useScrollableHeader({
     children: <NavBarTitle paddingRight={5}>{headerText}</NavBarTitle>,
     alwaysVisible: true,
@@ -78,54 +85,56 @@ function ConfirmTxContainer() {
   const isExpired = !!(txDetails && 'status' in txDetails.txInfo && txDetails.txInfo.status === 'expired')
 
   return (
-    <View flex={1}>
-      <ScrollView
-        onScroll={handleScroll}
-        refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />}
-        contentContainerStyle={isLoading || isError ? { flex: 1 } : undefined}
-      >
-        {isLoading ? (
-          <View flex={1} justifyContent="center" alignItems="center">
-            <Loader size={64} color="#12FF80" />
-          </View>
-        ) : isError && !txDetails ? (
-          <View justifyContent="center" padding="$4">
-            <Alert type="error" message="Error fetching transaction details" />
-          </View>
-        ) : (
-          txDetails && (
-            <>
-              <View paddingHorizontal="$4">
-                <ConfirmationView txDetails={txDetails} />
-              </View>
+    <DappOriginProvider value={dappOrigin}>
+      <View flex={1}>
+        <ScrollView
+          onScroll={handleScroll}
+          refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />}
+          contentContainerStyle={isLoading || isError ? { flex: 1 } : undefined}
+        >
+          {isLoading ? (
+            <View flex={1} justifyContent="center" alignItems="center">
+              <Loader size={64} color="#12FF80" />
+            </View>
+          ) : isError && !txDetails ? (
+            <View justifyContent="center" padding="$4">
+              <Alert type="error" message="Error fetching transaction details" />
+            </View>
+          ) : (
+            txDetails && (
+              <>
+                <View paddingHorizontal="$4">
+                  <ConfirmationView txDetails={txDetails} />
+                </View>
 
-              <TransactionInfo
-                txId={txId}
-                detailedExecutionInfo={detailedExecutionInfo}
-                txDetails={txDetails}
-                pendingTx={pendingTx}
-                onSeverityChange={setHighlightedSeverity}
-                key={refetchKey.toString()}
-              />
-            </>
-          )
+                <TransactionInfo
+                  txId={txId}
+                  detailedExecutionInfo={detailedExecutionInfo}
+                  txDetails={txDetails}
+                  pendingTx={pendingTx}
+                  onSeverityChange={setHighlightedSeverity}
+                  key={refetchKey.toString()}
+                />
+              </>
+            )
+          )}
+        </ScrollView>
+
+        {!isLoading && txDetails && (
+          <View paddingTop="$1">
+            <ConfirmTxForm
+              hasEnoughConfirmations={hasEnoughConfirmations}
+              isExpired={isExpired}
+              isPending={isProcessing}
+              txId={txId}
+              highlightedSeverity={highlightedSeverity}
+              riskAcknowledged={riskAcknowledged}
+              onRiskAcknowledgedChange={setRiskAcknowledged}
+            />
+          </View>
         )}
-      </ScrollView>
-
-      {!isLoading && txDetails && (
-        <View paddingTop="$1">
-          <ConfirmTxForm
-            hasEnoughConfirmations={hasEnoughConfirmations}
-            isExpired={isExpired}
-            isPending={isProcessing}
-            txId={txId}
-            highlightedSeverity={highlightedSeverity}
-            riskAcknowledged={riskAcknowledged}
-            onRiskAcknowledgedChange={setRiskAcknowledged}
-          />
-        </View>
-      )}
-    </View>
+      </View>
+    </DappOriginProvider>
   )
 }
 

--- a/apps/mobile/src/features/ConfirmTx/ConfirmTx.container.tsx
+++ b/apps/mobile/src/features/ConfirmTx/ConfirmTx.container.tsx
@@ -17,6 +17,7 @@ import { useTransactionProcessingState } from '@/src/hooks/useTransactionProcess
 import { useFocusEffect, useRouter } from 'expo-router'
 import { Severity } from '@safe-global/utils/features/safe-shield/types'
 import { selectDappMetadataByTxHash } from '@/src/features/WalletConnect/Wallet/store/walletKitSlice'
+import { WcRejectOnBack } from '@/src/features/WalletConnect/Wallet/components/WcRejectOnBack'
 import { DappOriginProvider } from './components/DappOriginContext'
 
 const getHeaderText = (isExecuting: boolean, isSigning: boolean): string => {
@@ -87,6 +88,7 @@ function ConfirmTxContainer() {
   return (
     <DappOriginProvider value={dappOrigin}>
       <View flex={1}>
+        <WcRejectOnBack safeTxHash={txId} />
         <ScrollView
           onScroll={handleScroll}
           refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />}

--- a/apps/mobile/src/features/ConfirmTx/components/DappOriginContext.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/DappOriginContext.tsx
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react'
+
+export type DappOrigin = {
+  name: string
+  logoUri?: string
+}
+
+// Carries the originating WalletConnect dApp (if any) from ConfirmTxContainer down to the
+// shared TransactionHeader, which is rendered by every confirmation-view. Avoids threading
+// a prop through each view; absent provider (e.g. history) → no dApp attribution.
+const DappOriginContext = createContext<DappOrigin | null>(null)
+
+export const DappOriginProvider = DappOriginContext.Provider
+
+export const useDappOrigin = (): DappOrigin | null => useContext(DappOriginContext)

--- a/apps/mobile/src/features/ConfirmTx/components/TransactionHeader/TransactionHeader.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionHeader/TransactionHeader.tsx
@@ -37,7 +37,8 @@ export function TransactionHeader({
   // When the tx originates from a WalletConnect dApp, surface its logo + name in place of the
   // contract logo/title (Figma `5316-26402`). Absent provider (history, native flows) → no-op.
   const dappOrigin = useDappOrigin()
-  const showTitle = dappOrigin?.name ?? title
+  // `||` not `??`: a dApp publishing metadata.name = '' must not blank the header.
+  const showTitle = dappOrigin?.name || title
 
   return (
     <YStack position="relative" alignItems="center" gap="$2" marginTop="$4">

--- a/apps/mobile/src/features/ConfirmTx/components/TransactionHeader/TransactionHeader.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionHeader/TransactionHeader.tsx
@@ -8,6 +8,8 @@ import { BadgeThemeTypes } from '@/src/components/Logo/Logo'
 import { Identicon } from '@/src/components/Identicon'
 import { Address } from 'blo'
 import { formatWithSchema } from '@/src/utils/date'
+import { DappIcon } from '@/src/features/WalletConnect/Wallet/components/DappIcon'
+import { useDappOrigin } from '../DappOriginContext'
 
 interface TransactionHeaderProps {
   logo?: string
@@ -32,10 +34,22 @@ export function TransactionHeader({
 }: TransactionHeaderProps) {
   const date = formatWithSchema(submittedAt, 'd MMM yyyy')
   const time = formatWithSchema(submittedAt, 'hh:mm a')
+  // When the tx originates from a WalletConnect dApp, surface its logo + name in place of the
+  // contract logo/title (Figma `5316-26402`). Absent provider (history, native flows) → no-op.
+  const dappOrigin = useDappOrigin()
+  const showTitle = dappOrigin?.name ?? title
 
   return (
     <YStack position="relative" alignItems="center" gap="$2" marginTop="$4">
-      {isIdenticon ? (
+      {dappOrigin ? (
+        <DappIcon
+          url={dappOrigin.logoUri}
+          size={44}
+          badgeContent={<SafeFontIcon name={badgeIcon} color={badgeColor} size={12} />}
+          badgeThemeName={badgeThemeName}
+          circle
+        />
+      ) : isIdenticon ? (
         <Identicon address={logo as Address} size={44} />
       ) : (
         (customLogo ?? (
@@ -49,12 +63,12 @@ export function TransactionHeader({
       )}
 
       <View alignItems="center" gap="$2">
-        {typeof title === 'string' ? (
-          <H3 fontWeight={600} fontSize="$7">
-            {title}
+        {typeof showTitle === 'string' ? (
+          <H3 fontWeight={600} fontSize="$7" textAlign="center">
+            {showTitle}
           </H3>
         ) : (
-          title
+          showTitle
         )}
         <Text color="$textSecondaryLight" fontSize="$2" lineHeight={16}>
           {date}, {time}

--- a/apps/mobile/src/features/ConfirmTx/components/TransactionHeader/__tests__/TransactionHeader.test.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionHeader/__tests__/TransactionHeader.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { renderWithStore, createTestStore } from '@/src/tests/test-utils'
+import { TransactionHeader } from '../TransactionHeader'
+import { DappOriginProvider } from '../../DappOriginContext'
+import type { IconName } from '@/src/types/iconTypes'
+
+const baseProps = {
+  badgeIcon: 'info' as IconName,
+  badgeColor: '$primary',
+  title: 'Some contract',
+  submittedAt: 1_700_000_000_000,
+}
+
+describe('TransactionHeader', () => {
+  it('shows the contract title when there is no dApp origin', () => {
+    const { getByText } = renderWithStore(<TransactionHeader {...baseProps} />, createTestStore())
+    expect(getByText('Some contract')).toBeTruthy()
+  })
+
+  it('replaces the title with the originating dApp name when present', () => {
+    const { getByText, queryByText } = renderWithStore(
+      <DappOriginProvider value={{ name: 'Uniswap', logoUri: 'https://x/icon.png' }}>
+        <TransactionHeader {...baseProps} />
+      </DappOriginProvider>,
+      createTestStore(),
+    )
+    expect(getByText('Uniswap')).toBeTruthy()
+    expect(queryByText('Some contract')).toBeNull()
+  })
+})

--- a/apps/mobile/src/features/ConfirmTx/components/TransactionHeader/__tests__/TransactionHeader.test.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionHeader/__tests__/TransactionHeader.test.tsx
@@ -17,6 +17,16 @@ describe('TransactionHeader', () => {
     expect(getByText('Some contract')).toBeTruthy()
   })
 
+  it('falls back to the contract title when the dApp publishes an empty name', () => {
+    const { getByText } = renderWithStore(
+      <DappOriginProvider value={{ name: '', logoUri: 'https://x/icon.png' }}>
+        <TransactionHeader {...baseProps} />
+      </DappOriginProvider>,
+      createTestStore(),
+    )
+    expect(getByText('Some contract')).toBeTruthy()
+  })
+
   it('replaces the title with the originating dApp name when present', () => {
     const { getByText, queryByText } = renderWithStore(
       <DappOriginProvider value={{ name: 'Uniswap', logoUri: 'https://x/icon.png' }}>

--- a/apps/mobile/src/features/Send/services/prepareSendDraft.ts
+++ b/apps/mobile/src/features/Send/services/prepareSendDraft.ts
@@ -1,11 +1,7 @@
 import { getAddress, isAddress } from 'ethers'
-import { cgwApi, type Operation } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
-import { getSafeSDK } from '@/src/hooks/coreSDK/safeCoreSDK'
 import { createTx } from '@/src/services/tx/tx-sender/create'
-import { setDraft, type DraftTx } from '@/src/store/draftTxSlice'
-import { synthesizeDraftTxDetails } from '@/src/features/ConfirmTx/utils/synthesizeDraftTxDetails'
-import { asError } from '@safe-global/utils/services/exceptions/utils'
+import { getVerifiedSafeSDK, previewAndStashDraft } from '@/src/services/tx/draft'
 import { createTokenTransferParams } from './tokenTransferParams'
 import type { SendTransactionParams } from '../types'
 import type { AppDispatch } from '@/src/store'
@@ -25,29 +21,14 @@ function validateAddresses(recipient: string, tokenAddress: string): void {
   }
 }
 
-async function getVerifiedSafeSDK(chainId: string) {
-  const safeSDK = getSafeSDK()
-  if (!safeSDK) {
-    throw new Error('Safe SDK is not initialized')
-  }
-
-  const sdkChainId = await safeSDK.getChainId()
-  if (sdkChainId.toString() !== chainId) {
-    throw new Error(`Chain mismatch: SDK on chain ${sdkChainId}, expected ${chainId}`)
-  }
-
-  return safeSDK
-}
-
 /**
- * Validates inputs, builds a SafeTransaction locally, asks CGW for a
- * preview, and stashes a draft so the existing sign/review screens can
- * render it without a CGW round-trip via /propose. The actual /propose
- * call only happens when the user signs — the signer at sign time
- * becomes the proposer recorded by CGW.
+ * Validates inputs, builds a token-transfer SafeTransaction locally, then runs the shared
+ * draft pipeline (CGW /preview → synthesized details → stashed DraftTx) so the existing
+ * sign/review screens can render it without a CGW round-trip via /propose. The actual
+ * /propose call only happens when the user signs — the signer at sign time becomes the
+ * proposer recorded by CGW.
  *
- * Returns the `safeTxHash` (used as the synthetic txId for the
- * downstream review screens).
+ * Returns the `safeTxHash` (used as the synthetic txId for the downstream review screens).
  */
 export const prepareSendDraft = async ({
   recipient,
@@ -65,50 +46,6 @@ export const prepareSendDraft = async ({
   const safeSDK = await getVerifiedSafeSDK(chainId)
   const txData = createTokenTransferParams(getAddress(recipient), amount, decimals, getAddress(tokenAddress))
   const safeTx = await createTx(txData, nonce)
-  const safeTxHash = await safeSDK.getTransactionHash(safeTx)
 
-  const previewPromise = dispatch(
-    cgwApi.endpoints.transactionsPreviewTransactionV1.initiate({
-      chainId,
-      safeAddress,
-      previewTransactionDto: {
-        to: safeTx.data.to,
-        data: safeTx.data.data || null,
-        value: safeTx.data.value?.toString() ?? '0',
-        operation: (safeTx.data.operation ?? 0) as Operation,
-      },
-    }),
-  )
-
-  let txDetails
-  try {
-    const previewResult = await previewPromise
-
-    if ('error' in previewResult || !previewResult.data) {
-      throw asError('error' in previewResult ? previewResult.error : new Error('Preview unavailable'))
-    }
-
-    txDetails = synthesizeDraftTxDetails({
-      safeAddress,
-      safeTxHash,
-      buildParams: safeTx.data,
-      owners: safe.owners,
-      threshold: safe.threshold,
-      preview: previewResult.data,
-    })
-  } finally {
-    previewPromise.reset()
-  }
-
-  const draft: DraftTx = {
-    chainId,
-    safeAddress,
-    buildParams: safeTx.data,
-    safeTxHash,
-    txDetails,
-  }
-
-  dispatch(setDraft(draft))
-
-  return safeTxHash
+  return previewAndStashDraft({ safeSDK, safeTx, chainId, safeAddress, safe, dispatch })
 }

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/DappIcon.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/DappIcon.tsx
@@ -21,8 +21,11 @@ type Props = {
 const isSvgUrl = (url?: string): boolean => !!url && /\.svg($|\?|#)/i.test(url)
 
 export const DappIcon: React.FC<Props> = ({ url, size = 64, circle = false, badgeContent, badgeThemeName }) => {
-  const [failed, setFailed] = useState(false)
-  const showPlaceholder = !url || failed
+  // Track WHICH url failed rather than a boolean latch: the request-sheet host re-renders
+  // this component in place when the FIFO head changes, so a failure for one dApp's icon
+  // must not blank the next dApp's perfectly valid one.
+  const [failedUrl, setFailedUrl] = useState<string | null>(null)
+  const showPlaceholder = !url || failedUrl === url
 
   const image = showPlaceholder ? (
     <YStack
@@ -33,13 +36,13 @@ export const DappIcon: React.FC<Props> = ({ url, size = 64, circle = false, badg
       testID="dapp-icon-placeholder"
     />
   ) : isSvgUrl(url) ? (
-    <SvgUri uri={url} width={size} height={size} onError={() => setFailed(true)} />
+    <SvgUri uri={url} width={size} height={size} onError={() => setFailedUrl(url)} />
   ) : (
     <Image
       source={url}
       style={{ width: size, height: size }}
       contentFit="contain"
-      onError={() => setFailed(true)}
+      onError={() => setFailedUrl(url)}
       testID="dapp-icon-image"
     />
   )

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/DappIcon.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/DappIcon.tsx
@@ -1,11 +1,16 @@
 import React from 'react'
 import { Image } from 'expo-image'
 import { SvgUri } from 'react-native-svg'
-import { YStack } from 'tamagui'
+import { View, YStack } from 'tamagui'
+import { Badge } from '@/src/components/Badge'
+import { BadgeThemeTypes } from '@/src/components/Badge/Badge'
 
 type Props = {
   url?: string
   size?: number
+  circle?: boolean
+  badgeContent?: React.ReactElement
+  badgeThemeName?: BadgeThemeTypes
 }
 
 // dApp metadata icons come in both raster (png/jpg/webp) and SVG. Tamagui's Image (RN Image)
@@ -14,7 +19,7 @@ type Props = {
 // render blank, the same as today; the placeholder covers the missing-icon case.
 const isSvgUrl = (url?: string): boolean => !!url && /\.svg($|\?|#)/i.test(url)
 
-export const DappIcon: React.FC<Props> = ({ url, size = 64 }) => {
+export const DappIcon: React.FC<Props> = ({ url, size = 64, circle = false, badgeContent, badgeThemeName }) => {
   if (!url) {
     return <YStack width={size} height={size} borderRadius="$3" backgroundColor="$backgroundSecondary" />
   }
@@ -26,8 +31,15 @@ export const DappIcon: React.FC<Props> = ({ url, size = 64 }) => {
   )
 
   return (
-    <YStack width={size} height={size} borderRadius="$3" overflow="hidden">
-      {image}
-    </YStack>
+    <View width={size}>
+      <View position="absolute" top={-10} right={-10} zIndex={1}>
+        {badgeContent && (
+          <Badge themeName={badgeThemeName} content={badgeContent} circleSize="$6" circleProps={{ bordered: true }} />
+        )}
+      </View>
+      <YStack width={size} height={size} borderRadius={circle ? size : '$3'} overflow="hidden">
+        {image}
+      </YStack>
+    </View>
   )
 }

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/DappIcon.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/DappIcon.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Image } from 'expo-image'
 import { SvgUri } from 'react-native-svg'
 import { View, YStack } from 'tamagui'
@@ -15,19 +15,33 @@ type Props = {
 
 // dApp metadata icons come in both raster (png/jpg/webp) and SVG. Tamagui's Image (RN Image)
 // and expo-image can't render SVG, so route SVG URLs through react-native-svg's SvgUri.
-// Detection is by extension — SVGs served without one fall through to expo-image and simply
-// render blank, the same as today; the placeholder covers the missing-icon case.
+// Detection is by extension — SVGs served without one (common behind CDNs) fail to load in
+// expo-image, which triggers onError and falls back to the placeholder below, same as any
+// other broken icon URL.
 const isSvgUrl = (url?: string): boolean => !!url && /\.svg($|\?|#)/i.test(url)
 
 export const DappIcon: React.FC<Props> = ({ url, size = 64, circle = false, badgeContent, badgeThemeName }) => {
-  if (!url) {
-    return <YStack width={size} height={size} borderRadius="$3" backgroundColor="$backgroundSecondary" />
-  }
+  const [failed, setFailed] = useState(false)
+  const showPlaceholder = !url || failed
 
-  const image = isSvgUrl(url) ? (
-    <SvgUri uri={url} width={size} height={size} />
+  const image = showPlaceholder ? (
+    <YStack
+      width={size}
+      height={size}
+      borderRadius={circle ? size : '$3'}
+      backgroundColor="$backgroundSecondary"
+      testID="dapp-icon-placeholder"
+    />
+  ) : isSvgUrl(url) ? (
+    <SvgUri uri={url} width={size} height={size} onError={() => setFailed(true)} />
   ) : (
-    <Image source={url} style={{ width: size, height: size }} contentFit="contain" />
+    <Image
+      source={url}
+      style={{ width: size, height: size }}
+      contentFit="contain"
+      onError={() => setFailed(true)}
+      testID="dapp-icon-image"
+    />
   )
 
   return (

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/DappIdentity.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/DappIdentity.tsx
@@ -34,8 +34,18 @@ export const DappIdentity: React.FC<Props> = ({
   onPressDomain,
   domainTestID,
 }) => {
-  // dApp domain without the scheme/trailing slash, e.g. 'https://uniswap.org/' -> 'uniswap.org'.
-  const domain = useMemo(() => url?.replace(/^https?:\/\//, '').replace(/\/+$/, '') || url || '', [url])
+  // dApp domain only, e.g. 'https://app.uniswap.org/swap?chain=1' -> 'app.uniswap.org'.
+  // Fall back to naive scheme/trailing-slash stripping for unparseable metadata URLs.
+  const domain = useMemo(() => {
+    if (!url) {
+      return ''
+    }
+    try {
+      return new URL(url).host
+    } catch {
+      return url.replace(/^https?:\/\//, '').replace(/\/+$/, '')
+    }
+  }, [url])
 
   return (
     <YStack gap="$5" padding="$4">

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/DappIdentity.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/DappIdentity.tsx
@@ -1,0 +1,82 @@
+import React, { useMemo } from 'react'
+import { Text, YStack, XStack } from 'tamagui'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+import { DappIcon } from './DappIcon'
+import { VerifyStatusIcon } from './VerifyStatusIcon'
+import type { VerifyVariant } from '../utils/verifyStatus'
+
+type Props = {
+  title: string
+  name?: string
+  url?: string
+  iconUrl?: string
+  variant: VerifyVariant
+  // Optional press handlers — the proposal sheet routes both to its permissions panel; the
+  // tx-request sheet has no panel and leaves them undefined (static identity).
+  onPressBadge?: () => void
+  onPressDomain?: () => void
+  domainTestID?: string
+}
+
+/**
+ * Shared dApp-identity header for the WalletConnect request sheets: title, dApp logo with an
+ * overlapping verify badge, name, and a domain pill with an info icon. The presentation is
+ * identical across the session-proposal and transaction-request sheets (Figma `16755-4705`);
+ * only the title, metadata source and press affordances differ.
+ */
+export const DappIdentity: React.FC<Props> = ({
+  title,
+  name,
+  url,
+  iconUrl,
+  variant,
+  onPressBadge,
+  onPressDomain,
+  domainTestID,
+}) => {
+  // dApp domain without the scheme/trailing slash, e.g. 'https://uniswap.org/' -> 'uniswap.org'.
+  const domain = useMemo(() => url?.replace(/^https?:\/\//, '').replace(/\/+$/, '') || url || '', [url])
+
+  return (
+    <YStack gap="$5" padding="$4">
+      <Text fontSize={20} fontWeight="600" letterSpacing={-0.2} textAlign="center">
+        {title}
+      </Text>
+
+      <YStack gap="$3" alignItems="center">
+        <YStack width={64} height={64}>
+          <DappIcon url={iconUrl} size={64} />
+          {/* Verify badge overlapping the icon's bottom-right corner. The $background ring
+              separates the badge from the dApp icon, matching the design. */}
+          <YStack position="absolute" bottom={-4} right={-4} borderRadius={100} backgroundColor="$background">
+            <VerifyStatusIcon variant={variant} size={22} onPress={onPressBadge} />
+          </YStack>
+        </YStack>
+
+        {!!name && (
+          <Text fontSize={17} fontWeight="600" textAlign="center">
+            {name}
+          </Text>
+        )}
+
+        {/* Only render the URL pill when the dApp provides one — an empty pill looks broken. */}
+        {!!domain && (
+          <XStack
+            gap="$1"
+            alignItems="center"
+            paddingVertical="$1"
+            paddingHorizontal="$2"
+            borderRadius="$8"
+            backgroundColor="$backgroundSecondary"
+            pressStyle={onPressDomain ? { opacity: 0.6 } : undefined}
+            onPress={onPressDomain}
+            testID={domainTestID}
+          >
+            <Text color="$colorSecondary">{domain}</Text>
+            <SafeFontIcon name="info" size={14} color="$colorSecondary" />
+          </XStack>
+        )}
+      </YStack>
+    </YStack>
+  )
+}

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/RequestSheetHost.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/RequestSheetHost.tsx
@@ -59,7 +59,10 @@ export const RequestSheetHost: React.FC<Props> = ({ walletKit }) => {
 
   const proposal = current?.kind === 'proposal' ? current : null
   const request = current?.kind === 'request' ? current : null
-  const variant = proposal ? verifyStatusToVariant(proposal.proposal.verifyContext?.verified) : 'unverified'
+  // Both sheet kinds carry WC's domain verification — the panel renders the same for either.
+  const variant = verifyStatusToVariant(
+    proposal ? proposal.proposal.verifyContext?.verified : request?.verifyContext?.verified,
+  )
 
   // Review/Reject for the transaction-request sheet. Review composes a draft and navigates to
   // the confirm flow; the dApp is answered later by the propose-success listener.
@@ -138,25 +141,32 @@ export const RequestSheetHost: React.FC<Props> = ({ walletKit }) => {
       if (!walletKit) {
         return null
       }
+      // The permissions panel replaces the active view for either kind; its "Got it" CTA
+      // returns to that view without responding to the dApp.
+      if ((proposal || request) && permissionsOpen) {
+        return (
+          <BottomSheetFooter {...footerProps} bottomInset={insets.bottom}>
+            <YStack paddingHorizontal="$4" paddingTop="$2" paddingBottom="$2">
+              <SafeButton primary onPress={closePermissions} testID="wc-permissions-dismiss">
+                Got it
+              </SafeButton>
+            </YStack>
+          </BottomSheetFooter>
+        )
+      }
       if (proposal) {
         return (
           <BottomSheetFooter {...footerProps} bottomInset={insets.bottom}>
             <YStack paddingHorizontal="$4" paddingTop="$2" paddingBottom="$2">
-              {permissionsOpen ? (
-                <SafeButton primary onPress={closePermissions} testID="wc-proposal-permissions-dismiss">
-                  Got it
-                </SafeButton>
-              ) : (
-                <SafeButton
-                  primary
-                  onPress={() => approve(proposal)}
-                  loading={busy}
-                  loadingText="Connecting…"
-                  testID="wc-proposal-connect"
-                >
-                  Connect
-                </SafeButton>
-              )}
+              <SafeButton
+                primary
+                onPress={() => approve(proposal)}
+                loading={busy}
+                loadingText="Connecting…"
+                testID="wc-proposal-connect"
+              >
+                Connect
+              </SafeButton>
             </YStack>
           </BottomSheetFooter>
         )
@@ -220,8 +230,10 @@ export const RequestSheetHost: React.FC<Props> = ({ walletKit }) => {
         {walletKit && proposal && !permissionsOpen && (
           <SessionProposalSheet pending={proposal} onOpenPermissions={openPermissions} />
         )}
-        {walletKit && proposal && permissionsOpen && <ConnectionPermissionsPanel variant={variant} />}
-        {walletKit && request && <SendTransactionSheet pending={request} />}
+        {walletKit && request && !permissionsOpen && (
+          <SendTransactionSheet pending={request} onOpenPermissions={openPermissions} />
+        )}
+        {walletKit && (proposal || request) && permissionsOpen && <ConnectionPermissionsPanel variant={variant} />}
       </BottomSheetScrollView>
     </BottomSheetModal>
   )

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/RequestSheetHost.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/RequestSheetHost.tsx
@@ -7,7 +7,7 @@ import {
 } from '@gorhom/bottom-sheet'
 import type { IWalletKit } from '@reown/walletkit'
 import { useStore } from 'react-redux'
-import { getVariable, useTheme, YStack } from 'tamagui'
+import { getVariable, useTheme, YStack, XStack } from 'tamagui'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { formatJsonRpcError } from '@walletconnect/jsonrpc-utils'
 import { getSdkError } from '@walletconnect/utils'
@@ -17,9 +17,11 @@ import { useAppDispatch, useAppSelector } from '@/src/store/hooks'
 import type { RootState } from '@/src/store'
 import { removePending, selectCurrentRequest } from '../store/walletKitSlice'
 import { useApproveProposal } from '../hooks/useApproveProposal'
+import { useSendTransaction } from '../hooks/useSendTransaction'
 import { verifyStatusToVariant } from '../utils/verifyStatus'
 import { logWalletKitError } from '../utils/errors'
 import { SessionProposalSheet } from './SessionProposalSheet'
+import { SendTransactionSheet } from './SendTransactionSheet'
 import { ConnectionPermissionsPanel } from './ConnectionPermissionsPanel'
 
 type Props = { walletKit: IWalletKit | null }
@@ -56,7 +58,12 @@ export const RequestSheetHost: React.FC<Props> = ({ walletKit }) => {
   const renderBackdrop = useCallback(() => <BackdropComponent shouldNavigateBack={false} />, [])
 
   const proposal = current?.kind === 'proposal' ? current : null
+  const request = current?.kind === 'request' ? current : null
   const variant = proposal ? verifyStatusToVariant(proposal.proposal.verifyContext?.verified) : 'unverified'
+
+  // Review/Reject for the transaction-request sheet. Review composes a draft and navigates to
+  // the confirm flow; the dApp is answered later by the propose-success listener.
+  const { review, reject, composing, ready } = useSendTransaction(walletKit, request)
 
   // Reset the permissions view whenever the queue head changes (new proposal or cleared).
   useEffect(() => {
@@ -90,9 +97,9 @@ export const RequestSheetHost: React.FC<Props> = ({ walletKit }) => {
     if (!walletKit) {
       return
     }
-    // A connect is in flight — let useApproveProposal own the outcome (approve resolves to
-    // success/reject and clears the pending item). Rejecting here would race its response.
-    if (busy) {
+    // A connect or compose is in flight — let useApproveProposal / useSendTransaction own the
+    // outcome (each clears the pending item). Rejecting here would race their response.
+    if (busy || composing) {
       return
     }
     const currentAtDismiss = selectCurrentRequest(store.getState())
@@ -121,39 +128,80 @@ export const RequestSheetHost: React.FC<Props> = ({ walletKit }) => {
       logWalletKitError('respondSessionRequest on sheet dismiss failed', e)
     }
     dispatch(removePending({ id: currentAtDismiss.id, kind: 'request' }))
-  }, [walletKit, busy, store, dispatch])
+  }, [walletKit, busy, composing, store, dispatch])
 
   // The active view's primary CTA, pinned to the bottom edge of the sheet. No background so
   // its top edge doesn't show a seam against the content; the panel/proposal content is short
   // enough that it never scrolls under the CTA.
   const renderFooter = useCallback(
     (footerProps: BottomSheetFooterProps) => {
-      if (!walletKit || !proposal) {
+      if (!walletKit) {
         return null
       }
-      return (
-        <BottomSheetFooter {...footerProps} bottomInset={insets.bottom}>
-          <YStack paddingHorizontal="$4" paddingTop="$2" paddingBottom="$2">
-            {permissionsOpen ? (
-              <SafeButton primary onPress={closePermissions} testID="wc-proposal-permissions-dismiss">
-                Got it
+      if (proposal) {
+        return (
+          <BottomSheetFooter {...footerProps} bottomInset={insets.bottom}>
+            <YStack paddingHorizontal="$4" paddingTop="$2" paddingBottom="$2">
+              {permissionsOpen ? (
+                <SafeButton primary onPress={closePermissions} testID="wc-proposal-permissions-dismiss">
+                  Got it
+                </SafeButton>
+              ) : (
+                <SafeButton
+                  primary
+                  onPress={() => approve(proposal)}
+                  loading={busy}
+                  loadingText="Connecting…"
+                  testID="wc-proposal-connect"
+                >
+                  Connect
+                </SafeButton>
+              )}
+            </YStack>
+          </BottomSheetFooter>
+        )
+      }
+      if (request) {
+        // Identity-only gate: Reject answers the dApp with USER_REJECTED; Review composes the
+        // draft and routes to the confirm flow. Review is disabled until the Safe/chain/SDK
+        // are ready (Figma `16755-4705`).
+        return (
+          <BottomSheetFooter {...footerProps} bottomInset={insets.bottom}>
+            <XStack gap="$3" paddingHorizontal="$4" paddingTop="$2" paddingBottom="$2">
+              <SafeButton flex={1} danger onPress={reject} disabled={composing} testID="wc-tx-reject">
+                Reject
               </SafeButton>
-            ) : (
               <SafeButton
+                flex={1}
                 primary
-                onPress={() => approve(proposal)}
-                loading={busy}
-                loadingText="Connecting…"
-                testID="wc-proposal-connect"
+                onPress={review}
+                loading={composing}
+                loadingText="Preparing…"
+                disabled={!ready}
+                testID="wc-tx-review"
               >
-                Connect
+                Review
               </SafeButton>
-            )}
-          </YStack>
-        </BottomSheetFooter>
-      )
+            </XStack>
+          </BottomSheetFooter>
+        )
+      }
+      return null
     },
-    [walletKit, proposal, permissionsOpen, closePermissions, approve, busy, insets.bottom],
+    [
+      walletKit,
+      proposal,
+      request,
+      permissionsOpen,
+      closePermissions,
+      approve,
+      busy,
+      review,
+      reject,
+      composing,
+      ready,
+      insets.bottom,
+    ],
   )
 
   return (
@@ -173,7 +221,7 @@ export const RequestSheetHost: React.FC<Props> = ({ walletKit }) => {
           <SessionProposalSheet pending={proposal} onOpenPermissions={openPermissions} />
         )}
         {walletKit && proposal && permissionsOpen && <ConnectionPermissionsPanel variant={variant} />}
-        {/* Transaction request sheet (current?.kind === 'request') added in WA-2321 / WA-2322. */}
+        {walletKit && request && <SendTransactionSheet pending={request} />}
       </BottomSheetScrollView>
     </BottomSheetModal>
   )

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/RequestSheetHost.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/RequestSheetHost.tsx
@@ -214,6 +214,10 @@ export const RequestSheetHost: React.FC<Props> = ({ walletKit }) => {
     ],
   )
 
+  if (!walletKit) {
+    return null
+  }
+
   return (
     <BottomSheetModal
       ref={ref}
@@ -227,13 +231,11 @@ export const RequestSheetHost: React.FC<Props> = ({ walletKit }) => {
     >
       {/* Scrollable so content can't clip under large font scaling; the footer is pinned. */}
       <BottomSheetScrollView contentContainerStyle={{ paddingBottom: insets.bottom + FOOTER_CLEARANCE }}>
-        {walletKit && proposal && !permissionsOpen && (
+        {proposal && !permissionsOpen && (
           <SessionProposalSheet pending={proposal} onOpenPermissions={openPermissions} />
         )}
-        {walletKit && request && !permissionsOpen && (
-          <SendTransactionSheet pending={request} onOpenPermissions={openPermissions} />
-        )}
-        {walletKit && (proposal || request) && permissionsOpen && <ConnectionPermissionsPanel variant={variant} />}
+        {request && !permissionsOpen && <SendTransactionSheet pending={request} onOpenPermissions={openPermissions} />}
+        {(proposal || request) && permissionsOpen && <ConnectionPermissionsPanel variant={variant} />}
       </BottomSheetScrollView>
     </BottomSheetModal>
   )

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/SendTransactionSheet.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/SendTransactionSheet.tsx
@@ -1,0 +1,29 @@
+import React, { useMemo } from 'react'
+import { useAppSelector } from '@/src/store/hooks'
+import { DappIdentity } from './DappIdentity'
+import { verifyStatusToVariant } from '../utils/verifyStatus'
+import { selectSessionsRecord, type PendingSessionRequest } from '../store/walletKitSlice'
+
+type Props = {
+  pending: PendingSessionRequest
+}
+
+// Identity-only "Transaction request" gate (Figma `16755-4705`): dApp logo + verify badge,
+// name and domain. No decoded transaction and no draft are created while this is open — the
+// draft is composed only when the user taps Review (handled by useSendTransaction in the
+// host footer). dApp metadata is resolved from the mirrored session by topic.
+export const SendTransactionSheet: React.FC<Props> = ({ pending }) => {
+  const meta = useAppSelector((s) => selectSessionsRecord(s)[pending.topic]?.peer.metadata)
+  const variant = useMemo(() => verifyStatusToVariant(pending.verifyContext?.verified), [pending.verifyContext])
+
+  return (
+    <DappIdentity
+      title="Transaction request"
+      name={meta?.name}
+      url={meta?.url}
+      iconUrl={meta?.icons?.[0]}
+      variant={variant}
+      domainTestID="wc-tx-domain"
+    />
+  )
+}

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/SendTransactionSheet.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/SendTransactionSheet.tsx
@@ -6,13 +6,16 @@ import { selectSessionsRecord, type PendingSessionRequest } from '../store/walle
 
 type Props = {
   pending: PendingSessionRequest
+  // Asks the host to swap in the permissions panel (same affordance as the proposal sheet:
+  // the verify badge and the domain pill both open it).
+  onOpenPermissions?: () => void
 }
 
 // Identity-only "Transaction request" gate (Figma `16755-4705`): dApp logo + verify badge,
 // name and domain. No decoded transaction and no draft are created while this is open — the
 // draft is composed only when the user taps Review (handled by useSendTransaction in the
 // host footer). dApp metadata is resolved from the mirrored session by topic.
-export const SendTransactionSheet: React.FC<Props> = ({ pending }) => {
+export const SendTransactionSheet: React.FC<Props> = ({ pending, onOpenPermissions }) => {
   const meta = useAppSelector((s) => selectSessionsRecord(s)[pending.topic]?.peer.metadata)
   const variant = useMemo(() => verifyStatusToVariant(pending.verifyContext?.verified), [pending.verifyContext])
 
@@ -23,6 +26,8 @@ export const SendTransactionSheet: React.FC<Props> = ({ pending }) => {
       url={meta?.url}
       iconUrl={meta?.icons?.[0]}
       variant={variant}
+      onPressBadge={onOpenPermissions}
+      onPressDomain={onOpenPermissions}
       domainTestID="wc-tx-domain"
     />
   )

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/SessionProposalSheet.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/SessionProposalSheet.tsx
@@ -1,9 +1,6 @@
 import React, { useMemo } from 'react'
-import { Text, YStack, XStack } from 'tamagui'
 import type { WalletKitTypes } from '@reown/walletkit'
-import { SafeFontIcon } from '@/src/components/SafeFontIcon'
-import { DappIcon } from './DappIcon'
-import { VerifyStatusIcon } from './VerifyStatusIcon'
+import { DappIdentity } from './DappIdentity'
 import { verifyStatusToVariant } from '../utils/verifyStatus'
 
 type Props = {
@@ -15,55 +12,25 @@ type Props = {
 
 // Presentation only — the "Connect" CTA is rendered by RequestSheetHost as a pinned
 // BottomSheetFooter (alongside the permissions panel's "Got it"), so both sit flush at the
-// bottom edge of the sheet regardless of content height.
+// bottom edge of the sheet regardless of content height. The verify badge and the domain
+// pill both open the permissions panel.
 export const SessionProposalSheet: React.FC<Props> = ({ pending, onOpenPermissions }) => {
   const { proposer } = pending.proposal.params
   const verifyContext = pending.proposal.verifyContext
   const variant = useMemo(() => verifyStatusToVariant(verifyContext?.verified), [verifyContext])
 
   const meta = proposer.metadata
-  // dApp domain without the scheme/trailing slash, e.g. 'https://uniswap.org/' -> 'uniswap.org'.
-  const domain = useMemo(() => meta.url?.replace(/^https?:\/\//, '').replace(/\/+$/, '') || meta.url || '', [meta.url])
 
   return (
-    <YStack gap="$5" padding="$4">
-      <Text fontSize={20} fontWeight="600" letterSpacing={-0.2} textAlign="center">
-        Connection request
-      </Text>
-
-      <YStack gap="$3" alignItems="center">
-        <YStack width={64} height={64}>
-          <DappIcon url={meta.icons?.[0]} size={64} />
-          {/* Verify badge overlapping the icon's bottom-right corner. The $background ring
-              separates the badge from the dApp icon, matching the design. */}
-          <YStack position="absolute" bottom={-4} right={-4} borderRadius={100} backgroundColor="$background">
-            <VerifyStatusIcon variant={variant} size={22} onPress={onOpenPermissions} />
-          </YStack>
-        </YStack>
-
-        <Text fontSize={17} fontWeight="600" textAlign="center">
-          {meta.name}
-        </Text>
-
-        {/* Only render the URL pill when the dApp provides one — an empty pill looks broken.
-            The verify badge above still opens the permissions panel. */}
-        {!!domain && (
-          <XStack
-            gap="$1"
-            alignItems="center"
-            paddingVertical="$1"
-            paddingHorizontal="$2"
-            borderRadius="$8"
-            backgroundColor="$backgroundSecondary"
-            pressStyle={{ opacity: 0.6 }}
-            onPress={onOpenPermissions}
-            testID="wc-proposal-domain"
-          >
-            <Text color="$colorSecondary">{domain}</Text>
-            <SafeFontIcon name="info" size={14} color="$colorSecondary" />
-          </XStack>
-        )}
-      </YStack>
-    </YStack>
+    <DappIdentity
+      title="Connection request"
+      name={meta.name}
+      url={meta.url}
+      iconUrl={meta.icons?.[0]}
+      variant={variant}
+      onPressBadge={onOpenPermissions}
+      onPressDomain={onOpenPermissions}
+      domainTestID="wc-proposal-domain"
+    />
   )
 }

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/WcRejectOnBack.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/WcRejectOnBack.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect } from 'react'
+import { useNavigation } from 'expo-router'
+import { useStore } from 'react-redux'
+import { formatJsonRpcError } from '@walletconnect/jsonrpc-utils'
+import { getSdkError } from '@walletconnect/utils'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import { useAppDispatch } from '@/src/store/hooks'
+import { useHasFeature } from '@/src/hooks/useHasFeature'
+import type { RootState } from '@/src/store'
+import { selectDraftByHash } from '@/src/store/draftTxSlice'
+import { getWalletKit } from '../walletKit'
+import { clearOutstandingRequest, selectOutstandingRequestByHash } from '../store/walletKitSlice'
+import { logWalletKitError } from '../utils/errors'
+
+type Props = { safeTxHash: string }
+
+/**
+ * Invisible side-effect component. Mounted inside the confirm-transaction flow to detect when
+ * the user navigates back (pop / iOS swipe / hardware back) — React Navigation's `beforeRemove`
+ * event fires on those but NOT on router.replace(), so the sign-success / sign-error
+ * transitions don't trigger it.
+ *
+ * Only sends USER_REJECTED to the dApp if the tx is still in DRAFT state. Once the tx is
+ * proposed (signed and submitted to CGW), the draft is cleared by draftTxSlice's auto-cleanup
+ * — at that point the propose-fulfilled listener has either already responded with success or
+ * is mid-flight, and a reject here would race with it and potentially overwrite the success
+ * response.
+ *
+ * If the txId on this screen isn't a WC request (e.g. native Send flow), the outstanding
+ * lookup misses and the handler is a no-op — safe to mount unconditionally.
+ *
+ * Gated by NATIVE_WALLETCONNECT: when the feature is off the listener is skipped, and
+ * WalletKitProvider is also absent from the tree (WalletKitGate renders children raw).
+ */
+export const WcRejectOnBack: React.FC<Props> = ({ safeTxHash }) => {
+  const navigation = useNavigation()
+  const dispatch = useAppDispatch()
+  const store = useStore<RootState>()
+  const isEnabled = useHasFeature(FEATURES.NATIVE_WALLETCONNECT) ?? false
+
+  useEffect(() => {
+    if (!isEnabled) {
+      return
+    }
+    const unsubscribe = navigation.addListener('beforeRemove', () => {
+      const state = store.getState()
+      const outstanding = selectOutstandingRequestByHash(state, safeTxHash)
+      if (!outstanding) {
+        return
+      }
+      // Only reject drafted txs. A cleared draft means the tx was proposed — let the
+      // propose-fulfilled listener handle the dApp response.
+      const draft = selectDraftByHash(state, safeTxHash)
+      if (!draft) {
+        return
+      }
+      void (async () => {
+        try {
+          const wk = await getWalletKit()
+          await wk.respondSessionRequest({
+            topic: outstanding.topic,
+            response: formatJsonRpcError(outstanding.id, getSdkError('USER_REJECTED').message),
+          })
+        } catch (e) {
+          logWalletKitError('reject-on-back failed', e)
+        }
+        dispatch(clearOutstandingRequest(safeTxHash))
+      })()
+    })
+    return unsubscribe
+  }, [isEnabled, navigation, safeTxHash, store, dispatch])
+
+  return null
+}

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/WcRejectOnBack.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/WcRejectOnBack.tsx
@@ -51,6 +51,10 @@ export const WcRejectOnBack: React.FC<Props> = ({ safeTxHash }) => {
       // The /propose mutation is in flight — the draft still exists, but a reject here
       // would race the propose-fulfilled success response. The flag is cleared again if
       // the propose fails (draft retained), so a later back-out still rejects.
+      // Known limitation: if the user backs out DURING the in-flight window and the
+      // propose then fails, beforeRemove has already fired and won't again — the dApp
+      // only resolves via the WC request timeout. Accepted: the alternative (rejecting
+      // here) would race a successful propose far more often than this edge occurs.
       if (outstanding.proposing) {
         return
       }

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/WcRejectOnBack.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/WcRejectOnBack.tsx
@@ -48,6 +48,12 @@ export const WcRejectOnBack: React.FC<Props> = ({ safeTxHash }) => {
       if (!outstanding) {
         return
       }
+      // The /propose mutation is in flight — the draft still exists, but a reject here
+      // would race the propose-fulfilled success response. The flag is cleared again if
+      // the propose fails (draft retained), so a later back-out still rejects.
+      if (outstanding.proposing) {
+        return
+      }
       // Only reject drafted txs. A cleared draft means the tx was proposed — let the
       // propose-fulfilled listener handle the dApp response.
       const draft = selectDraftByHash(state, safeTxHash)

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/DappIcon.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/DappIcon.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { fireEvent } from '@testing-library/react-native'
+import { render } from '@/src/tests/test-utils'
+import { DappIcon } from '../DappIcon'
+
+describe('DappIcon', () => {
+  it('renders the placeholder when no URL is provided', () => {
+    const { getByTestId } = render(<DappIcon />)
+    expect(getByTestId('dapp-icon-placeholder')).toBeTruthy()
+  })
+
+  it('renders the image for a raster URL', () => {
+    const { getByTestId, queryByTestId } = render(<DappIcon url="https://x/icon.png" />)
+    expect(getByTestId('dapp-icon-image')).toBeTruthy()
+    expect(queryByTestId('dapp-icon-placeholder')).toBeNull()
+  })
+
+  it('falls back to the placeholder when the image fails to load', () => {
+    const { getByTestId, queryByTestId } = render(<DappIcon url="https://x/broken.png" />)
+    fireEvent(getByTestId('dapp-icon-image'), 'error', { nativeEvent: { error: 'load failed' } })
+    expect(getByTestId('dapp-icon-placeholder')).toBeTruthy()
+    expect(queryByTestId('dapp-icon-image')).toBeNull()
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/DappIcon.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/DappIcon.test.tsx
@@ -21,4 +21,16 @@ describe('DappIcon', () => {
     expect(getByTestId('dapp-icon-placeholder')).toBeTruthy()
     expect(queryByTestId('dapp-icon-image')).toBeNull()
   })
+
+  it('recovers from a failure when re-rendered in place with a different URL', () => {
+    // The request-sheet host re-renders this component in place when the FIFO head changes —
+    // one dApp's broken icon must not blank the next dApp's valid one.
+    const { getByTestId, queryByTestId, rerender } = render(<DappIcon url="https://x/broken.png" />)
+    fireEvent(getByTestId('dapp-icon-image'), 'error', { nativeEvent: { error: 'load failed' } })
+    expect(getByTestId('dapp-icon-placeholder')).toBeTruthy()
+
+    rerender(<DappIcon url="https://y/valid.png" />)
+    expect(getByTestId('dapp-icon-image')).toBeTruthy()
+    expect(queryByTestId('dapp-icon-placeholder')).toBeNull()
+  })
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/RequestSheetHost.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/RequestSheetHost.test.tsx
@@ -203,13 +203,13 @@ describe('RequestSheetHost', () => {
     // Tapping the domain pill swaps in the permissions panel + the "Got it" footer.
     fireEvent.press(getByTestId('wc-proposal-domain'))
     expect(getByText('This domain has been verified.')).toBeTruthy()
-    expect(getByTestId('wc-proposal-permissions-dismiss')).toBeTruthy()
+    expect(getByTestId('wc-permissions-dismiss')).toBeTruthy()
     expect(queryByTestId('wc-proposal-connect')).toBeNull()
 
     // "Got it" returns to the proposal view.
-    fireEvent.press(getByTestId('wc-proposal-permissions-dismiss'))
+    fireEvent.press(getByTestId('wc-permissions-dismiss'))
     expect(getByTestId('wc-proposal-connect')).toBeTruthy()
-    expect(queryByTestId('wc-proposal-permissions-dismiss')).toBeNull()
+    expect(queryByTestId('wc-permissions-dismiss')).toBeNull()
   })
 
   it('rejects the proposal with USER_REJECTED when the sheet is dismissed', async () => {
@@ -292,5 +292,45 @@ describe('RequestSheetHost', () => {
       }),
     )
     await waitFor(() => expect(getPending(store)).toHaveLength(0))
+  })
+
+  it('opens the permissions panel from the tx-request domain pill and restores Reject/Review on "Got it"', () => {
+    const store = createTestStore({
+      activeSafe: { address: safeAddress, chainId: '1' },
+      [walletKitSliceName]: {
+        sessions: { 'topic-1': { peer: { metadata: { name: 'Uniswap', url: 'https://uniswap.org' } } } },
+        pending: [
+          {
+            kind: 'request',
+            id: 6,
+            topic: 'topic-1',
+            chainId: 'eip155:1',
+            method: 'eth_sendTransaction',
+            params: {},
+            verifyContext: { verified: { validation: 'VALID' } },
+          },
+        ],
+        outstandingRequests: {},
+      },
+    } as never)
+    const { getByTestId, queryByTestId, getByText } = renderWithStore(
+      <RequestSheetHost walletKit={fakeWalletKit} />,
+      store,
+    )
+
+    // Request view: Reject/Review in the footer.
+    expect(getByTestId('wc-tx-review')).toBeTruthy()
+
+    // Tapping the domain pill swaps in the permissions panel + the "Got it" footer.
+    fireEvent.press(getByTestId('wc-tx-domain'))
+    expect(getByText('This domain has been verified.')).toBeTruthy()
+    expect(getByTestId('wc-permissions-dismiss')).toBeTruthy()
+    expect(queryByTestId('wc-tx-review')).toBeNull()
+
+    // "Got it" returns to the request view without responding to the dApp.
+    fireEvent.press(getByTestId('wc-permissions-dismiss'))
+    expect(getByTestId('wc-tx-review')).toBeTruthy()
+    expect(mockRespondSessionRequest).not.toHaveBeenCalled()
+    expect(getPending(store)).toHaveLength(1)
   })
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/RequestSheetHost.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/RequestSheetHost.test.tsx
@@ -268,4 +268,29 @@ describe('RequestSheetHost', () => {
     expect(mockRejectSession).not.toHaveBeenCalled()
     expect(mockRespondSessionRequest).not.toHaveBeenCalled()
   })
+
+  it('renders the Reject/Review footer for a tx request and wires Reject to USER_REJECTED', async () => {
+    const store = createTestStore({
+      activeSafe: { address: safeAddress, chainId: '1' },
+      [walletKitSliceName]: {
+        sessions: { 'topic-1': { peer: { metadata: { name: 'Uniswap', url: 'https://uniswap.org' } } } },
+        pending: [
+          { kind: 'request', id: 4, topic: 'topic-1', chainId: 'eip155:1', method: 'eth_sendTransaction', params: {} },
+        ],
+        outstandingRequests: {},
+      },
+    } as never)
+    const { getByTestId } = renderWithStore(<RequestSheetHost walletKit={fakeWalletKit} />, store)
+
+    expect(getByTestId('wc-tx-review')).toBeTruthy()
+    fireEvent.press(getByTestId('wc-tx-reject'))
+
+    await waitFor(() =>
+      expect(mockRespondSessionRequest).toHaveBeenCalledWith({
+        topic: 'topic-1',
+        response: formatJsonRpcError(4, getSdkError('USER_REJECTED').message),
+      }),
+    )
+    await waitFor(() => expect(getPending(store)).toHaveLength(0))
+  })
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/SendTransactionSheet.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/SendTransactionSheet.test.tsx
@@ -34,6 +34,13 @@ describe('SendTransactionSheet', () => {
     expect(getByText('uniswap.org')).toBeTruthy()
   })
 
+  it('shows only the host for a metadata URL with path and query', () => {
+    const store = storeWith({ name: 'Uniswap', url: 'https://app.uniswap.org/swap?chain=1', icons: [] })
+    const { getByText, queryByText } = renderWithStore(<SendTransactionSheet pending={makePending()} />, store)
+    expect(getByText('app.uniswap.org')).toBeTruthy()
+    expect(queryByText(/swap\?chain=1/)).toBeNull()
+  })
+
   it('hides the domain pill when the dApp provides no URL', () => {
     const store = storeWith({ name: 'Uniswap', icons: [] })
     const { getByText, queryByTestId } = renderWithStore(<SendTransactionSheet pending={makePending()} />, store)

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/SendTransactionSheet.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/SendTransactionSheet.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { fireEvent } from '@testing-library/react-native'
 import { renderWithStore, createTestStore } from '@/src/tests/test-utils'
 import { SendTransactionSheet } from '../SendTransactionSheet'
 import { walletKitSliceName, type PendingSessionRequest } from '../../store/walletKitSlice'
@@ -38,5 +39,16 @@ describe('SendTransactionSheet', () => {
     const { getByText, queryByTestId } = renderWithStore(<SendTransactionSheet pending={makePending()} />, store)
     expect(getByText('Uniswap')).toBeTruthy()
     expect(queryByTestId('wc-tx-domain')).toBeNull()
+  })
+
+  it('asks the host to open the permissions panel when the domain pill is pressed', () => {
+    const onOpenPermissions = jest.fn()
+    const store = storeWith({ name: 'Uniswap', url: 'https://uniswap.org/', icons: [] })
+    const { getByTestId } = renderWithStore(
+      <SendTransactionSheet pending={makePending()} onOpenPermissions={onOpenPermissions} />,
+      store,
+    )
+    fireEvent.press(getByTestId('wc-tx-domain'))
+    expect(onOpenPermissions).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/SendTransactionSheet.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/SendTransactionSheet.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { renderWithStore, createTestStore } from '@/src/tests/test-utils'
+import { SendTransactionSheet } from '../SendTransactionSheet'
+import { walletKitSliceName, type PendingSessionRequest } from '../../store/walletKitSlice'
+
+const makePending = (overrides: Partial<PendingSessionRequest> = {}): PendingSessionRequest => ({
+  kind: 'request',
+  id: 1,
+  topic: 'topic',
+  chainId: 'eip155:1',
+  method: 'eth_sendTransaction',
+  params: [{ to: '0xabc', value: '0x0', data: '0x' }],
+  verifyContext: { verified: { validation: 'VALID' } } as PendingSessionRequest['verifyContext'],
+  ...overrides,
+})
+
+// Seed a mirrored session so the sheet can resolve the dApp's peer metadata by topic.
+const storeWith = (metadata: Record<string, unknown>) =>
+  createTestStore({
+    [walletKitSliceName]: {
+      sessions: { topic: { peer: { metadata } } },
+      pending: [],
+      outstandingRequests: {},
+    },
+  } as never)
+
+describe('SendTransactionSheet', () => {
+  it('renders the identity-only "Transaction request" gate with name and domain', () => {
+    const store = storeWith({ name: 'Uniswap', url: 'https://uniswap.org/', icons: ['https://x/icon.png'] })
+    const { getByText } = renderWithStore(<SendTransactionSheet pending={makePending()} />, store)
+    expect(getByText('Transaction request')).toBeTruthy()
+    expect(getByText('Uniswap')).toBeTruthy()
+    expect(getByText('uniswap.org')).toBeTruthy()
+  })
+
+  it('hides the domain pill when the dApp provides no URL', () => {
+    const store = storeWith({ name: 'Uniswap', icons: [] })
+    const { getByText, queryByTestId } = renderWithStore(<SendTransactionSheet pending={makePending()} />, store)
+    expect(getByText('Uniswap')).toBeTruthy()
+    expect(queryByTestId('wc-tx-domain')).toBeNull()
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/WcRejectOnBack.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/WcRejectOnBack.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import { waitFor } from '@testing-library/react-native'
+import { getSdkError } from '@walletconnect/utils'
+import { formatJsonRpcError } from '@walletconnect/jsonrpc-utils'
+import { renderWithStore, createTestStore } from '@/src/tests/test-utils'
+import { WcRejectOnBack } from '../WcRejectOnBack'
+import { walletKitSliceName } from '../../store/walletKitSlice'
+
+// Capture the beforeRemove listener so the test can simulate a back navigation.
+let beforeRemoveCb: (() => void) | undefined
+jest.mock('expo-router', () => ({
+  useNavigation: () => ({
+    addListener: (event: string, cb: () => void) => {
+      if (event === 'beforeRemove') {
+        beforeRemoveCb = cb
+      }
+      return jest.fn()
+    },
+  }),
+}))
+
+jest.mock('@/src/hooks/useHasFeature', () => ({ useHasFeature: () => true }))
+
+const mockRespond = jest.fn().mockResolvedValue(undefined)
+jest.mock('../../walletKit', () => ({ getWalletKit: () => Promise.resolve({ respondSessionRequest: mockRespond }) }))
+
+const HASH = '0xabc'
+
+const draft = {
+  chainId: '1',
+  safeAddress: '0x1111111111111111111111111111111111111111',
+  buildParams: {},
+  safeTxHash: HASH,
+  txDetails: {},
+}
+
+const storeWith = (withDraft: boolean) =>
+  createTestStore({
+    draftTx: { drafts: withDraft ? { [HASH]: draft } : {} },
+    [walletKitSliceName]: {
+      sessions: {},
+      pending: [],
+      outstandingRequests: { [HASH]: { topic: 't', id: 5, method: 'eth_sendTransaction' } },
+    },
+  } as never)
+
+beforeEach(() => {
+  beforeRemoveCb = undefined
+  jest.clearAllMocks()
+})
+
+describe('WcRejectOnBack', () => {
+  it('rejects a still-drafted WC tx with USER_REJECTED on back navigation', async () => {
+    const store = storeWith(true)
+    renderWithStore(<WcRejectOnBack safeTxHash={HASH} />, store)
+    expect(beforeRemoveCb).toBeDefined()
+    beforeRemoveCb?.()
+    await waitFor(() =>
+      expect(mockRespond).toHaveBeenCalledWith({
+        topic: 't',
+        response: formatJsonRpcError(5, getSdkError('USER_REJECTED').message),
+      }),
+    )
+    await waitFor(() => expect(store.getState()[walletKitSliceName].outstandingRequests).toEqual({}))
+  })
+
+  it('does not reject once the draft is cleared (tx already proposed)', async () => {
+    const store = storeWith(false)
+    renderWithStore(<WcRejectOnBack safeTxHash={HASH} />, store)
+    beforeRemoveCb?.()
+    await Promise.resolve()
+    expect(mockRespond).not.toHaveBeenCalled()
+    // Outstanding request retained for the propose-fulfilled listener to answer.
+    expect(store.getState()[walletKitSliceName].outstandingRequests[HASH]).toBeDefined()
+  })
+
+  it('is a no-op for a non-WC tx (no outstanding request)', async () => {
+    const store = createTestStore({
+      draftTx: { drafts: { [HASH]: draft } },
+      [walletKitSliceName]: { sessions: {}, pending: [], outstandingRequests: {} },
+    } as never)
+    renderWithStore(<WcRejectOnBack safeTxHash={HASH} />, store)
+    beforeRemoveCb?.()
+    await Promise.resolve()
+    expect(mockRespond).not.toHaveBeenCalled()
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/WcRejectOnBack.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/WcRejectOnBack.test.tsx
@@ -64,6 +64,23 @@ describe('WcRejectOnBack', () => {
     await waitFor(() => expect(store.getState()[walletKitSliceName].outstandingRequests).toEqual({}))
   })
 
+  it('does not reject while the propose mutation is in flight (proposing flag)', async () => {
+    const store = createTestStore({
+      draftTx: { drafts: { [HASH]: draft } },
+      [walletKitSliceName]: {
+        sessions: {},
+        pending: [],
+        outstandingRequests: { [HASH]: { topic: 't', id: 5, method: 'eth_sendTransaction', proposing: true } },
+      },
+    } as never)
+    renderWithStore(<WcRejectOnBack safeTxHash={HASH} />, store)
+    beforeRemoveCb?.()
+    await Promise.resolve()
+    expect(mockRespond).not.toHaveBeenCalled()
+    // Entry retained — the propose-fulfilled listener owns the response.
+    expect(store.getState()[walletKitSliceName].outstandingRequests[HASH]).toBeDefined()
+  })
+
   it('does not reject once the draft is cleared (tx already proposed)', async () => {
     const store = storeWith(false)
     renderWithStore(<WcRejectOnBack safeTxHash={HASH} />, store)

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
@@ -341,7 +341,9 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
         if (chain) {
           try {
             receipt = (await proxyReadOnlyCall(chain, 'eth_getTransactionReceipt', [tx.txHash])) as RawTxReceipt | null
-          } catch {
+          } catch (e) {
+            // Non-fatal: fall back to the receipt-less status envelope, but leave a breadcrumb.
+            logWalletKitError('getCallsStatus receipt fetch failed', e)
             receipt = null
           }
         }

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
@@ -3,11 +3,9 @@ import * as Linking from 'expo-linking'
 import type { IWalletKit, WalletKitTypes } from '@reown/walletkit'
 import { getSdkError } from '@walletconnect/utils'
 import { formatJsonRpcError, formatJsonRpcResult } from '@walletconnect/jsonrpc-utils'
-import { skipToken } from '@reduxjs/toolkit/query'
 import { isAnyOf } from '@reduxjs/toolkit'
 import { isPairingUri } from '@safe-global/utils/features/walletconnect/utils'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
-import { useSafesGetSafeV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import { cgwApi } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks'
 import { startAppListening } from '@/src/store'
@@ -214,18 +212,20 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     }
   }, [walletKit])
 
-  // Active context for the session-request router. `safe` is the full SafeState (owners,
-  // threshold, version) the compose path needs; `hasSigner` gates tx requests with 4100.
+  // Active context for the session-request router, read from local slices so cold-start
+  // requests aren't rejected while CGW fetches are in flight (the compose path loads the
+  // full SafeState itself); `hasSigner` gates tx requests with 4100.
   const activeSafe = useAppSelector(selectActiveSafe)
   const activeChain = useAppSelector((s) => (activeSafe ? (selectChainById(s, activeSafe.chainId) ?? null) : null))
-  const { data: safe } = useSafesGetSafeV1Query(
-    activeSafe ? { chainId: activeSafe.chainId, safeAddress: activeSafe.address } : skipToken,
-  )
   const activeSigner = useAppSelector((s) => (activeSafe ? selectActiveSigner(s, activeSafe.address) : undefined))
 
   const deps: SessionRequestHandlerDeps = useMemo(
-    () => ({ activeChain: activeChain ?? null, activeSafe: safe ?? null, hasSigner: !!activeSigner }),
-    [activeChain, safe, activeSigner],
+    () => ({
+      activeChain: activeChain ?? null,
+      activeSafeAddress: activeSafe?.address ?? null,
+      hasSigner: !!activeSigner,
+    }),
+    [activeChain, activeSafe?.address, activeSigner],
   )
 
   useSessionProposalHandler(walletKit)

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
@@ -1,13 +1,29 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import * as Linking from 'expo-linking'
 import type { IWalletKit, WalletKitTypes } from '@reown/walletkit'
 import { getSdkError } from '@walletconnect/utils'
+import { formatJsonRpcResult } from '@walletconnect/jsonrpc-utils'
+import { skipToken } from '@reduxjs/toolkit/query'
 import { isPairingUri } from '@safe-global/utils/features/walletconnect/utils'
-import { useAppDispatch } from '@/src/store/hooks'
+import { useSafesGetSafeV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { cgwApi } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { useAppDispatch, useAppSelector } from '@/src/store/hooks'
+import { startAppListening } from '@/src/store'
+import { selectActiveSafe } from '@/src/store/activeSafeSlice'
+import { selectChainById } from '@/src/store/chains'
+import { selectActiveSigner } from '@/src/store/activeSignerSlice'
 import { getWalletKit } from '../walletKit'
 import { useActiveSafeBinding } from '../hooks/useActiveSafeBinding'
 import { useSessionProposalHandler } from '../hooks/useSessionProposalHandler'
-import { setSessions, removeSession, pushPending, isDeferredTxMethod } from '../store/walletKitSlice'
+import { useSessionRequestHandler, type SessionRequestHandlerDeps } from '../hooks/useSessionRequestHandler'
+import {
+  setSessions,
+  removeSession,
+  pushPending,
+  isDeferredTxMethod,
+  clearOutstandingRequest,
+  selectOutstandingRequestByHash,
+} from '../store/walletKitSlice'
 import { RequestSheetHost } from '../components/RequestSheetHost'
 import { logWalletKitError } from '../utils/errors'
 
@@ -40,6 +56,7 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
               chainId: r.params.chainId,
               method,
               params: r.params.request.params,
+              verifyContext: r.verifyContext,
             }),
           )
         })
@@ -50,19 +67,16 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     }
   }, [dispatch])
 
-  // Subscribe to session events. session_proposal is handled by useSessionProposalHandler
-  // (WA-2318). session_request handling is wired in WA-2321/2322. delete/expire/update keep
-  // the slice's session mirror in sync; authenticate is rejected (out of scope).
+  // Subscribe to session lifecycle events. session_proposal is handled by
+  // useSessionProposalHandler (WA-2318) and session_request by useSessionRequestHandler
+  // (WA-2321). delete/expire keep the slice's session mirror in sync; authenticate is
+  // rejected (out of scope).
   useEffect(() => {
     if (!walletKit) {
       return
     }
     const refreshSessions = () => dispatch(setSessions(walletKit.getActiveSessions()))
 
-    const onRequest = (r: WalletKitTypes.SessionRequest) => {
-      // TODO(WA-2321 / WA-2322): route + render request sheets.
-      console.log('[walletKit] session_request (stub)', r.id)
-    }
     const onDelete = ({ topic }: { topic: string }) => dispatch(removeSession(topic))
     // proposal_expire / session_request_expire are the lifecycle-expiry events @reown/walletkit
     // actually surfaces (its event map has no `session_expire` / `session_update`). Re-seed from
@@ -77,20 +91,54 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       }
     }
 
-    walletKit.on('session_request', onRequest)
     walletKit.on('session_delete', onDelete)
     walletKit.on('proposal_expire', onProposalExpire)
     walletKit.on('session_request_expire', onRequestExpire)
     walletKit.on('session_authenticate', onAuthenticate)
 
     return () => {
-      walletKit.off('session_request', onRequest)
       walletKit.off('session_delete', onDelete)
       walletKit.off('proposal_expire', onProposalExpire)
       walletKit.off('session_request_expire', onRequestExpire)
       walletKit.off('session_authenticate', onAuthenticate)
     }
   }, [walletKit, dispatch])
+
+  // Respond to the dApp once the user has actually signed. The existing confirm flow calls
+  // transactionsProposeTransactionV1 after signing; match its fulfilled action against any
+  // outstanding tx request keyed by safeTxHash and reply with the hash (or { id } for 5792).
+  useEffect(() => {
+    if (!walletKit) {
+      return
+    }
+    const unsubscribe = startAppListening({
+      matcher: cgwApi.endpoints.transactionsProposeTransactionV1.matchFulfilled,
+      effect: async (action, api) => {
+        const arg = action.meta.arg.originalArgs as { proposeTransactionDto?: { safeTxHash?: string } }
+        const safeTxHash = arg.proposeTransactionDto?.safeTxHash
+        if (!safeTxHash) {
+          return
+        }
+        const outstanding = selectOutstandingRequestByHash(api.getState(), safeTxHash)
+        if (!outstanding) {
+          return
+        }
+        const result = outstanding.method === 'wallet_sendCalls' ? { id: safeTxHash } : safeTxHash
+        try {
+          await walletKit.respondSessionRequest({
+            topic: outstanding.topic,
+            response: formatJsonRpcResult(outstanding.id, result),
+          })
+        } catch (e) {
+          logWalletKitError('respondSessionRequest after propose failed', e)
+        }
+        api.dispatch(clearOutstandingRequest(safeTxHash))
+      },
+    })
+    return () => {
+      unsubscribe()
+    }
+  }, [walletKit])
 
   // Deep-link listener: wc: URIs arriving via the OS land here.
   useEffect(() => {
@@ -123,7 +171,22 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     }
   }, [walletKit])
 
+  // Active context for the session-request router. `safe` is the full SafeState (owners,
+  // threshold, version) the compose path needs; `hasSigner` gates tx requests with 4100.
+  const activeSafe = useAppSelector(selectActiveSafe)
+  const activeChain = useAppSelector((s) => (activeSafe ? (selectChainById(s, activeSafe.chainId) ?? null) : null))
+  const { data: safe } = useSafesGetSafeV1Query(
+    activeSafe ? { chainId: activeSafe.chainId, safeAddress: activeSafe.address } : skipToken,
+  )
+  const activeSigner = useAppSelector((s) => (activeSafe ? selectActiveSigner(s, activeSafe.address) : undefined))
+
+  const deps: SessionRequestHandlerDeps = useMemo(
+    () => ({ activeChain: activeChain ?? null, activeSafe: safe ?? null, hasSigner: !!activeSigner }),
+    [activeChain, safe, activeSigner],
+  )
+
   useSessionProposalHandler(walletKit)
+  useSessionRequestHandler(walletKit, deps)
   useActiveSafeBinding(walletKit)
 
   return (

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
@@ -221,27 +221,24 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
           return switchActiveChain.match(action) ? true : sameAddress(safeAddress, next?.address)
         }
 
-        // Handed-off requests (waiting on /propose).
-        const outstanding = selectOutstandingRequests(api.getState())
-        for (const [safeTxHash, req] of Object.entries(outstanding)) {
-          if (matchesNext(req.chainId, req.safeAddress)) {
-            continue
-          }
-          await respondRejected(req.topic, req.id)
-          api.dispatch(clearOutstandingRequest(safeTxHash))
-        }
-
-        // Pre-compose requests still showing (or queued behind) the sheet.
-        const pendingRequests = selectPending(api.getState()).filter(
-          (p): p is PendingSessionRequest => p.kind === 'request',
+        // Handed-off requests (waiting on /propose) + pre-compose requests still showing
+        // (or queued behind) the sheet. Clear the state first so the UI dismisses
+        // immediately, then send all rejections in parallel — a slow relay must not
+        // serialize the cleanup (respondRejected swallows its own errors).
+        const staleOutstanding = Object.entries(selectOutstandingRequests(api.getState())).filter(
+          ([, req]) => !matchesNext(req.chainId, req.safeAddress),
         )
-        for (const p of pendingRequests) {
-          if (matchesNext(stripEip155Prefix(p.chainId), p.safeAddress)) {
-            continue
-          }
-          await respondRejected(p.topic, p.id)
-          api.dispatch(removePending({ id: p.id, kind: 'request' }))
-        }
+        const stalePending = selectPending(api.getState())
+          .filter((p): p is PendingSessionRequest => p.kind === 'request')
+          .filter((p) => !matchesNext(stripEip155Prefix(p.chainId), p.safeAddress))
+
+        staleOutstanding.forEach(([safeTxHash]) => api.dispatch(clearOutstandingRequest(safeTxHash)))
+        stalePending.forEach((p) => api.dispatch(removePending({ id: p.id, kind: 'request' })))
+
+        await Promise.all([
+          ...staleOutstanding.map(([, req]) => respondRejected(req.topic, req.id)),
+          ...stalePending.map((p) => respondRejected(p.topic, p.id)),
+        ])
       },
     })
     return () => {

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
@@ -2,14 +2,16 @@ import React, { useEffect, useMemo, useState } from 'react'
 import * as Linking from 'expo-linking'
 import type { IWalletKit, WalletKitTypes } from '@reown/walletkit'
 import { getSdkError } from '@walletconnect/utils'
-import { formatJsonRpcResult } from '@walletconnect/jsonrpc-utils'
+import { formatJsonRpcError, formatJsonRpcResult } from '@walletconnect/jsonrpc-utils'
 import { skipToken } from '@reduxjs/toolkit/query'
+import { isAnyOf } from '@reduxjs/toolkit'
 import { isPairingUri } from '@safe-global/utils/features/walletconnect/utils'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { useSafesGetSafeV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import { cgwApi } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks'
 import { startAppListening } from '@/src/store'
-import { selectActiveSafe } from '@/src/store/activeSafeSlice'
+import { selectActiveSafe, setActiveSafe, switchActiveChain, clearActiveSafe } from '@/src/store/activeSafeSlice'
 import { selectChainById } from '@/src/store/chains'
 import { selectActiveSigner } from '@/src/store/activeSignerSlice'
 import { getWalletKit } from '../walletKit'
@@ -23,6 +25,7 @@ import {
   isDeferredTxMethod,
   clearOutstandingRequest,
   selectOutstandingRequestByHash,
+  selectOutstandingRequests,
 } from '../store/walletKitSlice'
 import { RequestSheetHost } from '../components/RequestSheetHost'
 import { logWalletKitError } from '../utils/errors'
@@ -133,6 +136,46 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
           logWalletKitError('respondSessionRequest after propose failed', e)
         }
         api.dispatch(clearOutstandingRequest(safeTxHash))
+      },
+    })
+    return () => {
+      unsubscribe()
+    }
+  }, [walletKit])
+
+  // A Safe/chain switch invalidates handed-off tx requests: draftTxSlice drops their drafts
+  // on the same actions, so the confirm flow can no longer answer them. Reject the stale
+  // entries so the dApp doesn't hang until the WC timeout (mirrors draftTxSlice's
+  // isSameSafe cleanup; entries matching the new active Safe are kept).
+  useEffect(() => {
+    if (!walletKit) {
+      return
+    }
+    const unsubscribe = startAppListening({
+      matcher: isAnyOf(setActiveSafe, switchActiveChain, clearActiveSafe),
+      effect: async (action, api) => {
+        const next = setActiveSafe.match(action) ? action.payload : null
+        const nextChainId = switchActiveChain.match(action) ? action.payload.chainId : next?.chainId
+        const outstanding = selectOutstandingRequests(api.getState())
+        for (const [safeTxHash, req] of Object.entries(outstanding)) {
+          const sameChain = req.chainId === nextChainId
+          // switchActiveChain keeps the Safe address; the other actions carry the full context.
+          const sameSafe = switchActiveChain.match(action)
+            ? sameChain
+            : sameChain && sameAddress(req.safeAddress, next?.address)
+          if (sameSafe) {
+            continue
+          }
+          try {
+            await walletKit.respondSessionRequest({
+              topic: req.topic,
+              response: formatJsonRpcError(req.id, getSdkError('USER_REJECTED').message),
+            })
+          } catch (e) {
+            logWalletKitError('respondSessionRequest after Safe switch failed', e)
+          }
+          api.dispatch(clearOutstandingRequest(safeTxHash))
+        }
       },
     })
     return () => {

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
@@ -1,13 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import * as Linking from 'expo-linking'
 import { router } from 'expo-router'
-import type { TransactionReceipt } from 'ethers'
 import type { IWalletKit, WalletKitTypes } from '@reown/walletkit'
 import { getSdkError } from '@walletconnect/utils'
 import { formatJsonRpcError, formatJsonRpcResult } from '@walletconnect/jsonrpc-utils'
 import { isAnyOf } from '@reduxjs/toolkit'
 import { useStore } from 'react-redux'
-import { chainIdToHex, isPairingUri, stripEip155Prefix } from '@safe-global/utils/features/walletconnect/utils'
+import { isPairingUri, stripEip155Prefix } from '@safe-global/utils/features/walletconnect/utils'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { cgwApi } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks'
@@ -21,6 +20,7 @@ import { useSessionProposalHandler } from '../hooks/useSessionProposalHandler'
 import { useSessionRequestHandler, type SessionRequestHandlerDeps } from '../hooks/useSessionRequestHandler'
 import { isValidTxRequestParams } from '../services/methodRouter'
 import { proxyReadOnlyCall } from '../services/readRpcProxy'
+import { buildGetCallsResult, type RawTxReceipt } from '../services/getCallsStatus'
 import {
   setSessions,
   removeSession,
@@ -317,7 +317,6 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   const getCallsStatus: SessionRequestHandlerDeps['getCallsStatus'] = useCallback(
     async (chainId, id) => {
       const numericChainId = stripEip155Prefix(chainId)
-      const chainIdHex = chainIdToHex(numericChainId) as `0x${string}`
 
       let tx
       try {
@@ -328,50 +327,21 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
         throw new Error('Transaction not found')
       }
 
-      // BundleTxStatuses (verbatim from web):
-      //   AWAITING_CONFIRMATIONS / AWAITING_EXECUTION → 100 PENDING
-      //   SUCCESS → 200 CONFIRMED | CANCELLED → 400 OFFCHAIN_FAILURE | FAILED → 500 REVERTED
-      const status =
-        tx.txStatus === 'SUCCESS' ? 200 : tx.txStatus === 'CANCELLED' ? 400 : tx.txStatus === 'FAILED' ? 500 : 100
-
-      const envelope = { version: '2.0.0' as const, id, chainId: chainIdHex, status, atomic: true as const }
-
-      if (!tx.txHash) {
-        return envelope
-      }
-      const chain = selectChainById(store.getState(), numericChainId)
-      if (!chain) {
-        return envelope
+      // Fetch the on-chain receipt only once there's a tx hash to look up and the chain config
+      // is available; buildGetCallsResult tolerates a null receipt (a pending bundle).
+      let receipt: RawTxReceipt | null = null
+      if (tx.txHash) {
+        const chain = selectChainById(store.getState(), numericChainId)
+        if (chain) {
+          try {
+            receipt = (await proxyReadOnlyCall(chain, 'eth_getTransactionReceipt', [tx.txHash])) as RawTxReceipt | null
+          } catch {
+            receipt = null
+          }
+        }
       }
 
-      let receipt: TransactionReceipt | null = null
-      try {
-        receipt = (await proxyReadOnlyCall(chain, 'eth_getTransactionReceipt', [
-          tx.txHash,
-        ])) as TransactionReceipt | null
-      } catch {
-        return envelope
-      }
-      if (!receipt) {
-        return envelope
-      }
-
-      // Web replicates the same receipt for each underlying call in the bundle.
-      const valueDecoded = tx.txData?.dataDecoded?.parameters?.[0]?.valueDecoded
-      const callsCount = Array.isArray(valueDecoded) && valueDecoded.length > 0 ? valueDecoded.length : 1
-      const onChainStatusHex = (tx.txStatus === 'SUCCESS' ? '0x1' : '0x0') as `0x${string}`
-
-      return {
-        ...envelope,
-        receipts: Array.from({ length: callsCount }, () => ({
-          logs: receipt.logs as unknown[],
-          status: onChainStatusHex,
-          blockHash: receipt.blockHash as `0x${string}`,
-          blockNumber: `0x${Number(receipt.blockNumber).toString(16)}` as `0x${string}`,
-          gasUsed: `0x${Number(receipt.gasUsed).toString(16)}` as `0x${string}`,
-          transactionHash: tx.txHash as `0x${string}`,
-        })),
-      }
+      return buildGetCallsResult(id, numericChainId, tx, receipt)
     },
     [dispatch, store],
   )

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
@@ -297,6 +297,8 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     async (caip2) => {
       const chainId = stripEip155Prefix(caip2)
       const state = store.getState()
+      // Two gates, both surfaced as NOT_DEPLOYED: the chain config must be loaded (we can't
+      // operate on a chain we have no config for), and the active Safe must be deployed there.
       if (!selectChainById(state, chainId)) {
         return { ok: false, reason: 'NOT_DEPLOYED' }
       }
@@ -313,7 +315,8 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
 
   // wallet_getCallsStatus — local Safe-tx status enriched with the on-chain receipt (mirrors
   // apps/web/.../safe-wallet-provider/index.ts). Throws 'Transaction not found' for an unknown
-  // id; the router converts that to a JSON-RPC error.
+  // id; the router converts that to a JSON-RPC error. `chainId` is the WC envelope's session
+  // chain — correct here because wallet_sendCalls is bound to the active chain at send time.
   const getCallsStatus: SessionRequestHandlerDeps['getCallsStatus'] = useCallback(
     async (chainId, id) => {
       const numericChainId = stripEip155Prefix(chainId)
@@ -346,6 +349,9 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     [dispatch, store],
   )
 
+  // wallet_showCallsStatus — open the pending-transactions queue. The screen doesn't yet read
+  // the chainId / txId params, so this lands on the queue rather than the specific tx detail;
+  // deep-linking to the exact entry is a follow-up.
   const navigateToCallsStatus: SessionRequestHandlerDeps['navigateToCallsStatus'] = useCallback((chainId, id) => {
     router.push({ pathname: '/pending-transactions', params: { chainId, txId: id } })
   }, [])

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
@@ -1,11 +1,13 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import * as Linking from 'expo-linking'
+import { router } from 'expo-router'
+import type { TransactionReceipt } from 'ethers'
 import type { IWalletKit, WalletKitTypes } from '@reown/walletkit'
 import { getSdkError } from '@walletconnect/utils'
 import { formatJsonRpcError, formatJsonRpcResult } from '@walletconnect/jsonrpc-utils'
 import { isAnyOf } from '@reduxjs/toolkit'
 import { useStore } from 'react-redux'
-import { isPairingUri, stripEip155Prefix } from '@safe-global/utils/features/walletconnect/utils'
+import { chainIdToHex, isPairingUri, stripEip155Prefix } from '@safe-global/utils/features/walletconnect/utils'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { cgwApi } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks'
@@ -18,6 +20,7 @@ import { useActiveSafeBinding } from '../hooks/useActiveSafeBinding'
 import { useSessionProposalHandler } from '../hooks/useSessionProposalHandler'
 import { useSessionRequestHandler, type SessionRequestHandlerDeps } from '../hooks/useSessionRequestHandler'
 import { isValidTxRequestParams } from '../services/methodRouter'
+import { proxyReadOnlyCall } from '../services/readRpcProxy'
 import {
   setSessions,
   removeSession,
@@ -286,13 +289,107 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   const activeChain = useAppSelector((s) => (activeSafe ? (selectChainById(s, activeSafe.chainId) ?? null) : null))
   const activeSigner = useAppSelector((s) => (activeSafe ? selectActiveSigner(s, activeSafe.address) : undefined))
 
+  // wallet_switchEthereumChain — only allow chains the active Safe is deployed on (derived
+  // from the safes slice, the same source the proposal handler uses). useActiveSafeBinding
+  // re-syncs the WC sessions off the resulting switchActiveChain dispatch, so no explicit
+  // walletKit.updateSession is needed here.
+  const switchActiveChainByCaip2: SessionRequestHandlerDeps['switchActiveChainByCaip2'] = useCallback(
+    async (caip2) => {
+      const chainId = stripEip155Prefix(caip2)
+      const state = store.getState()
+      if (!selectChainById(state, chainId)) {
+        return { ok: false, reason: 'NOT_DEPLOYED' }
+      }
+      const safeAddress = selectActiveSafe(state)?.address
+      const safeChains = safeAddress ? Object.keys(state.safes[safeAddress] ?? {}) : []
+      if (!safeChains.includes(chainId)) {
+        return { ok: false, reason: 'NOT_DEPLOYED' }
+      }
+      dispatch(switchActiveChain({ chainId }))
+      return { ok: true }
+    },
+    [store, dispatch],
+  )
+
+  // wallet_getCallsStatus — local Safe-tx status enriched with the on-chain receipt (mirrors
+  // apps/web/.../safe-wallet-provider/index.ts). Throws 'Transaction not found' for an unknown
+  // id; the router converts that to a JSON-RPC error.
+  const getCallsStatus: SessionRequestHandlerDeps['getCallsStatus'] = useCallback(
+    async (chainId, id) => {
+      const numericChainId = stripEip155Prefix(chainId)
+      const chainIdHex = chainIdToHex(numericChainId) as `0x${string}`
+
+      let tx
+      try {
+        tx = await dispatch(
+          cgwApi.endpoints.transactionsGetTransactionByIdV1.initiate({ chainId: numericChainId, id }),
+        ).unwrap()
+      } catch {
+        throw new Error('Transaction not found')
+      }
+
+      // BundleTxStatuses (verbatim from web):
+      //   AWAITING_CONFIRMATIONS / AWAITING_EXECUTION → 100 PENDING
+      //   SUCCESS → 200 CONFIRMED | CANCELLED → 400 OFFCHAIN_FAILURE | FAILED → 500 REVERTED
+      const status =
+        tx.txStatus === 'SUCCESS' ? 200 : tx.txStatus === 'CANCELLED' ? 400 : tx.txStatus === 'FAILED' ? 500 : 100
+
+      const envelope = { version: '2.0.0' as const, id, chainId: chainIdHex, status, atomic: true as const }
+
+      if (!tx.txHash) {
+        return envelope
+      }
+      const chain = selectChainById(store.getState(), numericChainId)
+      if (!chain) {
+        return envelope
+      }
+
+      let receipt: TransactionReceipt | null = null
+      try {
+        receipt = (await proxyReadOnlyCall(chain, 'eth_getTransactionReceipt', [
+          tx.txHash,
+        ])) as TransactionReceipt | null
+      } catch {
+        return envelope
+      }
+      if (!receipt) {
+        return envelope
+      }
+
+      // Web replicates the same receipt for each underlying call in the bundle.
+      const valueDecoded = tx.txData?.dataDecoded?.parameters?.[0]?.valueDecoded
+      const callsCount = Array.isArray(valueDecoded) && valueDecoded.length > 0 ? valueDecoded.length : 1
+      const onChainStatusHex = (tx.txStatus === 'SUCCESS' ? '0x1' : '0x0') as `0x${string}`
+
+      return {
+        ...envelope,
+        receipts: Array.from({ length: callsCount }, () => ({
+          logs: receipt.logs as unknown[],
+          status: onChainStatusHex,
+          blockHash: receipt.blockHash as `0x${string}`,
+          blockNumber: `0x${Number(receipt.blockNumber).toString(16)}` as `0x${string}`,
+          gasUsed: `0x${Number(receipt.gasUsed).toString(16)}` as `0x${string}`,
+          transactionHash: tx.txHash as `0x${string}`,
+        })),
+      }
+    },
+    [dispatch, store],
+  )
+
+  const navigateToCallsStatus: SessionRequestHandlerDeps['navigateToCallsStatus'] = useCallback((chainId, id) => {
+    router.push({ pathname: '/pending-transactions', params: { chainId, txId: id } })
+  }, [])
+
   const deps: SessionRequestHandlerDeps = useMemo(
     () => ({
       activeChain: activeChain ?? null,
       activeSafeAddress: activeSafe?.address ?? null,
       hasSigner: !!activeSigner,
+      switchActiveChainByCaip2,
+      getCallsStatus,
+      navigateToCallsStatus,
     }),
-    [activeChain, activeSafe?.address, activeSigner],
+    [activeChain, activeSafe?.address, activeSigner, switchActiveChainByCaip2, getCallsStatus, navigateToCallsStatus],
   )
 
   useSessionProposalHandler(walletKit)

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
@@ -346,6 +346,13 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
             logWalletKitError('getCallsStatus receipt fetch failed', e)
             receipt = null
           }
+        } else {
+          // A mined tx on a chain we have no config for is anomalous — log it too, rather than
+          // silently dropping to the receipt-less envelope (symmetry with the fetch-error path).
+          logWalletKitError(
+            'getCallsStatus: no chain config for receipt lookup',
+            new Error(`chainId=${numericChainId}`),
+          )
         }
       }
 
@@ -356,7 +363,8 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
 
   // wallet_showCallsStatus — open the pending-transactions queue. The screen doesn't yet read
   // the chainId / txId params, so this lands on the queue rather than the specific tx detail;
-  // deep-linking to the exact entry is a follow-up.
+  // deep-linking to the exact entry is a follow-up. Note: chainId here is the CAIP-2 envelope
+  // value (e.g. 'eip155:1') — a future consumer must stripEip155Prefix before using it numerically.
   const navigateToCallsStatus: SessionRequestHandlerDeps['navigateToCallsStatus'] = useCallback((chainId, id) => {
     router.push({ pathname: '/pending-transactions', params: { chainId, txId: id } })
   }, [])

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
@@ -17,6 +17,7 @@ import { getWalletKit } from '../walletKit'
 import { useActiveSafeBinding } from '../hooks/useActiveSafeBinding'
 import { useSessionProposalHandler } from '../hooks/useSessionProposalHandler'
 import { useSessionRequestHandler, type SessionRequestHandlerDeps } from '../hooks/useSessionRequestHandler'
+import { isValidTxRequestParams } from '../services/methodRouter'
 import {
   setSessions,
   removeSession,
@@ -55,6 +56,16 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
         pendings.forEach((r) => {
           const method = r.params.request.method
           if (!isDeferredTxMethod(method)) {
+            return
+          }
+          // Restored requests never passed routeSessionRequest, so enforce the same param
+          // shape here — a malformed bundle would otherwise only blow up inside compose
+          // with an unactionable toast. Reject it back to the dApp instead of seeding.
+          if (!isValidTxRequestParams(method, r.params.request.params)) {
+            wk.respondSessionRequest({
+              topic: r.topic,
+              response: formatJsonRpcError(r.id, { code: -32602, message: 'Invalid call parameters.' }),
+            }).catch((e) => logWalletKitError('respondSessionRequest (restored, invalid params) failed', e))
             return
           }
           dispatch(

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
@@ -25,6 +25,7 @@ import {
   removePending,
   isDeferredTxMethod,
   clearOutstandingRequest,
+  setOutstandingProposing,
   selectOutstandingRequestByHash,
   selectOutstandingRequests,
   selectPending,
@@ -128,36 +129,61 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   // Respond to the dApp once the user has actually signed. The existing confirm flow calls
   // transactionsProposeTransactionV1 after signing; match its fulfilled action against any
   // outstanding tx request keyed by safeTxHash and reply with the hash (or { id } for 5792).
+  // The pending/rejected matchers maintain the `proposing` flag so WcRejectOnBack can't
+  // race the success response with a USER_REJECTED while /propose is in flight.
   useEffect(() => {
     if (!walletKit) {
       return
     }
-    const unsubscribe = startAppListening({
-      matcher: cgwApi.endpoints.transactionsProposeTransactionV1.matchFulfilled,
-      effect: async (action, api) => {
-        const arg = action.meta.arg.originalArgs as { proposeTransactionDto?: { safeTxHash?: string } }
-        const safeTxHash = arg.proposeTransactionDto?.safeTxHash
-        if (!safeTxHash) {
-          return
-        }
-        const outstanding = selectOutstandingRequestByHash(api.getState(), safeTxHash)
-        if (!outstanding) {
-          return
-        }
-        const result = outstanding.method === 'wallet_sendCalls' ? { id: safeTxHash } : safeTxHash
-        try {
-          await walletKit.respondSessionRequest({
-            topic: outstanding.topic,
-            response: formatJsonRpcResult(outstanding.id, result),
-          })
-        } catch (e) {
-          logWalletKitError('respondSessionRequest after propose failed', e)
-        }
-        api.dispatch(clearOutstandingRequest(safeTxHash))
-      },
-    })
+    const safeTxHashOf = (action: { meta: { arg: { originalArgs: unknown } } }) =>
+      (action.meta.arg.originalArgs as { proposeTransactionDto?: { safeTxHash?: string } }).proposeTransactionDto
+        ?.safeTxHash
+    const unsubscribers = [
+      startAppListening({
+        matcher: cgwApi.endpoints.transactionsProposeTransactionV1.matchPending,
+        effect: async (action, api) => {
+          const safeTxHash = safeTxHashOf(action)
+          if (safeTxHash) {
+            api.dispatch(setOutstandingProposing({ safeTxHash, proposing: true }))
+          }
+        },
+      }),
+      startAppListening({
+        // A failed /propose keeps the draft (AC) — re-enable reject-on-back for it.
+        matcher: cgwApi.endpoints.transactionsProposeTransactionV1.matchRejected,
+        effect: async (action, api) => {
+          const safeTxHash = safeTxHashOf(action)
+          if (safeTxHash) {
+            api.dispatch(setOutstandingProposing({ safeTxHash, proposing: false }))
+          }
+        },
+      }),
+      startAppListening({
+        matcher: cgwApi.endpoints.transactionsProposeTransactionV1.matchFulfilled,
+        effect: async (action, api) => {
+          const safeTxHash = safeTxHashOf(action)
+          if (!safeTxHash) {
+            return
+          }
+          const outstanding = selectOutstandingRequestByHash(api.getState(), safeTxHash)
+          if (!outstanding) {
+            return
+          }
+          const result = outstanding.method === 'wallet_sendCalls' ? { id: safeTxHash } : safeTxHash
+          try {
+            await walletKit.respondSessionRequest({
+              topic: outstanding.topic,
+              response: formatJsonRpcResult(outstanding.id, result),
+            })
+          } catch (e) {
+            logWalletKitError('respondSessionRequest after propose failed', e)
+          }
+          api.dispatch(clearOutstandingRequest(safeTxHash))
+        },
+      }),
+    ]
     return () => {
-      unsubscribe()
+      unsubscribers.forEach((unsubscribe) => unsubscribe())
     }
   }, [walletKit])
 

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
@@ -288,6 +288,9 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   const activeSafe = useAppSelector(selectActiveSafe)
   const activeChain = useAppSelector((s) => (activeSafe ? (selectChainById(s, activeSafe.chainId) ?? null) : null))
   const activeSigner = useAppSelector((s) => (activeSafe ? selectActiveSigner(s, activeSafe.address) : undefined))
+  // Per-Safe deployment record (stable ref unless the safes slice changes); the deps memo
+  // derives the deployed chain ids from it to scope wallet_getCapabilities.
+  const activeSafeChains = useAppSelector((s) => (activeSafe ? s.safes[activeSafe.address] : undefined))
 
   // wallet_switchEthereumChain — only allow chains the active Safe is deployed on (derived
   // from the safes slice, the same source the proposal handler uses). useActiveSafeBinding
@@ -361,11 +364,20 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       activeChain: activeChain ?? null,
       activeSafeAddress: activeSafe?.address ?? null,
       hasSigner: !!activeSigner,
+      deployedChainIds: activeSafeChains ? Object.keys(activeSafeChains) : [],
       switchActiveChainByCaip2,
       getCallsStatus,
       navigateToCallsStatus,
     }),
-    [activeChain, activeSafe?.address, activeSigner, switchActiveChainByCaip2, getCallsStatus, navigateToCallsStatus],
+    [
+      activeChain,
+      activeSafe?.address,
+      activeSigner,
+      activeSafeChains,
+      switchActiveChainByCaip2,
+      getCallsStatus,
+      navigateToCallsStatus,
+    ],
   )
 
   useSessionProposalHandler(walletKit)

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
@@ -210,6 +210,8 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     const unsubscribe = startAppListening({
       matcher: isAnyOf(setActiveSafe, switchActiveChain, clearActiveSafe),
       effect: async (action, api) => {
+        // For clearActiveSafe (and setActiveSafe(null)) both `next` and `nextChainId` stay
+        // undefined, so matchesNext is false for every entry — all requests get rejected.
         const next = setActiveSafe.match(action) ? action.payload : null
         const nextChainId = switchActiveChain.match(action) ? action.payload.chainId : next?.chainId
         // switchActiveChain keeps the Safe address; the other actions carry the full context.

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
@@ -4,11 +4,12 @@ import type { IWalletKit, WalletKitTypes } from '@reown/walletkit'
 import { getSdkError } from '@walletconnect/utils'
 import { formatJsonRpcError, formatJsonRpcResult } from '@walletconnect/jsonrpc-utils'
 import { isAnyOf } from '@reduxjs/toolkit'
-import { isPairingUri } from '@safe-global/utils/features/walletconnect/utils'
+import { useStore } from 'react-redux'
+import { isPairingUri, stripEip155Prefix } from '@safe-global/utils/features/walletconnect/utils'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { cgwApi } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks'
-import { startAppListening } from '@/src/store'
+import { startAppListening, type RootState } from '@/src/store'
 import { selectActiveSafe, setActiveSafe, switchActiveChain, clearActiveSafe } from '@/src/store/activeSafeSlice'
 import { selectChainById } from '@/src/store/chains'
 import { selectActiveSigner } from '@/src/store/activeSignerSlice'
@@ -20,16 +21,20 @@ import {
   setSessions,
   removeSession,
   pushPending,
+  removePending,
   isDeferredTxMethod,
   clearOutstandingRequest,
   selectOutstandingRequestByHash,
   selectOutstandingRequests,
+  selectPending,
+  type PendingSessionRequest,
 } from '../store/walletKitSlice'
 import { RequestSheetHost } from '../components/RequestSheetHost'
 import { logWalletKitError } from '../utils/errors'
 
 export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const dispatch = useAppDispatch()
+  const store = useStore<RootState>()
   const [walletKit, setWalletKit] = useState<IWalletKit | null>(null)
 
   // Init + seed: mirror the SDK's active sessions and any deferred-tx requests that
@@ -43,6 +48,9 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
         }
         setWalletKit(wk)
         dispatch(setSessions(wk.getActiveSessions()))
+        // Restored requests are stamped with the rehydrated active Safe: the sheet always
+        // composes against the current active Safe, so that is the context Review would use.
+        const restoredSafeAddress = selectActiveSafe(store.getState())?.address
         const pendings = wk.getPendingSessionRequests() as WalletKitTypes.SessionRequest[]
         pendings.forEach((r) => {
           const method = r.params.request.method
@@ -57,6 +65,7 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
               chainId: r.params.chainId,
               method,
               params: r.params.request.params,
+              safeAddress: restoredSafeAddress,
               verifyContext: r.verifyContext,
             }),
           )
@@ -66,7 +75,7 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     return () => {
       mounted = false
     }
-  }, [dispatch])
+  }, [dispatch, store])
 
   // Subscribe to session lifecycle events. session_proposal is handled by
   // useSessionProposalHandler (WA-2318) and session_request by useSessionRequestHandler
@@ -141,38 +150,60 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     }
   }, [walletKit])
 
-  // A Safe/chain switch invalidates handed-off tx requests: draftTxSlice drops their drafts
-  // on the same actions, so the confirm flow can no longer answer them. Reject the stale
-  // entries so the dApp doesn't hang until the WC timeout (mirrors draftTxSlice's
-  // isSameSafe cleanup; entries matching the new active Safe are kept).
+  // A Safe/chain switch invalidates WC tx requests in both stages: handed-off entries lose
+  // their draft to draftTxSlice's cleanup on the same actions, and pre-compose sheet entries
+  // would otherwise let Review compose the dApp's calls against the wrong Safe. Reject the
+  // stale entries so the dApp doesn't hang until the WC timeout (mirrors draftTxSlice's
+  // isSameSafe semantics; entries matching the new active Safe are kept). Clearing a pending
+  // entry also dismisses its sheet via the FIFO head.
   useEffect(() => {
     if (!walletKit) {
       return
+    }
+    const respondRejected = async (topic: string, id: number) => {
+      try {
+        await walletKit.respondSessionRequest({
+          topic,
+          response: formatJsonRpcError(id, getSdkError('USER_REJECTED').message),
+        })
+      } catch (e) {
+        logWalletKitError('respondSessionRequest after Safe switch failed', e)
+      }
     }
     const unsubscribe = startAppListening({
       matcher: isAnyOf(setActiveSafe, switchActiveChain, clearActiveSafe),
       effect: async (action, api) => {
         const next = setActiveSafe.match(action) ? action.payload : null
         const nextChainId = switchActiveChain.match(action) ? action.payload.chainId : next?.chainId
+        // switchActiveChain keeps the Safe address; the other actions carry the full context.
+        // An unknown (undefined) entry address never matches — the conservative choice.
+        const matchesNext = (chainId: string, safeAddress: string | undefined) => {
+          if (chainId !== nextChainId) {
+            return false
+          }
+          return switchActiveChain.match(action) ? true : sameAddress(safeAddress, next?.address)
+        }
+
+        // Handed-off requests (waiting on /propose).
         const outstanding = selectOutstandingRequests(api.getState())
         for (const [safeTxHash, req] of Object.entries(outstanding)) {
-          const sameChain = req.chainId === nextChainId
-          // switchActiveChain keeps the Safe address; the other actions carry the full context.
-          const sameSafe = switchActiveChain.match(action)
-            ? sameChain
-            : sameChain && sameAddress(req.safeAddress, next?.address)
-          if (sameSafe) {
+          if (matchesNext(req.chainId, req.safeAddress)) {
             continue
           }
-          try {
-            await walletKit.respondSessionRequest({
-              topic: req.topic,
-              response: formatJsonRpcError(req.id, getSdkError('USER_REJECTED').message),
-            })
-          } catch (e) {
-            logWalletKitError('respondSessionRequest after Safe switch failed', e)
-          }
+          await respondRejected(req.topic, req.id)
           api.dispatch(clearOutstandingRequest(safeTxHash))
+        }
+
+        // Pre-compose requests still showing (or queued behind) the sheet.
+        const pendingRequests = selectPending(api.getState()).filter(
+          (p): p is PendingSessionRequest => p.kind === 'request',
+        )
+        for (const p of pendingRequests) {
+          if (matchesNext(stripEip155Prefix(p.chainId), p.safeAddress)) {
+            continue
+          }
+          await respondRejected(p.topic, p.id)
+          api.dispatch(removePending({ id: p.id, kind: 'request' }))
         }
       },
     })

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/__tests__/WalletKitProvider.listeners.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/__tests__/WalletKitProvider.listeners.test.tsx
@@ -1,0 +1,205 @@
+import React from 'react'
+import { Text } from 'react-native'
+import { waitFor } from '@testing-library/react-native'
+import { configureStore } from '@reduxjs/toolkit'
+import { http, HttpResponse, delay } from 'msw'
+import { formatJsonRpcResult } from '@walletconnect/jsonrpc-utils'
+import { GATEWAY_URL } from '@/src/config/constants'
+import { server } from '@/src/tests/server'
+import { renderWithStore } from '@/src/tests/test-utils'
+import { rootReducer, listenerMiddlewareInstance } from '@/src/store'
+import type { TestStore } from '@/src/tests/test-utils'
+import { cgwClient } from '@safe-global/store/gateway/cgwClient'
+import { cgwApi, type ProposeTransactionDto } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { setActiveSafe, switchActiveChain, clearActiveSafe } from '@/src/store/activeSafeSlice'
+import { WalletKitProvider } from '../WalletKitProvider'
+import {
+  walletKitSliceName,
+  setOutstandingRequest,
+  pushPending,
+  type DeferredTxMethod,
+} from '../../store/walletKitSlice'
+import type { IWalletKit } from '@reown/walletkit'
+
+// Same isolation mocks as WalletKitProvider.test.
+jest.mock('expo-linking', () => ({
+  addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+  getInitialURL: jest.fn().mockResolvedValue(null),
+}))
+jest.mock('../../components/RequestSheetHost', () => ({ RequestSheetHost: () => null }))
+jest.mock('../../hooks/useActiveSafeBinding', () => ({ useActiveSafeBinding: jest.fn() }))
+
+const mockRespond = jest.fn().mockResolvedValue(undefined)
+const mockWalletKit = {
+  getActiveSessions: jest.fn(() => ({})),
+  getPendingSessionRequests: jest.fn(() => []),
+  on: jest.fn(),
+  off: jest.fn(),
+  pair: jest.fn().mockResolvedValue(undefined),
+  rejectSessionAuthenticate: jest.fn().mockResolvedValue(undefined),
+  respondSessionRequest: mockRespond,
+} as unknown as IWalletKit
+
+jest.mock('../../walletKit', () => ({ getWalletKit: jest.fn(() => Promise.resolve(mockWalletKit)) }))
+
+const SAFE = '0x1111111111111111111111111111111111111111'
+const OTHER_SAFE = '0x2222222222222222222222222222222222222222'
+const HASH = '0xhash'
+
+// The provider registers its listeners via the app-singleton listener middleware, so the
+// test store must include that instance's middleware for the effects to run.
+const makeListenerStore = () =>
+  configureStore({
+    reducer: rootReducer,
+    middleware: (gdm) =>
+      gdm({ serializableCheck: false }).concat(cgwClient.middleware, listenerMiddlewareInstance.middleware),
+  }) as unknown as TestStore
+
+const outstanding = (method: DeferredTxMethod = 'eth_sendTransaction', chainId = '1', safeAddress = SAFE) =>
+  setOutstandingRequest({ safeTxHash: HASH, topic: 'topic-out', id: 1, method, chainId, safeAddress })
+
+const pendingRequest = (id: number, chainId: string, safeAddress: string) =>
+  pushPending({
+    kind: 'request',
+    id,
+    topic: `topic-${id}`,
+    chainId,
+    method: 'eth_sendTransaction',
+    params: [{ to: '0xabc' }],
+    safeAddress,
+  })
+
+const renderProvider = (store: TestStore) =>
+  renderWithStore(
+    <WalletKitProvider>
+      <Text>child</Text>
+    </WalletKitProvider>,
+    store,
+  )
+
+const waitForListeners = async () => {
+  await waitFor(() => expect(mockWalletKit.on).toHaveBeenCalled())
+}
+
+const dispatchPropose = (store: TestStore) =>
+  store.dispatch(
+    cgwApi.endpoints.transactionsProposeTransactionV1.initiate({
+      chainId: '1',
+      safeAddress: SAFE,
+      proposeTransactionDto: { safeTxHash: HASH } as ProposeTransactionDto,
+    }) as never,
+  )
+
+const proposeUrl = `${GATEWAY_URL}/v1/chains/1/transactions/${SAFE}/propose`
+
+const getWcState = (store: TestStore) => store.getState()[walletKitSliceName]
+
+describe('WalletKitProvider listeners', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('marks the outstanding request proposing while /propose is in flight, then responds and clears it', async () => {
+    server.use(
+      http.post(proposeUrl, async () => {
+        await delay(50)
+        return HttpResponse.json({})
+      }),
+    )
+    const store = makeListenerStore()
+    renderProvider(store)
+    await waitForListeners()
+    store.dispatch(outstanding('eth_sendTransaction'))
+
+    dispatchPropose(store)
+    await waitFor(() => expect(getWcState(store).outstandingRequests[HASH]?.proposing).toBe(true))
+
+    await waitFor(() =>
+      expect(mockRespond).toHaveBeenCalledWith({
+        topic: 'topic-out',
+        response: formatJsonRpcResult(1, HASH),
+      }),
+    )
+    expect(getWcState(store).outstandingRequests[HASH]).toBeUndefined()
+  })
+
+  it('answers wallet_sendCalls with the { id } envelope', async () => {
+    server.use(http.post(proposeUrl, () => HttpResponse.json({})))
+    const store = makeListenerStore()
+    renderProvider(store)
+    await waitForListeners()
+    store.dispatch(outstanding('wallet_sendCalls'))
+
+    dispatchPropose(store)
+    await waitFor(() =>
+      expect(mockRespond).toHaveBeenCalledWith({
+        topic: 'topic-out',
+        response: formatJsonRpcResult(1, { id: HASH }),
+      }),
+    )
+  })
+
+  it('keeps the entry and clears the proposing flag when /propose fails', async () => {
+    server.use(http.post(proposeUrl, () => HttpResponse.json({ error: 'boom' }, { status: 500 })))
+    const store = makeListenerStore()
+    renderProvider(store)
+    await waitForListeners()
+    store.dispatch(outstanding('eth_sendTransaction'))
+
+    dispatchPropose(store)
+    await waitFor(() => expect(getWcState(store).outstandingRequests[HASH]?.proposing).toBe(false))
+    // Retained for a retry or a reject-on-back; no success response sent.
+    expect(getWcState(store).outstandingRequests[HASH]).toBeDefined()
+    expect(mockRespond).not.toHaveBeenCalled()
+  })
+
+  it('rejects outstanding + pending requests that do not match the newly set active Safe', async () => {
+    const store = makeListenerStore()
+    renderProvider(store)
+    await waitForListeners()
+    store.dispatch(outstanding('eth_sendTransaction', '1', SAFE)) // stale: different address below
+    store.dispatch(pendingRequest(2, 'eip155:1', OTHER_SAFE)) // matches the new Safe
+    store.dispatch(pendingRequest(3, 'eip155:137', OTHER_SAFE)) // stale: different chain
+
+    store.dispatch(setActiveSafe({ address: OTHER_SAFE as `0x${string}`, chainId: '1' }))
+
+    await waitFor(() => expect(getWcState(store).outstandingRequests[HASH]).toBeUndefined())
+    await waitFor(() => expect(getWcState(store).pending).toHaveLength(1))
+    expect(getWcState(store).pending[0]).toMatchObject({ id: 2 })
+    expect(mockRespond).toHaveBeenCalledTimes(2)
+    expect(mockRespond).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: 'topic-out', response: expect.objectContaining({ error: expect.anything() }) }),
+    )
+    expect(mockRespond).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: 'topic-3', response: expect.objectContaining({ error: expect.anything() }) }),
+    )
+  })
+
+  it('keeps same-chain entries on switchActiveChain and rejects cross-chain ones', async () => {
+    const store = makeListenerStore()
+    renderProvider(store)
+    await waitForListeners()
+    store.dispatch(outstanding('eth_sendTransaction', '137', SAFE)) // stale after switching to 1
+    store.dispatch(pendingRequest(4, 'eip155:1', SAFE)) // same chain → kept (address irrelevant)
+
+    store.dispatch(switchActiveChain({ chainId: '1' }))
+
+    await waitFor(() => expect(getWcState(store).outstandingRequests[HASH]).toBeUndefined())
+    expect(getWcState(store).pending).toHaveLength(1)
+    expect(mockRespond).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects everything on clearActiveSafe', async () => {
+    const store = makeListenerStore()
+    renderProvider(store)
+    await waitForListeners()
+    store.dispatch(outstanding())
+    store.dispatch(pendingRequest(5, 'eip155:1', SAFE))
+
+    store.dispatch(clearActiveSafe())
+
+    await waitFor(() => expect(getWcState(store).outstandingRequests[HASH]).toBeUndefined())
+    await waitFor(() => expect(getWcState(store).pending).toHaveLength(0))
+    expect(mockRespond).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/__tests__/WalletKitProvider.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/__tests__/WalletKitProvider.test.tsx
@@ -34,6 +34,7 @@ const mockWalletKit = {
   off: jest.fn(),
   pair: jest.fn().mockResolvedValue(undefined),
   rejectSessionAuthenticate: jest.fn().mockResolvedValue(undefined),
+  respondSessionRequest: jest.fn().mockResolvedValue(undefined),
 } as unknown as IWalletKit & Record<string, jest.Mock>
 
 jest.mock('../../walletKit', () => ({ getWalletKit: jest.fn(() => Promise.resolve(mockWalletKit)) }))
@@ -69,6 +70,31 @@ describe('WalletKitProvider', () => {
     await waitFor(() => {
       expect(store.getState()[walletKitSliceName].sessions['seeded-topic']).toEqual(session)
     })
+  })
+
+  it('rejects restored tx requests with malformed params instead of seeding them', async () => {
+    ;(mockWalletKit.getPendingSessionRequests as jest.Mock).mockReturnValueOnce([
+      // Malformed: empty calls bundle — would crash extractCalls / compose downstream.
+      {
+        id: 11,
+        topic: 'topic-bad',
+        params: { chainId: 'eip155:1', request: { method: 'wallet_sendCalls', params: [{ calls: [] }] } },
+      },
+      // Valid: must still be seeded.
+      {
+        id: 12,
+        topic: 'topic-ok',
+        params: { chainId: 'eip155:1', request: { method: 'eth_sendTransaction', params: [{ to: '0xabc' }] } },
+      },
+    ])
+    const { store } = renderProvider()
+    await waitFor(() => {
+      expect(store.getState()[walletKitSliceName].pending).toHaveLength(1)
+    })
+    expect(store.getState()[walletKitSliceName].pending[0]).toMatchObject({ id: 12, topic: 'topic-ok' })
+    expect(mockWalletKit.respondSessionRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: 'topic-bad', response: expect.objectContaining({ error: expect.anything() }) }),
+    )
   })
 
   it('subscribes to all six session events', async () => {

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useSendTransaction.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useSendTransaction.test.ts
@@ -1,0 +1,96 @@
+import { act } from '@testing-library/react-native'
+import type { IWalletKit } from '@reown/walletkit'
+import { renderHookWithStore, createTestStore } from '@/src/tests/test-utils'
+import { useSendTransaction } from '../useSendTransaction'
+import { composeSafeTxDraft } from '../../services/composeSafeTxDraft'
+import { walletKitSliceName, type PendingSessionRequest } from '../../store/walletKitSlice'
+
+const mockPush = jest.fn()
+jest.mock('expo-router', () => ({ useRouter: () => ({ push: mockPush }) }))
+
+const mockToastShow = jest.fn()
+jest.mock('@tamagui/toast', () => ({ useToastController: () => ({ show: mockToastShow }) }))
+
+jest.mock('@/src/hooks/coreSDK/safeCoreSDK', () => ({ useSafeSDK: () => ({}) }))
+
+jest.mock('@/src/store/chains', () => ({ selectChainById: () => ({ chainId: '1' }) }))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/safes', () => ({
+  useSafesGetSafeV1Query: () => ({ data: { version: '1.3.0', owners: [], threshold: 1 } }),
+}))
+
+jest.mock('../../services/composeSafeTxDraft', () => ({ composeSafeTxDraft: jest.fn() }))
+const mockCompose = composeSafeTxDraft as jest.Mock
+
+const SAFE_ADDRESS = '0x1111111111111111111111111111111111111111'
+const SAFE_TX_HASH = '0xhash'
+
+const pending: PendingSessionRequest = {
+  kind: 'request',
+  id: 9,
+  topic: 'topic',
+  chainId: 'eip155:1',
+  method: 'eth_sendTransaction',
+  params: [{ to: '0xabc', value: '0x0', data: '0x' }],
+}
+
+const mockRespond = jest.fn().mockResolvedValue(undefined)
+const walletKit = { respondSessionRequest: mockRespond } as unknown as IWalletKit
+
+const seededStore = () =>
+  createTestStore({
+    activeSafe: { address: SAFE_ADDRESS, chainId: '1' },
+    [walletKitSliceName]: { sessions: {}, pending: [pending], outstandingRequests: {} },
+  } as never)
+
+beforeEach(() => jest.clearAllMocks())
+
+describe('useSendTransaction', () => {
+  it('reports ready once Safe, chain and SDK are resolved', () => {
+    const { result } = renderHookWithStore(() => useSendTransaction(walletKit, pending), seededStore())
+    expect(result.current.ready).toBe(true)
+  })
+
+  it('reject answers the dApp with USER_REJECTED and clears the pending request', async () => {
+    const store = seededStore()
+    const { result } = renderHookWithStore(() => useSendTransaction(walletKit, pending), store)
+    await act(async () => {
+      await result.current.reject()
+    })
+    expect(mockRespond).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: 'topic', response: expect.objectContaining({ error: expect.anything() }) }),
+    )
+    expect(store.getState()[walletKitSliceName].pending).toHaveLength(0)
+  })
+
+  it('review composes a draft, stashes the outstanding request, and navigates to the confirm flow', async () => {
+    mockCompose.mockResolvedValue(SAFE_TX_HASH)
+    const store = seededStore()
+    const { result } = renderHookWithStore(() => useSendTransaction(walletKit, pending), store)
+    await act(async () => {
+      await result.current.review()
+    })
+    expect(mockCompose).toHaveBeenCalledTimes(1)
+    expect(store.getState()[walletKitSliceName].outstandingRequests[SAFE_TX_HASH]).toMatchObject({
+      topic: 'topic',
+      id: 9,
+      method: 'eth_sendTransaction',
+    })
+    expect(store.getState()[walletKitSliceName].pending).toHaveLength(0)
+    expect(mockPush).toHaveBeenCalledWith({ pathname: '/confirm-transaction', params: { txId: SAFE_TX_HASH } })
+  })
+
+  it('review toasts and stays on the sheet when the preview fails', async () => {
+    mockCompose.mockRejectedValue(new Error('preview failed'))
+    const store = seededStore()
+    const { result } = renderHookWithStore(() => useSendTransaction(walletKit, pending), store)
+    await act(async () => {
+      await result.current.review()
+    })
+    expect(mockToastShow).toHaveBeenCalledWith('Failed to build transaction', expect.anything())
+    expect(mockPush).not.toHaveBeenCalled()
+    // No outstanding request, pending retained → user can retry or reject.
+    expect(store.getState()[walletKitSliceName].outstandingRequests).toEqual({})
+    expect(store.getState()[walletKitSliceName].pending).toHaveLength(1)
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useSessionRequestHandler.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useSessionRequestHandler.test.ts
@@ -1,7 +1,6 @@
 import { getSdkError } from '@walletconnect/utils'
 import type { WalletKitTypes, IWalletKit } from '@reown/walletkit'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
-import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import { renderHookWithStore, createTestStore, waitFor } from '@/src/tests/test-utils'
 import { useSessionRequestHandler, type SessionRequestHandlerDeps } from '../useSessionRequestHandler'
 import { selectPending } from '../../store/walletKitSlice'
@@ -12,9 +11,8 @@ jest.mock('@tamagui/toast', () => ({ useToastController: () => ({ show: mockToas
 const SAFE_ADDRESS = '0x1111111111111111111111111111111111111111'
 
 const chain = { chainId: '1', chainName: 'Ethereum' } as unknown as Chain
-const safe = { address: { value: SAFE_ADDRESS } } as unknown as SafeState
 
-const baseDeps: SessionRequestHandlerDeps = { activeChain: chain, activeSafe: safe, hasSigner: true }
+const baseDeps: SessionRequestHandlerDeps = { activeChain: chain, activeSafeAddress: SAFE_ADDRESS, hasSigner: true }
 
 // Capture the registered session_request listener so tests can invoke it directly.
 const makeWalletKit = () => {

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useSessionRequestHandler.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useSessionRequestHandler.test.ts
@@ -1,0 +1,99 @@
+import { getSdkError } from '@walletconnect/utils'
+import type { WalletKitTypes, IWalletKit } from '@reown/walletkit'
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { renderHookWithStore, createTestStore, waitFor } from '@/src/tests/test-utils'
+import { useSessionRequestHandler, type SessionRequestHandlerDeps } from '../useSessionRequestHandler'
+import { selectPending } from '../../store/walletKitSlice'
+
+const mockToastShow = jest.fn()
+jest.mock('@tamagui/toast', () => ({ useToastController: () => ({ show: mockToastShow }) }))
+
+const SAFE_ADDRESS = '0x1111111111111111111111111111111111111111'
+
+const chain = { chainId: '1', chainName: 'Ethereum' } as unknown as Chain
+const safe = { address: { value: SAFE_ADDRESS } } as unknown as SafeState
+
+const baseDeps: SessionRequestHandlerDeps = { activeChain: chain, activeSafe: safe, hasSigner: true }
+
+// Capture the registered session_request listener so tests can invoke it directly.
+const makeWalletKit = () => {
+  let listener: ((r: WalletKitTypes.SessionRequest) => void) | undefined
+  const wk = {
+    on: jest.fn((event: string, cb: (r: WalletKitTypes.SessionRequest) => void) => {
+      if (event === 'session_request') {
+        listener = cb
+      }
+    }),
+    off: jest.fn(),
+    respondSessionRequest: jest.fn().mockResolvedValue(undefined),
+    getActiveSessions: jest.fn(() => ({ topic: { peer: { metadata: { name: 'Uniswap' } } } })),
+  }
+  return {
+    wk: wk as unknown as IWalletKit,
+    respond: wk.respondSessionRequest,
+    emit: (r: WalletKitTypes.SessionRequest) => listener?.(r),
+  }
+}
+
+const makeRequest = (method: string, params: unknown[] = [], chainId = 'eip155:1'): WalletKitTypes.SessionRequest =>
+  ({
+    id: 7,
+    topic: 'topic',
+    params: { chainId, request: { method, params } },
+  }) as unknown as WalletKitTypes.SessionRequest
+
+beforeEach(() => jest.clearAllMocks())
+
+describe('useSessionRequestHandler', () => {
+  it('does nothing without a walletKit', () => {
+    renderHookWithStore(() => useSessionRequestHandler(null, baseDeps), createTestStore({}))
+  })
+
+  it('pushes a deferred tx request to pending instead of responding', async () => {
+    const { wk, respond, emit } = makeWalletKit()
+    const store = createTestStore({})
+    renderHookWithStore(() => useSessionRequestHandler(wk, baseDeps), store)
+    emit(makeRequest('eth_sendTransaction', [{ to: '0xabc', value: '0x0', data: '0x' }]))
+    await waitFor(() => expect(selectPending(store.getState())).toHaveLength(1))
+    expect(respond).not.toHaveBeenCalled()
+  })
+
+  it('responds with 4100 and toasts when no signer is attached', async () => {
+    const { wk, respond, emit } = makeWalletKit()
+    renderHookWithStore(() => useSessionRequestHandler(wk, { ...baseDeps, hasSigner: false }), createTestStore({}))
+    emit(makeRequest('eth_sendTransaction', [{ to: '0xabc' }]))
+    await waitFor(() => expect(respond).toHaveBeenCalled())
+    expect(mockToastShow).toHaveBeenCalledWith('No signer attached to this Safe', expect.anything())
+  })
+
+  it('responds and toasts for rejected message-signing methods', async () => {
+    const { wk, respond, emit } = makeWalletKit()
+    renderHookWithStore(() => useSessionRequestHandler(wk, baseDeps), createTestStore({}))
+    emit(makeRequest('personal_sign', ['0xmsg', SAFE_ADDRESS]))
+    await waitFor(() => expect(respond).toHaveBeenCalled())
+    expect(mockToastShow).toHaveBeenCalledWith('Message signing is not yet supported on mobile', expect.anything())
+  })
+
+  it('toasts a switch-network hint when the dApp session is on a different chain', async () => {
+    const { wk, respond, emit } = makeWalletKit()
+    renderHookWithStore(() => useSessionRequestHandler(wk, baseDeps), createTestStore({}))
+    // Active chain is 1; the dApp request targets eip155:137 → UNSUPPORTED_CHAINS reject.
+    emit(makeRequest('eth_sendTransaction', [{ to: '0xabc' }], 'eip155:137'))
+    await waitFor(() =>
+      expect(respond).toHaveBeenCalledWith(
+        expect.objectContaining({ response: expect.objectContaining({ error: expect.anything() }) }),
+      ),
+    )
+    expect(mockToastShow).toHaveBeenCalledWith(expect.stringContaining('Uniswap'), expect.anything())
+  })
+
+  it('passes the SDK error message through for unsupported methods', async () => {
+    const { wk, respond, emit } = makeWalletKit()
+    renderHookWithStore(() => useSessionRequestHandler(wk, baseDeps), createTestStore({}))
+    emit(makeRequest('eth_unknownMethod'))
+    await waitFor(() => expect(respond).toHaveBeenCalled())
+    const arg = respond.mock.calls[0][0] as { response: { error: { message: string } } }
+    expect(arg.response.error.message).toBe(getSdkError('UNSUPPORTED_METHODS').message)
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useSessionRequestHandler.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useSessionRequestHandler.test.ts
@@ -12,7 +12,14 @@ const SAFE_ADDRESS = '0x1111111111111111111111111111111111111111'
 
 const chain = { chainId: '1', chainName: 'Ethereum' } as unknown as Chain
 
-const baseDeps: SessionRequestHandlerDeps = { activeChain: chain, activeSafeAddress: SAFE_ADDRESS, hasSigner: true }
+const baseDeps: SessionRequestHandlerDeps = {
+  activeChain: chain,
+  activeSafeAddress: SAFE_ADDRESS,
+  hasSigner: true,
+  switchActiveChainByCaip2: jest.fn().mockResolvedValue({ ok: true }),
+  getCallsStatus: jest.fn(),
+  navigateToCallsStatus: jest.fn(),
+}
 
 // Capture the registered session_request listener so tests can invoke it directly.
 const makeWalletKit = () => {

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useSessionRequestHandler.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useSessionRequestHandler.test.ts
@@ -75,6 +75,14 @@ describe('useSessionRequestHandler', () => {
     expect(mockToastShow).toHaveBeenCalledWith('Message signing is not yet supported on mobile', expect.anything())
   })
 
+  it('rejects safe_setSettings silently — no message-signing toast', async () => {
+    const { wk, respond, emit } = makeWalletKit()
+    renderHookWithStore(() => useSessionRequestHandler(wk, baseDeps), createTestStore({}))
+    emit(makeRequest('safe_setSettings', [{ offChainSigning: true }]))
+    await waitFor(() => expect(respond).toHaveBeenCalled())
+    expect(mockToastShow).not.toHaveBeenCalled()
+  })
+
   it('toasts a switch-network hint when the dApp session is on a different chain', async () => {
     const { wk, respond, emit } = makeWalletKit()
     renderHookWithStore(() => useSessionRequestHandler(wk, baseDeps), createTestStore({}))

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useSessionRequestHandler.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useSessionRequestHandler.test.ts
@@ -16,6 +16,7 @@ const baseDeps: SessionRequestHandlerDeps = {
   activeChain: chain,
   activeSafeAddress: SAFE_ADDRESS,
   hasSigner: true,
+  deployedChainIds: ['1'],
   switchActiveChainByCaip2: jest.fn().mockResolvedValue({ ok: true }),
   getCallsStatus: jest.fn(),
   navigateToCallsStatus: jest.fn(),

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useSessionRequestHandler.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useSessionRequestHandler.test.ts
@@ -55,6 +55,8 @@ describe('useSessionRequestHandler', () => {
     emit(makeRequest('eth_sendTransaction', [{ to: '0xabc', value: '0x0', data: '0x' }]))
     await waitFor(() => expect(selectPending(store.getState())).toHaveLength(1))
     expect(respond).not.toHaveBeenCalled()
+    // Stamped with the Safe it was routed against, so the safe-switch listener can match it.
+    expect(selectPending(store.getState())[0]).toMatchObject({ safeAddress: SAFE_ADDRESS })
   })
 
   it('responds with 4100 and toasts when no signer is attached', async () => {

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/useSendTransaction.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/useSendTransaction.ts
@@ -82,7 +82,16 @@ export const useSendTransaction = (walletKit: IWalletKit | null, pending: Pendin
       })
       // Hand off to the confirm-transaction flow. The dApp response is sent later by the
       // propose-success listener in WalletKitProvider, NOT here — the user hasn't signed yet.
-      dispatch(setOutstandingRequest({ safeTxHash, topic: pending.topic, id: pending.id, method: pending.method }))
+      dispatch(
+        setOutstandingRequest({
+          safeTxHash,
+          topic: pending.topic,
+          id: pending.id,
+          method: pending.method,
+          chainId: activeSafe.chainId,
+          safeAddress: activeSafe.address,
+        }),
+      )
       dispatch(removePending({ id: pending.id, kind: 'request' }))
       router.push({ pathname: '/confirm-transaction', params: { txId: safeTxHash } })
     } catch (e) {

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/useSendTransaction.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/useSendTransaction.ts
@@ -1,0 +1,99 @@
+import { useCallback, useState } from 'react'
+import { useRouter } from 'expo-router'
+import { skipToken } from '@reduxjs/toolkit/query'
+import { useToastController } from '@tamagui/toast'
+import { formatJsonRpcError } from '@walletconnect/jsonrpc-utils'
+import { getSdkError } from '@walletconnect/utils'
+import type { IWalletKit } from '@reown/walletkit'
+import { useAppDispatch, useAppSelector } from '@/src/store/hooks'
+import { selectActiveSafe } from '@/src/store/activeSafeSlice'
+import { selectChainById } from '@/src/store/chains'
+import { useSafeSDK } from '@/src/hooks/coreSDK/safeCoreSDK'
+import { useSafesGetSafeV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { composeSafeTxDraft, type DappCall } from '../services/composeSafeTxDraft'
+import { removePending, setOutstandingRequest, type PendingSessionRequest } from '../store/walletKitSlice'
+import { logWalletKitError } from '../utils/errors'
+
+// pending.method is the narrowed DeferredTxMethod, so this is total — no throw needed.
+const extractCalls = (method: PendingSessionRequest['method'], params: unknown): DappCall[] => {
+  if (method === 'eth_sendTransaction') {
+    const [tx] = params as [DappCall]
+    return [tx]
+  }
+  // wallet_sendCalls
+  const [batch] = params as [{ calls: DappCall[] }]
+  return batch.calls
+}
+
+/**
+ * Review / Reject actions for a transaction-request sheet, consumed by RequestSheetHost's
+ * pinned footer. Review composes a draft on tap (one CGW /preview), then hands off to the
+ * confirm-transaction flow — the dApp is answered later by the propose-success listener, not
+ * here. A /preview failure surfaces a toast and stays on the sheet with no draft (compose
+ * throws before setDraft). Reject answers the dApp with USER_REJECTED.
+ */
+export const useSendTransaction = (walletKit: IWalletKit | null, pending: PendingSessionRequest | null) => {
+  const dispatch = useAppDispatch()
+  const router = useRouter()
+  const toast = useToastController()
+  const activeSafe = useAppSelector(selectActiveSafe)
+  const chain = useAppSelector((s) => (activeSafe ? (selectChainById(s, activeSafe.chainId) ?? null) : null))
+  // Only subscribe while a request sheet is up — the host is mounted at the app root.
+  const { data: safe } = useSafesGetSafeV1Query(
+    pending && activeSafe ? { chainId: activeSafe.chainId, safeAddress: activeSafe.address } : skipToken,
+  )
+  const safeSDK = useSafeSDK()
+  const [composing, setComposing] = useState(false)
+
+  // Review can only compose once the Safe state, chain config and protocol-kit SDK are ready.
+  const ready = !!(activeSafe && safe && chain && safeSDK)
+
+  const reject = useCallback(async () => {
+    if (!walletKit || !pending) {
+      return
+    }
+    // Swallow stale-topic errors (typical after a Metro reload — the relayer may have dropped
+    // the topic locally; the dApp will eventually time out client-side).
+    try {
+      await walletKit.respondSessionRequest({
+        topic: pending.topic,
+        response: formatJsonRpcError(pending.id, getSdkError('USER_REJECTED').message),
+      })
+    } catch (e) {
+      logWalletKitError('respondSessionRequest (reject) failed', e)
+    }
+    dispatch(removePending({ id: pending.id, kind: 'request' }))
+  }, [walletKit, pending, dispatch])
+
+  const review = useCallback(async () => {
+    if (!walletKit || !pending || !activeSafe || !safe || !chain) {
+      return
+    }
+    setComposing(true)
+    try {
+      const calls = extractCalls(pending.method, pending.params)
+      const safeTxHash = await composeSafeTxDraft({
+        calls,
+        chainId: activeSafe.chainId,
+        safeAddress: activeSafe.address,
+        safe,
+        chain,
+        dispatch,
+      })
+      // Hand off to the confirm-transaction flow. The dApp response is sent later by the
+      // propose-success listener in WalletKitProvider, NOT here — the user hasn't signed yet.
+      dispatch(setOutstandingRequest({ safeTxHash, topic: pending.topic, id: pending.id, method: pending.method }))
+      dispatch(removePending({ id: pending.id, kind: 'request' }))
+      router.push({ pathname: '/confirm-transaction', params: { txId: safeTxHash } })
+    } catch (e) {
+      // composeSafeTxDraft throws before setDraft on a /preview failure, so there is no draft
+      // to clean up; stay on the sheet so the user can retry or reject.
+      logWalletKitError('composeSafeTxDraft failed', e)
+      toast.show('Failed to build transaction', { native: false, duration: 3000, variant: 'error' })
+    } finally {
+      setComposing(false)
+    }
+  }, [walletKit, pending, activeSafe, safe, chain, dispatch, router, toast])
+
+  return { review, reject, composing, ready }
+}

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/useSessionRequestHandler.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/useSessionRequestHandler.ts
@@ -58,6 +58,7 @@ export const useSessionRequestHandler = (walletKit: IWalletKit | null, deps: Ses
             chainId: request.params.chainId,
             method,
             params: request.params.request.params,
+            verifyContext: request.verifyContext,
           }),
         )
         return

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/useSessionRequestHandler.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/useSessionRequestHandler.ts
@@ -1,0 +1,109 @@
+import { useEffect, useCallback } from 'react'
+import type { IWalletKit, WalletKitTypes } from '@reown/walletkit'
+import { useAppDispatch } from '@/src/store/hooks'
+import { useStore } from 'react-redux'
+import { useToastController } from '@tamagui/toast'
+import { stripEip155Prefix } from '@safe-global/utils/features/walletconnect/utils'
+import { getSdkError } from '@walletconnect/utils'
+import type { RootState, AppDispatch } from '@/src/store'
+import { pushPending, removePending, isDeferredTxMethod } from '../store/walletKitSlice'
+import { selectChainById } from '@/src/store/chains'
+import { logWalletKitError } from '../utils/errors'
+import {
+  routeSessionRequest,
+  isDeferredResponse,
+  NO_SIGNER_ERROR_CODE,
+  type RouteContext,
+} from '../services/methodRouter'
+import { REJECTED_SIGNING_METHODS } from '../services/constants'
+
+// The provider resolves the active context; request/dispatch/getState are wired here.
+export type SessionRequestHandlerDeps = Omit<RouteContext, 'request' | 'dispatch' | 'getState'>
+
+const WRONG_ACTIVE_CHAIN_CODE = getSdkError('UNSUPPORTED_CHAINS').code
+
+const REJECTED_SIGNING_METHODS_SET: ReadonlySet<string> = new Set(REJECTED_SIGNING_METHODS)
+
+export const useSessionRequestHandler = (walletKit: IWalletKit | null, deps: SessionRequestHandlerDeps) => {
+  const dispatch = useAppDispatch()
+  const store = useStore<RootState>()
+  const toast = useToastController()
+
+  const handleRequest = useCallback(
+    async (request: WalletKitTypes.SessionRequest) => {
+      if (!walletKit) {
+        return
+      }
+      const ctx: RouteContext = {
+        request,
+        dispatch: dispatch as AppDispatch,
+        getState: store.getState,
+        ...deps,
+      }
+      const response = await routeSessionRequest(ctx)
+      if (isDeferredResponse(response)) {
+        // UI sheet will respond later. Push to pending so the host can render it.
+        // methodRouter only emits the deferred sentinel for eth_sendTransaction /
+        // wallet_sendCalls, so this guard is true by construction — it just propagates that
+        // invariant to the slice's tightened method type.
+        const method = request.params.request.method
+        if (!isDeferredTxMethod(method)) {
+          return
+        }
+        dispatch(
+          pushPending({
+            kind: 'request',
+            id: request.id,
+            topic: request.topic,
+            chainId: request.params.chainId,
+            method,
+            params: request.params.request.params,
+          }),
+        )
+        return
+      }
+      // Swallow stale-topic errors (typical after a Metro reload / long backgrounding —
+      // the relayer reconnects and processes backlogged messages that reference sessions
+      // WalletKit no longer knows about). Surfacing these to LogBox is noise; the dApp
+      // will retry the request.
+      try {
+        await walletKit.respondSessionRequest({ topic: request.topic, response })
+      } catch (e) {
+        logWalletKitError('respondSessionRequest failed', e)
+      }
+      // Surface the spec-mandated toast on the no-signer auto-reject path.
+      if ('error' in response && response.error?.code === NO_SIGNER_ERROR_CODE) {
+        toast.show('No signer attached to this Safe', { native: false, duration: 2500 })
+      }
+      // Explain rejections of message-signing methods (eth_signTypedData_v4, personal_sign, …) —
+      // dApps like CowSwap fire these in parallel with their tx request, and without a toast
+      // the user just sees a red "unknown RPC error" in the dApp with no context.
+      if (REJECTED_SIGNING_METHODS_SET.has(request.params.request.method)) {
+        toast.show('Message signing is not yet supported on mobile', { native: false, duration: 2500 })
+      }
+      // Explain tx requests we auto-reject because the active Safe was switched to a chain the
+      // dApp's session doesn't cover (methodRouter returns WRONG_ACTIVE_CHAIN_CODE rather than
+      // deferring). The dApp just sees a rejection; the toast tells the user which network to
+      // switch back to.
+      if ('error' in response && response.error?.code === WRONG_ACTIVE_CHAIN_CODE) {
+        const requestChainId = stripEip155Prefix(request.params.chainId)
+        const network = selectChainById(store.getState(), requestChainId)?.chainName ?? `chain ${requestChainId}`
+        const dappName = walletKit.getActiveSessions()[request.topic]?.peer.metadata.name || 'this dApp'
+        toast.show(`Switch your active Safe to ${network} to use ${dappName}`, { native: false, duration: 3000 })
+      }
+      // Ensure no stray pending entry for this id.
+      dispatch(removePending({ id: request.id, kind: 'request' }))
+    },
+    [walletKit, dispatch, store, deps, toast],
+  )
+
+  useEffect(() => {
+    if (!walletKit) {
+      return
+    }
+    walletKit.on('session_request', handleRequest)
+    return () => {
+      walletKit.off('session_request', handleRequest)
+    }
+  }, [walletKit, handleRequest])
+}

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/useSessionRequestHandler.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/useSessionRequestHandler.ts
@@ -22,7 +22,11 @@ export type SessionRequestHandlerDeps = Omit<RouteContext, 'request' | 'dispatch
 
 const WRONG_ACTIVE_CHAIN_CODE = getSdkError('UNSUPPORTED_CHAINS').code
 
-const REJECTED_SIGNING_METHODS_SET: ReadonlySet<string> = new Set(REJECTED_SIGNING_METHODS)
+// safe_setSettings is in the reject list but isn't a signing method — showing the
+// "message signing" toast for it would be misleading, so it's rejected silently.
+const MESSAGE_SIGNING_METHODS_SET: ReadonlySet<string> = new Set(
+  REJECTED_SIGNING_METHODS.filter((m) => m !== 'safe_setSettings'),
+)
 
 export const useSessionRequestHandler = (walletKit: IWalletKit | null, deps: SessionRequestHandlerDeps) => {
   const dispatch = useAppDispatch()
@@ -79,7 +83,7 @@ export const useSessionRequestHandler = (walletKit: IWalletKit | null, deps: Ses
       // Explain rejections of message-signing methods (eth_signTypedData_v4, personal_sign, …) —
       // dApps like CowSwap fire these in parallel with their tx request, and without a toast
       // the user just sees a red "unknown RPC error" in the dApp with no context.
-      if (REJECTED_SIGNING_METHODS_SET.has(request.params.request.method)) {
+      if (MESSAGE_SIGNING_METHODS_SET.has(request.params.request.method)) {
         toast.show('Message signing is not yet supported on mobile', { native: false, duration: 2500 })
       }
       // Explain tx requests we auto-reject because the active Safe was switched to a chain the

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/useSessionRequestHandler.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/useSessionRequestHandler.ts
@@ -97,7 +97,8 @@ export const useSessionRequestHandler = (walletKit: IWalletKit | null, deps: Ses
         const dappName = walletKit.getActiveSessions()[request.topic]?.peer.metadata.name || 'this dApp'
         toast.show(`Switch your active Safe to ${network} to use ${dappName}`, { native: false, duration: 3000 })
       }
-      // Ensure no stray pending entry for this id.
+      // Defensive only: sync-answered methods were never pushed to pending, so this is
+      // normally a no-op — it just guarantees no stray entry can survive for this id.
       dispatch(removePending({ id: request.id, kind: 'request' }))
     },
     [walletKit, dispatch, store, deps, toast],

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/useSessionRequestHandler.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/useSessionRequestHandler.ts
@@ -62,6 +62,7 @@ export const useSessionRequestHandler = (walletKit: IWalletKit | null, deps: Ses
             chainId: request.params.chainId,
             method,
             params: request.params.request.params,
+            safeAddress: deps.activeSafeAddress ?? undefined,
             verifyContext: request.verifyContext,
           }),
         )

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/composeSafeTxDraft.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/composeSafeTxDraft.test.ts
@@ -1,0 +1,137 @@
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { composeSafeTxDraft, type DappCall } from '../composeSafeTxDraft'
+import { getSafeSDK } from '@/src/hooks/coreSDK/safeCoreSDK'
+import { synthesizeDraftTxDetails } from '@/src/features/ConfirmTx/utils/synthesizeDraftTxDetails'
+import { getCreateCallContractDeployment } from '@safe-global/utils/services/contracts/deployments'
+import { setDraft } from '@/src/store/draftTxSlice'
+
+jest.mock('@/src/hooks/coreSDK/safeCoreSDK')
+jest.mock('@/src/features/ConfirmTx/utils/synthesizeDraftTxDetails')
+jest.mock('@safe-global/utils/services/contracts/deployments')
+
+const mockGetSafeSDK = getSafeSDK as jest.Mock
+const mockSynthesize = synthesizeDraftTxDetails as jest.Mock
+const mockGetCreateCall = getCreateCallContractDeployment as jest.Mock
+
+const SAFE_ADDRESS = '0x1111111111111111111111111111111111111111'
+const CHAIN_ID = '1'
+const SAFE_TX_HASH = '0xdeadbeef'
+
+const chain = { chainId: CHAIN_ID } as unknown as Chain
+const safe = {
+  version: '1.3.0',
+  owners: [{ value: SAFE_ADDRESS }],
+  threshold: 1,
+} as unknown as SafeState
+
+let createTransaction: jest.Mock
+
+const makeSdk = () => {
+  createTransaction = jest.fn(async ({ transactions }: { transactions: unknown[] }) => ({
+    data: { to: '0xto', value: '0', data: '0x', operation: 0, nonce: 0, transactions },
+  }))
+  return {
+    getChainId: jest.fn(async () => BigInt(CHAIN_ID)),
+    createTransaction,
+    getTransactionHash: jest.fn(async () => SAFE_TX_HASH),
+  }
+}
+
+// dispatch: RTK Query initiate returns a thunk (function); plain actions are objects.
+// The preview thunk resolves to { data } / { error } and carries a .reset() method.
+const makeDispatch = (previewResult: unknown) => {
+  const reset = jest.fn()
+  const dispatch = jest.fn((action: unknown) => {
+    if (typeof action === 'function') {
+      const p = Promise.resolve(previewResult) as Promise<unknown> & { reset: jest.Mock }
+      p.reset = reset
+      return p
+    }
+    return action
+  })
+  return { dispatch, reset }
+}
+
+const run = (calls: DappCall[], previewResult: unknown = { data: { txInfo: {} } }) => {
+  const { dispatch, reset } = makeDispatch(previewResult)
+  return {
+    promise: composeSafeTxDraft({
+      calls,
+      chainId: CHAIN_ID,
+      safeAddress: SAFE_ADDRESS,
+      safe,
+      chain,
+      dispatch: dispatch as never,
+    }),
+    dispatch,
+    reset,
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockGetSafeSDK.mockReturnValue(makeSdk())
+  mockSynthesize.mockReturnValue({ txId: SAFE_TX_HASH })
+})
+
+describe('composeSafeTxDraft', () => {
+  it('throws on an empty calls array', async () => {
+    await expect(run([]).promise).rejects.toThrow('empty calls array')
+  })
+
+  it('composes a single call and stashes a draft keyed by safeTxHash', async () => {
+    const { promise, dispatch } = run([{ to: '0xabc', value: '0x0', data: '0x' }])
+    const hash = await promise
+    expect(hash).toBe(SAFE_TX_HASH)
+    expect(createTransaction).toHaveBeenCalledWith({
+      transactions: [{ to: '0xabc', value: '0', data: '0x', operation: 0 }],
+    })
+    expect(dispatch).toHaveBeenCalledWith(setDraft(expect.objectContaining({ safeTxHash: SAFE_TX_HASH })))
+  })
+
+  it('normalizes a hex value to a decimal string', async () => {
+    // 0x16345785d8a0000 == 100000000000000000 (0.1 ETH)
+    await run([{ to: '0xabc', value: '0x16345785d8a0000', data: '0x' }]).promise
+    expect(createTransaction).toHaveBeenCalledWith({
+      transactions: [{ to: '0xabc', value: '100000000000000000', data: '0x', operation: 0 }],
+    })
+  })
+
+  it('wraps a batch of calls into a single SafeTransaction', async () => {
+    await run([
+      { to: '0xaaa', value: '0x1', data: '0x' },
+      { to: '0xbbb', value: '0x0', data: '0xfeed' },
+    ]).promise
+    expect(createTransaction).toHaveBeenCalledWith({
+      transactions: [
+        { to: '0xaaa', value: '1', data: '0x', operation: 0 },
+        { to: '0xbbb', value: '0', data: '0xfeed', operation: 0 },
+      ],
+    })
+  })
+
+  it('routes a no-to + data-only call through CreateCall', async () => {
+    mockGetCreateCall.mockReturnValue({
+      abi: ['function performCreate(uint256 value, bytes deploymentData) returns (address)'],
+      networkAddresses: { [CHAIN_ID]: '0xCreateCall' },
+    })
+    await run([{ data: '0xdeadbeef' }]).promise
+    const { transactions } = createTransaction.mock.calls[0][0]
+    expect(transactions[0].to).toBe('0xCreateCall')
+    expect(transactions[0].operation).toBe(0)
+    expect(transactions[0].data).toMatch(/^0x/)
+  })
+
+  it('throws when the SDK is on a different chain', async () => {
+    mockGetSafeSDK.mockReturnValue({ ...makeSdk(), getChainId: jest.fn(async () => BigInt(137)) })
+    await expect(run([{ to: '0xabc' }]).promise).rejects.toThrow(/Chain mismatch/)
+  })
+
+  it('throws and stashes no draft when the preview fails', async () => {
+    const { promise, dispatch, reset } = run([{ to: '0xabc' }], { error: { status: 500 } })
+    await expect(promise).rejects.toBeDefined()
+    expect(reset).toHaveBeenCalled()
+    expect(dispatch).not.toHaveBeenCalledWith(setDraft(expect.anything()))
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/getCallsStatus.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/getCallsStatus.test.ts
@@ -1,0 +1,76 @@
+import { buildGetCallsResult, type CallsStatusTx, type RawTxReceipt } from '../getCallsStatus'
+
+const receipt: RawTxReceipt = {
+  logs: [{ address: '0xabc' }],
+  blockHash: '0xbbb',
+  blockNumber: '0x10',
+  gasUsed: '0x5208',
+  transactionHash: '0xrcptHash',
+}
+
+describe('buildGetCallsResult', () => {
+  describe('status mapping', () => {
+    it.each([
+      ['SUCCESS', 200],
+      ['CANCELLED', 400],
+      ['FAILED', 500],
+      ['AWAITING_CONFIRMATIONS', 100],
+      ['AWAITING_EXECUTION', 100],
+      [undefined, 100],
+    ])('maps txStatus %s to %i', (txStatus, expected) => {
+      const result = buildGetCallsResult('0xhash', '1', { txStatus: txStatus as string }, null)
+      expect(result.status).toBe(expected)
+    })
+  })
+
+  it('returns a receipt-less envelope when no receipt is provided', () => {
+    const result = buildGetCallsResult('0xhash', '137', { txStatus: 'AWAITING_EXECUTION', txHash: null }, null)
+    expect(result).toEqual({ version: '2.0.0', id: '0xhash', chainId: '0x89', status: 100, atomic: true })
+    expect(result.receipts).toBeUndefined()
+  })
+
+  it('hex-encodes the chain id in the envelope', () => {
+    expect(buildGetCallsResult('0xhash', '11155111', {}, null).chainId).toBe('0xaa36a7')
+  })
+
+  it('builds one receipt with normalized hex fields for a confirmed single call', () => {
+    const tx: CallsStatusTx = { txStatus: 'SUCCESS', txHash: '0xtxHash' }
+    const result = buildGetCallsResult('0xhash', '1', tx, receipt)
+    expect(result.receipts).toHaveLength(1)
+    expect(result.receipts?.[0]).toEqual({
+      logs: receipt.logs,
+      status: '0x1',
+      blockHash: '0xbbb',
+      blockNumber: '0x10',
+      gasUsed: '0x5208',
+      transactionHash: '0xtxHash',
+    })
+  })
+
+  it('marks the on-chain receipt status 0x0 for a non-success tx', () => {
+    const result = buildGetCallsResult('0xhash', '1', { txStatus: 'FAILED', txHash: '0xtxHash' }, receipt)
+    expect(result.receipts?.[0].status).toBe('0x0')
+  })
+
+  it('replicates the receipt once per bundled call from valueDecoded', () => {
+    const tx: CallsStatusTx = {
+      txStatus: 'SUCCESS',
+      txHash: '0xtxHash',
+      txData: { dataDecoded: { parameters: [{ valueDecoded: [{}, {}, {}] }] } },
+    }
+    const result = buildGetCallsResult('0xhash', '1', tx, receipt)
+    expect(result.receipts).toHaveLength(3)
+  })
+
+  it('falls back to the receipt transactionHash when the tx hash is absent', () => {
+    const result = buildGetCallsResult('0xhash', '1', { txStatus: 'SUCCESS' }, receipt)
+    expect(result.receipts?.[0].transactionHash).toBe('0xrcptHash')
+  })
+
+  it('normalizes zero-padded receipt hex (e.g. 0x010) to canonical form', () => {
+    const padded: RawTxReceipt = { ...receipt, blockNumber: '0x010', gasUsed: '0x0a' }
+    const result = buildGetCallsResult('0xhash', '1', { txStatus: 'SUCCESS', txHash: '0xtxHash' }, padded)
+    expect(result.receipts?.[0].blockNumber).toBe('0x10')
+    expect(result.receipts?.[0].gasUsed).toBe('0xa')
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
@@ -2,7 +2,13 @@ import type { WalletKitTypes } from '@reown/walletkit'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { getSdkError } from '@walletconnect/utils'
 import { getAddress } from 'ethers'
-import { routeSessionRequest, isDeferredResponse, NO_SIGNER_ERROR_CODE, type RouteContext } from '../methodRouter'
+import {
+  routeSessionRequest,
+  isDeferredResponse,
+  isValidTxRequestParams,
+  NO_SIGNER_ERROR_CODE,
+  type RouteContext,
+} from '../methodRouter'
 
 // Contains hex letters so casing-sensitivity tests actually exercise a different string.
 const SAFE_ADDRESS = '0xAbCd111111111111111111111111111111111111'
@@ -112,7 +118,7 @@ describe('routeSessionRequest', () => {
   })
 
   it('rejects a wallet_sendCalls bundle on a mismatched chainId', async () => {
-    const params = [{ chainId: '0x89', from: SAFE_ADDRESS, calls: [] }]
+    const params = [{ chainId: '0x89', from: SAFE_ADDRESS, calls: [{ to: '0xabc' }] }]
     const res = await routeSessionRequest(makeCtx(makeRequest('wallet_sendCalls', params)))
     expect((res as { error: { code: number } }).error.code).toBe(-32602)
   })
@@ -150,7 +156,7 @@ describe('routeSessionRequest', () => {
   })
 
   it('rejects a wallet_sendCalls bundle from a mismatched address', async () => {
-    const params = [{ chainId: '0x1', from: '0x2222222222222222222222222222222222222222', calls: [] }]
+    const params = [{ chainId: '0x1', from: '0x2222222222222222222222222222222222222222', calls: [{ to: '0xabc' }] }]
     const res = await routeSessionRequest(makeCtx(makeRequest('wallet_sendCalls', params)))
     expect((res as { error: { code: number } }).error.code).toBe(-32602)
     expect(isDeferredResponse(res)).toBe(false)
@@ -171,5 +177,31 @@ describe('routeSessionRequest', () => {
   it('returns UNSUPPORTED_METHODS for unknown methods', async () => {
     const res = await routeSessionRequest(makeCtx(makeRequest('eth_unknownMethod')))
     expect((res as { error: { message: string } }).error.message).toBe(getSdkError('UNSUPPORTED_METHODS').message)
+  })
+})
+
+// Also consumed by WalletKitProvider when seeding requests restored after a restart, which
+// bypass routeSessionRequest entirely.
+describe('isValidTxRequestParams', () => {
+  it('accepts a valid eth_sendTransaction call and a deployment', () => {
+    expect(isValidTxRequestParams('eth_sendTransaction', [{ to: '0xabc', value: '0x0', data: '0x' }])).toBe(true)
+    expect(isValidTxRequestParams('eth_sendTransaction', [{ data: '0xdeadbeef' }])).toBe(true)
+  })
+
+  it('rejects non-array, empty, and malformed eth_sendTransaction params', () => {
+    expect(isValidTxRequestParams('eth_sendTransaction', undefined)).toBe(false)
+    expect(isValidTxRequestParams('eth_sendTransaction', [])).toBe(false)
+    expect(isValidTxRequestParams('eth_sendTransaction', [{ value: '0x1' }])).toBe(false)
+  })
+
+  it('accepts a valid wallet_sendCalls bundle', () => {
+    expect(isValidTxRequestParams('wallet_sendCalls', [{ calls: [{ to: '0xabc' }, { data: '0xfeed' }] }])).toBe(true)
+  })
+
+  it('rejects empty or malformed wallet_sendCalls bundles', () => {
+    expect(isValidTxRequestParams('wallet_sendCalls', [])).toBe(false)
+    expect(isValidTxRequestParams('wallet_sendCalls', [{}])).toBe(false)
+    expect(isValidTxRequestParams('wallet_sendCalls', [{ calls: [] }])).toBe(false)
+    expect(isValidTxRequestParams('wallet_sendCalls', [{ calls: [{ value: '0x1' }] }])).toBe(false)
   })
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
@@ -247,6 +247,16 @@ describe('routeSessionRequest — WA-2322 read-only + wallet-control branches', 
       const result = (res as { result: Record<string, unknown> }).result
       expect(Object.keys(result)).toEqual(['0x1'])
     })
+
+    it('tolerates malformed (non-string) chainIds and falls back to the envelope chain', async () => {
+      // A malformed dApp request must not throw out of the router (which would leave the dApp
+      // without any response); non-string entries are dropped.
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_getCapabilities', [SAFE_ADDRESS, [1, 137] as unknown as string[]])),
+      )
+      const result = (res as { result: Record<string, unknown> }).result
+      expect(Object.keys(result)).toEqual(['0x1'])
+    })
   })
 
   describe('wallet_getCallsStatus', () => {

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
@@ -3,7 +3,8 @@ import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { getSdkError } from '@walletconnect/utils'
 import { routeSessionRequest, isDeferredResponse, NO_SIGNER_ERROR_CODE, type RouteContext } from '../methodRouter'
 
-const SAFE_ADDRESS = '0x1111111111111111111111111111111111111111'
+// Contains hex letters so casing-sensitivity tests actually exercise a different string.
+const SAFE_ADDRESS = '0xAbCd111111111111111111111111111111111111'
 const CHAIN_ID = '1'
 
 const chain = { chainId: CHAIN_ID } as unknown as Chain
@@ -135,7 +136,10 @@ describe('routeSessionRequest', () => {
   })
 
   it('accepts a wallet_sendCalls bundle whose from differs only in casing', async () => {
-    const params = [{ chainId: '0x1', from: SAFE_ADDRESS.toUpperCase().replace('0X', '0x'), calls: [{ to: '0xabc' }] }]
+    const from = SAFE_ADDRESS.toLowerCase()
+    // Guard against a vacuous comparison — the fixture must actually differ in casing.
+    expect(from).not.toBe(SAFE_ADDRESS)
+    const params = [{ chainId: '0x1', from, calls: [{ to: '0xabc' }] }]
     const res = await routeSessionRequest(makeCtx(makeRequest('wallet_sendCalls', params)))
     expect(isDeferredResponse(res)).toBe(true)
   })

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
@@ -39,6 +39,7 @@ const makeCtx = (request: WalletKitTypes.SessionRequest, overrides: Partial<Rout
     activeChain: chain,
     activeSafeAddress: SAFE_ADDRESS,
     hasSigner: true,
+    deployedChainIds: ['1', '137'],
     switchActiveChainByCaip2: jest.fn().mockResolvedValue({ ok: true }),
     getCallsStatus: jest.fn(),
     navigateToCallsStatus: jest.fn(),
@@ -256,6 +257,23 @@ describe('routeSessionRequest — WA-2322 read-only + wallet-control branches', 
       )
       const result = (res as { result: Record<string, unknown> }).result
       expect(Object.keys(result)).toEqual(['0x1'])
+    })
+
+    it('omits requested chains the Safe is not deployed on', async () => {
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_getCapabilities', [SAFE_ADDRESS, ['0x1', '0x89']]), {
+          deployedChainIds: ['1'],
+        }),
+      )
+      const result = (res as { result: Record<string, unknown> }).result
+      expect(Object.keys(result)).toEqual(['0x1'])
+    })
+
+    it('returns {} when no requested chain is deployed', async () => {
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_getCapabilities', [SAFE_ADDRESS, ['0x89']]), { deployedChainIds: ['1'] }),
+      )
+      expect((res as { result: Record<string, unknown> }).result).toEqual({})
     })
   })
 

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
@@ -106,6 +106,12 @@ describe('routeSessionRequest', () => {
     expect((res as { error: { code: number } }).error.code).toBe(-32602)
   })
 
+  it('accepts a wallet_sendCalls bundle whose from differs only in casing', async () => {
+    const params = [{ chainId: '0x1', from: SAFE_ADDRESS.toUpperCase().replace('0X', '0x'), calls: [{ to: '0xabc' }] }]
+    const res = await routeSessionRequest(makeCtx(makeRequest('wallet_sendCalls', params)))
+    expect(isDeferredResponse(res)).toBe(true)
+  })
+
   it('rejects a wallet_sendCalls bundle from a mismatched address', async () => {
     const params = [{ chainId: '0x1', from: '0x2222222222222222222222222222222222222222', calls: [] }]
     const res = await routeSessionRequest(makeCtx(makeRequest('wallet_sendCalls', params)))

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
@@ -275,6 +275,16 @@ describe('routeSessionRequest — WA-2322 read-only + wallet-control branches', 
       )
       expect((res as { result: Record<string, unknown> }).result).toEqual({})
     })
+
+    it('skips a non-numeric deployed chain id instead of throwing (BigInt safety)', async () => {
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_getCapabilities', [SAFE_ADDRESS, ['0x1']]), {
+          deployedChainIds: ['1', 'not-a-chain'],
+        }),
+      )
+      const result = (res as { result: Record<string, unknown> }).result
+      expect(Object.keys(result)).toEqual(['0x1'])
+    })
   })
 
   describe('wallet_getCallsStatus', () => {

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
@@ -1,6 +1,5 @@
 import type { WalletKitTypes } from '@reown/walletkit'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
-import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import { getSdkError } from '@walletconnect/utils'
 import { routeSessionRequest, isDeferredResponse, NO_SIGNER_ERROR_CODE, type RouteContext } from '../methodRouter'
 
@@ -8,7 +7,6 @@ const SAFE_ADDRESS = '0x1111111111111111111111111111111111111111'
 const CHAIN_ID = '1'
 
 const chain = { chainId: CHAIN_ID } as unknown as Chain
-const safe = { address: { value: SAFE_ADDRESS } } as unknown as SafeState
 
 const makeRequest = (method: string, params: unknown[] = [], chainId = 'eip155:1'): WalletKitTypes.SessionRequest =>
   ({
@@ -23,7 +21,7 @@ const makeCtx = (request: WalletKitTypes.SessionRequest, overrides: Partial<Rout
     dispatch: jest.fn(),
     getState: jest.fn(),
     activeChain: chain,
-    activeSafe: safe,
+    activeSafeAddress: SAFE_ADDRESS,
     hasSigner: true,
     ...overrides,
   }) as unknown as RouteContext
@@ -49,7 +47,7 @@ describe('routeSessionRequest', () => {
   })
 
   it('answers eth_accounts with [] when no active Safe', async () => {
-    const res = await routeSessionRequest(makeCtx(makeRequest('eth_accounts'), { activeSafe: null }))
+    const res = await routeSessionRequest(makeCtx(makeRequest('eth_accounts'), { activeSafeAddress: null }))
     expect((res as { result: string[] }).result).toEqual([])
   })
 
@@ -75,7 +73,7 @@ describe('routeSessionRequest', () => {
 
   it('rejects tx requests with no active Safe', async () => {
     const res = await routeSessionRequest(
-      makeCtx(makeRequest('eth_sendTransaction', sendTxParams), { activeSafe: null }),
+      makeCtx(makeRequest('eth_sendTransaction', sendTxParams), { activeSafeAddress: null }),
     )
     expect((res as { error: { code: number } }).error.code).toBe(-32603)
     expect(isDeferredResponse(res)).toBe(false)

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
@@ -106,6 +106,29 @@ describe('routeSessionRequest', () => {
     expect((res as { error: { code: number } }).error.code).toBe(-32602)
   })
 
+  it('rejects an eth_sendTransaction with no tx object instead of deferring', async () => {
+    const res = await routeSessionRequest(makeCtx(makeRequest('eth_sendTransaction', [])))
+    expect((res as { error: { code: number } }).error.code).toBe(-32602)
+    expect(isDeferredResponse(res)).toBe(false)
+  })
+
+  it('rejects an eth_sendTransaction whose call is neither valid nor a deployment', async () => {
+    const res = await routeSessionRequest(makeCtx(makeRequest('eth_sendTransaction', [{ value: '0x1' }])))
+    expect((res as { error: { code: number } }).error.code).toBe(-32602)
+  })
+
+  it('defers an eth_sendTransaction contract deployment (no-to + data only)', async () => {
+    const res = await routeSessionRequest(makeCtx(makeRequest('eth_sendTransaction', [{ data: '0xdeadbeef' }])))
+    expect(isDeferredResponse(res)).toBe(true)
+  })
+
+  it('rejects a wallet_sendCalls bundle with an empty calls array', async () => {
+    const params = [{ chainId: '0x1', from: SAFE_ADDRESS, calls: [] }]
+    const res = await routeSessionRequest(makeCtx(makeRequest('wallet_sendCalls', params)))
+    expect((res as { error: { code: number } }).error.code).toBe(-32602)
+    expect(isDeferredResponse(res)).toBe(false)
+  })
+
   it('accepts a wallet_sendCalls bundle whose from differs only in casing', async () => {
     const params = [{ chainId: '0x1', from: SAFE_ADDRESS.toUpperCase().replace('0X', '0x'), calls: [{ to: '0xabc' }] }]
     const res = await routeSessionRequest(makeCtx(makeRequest('wallet_sendCalls', params)))

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
@@ -61,6 +61,13 @@ describe('routeSessionRequest', () => {
     expect((res as { result: string }).result).toBe('1')
   })
 
+  it('errors on eth_chainId / net_version while the chain config is unresolved', async () => {
+    const chainIdRes = await routeSessionRequest(makeCtx(makeRequest('eth_chainId'), { activeChain: null }))
+    expect((chainIdRes as { error: { code: number } }).error.code).toBe(-32603)
+    const netVersionRes = await routeSessionRequest(makeCtx(makeRequest('net_version'), { activeChain: null }))
+    expect((netVersionRes as { error: { code: number } }).error.code).toBe(-32603)
+  })
+
   it('defers eth_sendTransaction for the sheet', async () => {
     const res = await routeSessionRequest(makeCtx(makeRequest('eth_sendTransaction', sendTxParams)))
     expect(isDeferredResponse(res)).toBe(true)

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
@@ -9,6 +9,14 @@ import {
   NO_SIGNER_ERROR_CODE,
   type RouteContext,
 } from '../methodRouter'
+import { proxyReadOnlyCall } from '../readRpcProxy'
+
+// Keep the real allow-list guard (isReadOnlyMethod) but stub the network call.
+jest.mock('../readRpcProxy', () => ({
+  ...jest.requireActual('../readRpcProxy'),
+  proxyReadOnlyCall: jest.fn(),
+}))
+const mockProxyReadOnlyCall = proxyReadOnlyCall as jest.Mock
 
 // Contains hex letters so casing-sensitivity tests actually exercise a different string.
 const SAFE_ADDRESS = '0xAbCd111111111111111111111111111111111111'
@@ -31,6 +39,9 @@ const makeCtx = (request: WalletKitTypes.SessionRequest, overrides: Partial<Rout
     activeChain: chain,
     activeSafeAddress: SAFE_ADDRESS,
     hasSigner: true,
+    switchActiveChainByCaip2: jest.fn().mockResolvedValue({ ok: true }),
+    getCallsStatus: jest.fn(),
+    navigateToCallsStatus: jest.fn(),
     ...overrides,
   }) as unknown as RouteContext
 
@@ -190,6 +201,105 @@ describe('routeSessionRequest', () => {
   it('returns UNSUPPORTED_METHODS for unknown methods', async () => {
     const res = await routeSessionRequest(makeCtx(makeRequest('eth_unknownMethod')))
     expect((res as { error: { message: string } }).error.message).toBe(getSdkError('UNSUPPORTED_METHODS').message)
+  })
+})
+
+describe('routeSessionRequest — WA-2322 read-only + wallet-control branches', () => {
+  beforeEach(() => {
+    mockProxyReadOnlyCall.mockReset()
+  })
+
+  describe('wallet_switchEthereumChain', () => {
+    it('switches to a deployed chain and responds null', async () => {
+      const switchActiveChainByCaip2 = jest.fn().mockResolvedValue({ ok: true })
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_switchEthereumChain', [{ chainId: '0x89' }]), { switchActiveChainByCaip2 }),
+      )
+      expect(switchActiveChainByCaip2).toHaveBeenCalledWith('eip155:137')
+      expect((res as { result: null }).result).toBeNull()
+    })
+
+    it('responds 4901 for a non-deployed chain', async () => {
+      const switchActiveChainByCaip2 = jest.fn().mockResolvedValue({ ok: false, reason: 'NOT_DEPLOYED' })
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_switchEthereumChain', [{ chainId: '0x89' }]), { switchActiveChainByCaip2 }),
+      )
+      expect((res as { error: { code: number } }).error.code).toBe(4901)
+    })
+
+    it('responds -32602 when the target chainId is missing', async () => {
+      const res = await routeSessionRequest(makeCtx(makeRequest('wallet_switchEthereumChain', [{}])))
+      expect((res as { error: { code: number } }).error.code).toBe(-32602)
+    })
+  })
+
+  describe('wallet_getCapabilities', () => {
+    it('reports atomic capability for explicitly requested chains', async () => {
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_getCapabilities', [SAFE_ADDRESS, ['0x1', '0x89']])),
+      )
+      const result = (res as { result: Record<string, unknown> }).result
+      expect(Object.keys(result)).toEqual(['0x1', '0x89'])
+    })
+
+    it('falls back to the envelope session chain when no chains are requested', async () => {
+      const res = await routeSessionRequest(makeCtx(makeRequest('wallet_getCapabilities', [SAFE_ADDRESS])))
+      const result = (res as { result: Record<string, unknown> }).result
+      expect(Object.keys(result)).toEqual(['0x1'])
+    })
+  })
+
+  describe('wallet_getCallsStatus', () => {
+    it('returns the status envelope from getCallsStatus', async () => {
+      const envelope = { version: '2.0.0', id: '0xhash', chainId: '0x1', status: 200, atomic: true }
+      const getCallsStatus = jest.fn().mockResolvedValue(envelope)
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_getCallsStatus', ['0xhash']), { getCallsStatus }),
+      )
+      expect(getCallsStatus).toHaveBeenCalledWith('eip155:1', '0xhash')
+      expect((res as { result: unknown }).result).toEqual(envelope)
+    })
+
+    it('maps a thrown lookup to -32603', async () => {
+      const getCallsStatus = jest.fn().mockRejectedValue(new Error('Transaction not found'))
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_getCallsStatus', ['0xunknown']), { getCallsStatus }),
+      )
+      // jsonrpc-utils normalizes the message for the reserved -32603 code, so assert the code.
+      expect((res as { error: { code: number } }).error.code).toBe(-32603)
+    })
+  })
+
+  describe('wallet_showCallsStatus', () => {
+    it('navigates and responds null', async () => {
+      const navigateToCallsStatus = jest.fn()
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_showCallsStatus', ['0xhash']), { navigateToCallsStatus }),
+      )
+      expect(navigateToCallsStatus).toHaveBeenCalledWith('eip155:1', '0xhash')
+      expect((res as { result: null }).result).toBeNull()
+    })
+  })
+
+  describe('read-only RPC passthrough', () => {
+    it('proxies an allow-listed method to the active chain', async () => {
+      mockProxyReadOnlyCall.mockResolvedValue('0x10')
+      const res = await routeSessionRequest(makeCtx(makeRequest('eth_blockNumber', [])))
+      expect(mockProxyReadOnlyCall).toHaveBeenCalledWith(chain, 'eth_blockNumber', [])
+      expect((res as { result: string }).result).toBe('0x10')
+    })
+
+    it('responds -32603 when no active chain is resolved', async () => {
+      const res = await routeSessionRequest(makeCtx(makeRequest('eth_call', [{}]), { activeChain: null }))
+      expect((res as { error: { code: number } }).error.code).toBe(-32603)
+      expect(mockProxyReadOnlyCall).not.toHaveBeenCalled()
+    })
+
+    it('maps a proxy failure to -32603', async () => {
+      mockProxyReadOnlyCall.mockRejectedValue(new Error('RPC down'))
+      const res = await routeSessionRequest(makeCtx(makeRequest('eth_getBalance', [SAFE_ADDRESS, 'latest'])))
+      expect((res as { error: { code: number } }).error.code).toBe(-32603)
+    })
   })
 })
 

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
@@ -1,6 +1,7 @@
 import type { WalletKitTypes } from '@reown/walletkit'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { getSdkError } from '@walletconnect/utils'
+import { getAddress } from 'ethers'
 import { routeSessionRequest, isDeferredResponse, NO_SIGNER_ERROR_CODE, type RouteContext } from '../methodRouter'
 
 // Contains hex letters so casing-sensitivity tests actually exercise a different string.
@@ -42,9 +43,13 @@ describe('routeSessionRequest', () => {
     expect((res as { error: { message: string } }).error.message).toBe(getSdkError('UNSUPPORTED_METHODS').message)
   })
 
-  it('answers eth_accounts with the active Safe address', async () => {
-    const res = await routeSessionRequest(makeCtx(makeRequest('eth_accounts')))
-    expect((res as { result: string[] }).result).toEqual([SAFE_ADDRESS])
+  it('answers eth_accounts with the checksummed active Safe address', async () => {
+    // Lowercase input must come back EIP-55 checksummed — dApps compare against the
+    // session-namespace accounts verbatim.
+    const res = await routeSessionRequest(
+      makeCtx(makeRequest('eth_accounts'), { activeSafeAddress: SAFE_ADDRESS.toLowerCase() }),
+    )
+    expect((res as { result: string[] }).result).toEqual([getAddress(SAFE_ADDRESS.toLowerCase())])
   })
 
   it('answers eth_accounts with [] when no active Safe', async () => {

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
@@ -1,0 +1,132 @@
+import type { WalletKitTypes } from '@reown/walletkit'
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { getSdkError } from '@walletconnect/utils'
+import { routeSessionRequest, isDeferredResponse, NO_SIGNER_ERROR_CODE, type RouteContext } from '../methodRouter'
+
+const SAFE_ADDRESS = '0x1111111111111111111111111111111111111111'
+const CHAIN_ID = '1'
+
+const chain = { chainId: CHAIN_ID } as unknown as Chain
+const safe = { address: { value: SAFE_ADDRESS } } as unknown as SafeState
+
+const makeRequest = (method: string, params: unknown[] = [], chainId = 'eip155:1'): WalletKitTypes.SessionRequest =>
+  ({
+    id: 42,
+    topic: 'topic',
+    params: { chainId, request: { method, params } },
+  }) as unknown as WalletKitTypes.SessionRequest
+
+const makeCtx = (request: WalletKitTypes.SessionRequest, overrides: Partial<RouteContext> = {}): RouteContext =>
+  ({
+    request,
+    dispatch: jest.fn(),
+    getState: jest.fn(),
+    activeChain: chain,
+    activeSafe: safe,
+    hasSigner: true,
+    ...overrides,
+  }) as unknown as RouteContext
+
+const sendTxParams = [{ to: '0xabc', value: '0x0', data: '0x' }]
+const sendCallsParams = [{ chainId: '0x1', from: SAFE_ADDRESS, calls: [{ to: '0xabc', value: '0x0', data: '0x' }] }]
+
+describe('routeSessionRequest', () => {
+  it('rejects cross-namespace requests', async () => {
+    const res = await routeSessionRequest(makeCtx(makeRequest('eth_sendTransaction', sendTxParams, 'cosmos:1')))
+    expect(res).toHaveProperty('error')
+    expect(isDeferredResponse(res)).toBe(false)
+  })
+
+  it('rejects message-signing methods without UI', async () => {
+    const res = await routeSessionRequest(makeCtx(makeRequest('personal_sign', ['0xmsg', SAFE_ADDRESS])))
+    expect((res as { error: { message: string } }).error.message).toBe(getSdkError('UNSUPPORTED_METHODS').message)
+  })
+
+  it('answers eth_accounts with the active Safe address', async () => {
+    const res = await routeSessionRequest(makeCtx(makeRequest('eth_accounts')))
+    expect((res as { result: string[] }).result).toEqual([SAFE_ADDRESS])
+  })
+
+  it('answers eth_accounts with [] when no active Safe', async () => {
+    const res = await routeSessionRequest(makeCtx(makeRequest('eth_accounts'), { activeSafe: null }))
+    expect((res as { result: string[] }).result).toEqual([])
+  })
+
+  it('answers eth_chainId as hex', async () => {
+    const res = await routeSessionRequest(makeCtx(makeRequest('eth_chainId')))
+    expect((res as { result: string }).result).toBe('0x1')
+  })
+
+  it('answers net_version as decimal', async () => {
+    const res = await routeSessionRequest(makeCtx(makeRequest('net_version')))
+    expect((res as { result: string }).result).toBe('1')
+  })
+
+  it('defers eth_sendTransaction for the sheet', async () => {
+    const res = await routeSessionRequest(makeCtx(makeRequest('eth_sendTransaction', sendTxParams)))
+    expect(isDeferredResponse(res)).toBe(true)
+  })
+
+  it('defers a valid wallet_sendCalls bundle', async () => {
+    const res = await routeSessionRequest(makeCtx(makeRequest('wallet_sendCalls', sendCallsParams)))
+    expect(isDeferredResponse(res)).toBe(true)
+  })
+
+  it('rejects tx requests with no active Safe', async () => {
+    const res = await routeSessionRequest(
+      makeCtx(makeRequest('eth_sendTransaction', sendTxParams), { activeSafe: null }),
+    )
+    expect((res as { error: { code: number } }).error.code).toBe(-32603)
+    expect(isDeferredResponse(res)).toBe(false)
+  })
+
+  it('rejects tx requests with 4100 when no signer is attached', async () => {
+    const res = await routeSessionRequest(
+      makeCtx(makeRequest('eth_sendTransaction', sendTxParams), { hasSigner: false }),
+    )
+    expect((res as { error: { code: number } }).error.code).toBe(NO_SIGNER_ERROR_CODE)
+  })
+
+  it('rejects tx requests with no active chain', async () => {
+    const res = await routeSessionRequest(
+      makeCtx(makeRequest('eth_sendTransaction', sendTxParams), { activeChain: null }),
+    )
+    expect((res as { error: { code: number } }).error.code).toBe(-32603)
+  })
+
+  it('rejects tx requests on the wrong active chain with UNSUPPORTED_CHAINS', async () => {
+    const res = await routeSessionRequest(makeCtx(makeRequest('eth_sendTransaction', sendTxParams, 'eip155:137')))
+    expect((res as { error: { code: number } }).error.code).toBe(getSdkError('UNSUPPORTED_CHAINS').code)
+  })
+
+  it('rejects a wallet_sendCalls bundle on a mismatched chainId', async () => {
+    const params = [{ chainId: '0x89', from: SAFE_ADDRESS, calls: [] }]
+    const res = await routeSessionRequest(makeCtx(makeRequest('wallet_sendCalls', params)))
+    expect((res as { error: { code: number } }).error.code).toBe(-32602)
+  })
+
+  it('rejects a wallet_sendCalls bundle from a mismatched address', async () => {
+    const params = [{ chainId: '0x1', from: '0x2222222222222222222222222222222222222222', calls: [] }]
+    const res = await routeSessionRequest(makeCtx(makeRequest('wallet_sendCalls', params)))
+    expect((res as { error: { code: number } }).error.code).toBe(-32602)
+    expect(isDeferredResponse(res)).toBe(false)
+  })
+
+  it('rejects a wallet_sendCalls call that is neither a valid call nor a deployment', async () => {
+    const params = [{ chainId: '0x1', from: SAFE_ADDRESS, calls: [{ value: '0x1' }] }]
+    const res = await routeSessionRequest(makeCtx(makeRequest('wallet_sendCalls', params)))
+    expect((res as { error: { code: number } }).error.code).toBe(-32602)
+  })
+
+  it('allows a wallet_sendCalls contract-deployment call (no-to + data only)', async () => {
+    const params = [{ chainId: '0x1', from: SAFE_ADDRESS, calls: [{ data: '0xdeadbeef' }] }]
+    const res = await routeSessionRequest(makeCtx(makeRequest('wallet_sendCalls', params)))
+    expect(isDeferredResponse(res)).toBe(true)
+  })
+
+  it('returns UNSUPPORTED_METHODS for unknown methods', async () => {
+    const res = await routeSessionRequest(makeCtx(makeRequest('eth_unknownMethod')))
+    expect((res as { error: { message: string } }).error.message).toBe(getSdkError('UNSUPPORTED_METHODS').message)
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
@@ -123,6 +123,19 @@ describe('routeSessionRequest', () => {
     expect((res as { error: { code: number } }).error.code).toBe(-32602)
   })
 
+  it('accepts a wallet_sendCalls bundle with zero-padded hex chainId', async () => {
+    // EIP-5792 says Quantity (no leading zeros), but dApps send '0x01' in the wild.
+    const params = [{ chainId: '0x01', from: SAFE_ADDRESS, calls: [{ to: '0xabc' }] }]
+    const res = await routeSessionRequest(makeCtx(makeRequest('wallet_sendCalls', params)))
+    expect(isDeferredResponse(res)).toBe(true)
+  })
+
+  it('rejects a wallet_sendCalls bundle with malformed hex chainId', async () => {
+    const params = [{ chainId: '0xZZ', from: SAFE_ADDRESS, calls: [{ to: '0xabc' }] }]
+    const res = await routeSessionRequest(makeCtx(makeRequest('wallet_sendCalls', params)))
+    expect((res as { error: { code: number } }).error.code).toBe(-32602)
+  })
+
   it('rejects an eth_sendTransaction with no tx object instead of deferring', async () => {
     const res = await routeSessionRequest(makeCtx(makeRequest('eth_sendTransaction', [])))
     expect((res as { error: { code: number } }).error.code).toBe(-32602)

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/readRpcProxy.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/readRpcProxy.test.ts
@@ -2,10 +2,15 @@ import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { createWeb3ReadOnly } from '@/src/services/web3'
 import { isReadOnlyMethod, proxyReadOnlyCall } from '../readRpcProxy'
 
-jest.mock('@/src/services/web3', () => ({ createWeb3ReadOnly: jest.fn() }))
+jest.mock('@/src/services/web3', () => ({
+  createWeb3ReadOnly: jest.fn(),
+  // The proxy keys its cache by the resolved url, so the mock derives it from rpcUri.value.
+  getRpcServiceUrl: jest.fn((rpcUri?: { value?: string }) => rpcUri?.value ?? ''),
+}))
 const mockCreateWeb3ReadOnly = createWeb3ReadOnly as jest.Mock
 
-const makeChain = (chainId: string): Chain => ({ chainId }) as unknown as Chain
+const makeChain = (chainId: string, url = `https://rpc.test/${chainId}`): Chain =>
+  ({ chainId, rpcUri: { authentication: 'NO_AUTHENTICATION', value: url } }) as unknown as Chain
 
 describe('isReadOnlyMethod', () => {
   it('accepts allow-listed read-only methods', () => {
@@ -49,18 +54,26 @@ describe('proxyReadOnlyCall', () => {
   })
 
   it('throws when no RPC URL is configured for the chain', async () => {
-    mockCreateWeb3ReadOnly.mockReturnValue(undefined)
-    await expect(proxyReadOnlyCall(makeChain('103'), 'eth_call', [{}])).rejects.toThrow(
+    await expect(proxyReadOnlyCall(makeChain('103', ''), 'eth_call', [{}])).rejects.toThrow(
       'No RPC URL configured for chainId=103',
     )
+    expect(mockCreateWeb3ReadOnly).not.toHaveBeenCalled()
   })
 
-  it('caches one provider per chain across calls', async () => {
+  it('caches one provider per chain+url across calls', async () => {
     const send = jest.fn().mockResolvedValue('0x1')
     mockCreateWeb3ReadOnly.mockReturnValue({ send })
     const chain = makeChain('104')
     await proxyReadOnlyCall(chain, 'eth_blockNumber', [])
     await proxyReadOnlyCall(chain, 'eth_gasPrice', [])
     expect(mockCreateWeb3ReadOnly).toHaveBeenCalledTimes(1)
+  })
+
+  it('rebuilds the provider when the same chain reports a new RPC url', async () => {
+    const send = jest.fn().mockResolvedValue('0x1')
+    mockCreateWeb3ReadOnly.mockReturnValue({ send })
+    await proxyReadOnlyCall(makeChain('105', 'https://rpc.old/105'), 'eth_blockNumber', [])
+    await proxyReadOnlyCall(makeChain('105', 'https://rpc.new/105'), 'eth_blockNumber', [])
+    expect(mockCreateWeb3ReadOnly).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/readRpcProxy.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/readRpcProxy.test.ts
@@ -1,0 +1,66 @@
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import { createWeb3ReadOnly } from '@/src/services/web3'
+import { isReadOnlyMethod, proxyReadOnlyCall } from '../readRpcProxy'
+
+jest.mock('@/src/services/web3', () => ({ createWeb3ReadOnly: jest.fn() }))
+const mockCreateWeb3ReadOnly = createWeb3ReadOnly as jest.Mock
+
+const makeChain = (chainId: string): Chain => ({ chainId }) as unknown as Chain
+
+describe('isReadOnlyMethod', () => {
+  it('accepts allow-listed read-only methods', () => {
+    expect(isReadOnlyMethod('eth_call')).toBe(true)
+    expect(isReadOnlyMethod('eth_getBalance')).toBe(true)
+    expect(isReadOnlyMethod('eth_blockNumber')).toBe(true)
+  })
+
+  it('rejects non-allow-listed methods', () => {
+    expect(isReadOnlyMethod('eth_sendTransaction')).toBe(false)
+    expect(isReadOnlyMethod('personal_sign')).toBe(false)
+    expect(isReadOnlyMethod('eth_unknown')).toBe(false)
+  })
+})
+
+describe('proxyReadOnlyCall', () => {
+  beforeEach(() => {
+    mockCreateWeb3ReadOnly.mockReset()
+  })
+
+  it('forwards an allow-listed call to provider.send', async () => {
+    const send = jest.fn().mockResolvedValue('0x10')
+    mockCreateWeb3ReadOnly.mockReturnValue({ send })
+    const result = await proxyReadOnlyCall(makeChain('100'), 'eth_blockNumber', [])
+    expect(send).toHaveBeenCalledWith('eth_blockNumber', [])
+    expect(result).toBe('0x10')
+  })
+
+  it('defaults missing params to an empty array', async () => {
+    const send = jest.fn().mockResolvedValue(null)
+    mockCreateWeb3ReadOnly.mockReturnValue({ send })
+    await proxyReadOnlyCall(makeChain('101'), 'eth_gasPrice', undefined as unknown as unknown[])
+    expect(send).toHaveBeenCalledWith('eth_gasPrice', [])
+  })
+
+  it('throws for a method outside the allow-list without building a provider', async () => {
+    await expect(proxyReadOnlyCall(makeChain('102'), 'eth_sendTransaction', [])).rejects.toThrow(
+      'is not in the read-only allow-list',
+    )
+    expect(mockCreateWeb3ReadOnly).not.toHaveBeenCalled()
+  })
+
+  it('throws when no RPC URL is configured for the chain', async () => {
+    mockCreateWeb3ReadOnly.mockReturnValue(undefined)
+    await expect(proxyReadOnlyCall(makeChain('103'), 'eth_call', [{}])).rejects.toThrow(
+      'No RPC URL configured for chainId=103',
+    )
+  })
+
+  it('caches one provider per chain across calls', async () => {
+    const send = jest.fn().mockResolvedValue('0x1')
+    mockCreateWeb3ReadOnly.mockReturnValue({ send })
+    const chain = makeChain('104')
+    await proxyReadOnlyCall(chain, 'eth_blockNumber', [])
+    await proxyReadOnlyCall(chain, 'eth_gasPrice', [])
+    expect(mockCreateWeb3ReadOnly).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/composeSafeTxDraft.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/composeSafeTxDraft.ts
@@ -1,0 +1,159 @@
+import { type Operation, cgwApi } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import type { MetaTransactionData } from '@safe-global/types-kit'
+import { Interface } from 'ethers'
+import { getSafeSDK } from '@/src/hooks/coreSDK/safeCoreSDK'
+import { setDraft, type DraftTx } from '@/src/store/draftTxSlice'
+import { synthesizeDraftTxDetails } from '@/src/features/ConfirmTx/utils/synthesizeDraftTxDetails'
+import { asError } from '@safe-global/utils/services/exceptions/utils'
+import { getCreateCallContractDeployment } from '@safe-global/utils/services/contracts/deployments'
+import type { AppDispatch } from '@/src/store'
+
+// dApp call shape per EIP-5792 / WC. Contract deployments omit `to` and provide `data` only.
+export type DappCall = {
+  to?: string
+  value?: string // hex or decimal string
+  data?: string
+}
+
+export type ComposeSafeTxDraftInput = {
+  calls: DappCall[] // single for eth_sendTransaction, batch for wallet_sendCalls
+  chainId: string
+  safeAddress: string
+  safe: SafeState
+  chain: Chain
+  dispatch: AppDispatch
+}
+
+// dApps send numeric fields as hex per JSON-RPC convention (e.g. Uniswap: value = '0x16345785d8a0000').
+// Protocol-kit / ethers expect decimal strings here — failure mode is a misleading
+// "invalid base-10 numeric string" thrown deep in the sign path. BigInt() accepts both '0x...' and
+// decimal input, and .toString() always emits decimal, so this normalizes either form safely.
+const normalizeValue = (value: string | undefined): string => {
+  if (!value) {
+    return '0'
+  }
+  return BigInt(value).toString()
+}
+
+// Contract deployment routed through CreateCall (no-to + only-data); mirrors web's
+// WalletSDK.getCreateCallTransaction in apps/web/.../useSafeWalletProvider.tsx.
+const buildCreateCallTx = (chain: Chain, safeVersion: SafeState['version'], data: string): MetaTransactionData => {
+  const deployment = getCreateCallContractDeployment(chain, safeVersion)
+  if (!deployment) {
+    throw new Error('No CreateCall deployment found for chain and safe version')
+  }
+  const addressOrAddresses = deployment.networkAddresses[chain.chainId]
+  const createCallAddress = Array.isArray(addressOrAddresses) ? addressOrAddresses[0] : addressOrAddresses
+  if (!createCallAddress) {
+    throw new Error('No CreateCall address for this chain')
+  }
+  const iface = new Interface(deployment.abi)
+  return {
+    to: createCallAddress,
+    value: '0',
+    data: iface.encodeFunctionData('performCreate', ['0', data]),
+    operation: 0,
+  }
+}
+
+const toMetaTx = (call: DappCall, chain: Chain, safeVersion: SafeState['version']): MetaTransactionData => {
+  if (!call.to) {
+    // The router has already ruled out empty / no-to-with-value; this branch is
+    // strictly the contract-deployment case (data-only).
+    return buildCreateCallTx(chain, safeVersion, call.data ?? '0x')
+  }
+  return {
+    to: call.to,
+    value: normalizeValue(call.value),
+    data: call.data ?? '0x',
+    operation: 0,
+  }
+}
+
+async function getVerifiedSafeSDK(chainId: string) {
+  const safeSDK = getSafeSDK()
+  if (!safeSDK) {
+    throw new Error('Safe SDK is not initialized')
+  }
+
+  const sdkChainId = await safeSDK.getChainId()
+  if (sdkChainId.toString() !== chainId) {
+    throw new Error(`Chain mismatch: SDK on chain ${sdkChainId}, expected ${chainId}`)
+  }
+
+  return safeSDK
+}
+
+/**
+ * Build a SafeTransaction from one or more dApp-supplied calls, ask CGW for a preview,
+ * and stash a DraftTx so the existing review-and-confirm flow can render it without a
+ * /propose round-trip. The /propose call happens when the user signs.
+ *
+ * For batches (calls.length > 1) the SDK auto-wraps via multiSend (DelegateCall).
+ *
+ * Returns the safeTxHash (used as the txId in downstream navigation).
+ */
+export const composeSafeTxDraft = async ({
+  calls,
+  chainId,
+  safeAddress,
+  safe,
+  chain,
+  dispatch,
+}: ComposeSafeTxDraftInput): Promise<string> => {
+  if (calls.length === 0) {
+    throw new Error('composeSafeTxDraft: empty calls array')
+  }
+
+  const safeSDK = await getVerifiedSafeSDK(chainId)
+  const metaTxs: MetaTransactionData[] = calls.map((c) => toMetaTx(c, chain, safe.version))
+  const safeTx = await safeSDK.createTransaction({ transactions: metaTxs })
+  const safeTxHash = await safeSDK.getTransactionHash(safeTx)
+
+  const previewPromise = dispatch(
+    cgwApi.endpoints.transactionsPreviewTransactionV1.initiate({
+      chainId,
+      safeAddress,
+      previewTransactionDto: {
+        to: safeTx.data.to,
+        data: safeTx.data.data || null,
+        value: safeTx.data.value?.toString() ?? '0',
+        operation: (safeTx.data.operation ?? 0) as Operation,
+      },
+    }),
+  )
+
+  let txDetails
+  try {
+    const previewResult = await previewPromise
+
+    if ('error' in previewResult || !previewResult.data) {
+      throw asError('error' in previewResult ? previewResult.error : new Error('Preview unavailable'))
+    }
+
+    txDetails = synthesizeDraftTxDetails({
+      safeAddress,
+      safeTxHash,
+      buildParams: safeTx.data,
+      owners: safe.owners,
+      threshold: safe.threshold,
+      preview: previewResult.data,
+    })
+  } finally {
+    previewPromise.reset()
+  }
+
+  const draft: DraftTx = {
+    chainId,
+    safeAddress,
+    buildParams: safeTx.data,
+    safeTxHash,
+    txDetails,
+  }
+
+  dispatch(setDraft(draft))
+
+  return safeTxHash
+}

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/composeSafeTxDraft.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/composeSafeTxDraft.ts
@@ -1,12 +1,8 @@
-import { type Operation, cgwApi } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import type { MetaTransactionData } from '@safe-global/types-kit'
 import { Interface } from 'ethers'
-import { getSafeSDK } from '@/src/hooks/coreSDK/safeCoreSDK'
-import { setDraft, type DraftTx } from '@/src/store/draftTxSlice'
-import { synthesizeDraftTxDetails } from '@/src/features/ConfirmTx/utils/synthesizeDraftTxDetails'
-import { asError } from '@safe-global/utils/services/exceptions/utils'
+import { getVerifiedSafeSDK, previewAndStashDraft } from '@/src/services/tx/draft'
 import { getCreateCallContractDeployment } from '@safe-global/utils/services/contracts/deployments'
 import type { AppDispatch } from '@/src/store'
 
@@ -72,24 +68,11 @@ const toMetaTx = (call: DappCall, chain: Chain, safeVersion: SafeState['version'
   }
 }
 
-async function getVerifiedSafeSDK(chainId: string) {
-  const safeSDK = getSafeSDK()
-  if (!safeSDK) {
-    throw new Error('Safe SDK is not initialized')
-  }
-
-  const sdkChainId = await safeSDK.getChainId()
-  if (sdkChainId.toString() !== chainId) {
-    throw new Error(`Chain mismatch: SDK on chain ${sdkChainId}, expected ${chainId}`)
-  }
-
-  return safeSDK
-}
-
 /**
- * Build a SafeTransaction from one or more dApp-supplied calls, ask CGW for a preview,
- * and stash a DraftTx so the existing review-and-confirm flow can render it without a
- * /propose round-trip. The /propose call happens when the user signs.
+ * Build a SafeTransaction from one or more dApp-supplied calls, then run the shared draft
+ * pipeline (CGW /preview → synthesized details → stashed DraftTx) so the existing
+ * review-and-confirm flow can render it without a /propose round-trip. The /propose call
+ * happens when the user signs.
  *
  * For batches (calls.length > 1) the SDK auto-wraps via multiSend (DelegateCall).
  *
@@ -110,50 +93,6 @@ export const composeSafeTxDraft = async ({
   const safeSDK = await getVerifiedSafeSDK(chainId)
   const metaTxs: MetaTransactionData[] = calls.map((c) => toMetaTx(c, chain, safe.version))
   const safeTx = await safeSDK.createTransaction({ transactions: metaTxs })
-  const safeTxHash = await safeSDK.getTransactionHash(safeTx)
 
-  const previewPromise = dispatch(
-    cgwApi.endpoints.transactionsPreviewTransactionV1.initiate({
-      chainId,
-      safeAddress,
-      previewTransactionDto: {
-        to: safeTx.data.to,
-        data: safeTx.data.data || null,
-        value: safeTx.data.value?.toString() ?? '0',
-        operation: (safeTx.data.operation ?? 0) as Operation,
-      },
-    }),
-  )
-
-  let txDetails
-  try {
-    const previewResult = await previewPromise
-
-    if ('error' in previewResult || !previewResult.data) {
-      throw asError('error' in previewResult ? previewResult.error : new Error('Preview unavailable'))
-    }
-
-    txDetails = synthesizeDraftTxDetails({
-      safeAddress,
-      safeTxHash,
-      buildParams: safeTx.data,
-      owners: safe.owners,
-      threshold: safe.threshold,
-      preview: previewResult.data,
-    })
-  } finally {
-    previewPromise.reset()
-  }
-
-  const draft: DraftTx = {
-    chainId,
-    safeAddress,
-    buildParams: safeTx.data,
-    safeTxHash,
-    txDetails,
-  }
-
-  dispatch(setDraft(draft))
-
-  return safeTxHash
+  return previewAndStashDraft({ safeSDK, safeTx, chainId, safeAddress, safe, dispatch })
 }

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/getCallsStatus.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/getCallsStatus.ts
@@ -1,0 +1,83 @@
+import { chainIdToHex } from '@safe-global/utils/features/walletconnect/utils'
+
+// EIP-5792 GetCallsResult envelope (mirrors apps/web/.../safe-wallet-provider/index.ts).
+// status codes: 100 PENDING | 200 CONFIRMED | 400 OFFCHAIN_FAILURE | 500 REVERTED.
+export type GetCallsResult = {
+  version: '2.0.0'
+  id: string
+  chainId: `0x${string}`
+  status: number
+  atomic: true
+  receipts?: {
+    logs: unknown[]
+    status: `0x${string}`
+    blockHash: `0x${string}`
+    blockNumber: `0x${string}`
+    gasUsed: `0x${string}`
+    transactionHash: `0x${string}`
+  }[]
+}
+
+// Raw eth_getTransactionReceipt JSON-RPC result — hex-string fields, as returned by
+// provider.send(). Distinct from ethers' parsed TransactionReceipt class.
+export type RawTxReceipt = {
+  logs: unknown[]
+  blockHash: `0x${string}`
+  blockNumber: `0x${string}`
+  gasUsed: `0x${string}`
+  transactionHash: `0x${string}`
+}
+
+// Minimal shape of the CGW transaction details this builder reads (assignable from the
+// generated TransactionDetails, whose nested fields are nullable).
+export type CallsStatusTx = {
+  txStatus?: string
+  txHash?: string | null
+  txData?: { dataDecoded?: { parameters?: { valueDecoded?: unknown }[] | null } | null } | null
+}
+
+// BundleTxStatuses (verbatim from web):
+//   AWAITING_CONFIRMATIONS / AWAITING_EXECUTION → 100 PENDING
+//   SUCCESS → 200 CONFIRMED | CANCELLED → 400 OFFCHAIN_FAILURE | FAILED → 500 REVERTED
+const mapTxStatus = (txStatus?: string): number =>
+  txStatus === 'SUCCESS' ? 200 : txStatus === 'CANCELLED' ? 400 : txStatus === 'FAILED' ? 500 : 100
+
+/**
+ * Build the EIP-5792 GetCallsResult envelope from a CGW transaction and an optional on-chain
+ * receipt. Pure: the caller fetches `tx` (and `receipt` when there's a tx hash to look up).
+ * When `receipt` is null the envelope is still valid (a pending / off-chain-failed bundle).
+ */
+export const buildGetCallsResult = (
+  id: string,
+  numericChainId: string,
+  tx: CallsStatusTx,
+  receipt: RawTxReceipt | null,
+): GetCallsResult => {
+  const envelope = {
+    version: '2.0.0' as const,
+    id,
+    chainId: chainIdToHex(numericChainId) as `0x${string}`,
+    status: mapTxStatus(tx.txStatus),
+    atomic: true as const,
+  }
+  if (!receipt) {
+    return envelope
+  }
+
+  // Web replicates the same receipt for each underlying call in the bundle.
+  const valueDecoded = tx.txData?.dataDecoded?.parameters?.[0]?.valueDecoded
+  const callsCount = Array.isArray(valueDecoded) && valueDecoded.length > 0 ? valueDecoded.length : 1
+  const onChainStatusHex = (tx.txStatus === 'SUCCESS' ? '0x1' : '0x0') as `0x${string}`
+
+  return {
+    ...envelope,
+    receipts: Array.from({ length: callsCount }, () => ({
+      logs: receipt.logs,
+      status: onChainStatusHex,
+      blockHash: receipt.blockHash,
+      blockNumber: `0x${Number(receipt.blockNumber).toString(16)}` as `0x${string}`,
+      gasUsed: `0x${Number(receipt.gasUsed).toString(16)}` as `0x${string}`,
+      transactionHash: (tx.txHash ?? receipt.transactionHash) as `0x${string}`,
+    })),
+  }
+}

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/getCallsStatus.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/getCallsStatus.ts
@@ -75,8 +75,10 @@ export const buildGetCallsResult = (
       logs: receipt.logs,
       status: onChainStatusHex,
       blockHash: receipt.blockHash,
-      blockNumber: `0x${Number(receipt.blockNumber).toString(16)}` as `0x${string}`,
-      gasUsed: `0x${Number(receipt.gasUsed).toString(16)}` as `0x${string}`,
+      // chainIdToHex is a BigInt-based int→hex quantity converter — safe for block numbers /
+      // gas that can exceed 2^53 and normalizes any zero-padding from the RPC.
+      blockNumber: chainIdToHex(receipt.blockNumber) as `0x${string}`,
+      gasUsed: chainIdToHex(receipt.gasUsed) as `0x${string}`,
       transactionHash: (tx.txHash ?? receipt.transactionHash) as `0x${string}`,
     })),
   }

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -9,26 +9,9 @@ import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { buildAtomicCapabilities } from '@safe-global/utils/features/walletconnect/eip5792'
 import { REJECTED_SIGNING_METHODS, SUPPORTED_NAMESPACE } from './constants'
 import { isReadOnlyMethod, proxyReadOnlyCall } from './readRpcProxy'
+import type { GetCallsResult } from './getCallsStatus'
 
 export type RoutedResponse = ReturnType<typeof formatJsonRpcResult> | ReturnType<typeof formatJsonRpcError>
-
-// EIP-5792 GetCallsResult envelope (mirrors apps/web/.../safe-wallet-provider/index.ts).
-// status codes: 100 PENDING | 200 CONFIRMED | 400 OFFCHAIN_FAILURE | 500 REVERTED.
-export type GetCallsResult = {
-  version: '2.0.0'
-  id: string
-  chainId: `0x${string}`
-  status: number
-  atomic: true
-  receipts?: {
-    logs: unknown[]
-    status: `0x${string}`
-    blockHash: `0x${string}`
-    blockNumber: `0x${string}`
-    gasUsed: `0x${string}`
-    transactionHash: `0x${string}`
-  }[]
-}
 
 export type RouteContext = {
   request: WalletKitTypes.SessionRequest

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -3,7 +3,6 @@ import { getSdkError } from '@walletconnect/utils'
 import type { WalletKitTypes } from '@reown/walletkit'
 import type { AppDispatch, RootState } from '@/src/store'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
-import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import { chainIdToHex } from '@safe-global/utils/features/walletconnect/utils'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { REJECTED_SIGNING_METHODS, SUPPORTED_NAMESPACE } from './constants'
@@ -15,10 +14,11 @@ export type RouteContext = {
   dispatch: AppDispatch
   getState: () => RootState
   // Active context resolved by the caller — null when no Safe is selected or its chain
-  // config hasn't loaded. The router answers account/chain queries regardless and defers
-  // the tx methods only when the active context is complete.
+  // config hasn't loaded. The address comes from the local activeSafe slice (not the CGW
+  // Safe query) so requests arriving during a cold start aren't spuriously rejected while
+  // the fetch is still in flight; the compose path loads the full SafeState itself.
   activeChain: Chain | null
-  activeSafe: SafeState | null
+  activeSafeAddress: string | null
   hasSigner: boolean
 }
 
@@ -57,7 +57,7 @@ const isValidDappCall = (call: { to?: string; value?: string; data?: string } | 
 // wallet_switchEthereumChain) are wired in WA-2322 — they slot in as extra branches here
 // without reworking this router or its RouteContext.
 export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResponse> => {
-  const { request, activeChain, activeSafe, hasSigner } = ctx
+  const { request, activeChain, activeSafeAddress, hasSigner } = ctx
   const { id, params } = request
   const { request: rpc, chainId } = params
   const { method } = rpc
@@ -77,7 +77,7 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
   // Local-answerable methods — a dApp needs these to establish the session before it can
   // send a transaction.
   if (method === 'eth_accounts') {
-    return formatJsonRpcResult(id, activeSafe ? [activeSafe.address.value] : [])
+    return formatJsonRpcResult(id, activeSafeAddress ? [activeSafeAddress] : [])
   }
   if (method === 'eth_chainId') {
     return formatJsonRpcResult(id, activeChain ? chainIdToHex(activeChain.chainId) : '0x0')
@@ -89,7 +89,7 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
   // Transaction methods — the handler pushes the request to the slice so RequestSheetHost
   // renders the sheet. The sheet sends the response when the user reviews+signs or rejects.
   if (method === 'eth_sendTransaction' || method === 'wallet_sendCalls') {
-    if (!activeSafe) {
+    if (!activeSafeAddress) {
       return formatJsonRpcError(id, { code: -32603, message: 'No active Safe' })
     }
     if (!hasSigner) {
@@ -139,7 +139,7 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
         })
       }
       // Case-insensitive: dApps don't reliably checksum `from`, while CGW's address is checksummed.
-      if (!sameAddress(bundle.from, activeSafe.address.value)) {
+      if (!sameAddress(bundle.from, activeSafeAddress)) {
         return formatJsonRpcError(id, { code: -32602, message: 'Invalid from address' })
       }
       // An empty bundle would only throw later inside composeSafeTxDraft — reject it here.

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -56,6 +56,17 @@ const invalidParamsError = (id: number) => formatJsonRpcError(id, { code: -32602
 // The active chain config hasn't resolved (yet) — the dApp can retry.
 const noActiveChainError = (id: number) => formatJsonRpcError(id, { code: -32603, message: 'No active chain' })
 
+// chainIdToHex is BigInt-based and throws on a non-integer id. wallet_getCapabilities converts
+// chain ids we don't fully control (the dApp's envelope chain, the Safe's deployed-chain keys),
+// so convert defensively and drop anything malformed rather than throwing the whole request.
+const toChainHexOrNull = (chainId: string): string | null => {
+  try {
+    return chainIdToHex(chainId)
+  } catch {
+    return null
+  }
+}
+
 // Per-call shape (web's mapping rules), shared by eth_sendTransaction and wallet_sendCalls:
 //   - missing / all-fields-empty → invalid
 //   - no-to + only data → contract deployment (allowed; composeSafeTxDraft routes via CreateCall)
@@ -155,10 +166,12 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
     const normalizedRequested = Array.isArray(requestedChainIds)
       ? requestedChainIds.filter((c): c is string => typeof c === 'string').map((c) => c.toLowerCase())
       : []
-    // chainId is guaranteed to be in the eip155 namespace here (cross-namespace was rejected above).
-    const envelopeChainHex = chainIdToHex(stripEip155Prefix(chainId))
-    const candidateChains = normalizedRequested.length > 0 ? normalizedRequested : [envelopeChainHex]
-    const deployedChainsHex = new Set(ctx.deployedChainIds.map((c) => chainIdToHex(c)))
+    // chainId is in the eip155 namespace here (cross-namespace was rejected above), but the
+    // suffix could still be non-numeric — toChainHexOrNull skips it rather than throwing.
+    const envelopeChainHex = toChainHexOrNull(stripEip155Prefix(chainId))
+    const candidateChains =
+      normalizedRequested.length > 0 ? normalizedRequested : envelopeChainHex ? [envelopeChainHex] : []
+    const deployedChainsHex = new Set(ctx.deployedChainIds.map(toChainHexOrNull).filter((c): c is string => c !== null))
     const chainsToReport = candidateChains.filter((c) => deployedChainsHex.has(c))
     if (chainsToReport.length === 0) {
       return formatJsonRpcResult(id, {})

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -47,13 +47,35 @@ const noActiveChainError = (id: number) => formatJsonRpcError(id, { code: -32603
 //   - no-to + only data → contract deployment (allowed; composeSafeTxDraft routes via CreateCall)
 //   - no-to + (value or no-data) → invalid
 const isValidDappCall = (call: { to?: string; value?: string; data?: string } | undefined): boolean => {
-  if (!call) {
+  if (!call || typeof call !== 'object') {
     return false
   }
   if (call.to) {
     return true
   }
   return !call.value && !!call.data
+}
+
+/**
+ * Structural validation of a tx request's params — everything extractCalls /
+ * composeSafeTxDraft rely on downstream. Used by the live routing path below AND by
+ * WalletKitProvider when seeding requests restored after a restart, which never pass
+ * through routeSessionRequest (so a malformed bundle would otherwise only blow up
+ * inside compose with an unactionable toast).
+ */
+export const isValidTxRequestParams = (
+  method: 'eth_sendTransaction' | 'wallet_sendCalls',
+  params: unknown,
+): boolean => {
+  if (!Array.isArray(params)) {
+    return false
+  }
+  if (method === 'eth_sendTransaction') {
+    const [tx] = params as [{ to?: string; value?: string; data?: string } | undefined]
+    return isValidDappCall(tx)
+  }
+  const [bundle] = params as [{ calls?: { to?: string; value?: string; data?: string }[] } | undefined]
+  return !!bundle?.calls?.length && Array.isArray(bundle.calls) && bundle.calls.every(isValidDappCall)
 }
 
 // Scope (WA-2321): the transaction-request flow only. Read-only RPC passthrough and the
@@ -123,24 +145,12 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
     // Validate the call shape(s) up front (mirrors apps/web/.../safe-wallet-provider/index.ts
     // wallet_sendCalls). Malformed requests fail synchronously with -32602 rather than
     // burning a sheet + compose pass that can only end in an opaque toast.
-    if (method === 'eth_sendTransaction') {
-      const [tx] = rpcParams as [{ to?: string; value?: string; data?: string } | undefined]
-      if (!isValidDappCall(tx)) {
-        return invalidParamsError(id)
-      }
+    if (!isValidTxRequestParams(method, rpcParams)) {
+      return invalidParamsError(id)
     }
+    // wallet_sendCalls additionally binds the bundle to the active context.
     if (method === 'wallet_sendCalls') {
-      const [bundle] = rpcParams as [
-        | {
-            chainId?: `0x${string}`
-            from?: `0x${string}`
-            calls?: { to?: string; value?: string; data?: string }[]
-          }
-        | undefined,
-      ]
-      if (!bundle) {
-        return invalidParamsError(id)
-      }
+      const [bundle] = rpcParams as [{ chainId?: `0x${string}`; from?: `0x${string}` }]
       const expectedChainHex = chainIdToHex(activeChain.chainId)
       if (bundle.chainId !== expectedChainHex) {
         return formatJsonRpcError(id, {
@@ -151,10 +161,6 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
       // Case-insensitive: dApps don't reliably checksum `from`, while CGW's address is checksummed.
       if (!sameAddress(bundle.from, activeSafeAddress)) {
         return formatJsonRpcError(id, { code: -32602, message: 'Invalid from address' })
-      }
-      // An empty bundle would only throw later inside composeSafeTxDraft — reject it here.
-      if (!bundle.calls?.length || !bundle.calls.every(isValidDappCall)) {
-        return invalidParamsError(id)
       }
     }
     return { id, jsonrpc: '2.0', result: DEFERRED_RESULT } as unknown as RoutedResponse

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -4,11 +4,31 @@ import { getAddress } from 'ethers'
 import type { WalletKitTypes } from '@reown/walletkit'
 import type { AppDispatch, RootState } from '@/src/store'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
-import { chainIdToHex } from '@safe-global/utils/features/walletconnect/utils'
+import { chainIdToHex, getEip155ChainId, stripEip155Prefix } from '@safe-global/utils/features/walletconnect/utils'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
+import { buildAtomicCapabilities } from '@safe-global/utils/features/walletconnect/eip5792'
 import { REJECTED_SIGNING_METHODS, SUPPORTED_NAMESPACE } from './constants'
+import { isReadOnlyMethod, proxyReadOnlyCall } from './readRpcProxy'
 
 export type RoutedResponse = ReturnType<typeof formatJsonRpcResult> | ReturnType<typeof formatJsonRpcError>
+
+// EIP-5792 GetCallsResult envelope (mirrors apps/web/.../safe-wallet-provider/index.ts).
+// status codes: 100 PENDING | 200 CONFIRMED | 400 OFFCHAIN_FAILURE | 500 REVERTED.
+export type GetCallsResult = {
+  version: '2.0.0'
+  id: string
+  chainId: `0x${string}`
+  status: number
+  atomic: true
+  receipts?: {
+    logs: unknown[]
+    status: `0x${string}`
+    blockHash: `0x${string}`
+    blockNumber: `0x${string}`
+    gasUsed: `0x${string}`
+    transactionHash: `0x${string}`
+  }[]
+}
 
 export type RouteContext = {
   request: WalletKitTypes.SessionRequest
@@ -21,6 +41,14 @@ export type RouteContext = {
   activeChain: Chain | null
   activeSafeAddress: string | null
   hasSigner: boolean
+  // Switch the active chain to a CAIP-2 target (resolves once the state is committed).
+  // Rejects NOT_DEPLOYED when the Safe isn't deployed on that chain.
+  switchActiveChainByCaip2: (caip2: string) => Promise<{ ok: true } | { ok: false; reason: 'NOT_DEPLOYED' }>
+  // Local Safe-tx status lookup for a wallet_sendCalls id (a safeTxHash). Throws
+  // 'Transaction not found' when the id is unknown — the router wraps it in a JSON-RPC error.
+  getCallsStatus: (chainId: string, id: string) => Promise<GetCallsResult>
+  // Navigate to the queue / tx-detail screen for wallet_showCallsStatus.
+  navigateToCallsStatus: (chainId: string, id: string) => void
 }
 
 const NS = SUPPORTED_NAMESPACE + ':'
@@ -78,10 +106,6 @@ export const isValidTxRequestParams = (
   return !!bundle?.calls?.length && Array.isArray(bundle.calls) && bundle.calls.every(isValidDappCall)
 }
 
-// Scope (WA-2321): the transaction-request flow only. Read-only RPC passthrough and the
-// EIP-5792 capabilities / getCallsStatus / showCallsStatus surface (plus
-// wallet_switchEthereumChain) are wired in WA-2322 — they slot in as extra branches here
-// without reworking this router or its RouteContext.
 export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResponse> => {
   const { request, activeChain, activeSafeAddress, hasSigner } = ctx
   const { id, params } = request
@@ -116,6 +140,73 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
       return noActiveChainError(id)
     }
     return formatJsonRpcResult(id, method === 'eth_chainId' ? chainIdToHex(activeChain.chainId) : activeChain.chainId)
+  }
+
+  // Chain switch — the target chain lives in rpc.params[0].chainId as a hex string (EIP-3326).
+  // `chainId` on the WC envelope is the *current* session chain, so don't read it here.
+  if (method === 'wallet_switchEthereumChain') {
+    const [target] = rpcParams as [{ chainId?: string } | undefined]
+    if (!target?.chainId) {
+      return formatJsonRpcError(id, { code: -32602, message: 'Missing target chainId' })
+    }
+    const targetDecimal = String(parseInt(target.chainId, 16))
+    const result = await ctx.switchActiveChainByCaip2(getEip155ChainId(targetDecimal))
+    if (!result.ok) {
+      return formatJsonRpcError(id, { code: 4901, message: 'Safe is not deployed on this chain' })
+    }
+    return formatJsonRpcResult(id, null)
+  }
+
+  // Capabilities (EIP-5792) — response is keyed by hex chain id, not CAIP-2.
+  // Request shape: wallet_getCapabilities(address, chainIds?). dApps compare the response
+  // keys against the chain THEY operate on, so key off the requested chains (falling back to
+  // the envelope's session chain), not the wallet's active chain.
+  if (method === 'wallet_getCapabilities') {
+    const [, requestedChainIds] = rpcParams as [string, string[] | undefined]
+    const envelopeChainHex = chainId.startsWith(NS) ? chainIdToHex(stripEip155Prefix(chainId)) : null
+    const chainsToReport: string[] =
+      requestedChainIds && requestedChainIds.length > 0
+        ? requestedChainIds.map((c) => c.toLowerCase())
+        : envelopeChainHex
+          ? [envelopeChainHex]
+          : []
+    if (chainsToReport.length === 0) {
+      return formatJsonRpcResult(id, {})
+    }
+    return formatJsonRpcResult(id, buildAtomicCapabilities(chainsToReport))
+  }
+
+  // Calls status — local Safe-tx lookup for a wallet_sendCalls id (a safeTxHash).
+  if (method === 'wallet_getCallsStatus') {
+    const [callsId] = rpcParams as [string]
+    try {
+      const result = await ctx.getCallsStatus(chainId, callsId)
+      return formatJsonRpcResult(id, result)
+    } catch (e) {
+      // Web maps an unknown id to a JSON-RPC error (not {status:100}) — viem/wagmi treat
+      // "missing" and "pending" as distinct outcomes.
+      return formatJsonRpcError(id, { code: -32603, message: e instanceof Error ? e.message : 'Transaction not found' })
+    }
+  }
+  if (method === 'wallet_showCallsStatus') {
+    const [callsId] = rpcParams as [string]
+    ctx.navigateToCallsStatus(chainId, callsId)
+    return formatJsonRpcResult(id, null)
+  }
+
+  // Read-only RPC passthrough — proxied to the active chain's JSON-RPC. A multichain session
+  // requesting a non-active (but approved) chain still hits the active chain (WA-2322 decision,
+  // matching the POC).
+  if (isReadOnlyMethod(method)) {
+    if (!activeChain) {
+      return noActiveChainError(id)
+    }
+    try {
+      const result = await proxyReadOnlyCall(activeChain, method, rpcParams)
+      return formatJsonRpcResult(id, result)
+    } catch (e) {
+      return formatJsonRpcError(id, { code: -32603, message: e instanceof Error ? e.message : 'RPC proxy failed' })
+    }
   }
 
   // Transaction methods — the handler pushes the request to the slice so RequestSheetHost

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -38,6 +38,9 @@ const unsupportedError = (id: number) => formatJsonRpcError(id, getSdkError('UNS
 
 const invalidParamsError = (id: number) => formatJsonRpcError(id, { code: -32602, message: 'Invalid call parameters.' })
 
+// The active chain config hasn't resolved (yet) — the dApp can retry.
+const noActiveChainError = (id: number) => formatJsonRpcError(id, { code: -32603, message: 'No active chain' })
+
 // Per-call shape (web's mapping rules), shared by eth_sendTransaction and wallet_sendCalls:
 //   - missing / all-fields-empty → invalid
 //   - no-to + only data → contract deployment (allowed; composeSafeTxDraft routes via CreateCall)
@@ -79,19 +82,13 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
   if (method === 'eth_accounts') {
     return formatJsonRpcResult(id, activeSafeAddress ? [activeSafeAddress] : [])
   }
-  // A fabricated '0x0' would be an invalid EIP-695 response — error instead when the
-  // chain config hasn't resolved yet, so the dApp can retry.
-  if (method === 'eth_chainId') {
+  // A fabricated '0x0' / '0' would be an invalid EIP-695 / net_version response — error
+  // instead when the chain config hasn't resolved yet.
+  if (method === 'eth_chainId' || method === 'net_version') {
     if (!activeChain) {
-      return formatJsonRpcError(id, { code: -32603, message: 'No active chain' })
+      return noActiveChainError(id)
     }
-    return formatJsonRpcResult(id, chainIdToHex(activeChain.chainId))
-  }
-  if (method === 'net_version') {
-    if (!activeChain) {
-      return formatJsonRpcError(id, { code: -32603, message: 'No active chain' })
-    }
-    return formatJsonRpcResult(id, activeChain.chainId)
+    return formatJsonRpcResult(id, method === 'eth_chainId' ? chainIdToHex(activeChain.chainId) : activeChain.chainId)
   }
 
   // Transaction methods — the handler pushes the request to the slice so RequestSheetHost
@@ -108,7 +105,7 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
     // synchronously so the dApp sees a structured error instead of an opaque compose
     // failure later.
     if (!activeChain) {
-      return formatJsonRpcError(id, { code: -32603, message: 'No active chain' })
+      return noActiveChainError(id)
     }
     // The dApp's session can be bound to a chain the active Safe is no longer on (the user
     // switched networks after connecting). We can only sign on the active chain, so reject

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -151,8 +151,15 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
     // wallet_sendCalls additionally binds the bundle to the active context.
     if (method === 'wallet_sendCalls') {
       const [bundle] = rpcParams as [{ chainId?: `0x${string}`; from?: `0x${string}` }]
-      const expectedChainHex = chainIdToHex(activeChain.chainId)
-      if (bundle.chainId !== expectedChainHex) {
+      // Numeric comparison, not string equality: EIP-5792 specifies a Quantity but dApps
+      // do send padded hex like '0x01'. BigInt throws on malformed hex → mismatch.
+      let chainMatches = false
+      try {
+        chainMatches = bundle.chainId !== undefined && BigInt(bundle.chainId) === BigInt(activeChain.chainId)
+      } catch {
+        // malformed bundle.chainId
+      }
+      if (!chainMatches) {
         return formatJsonRpcError(id, {
           code: -32602,
           message: `Safe is not on chain ${activeChain.chainId}`,

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -1,5 +1,6 @@
 import { formatJsonRpcError, formatJsonRpcResult } from '@walletconnect/jsonrpc-utils'
 import { getSdkError } from '@walletconnect/utils'
+import { getAddress } from 'ethers'
 import type { WalletKitTypes } from '@reown/walletkit'
 import type { AppDispatch, RootState } from '@/src/store'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
@@ -80,7 +81,11 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
   // Local-answerable methods — a dApp needs these to establish the session before it can
   // send a transaction.
   if (method === 'eth_accounts') {
-    return formatJsonRpcResult(id, activeSafeAddress ? [activeSafeAddress] : [])
+    // EIP-55 checksummed to match the session-namespace accounts (buildSafeApprovedNamespaces
+    // checksums them the same way) — dApps compare the two strings verbatim. Lowercase first:
+    // getAddress treats mixed-case input as a checksum assertion and throws on a mismatch,
+    // while lowercase input is always re-checksummed.
+    return formatJsonRpcResult(id, activeSafeAddress ? [getAddress(activeSafeAddress.toLowerCase())] : [])
   }
   // A fabricated '0x0' / '0' would be an invalid EIP-695 / net_version response — error
   // instead when the chain config hasn't resolved yet.

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -1,0 +1,140 @@
+import { formatJsonRpcError, formatJsonRpcResult } from '@walletconnect/jsonrpc-utils'
+import { getSdkError } from '@walletconnect/utils'
+import type { WalletKitTypes } from '@reown/walletkit'
+import type { AppDispatch, RootState } from '@/src/store'
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { chainIdToHex } from '@safe-global/utils/features/walletconnect/utils'
+import { REJECTED_SIGNING_METHODS, SUPPORTED_NAMESPACE } from './constants'
+
+export type RoutedResponse = ReturnType<typeof formatJsonRpcResult> | ReturnType<typeof formatJsonRpcError>
+
+export type RouteContext = {
+  request: WalletKitTypes.SessionRequest
+  dispatch: AppDispatch
+  getState: () => RootState
+  // Active context resolved by the caller — null when no Safe is selected or its chain
+  // config hasn't loaded. The router answers account/chain queries regardless and defers
+  // the tx methods only when the active context is complete.
+  activeChain: Chain | null
+  activeSafe: SafeState | null
+  hasSigner: boolean
+}
+
+const NS = SUPPORTED_NAMESPACE + ':'
+
+// EIP-1193 4100 "Unauthorized" — returned when the active Safe has no signer attached.
+// useSessionRequestHandler keys its "No signer attached" toast off this code.
+export const NO_SIGNER_ERROR_CODE = 4100
+
+// Sentinel result the caller checks for via isDeferredResponse: the request needs UI, so
+// the caller pushes it to the slice and does NOT call respondSessionRequest yet.
+const DEFERRED_RESULT = '__DEFERRED__'
+
+const crossNamespaceError = (id: number) => formatJsonRpcError(id, getSdkError('UNAUTHORIZED_METHOD').message)
+
+const unsupportedError = (id: number) => formatJsonRpcError(id, getSdkError('UNSUPPORTED_METHODS').message)
+
+// Scope (WA-2321): the transaction-request flow only. Read-only RPC passthrough and the
+// EIP-5792 capabilities / getCallsStatus / showCallsStatus surface (plus
+// wallet_switchEthereumChain) are wired in WA-2322 — they slot in as extra branches here
+// without reworking this router or its RouteContext.
+export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResponse> => {
+  const { request, activeChain, activeSafe, hasSigner } = ctx
+  const { id, params } = request
+  const { request: rpc, chainId } = params
+  const { method } = rpc
+  const rpcParams = (rpc.params as unknown[]) ?? []
+
+  if (!chainId.startsWith(NS)) {
+    return crossNamespaceError(id)
+  }
+
+  // Methods we explicitly reject without UI (message signing isn't supported on mobile yet).
+  // dApps like CowSwap fire these in parallel with their tx request; the handler surfaces a
+  // toast so the rejection is explained rather than showing an opaque dApp-side error.
+  if ((REJECTED_SIGNING_METHODS as readonly string[]).includes(method)) {
+    return unsupportedError(id)
+  }
+
+  // Local-answerable methods — a dApp needs these to establish the session before it can
+  // send a transaction.
+  if (method === 'eth_accounts') {
+    return formatJsonRpcResult(id, activeSafe ? [activeSafe.address.value] : [])
+  }
+  if (method === 'eth_chainId') {
+    return formatJsonRpcResult(id, activeChain ? chainIdToHex(activeChain.chainId) : '0x0')
+  }
+  if (method === 'net_version') {
+    return formatJsonRpcResult(id, activeChain?.chainId ?? '0')
+  }
+
+  // Transaction methods — the handler pushes the request to the slice so RequestSheetHost
+  // renders the sheet. The sheet sends the response when the user reviews+signs or rejects.
+  if (method === 'eth_sendTransaction' || method === 'wallet_sendCalls') {
+    if (!activeSafe) {
+      return formatJsonRpcError(id, { code: -32603, message: 'No active Safe' })
+    }
+    if (!hasSigner) {
+      return formatJsonRpcError(id, { code: NO_SIGNER_ERROR_CODE, message: 'No signer attached to this Safe' })
+    }
+    // Both tx methods need the active chain config (downstream compose uses it to look up
+    // CreateCall deployments and to verify the SDK is bound to the same chain). Fail
+    // synchronously so the dApp sees a structured error instead of an opaque compose
+    // failure later.
+    if (!activeChain) {
+      return formatJsonRpcError(id, { code: -32603, message: 'No active chain' })
+    }
+    // The dApp's session can be bound to a chain the active Safe is no longer on (the user
+    // switched networks after connecting). We can only sign on the active chain, so reject
+    // here rather than composing on the wrong chain; useSessionRequestHandler surfaces a
+    // toast telling the user which network to switch back to. `chainId` is the dApp's
+    // session chain.
+    if (chainId !== `${NS}${activeChain.chainId}`) {
+      return formatJsonRpcError(id, getSdkError('UNSUPPORTED_CHAINS'))
+    }
+    // wallet_sendCalls — validate the bundle envelope up front (mirrors apps/web/.../
+    // safe-wallet-provider/index.ts wallet_sendCalls). chainId / from mismatches and
+    // malformed calls fail synchronously rather than burning a sheet + compose pass.
+    if (method === 'wallet_sendCalls') {
+      const [bundle] = rpcParams as [
+        | {
+            chainId?: `0x${string}`
+            from?: `0x${string}`
+            calls?: { to?: string; value?: string; data?: string }[]
+          }
+        | undefined,
+      ]
+      if (!bundle) {
+        return formatJsonRpcError(id, { code: -32602, message: 'Invalid call parameters.' })
+      }
+      const expectedChainHex = chainIdToHex(activeChain.chainId)
+      if (bundle.chainId !== expectedChainHex) {
+        return formatJsonRpcError(id, {
+          code: -32602,
+          message: `Safe is not on chain ${activeChain.chainId}`,
+        })
+      }
+      if (bundle.from !== activeSafe.address.value) {
+        return formatJsonRpcError(id, { code: -32602, message: 'Invalid from address' })
+      }
+      // Per-call shape (web's mapping rules):
+      //   - all-fields-empty → invalid
+      //   - no-to + only data → contract deployment (allowed; composeSafeTxDraft routes via CreateCall)
+      //   - no-to + (value or no-data) → invalid
+      for (const call of bundle.calls ?? []) {
+        if (!call.to) {
+          const isDeployment = !call.value && !!call.data
+          if (!isDeployment) {
+            return formatJsonRpcError(id, { code: -32602, message: 'Invalid call parameters.' })
+          }
+        }
+      }
+    }
+    return { id, jsonrpc: '2.0', result: DEFERRED_RESULT } as unknown as RoutedResponse
+  }
+
+  return unsupportedError(id)
+}
+
+export const isDeferredResponse = (r: RoutedResponse): boolean => 'result' in r && r.result === DEFERRED_RESULT

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -155,9 +155,9 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
     const normalizedRequested = Array.isArray(requestedChainIds)
       ? requestedChainIds.filter((c): c is string => typeof c === 'string').map((c) => c.toLowerCase())
       : []
-    const envelopeChainHex = chainId.startsWith(NS) ? chainIdToHex(stripEip155Prefix(chainId)) : null
-    const candidateChains =
-      normalizedRequested.length > 0 ? normalizedRequested : envelopeChainHex ? [envelopeChainHex] : []
+    // chainId is guaranteed to be in the eip155 namespace here (cross-namespace was rejected above).
+    const envelopeChainHex = chainIdToHex(stripEip155Prefix(chainId))
+    const candidateChains = normalizedRequested.length > 0 ? normalizedRequested : [envelopeChainHex]
     const deployedChainsHex = new Set(ctx.deployedChainIds.map((c) => chainIdToHex(c)))
     const chainsToReport = candidateChains.filter((c) => deployedChainsHex.has(c))
     if (chainsToReport.length === 0) {
@@ -174,7 +174,9 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
       return formatJsonRpcResult(id, result)
     } catch (e) {
       // Web maps an unknown id to a JSON-RPC error (not {status:100}) — viem/wagmi treat
-      // "missing" and "pending" as distinct outcomes.
+      // "missing" and "pending" as distinct outcomes. jsonrpc-utils overrides the message for
+      // the reserved -32603 code (the dApp sees "Internal error"), so the message we pass is
+      // only a developer-facing hint, not what reaches the wire.
       return formatJsonRpcError(id, { code: -32603, message: e instanceof Error ? e.message : 'Transaction not found' })
     }
   }

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -162,14 +162,15 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
   // keys against the chain THEY operate on, so key off the requested chains (falling back to
   // the envelope's session chain), not the wallet's active chain.
   if (method === 'wallet_getCapabilities') {
-    const [, requestedChainIds] = rpcParams as [string, string[] | undefined]
+    const [, requestedChainIds] = rpcParams as [string, unknown]
+    // Filter to strings before lowercasing — a dApp can send malformed chainIds (e.g. numbers),
+    // and an uncaught throw here would reject the whole request so the dApp never gets a reply.
+    const normalizedRequested = Array.isArray(requestedChainIds)
+      ? requestedChainIds.filter((c): c is string => typeof c === 'string').map((c) => c.toLowerCase())
+      : []
     const envelopeChainHex = chainId.startsWith(NS) ? chainIdToHex(stripEip155Prefix(chainId)) : null
     const chainsToReport: string[] =
-      requestedChainIds && requestedChainIds.length > 0
-        ? requestedChainIds.map((c) => c.toLowerCase())
-        : envelopeChainHex
-          ? [envelopeChainHex]
-          : []
+      normalizedRequested.length > 0 ? normalizedRequested : envelopeChainHex ? [envelopeChainHex] : []
     if (chainsToReport.length === 0) {
       return formatJsonRpcResult(id, {})
     }

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -5,6 +5,7 @@ import type { AppDispatch, RootState } from '@/src/store'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import { chainIdToHex } from '@safe-global/utils/features/walletconnect/utils'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { REJECTED_SIGNING_METHODS, SUPPORTED_NAMESPACE } from './constants'
 
 export type RoutedResponse = ReturnType<typeof formatJsonRpcResult> | ReturnType<typeof formatJsonRpcError>
@@ -115,7 +116,8 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
           message: `Safe is not on chain ${activeChain.chainId}`,
         })
       }
-      if (bundle.from !== activeSafe.address.value) {
+      // Case-insensitive: dApps don't reliably checksum `from`, while CGW's address is checksummed.
+      if (!sameAddress(bundle.from, activeSafe.address.value)) {
         return formatJsonRpcError(id, { code: -32602, message: 'Invalid from address' })
       }
       // Per-call shape (web's mapping rules):

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -79,11 +79,19 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
   if (method === 'eth_accounts') {
     return formatJsonRpcResult(id, activeSafeAddress ? [activeSafeAddress] : [])
   }
+  // A fabricated '0x0' would be an invalid EIP-695 response — error instead when the
+  // chain config hasn't resolved yet, so the dApp can retry.
   if (method === 'eth_chainId') {
-    return formatJsonRpcResult(id, activeChain ? chainIdToHex(activeChain.chainId) : '0x0')
+    if (!activeChain) {
+      return formatJsonRpcError(id, { code: -32603, message: 'No active chain' })
+    }
+    return formatJsonRpcResult(id, chainIdToHex(activeChain.chainId))
   }
   if (method === 'net_version') {
-    return formatJsonRpcResult(id, activeChain?.chainId ?? '0')
+    if (!activeChain) {
+      return formatJsonRpcError(id, { code: -32603, message: 'No active chain' })
+    }
+    return formatJsonRpcResult(id, activeChain.chainId)
   }
 
   // Transaction methods — the handler pushes the request to the slice so RequestSheetHost

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -36,6 +36,22 @@ const crossNamespaceError = (id: number) => formatJsonRpcError(id, getSdkError('
 
 const unsupportedError = (id: number) => formatJsonRpcError(id, getSdkError('UNSUPPORTED_METHODS').message)
 
+const invalidParamsError = (id: number) => formatJsonRpcError(id, { code: -32602, message: 'Invalid call parameters.' })
+
+// Per-call shape (web's mapping rules), shared by eth_sendTransaction and wallet_sendCalls:
+//   - missing / all-fields-empty → invalid
+//   - no-to + only data → contract deployment (allowed; composeSafeTxDraft routes via CreateCall)
+//   - no-to + (value or no-data) → invalid
+const isValidDappCall = (call: { to?: string; value?: string; data?: string } | undefined): boolean => {
+  if (!call) {
+    return false
+  }
+  if (call.to) {
+    return true
+  }
+  return !call.value && !!call.data
+}
+
 // Scope (WA-2321): the transaction-request flow only. Read-only RPC passthrough and the
 // EIP-5792 capabilities / getCallsStatus / showCallsStatus surface (plus
 // wallet_switchEthereumChain) are wired in WA-2322 — they slot in as extra branches here
@@ -94,9 +110,15 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
     if (chainId !== `${NS}${activeChain.chainId}`) {
       return formatJsonRpcError(id, getSdkError('UNSUPPORTED_CHAINS'))
     }
-    // wallet_sendCalls — validate the bundle envelope up front (mirrors apps/web/.../
-    // safe-wallet-provider/index.ts wallet_sendCalls). chainId / from mismatches and
-    // malformed calls fail synchronously rather than burning a sheet + compose pass.
+    // Validate the call shape(s) up front (mirrors apps/web/.../safe-wallet-provider/index.ts
+    // wallet_sendCalls). Malformed requests fail synchronously with -32602 rather than
+    // burning a sheet + compose pass that can only end in an opaque toast.
+    if (method === 'eth_sendTransaction') {
+      const [tx] = rpcParams as [{ to?: string; value?: string; data?: string } | undefined]
+      if (!isValidDappCall(tx)) {
+        return invalidParamsError(id)
+      }
+    }
     if (method === 'wallet_sendCalls') {
       const [bundle] = rpcParams as [
         | {
@@ -107,7 +129,7 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
         | undefined,
       ]
       if (!bundle) {
-        return formatJsonRpcError(id, { code: -32602, message: 'Invalid call parameters.' })
+        return invalidParamsError(id)
       }
       const expectedChainHex = chainIdToHex(activeChain.chainId)
       if (bundle.chainId !== expectedChainHex) {
@@ -120,17 +142,9 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
       if (!sameAddress(bundle.from, activeSafe.address.value)) {
         return formatJsonRpcError(id, { code: -32602, message: 'Invalid from address' })
       }
-      // Per-call shape (web's mapping rules):
-      //   - all-fields-empty → invalid
-      //   - no-to + only data → contract deployment (allowed; composeSafeTxDraft routes via CreateCall)
-      //   - no-to + (value or no-data) → invalid
-      for (const call of bundle.calls ?? []) {
-        if (!call.to) {
-          const isDeployment = !call.value && !!call.data
-          if (!isDeployment) {
-            return formatJsonRpcError(id, { code: -32602, message: 'Invalid call parameters.' })
-          }
-        }
+      // An empty bundle would only throw later inside composeSafeTxDraft — reject it here.
+      if (!bundle.calls?.length || !bundle.calls.every(isValidDappCall)) {
+        return invalidParamsError(id)
       }
     }
     return { id, jsonrpc: '2.0', result: DEFERRED_RESULT } as unknown as RoutedResponse

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -24,6 +24,9 @@ export type RouteContext = {
   activeChain: Chain | null
   activeSafeAddress: string | null
   hasSigner: boolean
+  // Decimal chain ids the active Safe is deployed on. Used to scope wallet_getCapabilities to
+  // chains we can actually batch on (mirrors web, which only reports the Safe's own chain).
+  deployedChainIds: string[]
   // Switch the active chain to a CAIP-2 target (resolves once the state is committed).
   // Rejects NOT_DEPLOYED when the Safe isn't deployed on that chain.
   switchActiveChainByCaip2: (caip2: string) => Promise<{ ok: true } | { ok: false; reason: 'NOT_DEPLOYED' }>
@@ -141,9 +144,10 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
   }
 
   // Capabilities (EIP-5792) — response is keyed by hex chain id, not CAIP-2.
-  // Request shape: wallet_getCapabilities(address, chainIds?). dApps compare the response
-  // keys against the chain THEY operate on, so key off the requested chains (falling back to
-  // the envelope's session chain), not the wallet's active chain.
+  // Request shape: wallet_getCapabilities(address, chainIds?). dApps compare the response keys
+  // against the chain THEY operate on, so key off the requested chains (falling back to the
+  // envelope's session chain). Only advertise atomic batching for chains the Safe is actually
+  // deployed on, so we never claim support for a chain a later wallet_sendCalls would reject.
   if (method === 'wallet_getCapabilities') {
     const [, requestedChainIds] = rpcParams as [string, unknown]
     // Filter to strings before lowercasing — a dApp can send malformed chainIds (e.g. numbers),
@@ -152,8 +156,10 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
       ? requestedChainIds.filter((c): c is string => typeof c === 'string').map((c) => c.toLowerCase())
       : []
     const envelopeChainHex = chainId.startsWith(NS) ? chainIdToHex(stripEip155Prefix(chainId)) : null
-    const chainsToReport: string[] =
+    const candidateChains =
       normalizedRequested.length > 0 ? normalizedRequested : envelopeChainHex ? [envelopeChainHex] : []
+    const deployedChainsHex = new Set(ctx.deployedChainIds.map((c) => chainIdToHex(c)))
+    const chainsToReport = candidateChains.filter((c) => deployedChainsHex.has(c))
     if (chainsToReport.length === 0) {
       return formatJsonRpcResult(id, {})
     }

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/readRpcProxy.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/readRpcProxy.ts
@@ -1,12 +1,18 @@
 import type { JsonRpcProvider } from 'ethers'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
-import { createWeb3ReadOnly } from '@/src/services/web3'
+import { createWeb3ReadOnly, getRpcServiceUrl } from '@/src/services/web3'
 import { READ_ONLY_RPC_ALLOW_LIST } from './constants'
 
 const providerCache = new Map<string, JsonRpcProvider>()
 
 const getProviderForChain = (chain: Chain): JsonRpcProvider => {
-  const cached = providerCache.get(chain.chainId)
+  const url = getRpcServiceUrl(chain.rpcUri)
+  if (!url) {
+    throw new Error(`No RPC URL configured for chainId=${chain.chainId}`)
+  }
+  // Key by url as well as chainId so a changed RPC endpoint isn't served by a stale provider.
+  const cacheKey = `${chain.chainId}|${url}`
+  const cached = providerCache.get(cacheKey)
   if (cached) {
     return cached
   }
@@ -14,7 +20,7 @@ const getProviderForChain = (chain: Chain): JsonRpcProvider => {
   if (!provider) {
     throw new Error(`No RPC URL configured for chainId=${chain.chainId}`)
   }
-  providerCache.set(chain.chainId, provider)
+  providerCache.set(cacheKey, provider)
   return provider
 }
 

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/readRpcProxy.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/readRpcProxy.ts
@@ -1,0 +1,30 @@
+import type { JsonRpcProvider } from 'ethers'
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import { createWeb3ReadOnly } from '@/src/services/web3'
+import { READ_ONLY_RPC_ALLOW_LIST } from './constants'
+
+const providerCache = new Map<string, JsonRpcProvider>()
+
+const getProviderForChain = (chain: Chain): JsonRpcProvider => {
+  const cached = providerCache.get(chain.chainId)
+  if (cached) {
+    return cached
+  }
+  const provider = createWeb3ReadOnly(chain)
+  if (!provider) {
+    throw new Error(`No RPC URL configured for chainId=${chain.chainId}`)
+  }
+  providerCache.set(chain.chainId, provider)
+  return provider
+}
+
+export const isReadOnlyMethod = (method: string): boolean =>
+  (READ_ONLY_RPC_ALLOW_LIST as readonly string[]).includes(method)
+
+export const proxyReadOnlyCall = async (chain: Chain, method: string, params: unknown[]): Promise<unknown> => {
+  if (!isReadOnlyMethod(method)) {
+    throw new Error(`Method ${method} is not in the read-only allow-list`)
+  }
+  const provider = getProviderForChain(chain)
+  return provider.send(method, params ?? [])
+}

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/__tests__/walletKitSlice.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/__tests__/walletKitSlice.test.ts
@@ -60,9 +60,22 @@ describe('walletKitSlice reducers', () => {
   it('setOutstandingRequest / clearOutstandingRequest key by safeTxHash', () => {
     let state = reducer(
       undefined,
-      setOutstandingRequest({ safeTxHash: '0xhash', topic: 't', id: 7, method: 'wallet_sendCalls' }),
+      setOutstandingRequest({
+        safeTxHash: '0xhash',
+        topic: 't',
+        id: 7,
+        method: 'wallet_sendCalls',
+        chainId: '1',
+        safeAddress: '0xsafe',
+      }),
     )
-    expect(state.outstandingRequests['0xhash']).toEqual({ topic: 't', id: 7, method: 'wallet_sendCalls' })
+    expect(state.outstandingRequests['0xhash']).toEqual({
+      topic: 't',
+      id: 7,
+      method: 'wallet_sendCalls',
+      chainId: '1',
+      safeAddress: '0xsafe',
+    })
     state = reducer(state, clearOutstandingRequest('0xhash'))
     expect(state.outstandingRequests).toEqual({})
   })
@@ -91,12 +104,21 @@ describe('walletKitSlice selectors', () => {
   it('selectOutstandingRequestByHash looks up by hash', () => {
     const state = reducer(
       undefined,
-      setOutstandingRequest({ safeTxHash: '0xabc', topic: 't', id: 1, method: 'eth_sendTransaction' }),
+      setOutstandingRequest({
+        safeTxHash: '0xabc',
+        topic: 't',
+        id: 1,
+        method: 'eth_sendTransaction',
+        chainId: '1',
+        safeAddress: '0xsafe',
+      }),
     )
     expect(selectOutstandingRequestByHash(wrap(state), '0xabc')).toEqual({
       topic: 't',
       id: 1,
       method: 'eth_sendTransaction',
+      chainId: '1',
+      safeAddress: '0xsafe',
     })
   })
 
@@ -105,7 +127,14 @@ describe('walletKitSlice selectors', () => {
     let state = reducer(undefined, addSession({ topic: 't', peer: { metadata } } as unknown as SessionTypes.Struct))
     state = reducer(
       state,
-      setOutstandingRequest({ safeTxHash: '0xabc', topic: 't', id: 1, method: 'eth_sendTransaction' }),
+      setOutstandingRequest({
+        safeTxHash: '0xabc',
+        topic: 't',
+        id: 1,
+        method: 'eth_sendTransaction',
+        chainId: '1',
+        safeAddress: '0xsafe',
+      }),
     )
     expect(selectDappMetadataByTxHash(wrap(state), '0xabc')).toEqual(metadata)
   })

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/__tests__/walletKitSlice.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/__tests__/walletKitSlice.test.ts
@@ -6,6 +6,7 @@ import reducer, {
   pushPending,
   removePending,
   setOutstandingRequest,
+  setOutstandingProposing,
   clearOutstandingRequest,
   clearWalletKitState,
   selectSessions,
@@ -55,6 +56,26 @@ describe('walletKitSlice reducers', () => {
     let state = reducer(undefined, setPending([requestItem(1), proposalItem(1)]))
     state = reducer(state, removePending({ id: 1, kind: 'request' }))
     expect(state.pending).toEqual([proposalItem(1)])
+  })
+
+  it('setOutstandingProposing toggles the flag and is a no-op for unknown hashes', () => {
+    let state = reducer(
+      undefined,
+      setOutstandingRequest({
+        safeTxHash: '0xhash',
+        topic: 't',
+        id: 7,
+        method: 'wallet_sendCalls',
+        chainId: '1',
+        safeAddress: '0xsafe',
+      }),
+    )
+    state = reducer(state, setOutstandingProposing({ safeTxHash: '0xhash', proposing: true }))
+    expect(state.outstandingRequests['0xhash'].proposing).toBe(true)
+    state = reducer(state, setOutstandingProposing({ safeTxHash: '0xhash', proposing: false }))
+    expect(state.outstandingRequests['0xhash'].proposing).toBe(false)
+    state = reducer(state, setOutstandingProposing({ safeTxHash: '0xnope', proposing: true }))
+    expect(state.outstandingRequests['0xnope']).toBeUndefined()
   })
 
   it('setOutstandingRequest / clearOutstandingRequest key by safeTxHash', () => {

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/__tests__/walletKitSlice.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/__tests__/walletKitSlice.test.ts
@@ -12,6 +12,7 @@ import reducer, {
   selectSessionCount,
   selectCurrentRequest,
   selectOutstandingRequestByHash,
+  selectDappMetadataByTxHash,
   walletKitSliceName,
   type PendingItem,
 } from '../walletKitSlice'
@@ -97,5 +98,20 @@ describe('walletKitSlice selectors', () => {
       id: 1,
       method: 'eth_sendTransaction',
     })
+  })
+
+  it('selectDappMetadataByTxHash resolves safeTxHash → session peer metadata', () => {
+    const metadata = { name: 'Uniswap', url: 'https://uniswap.org', icons: ['https://x/i.png'] }
+    let state = reducer(undefined, addSession({ topic: 't', peer: { metadata } } as unknown as SessionTypes.Struct))
+    state = reducer(
+      state,
+      setOutstandingRequest({ safeTxHash: '0xabc', topic: 't', id: 1, method: 'eth_sendTransaction' }),
+    )
+    expect(selectDappMetadataByTxHash(wrap(state), '0xabc')).toEqual(metadata)
+  })
+
+  it('selectDappMetadataByTxHash returns undefined for an unknown hash (non-WC tx)', () => {
+    const state = reducer(undefined, { type: '@@init' })
+    expect(selectDappMetadataByTxHash(wrap(state), '0xnope')).toBeUndefined()
   })
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitSlice.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitSlice.ts
@@ -24,6 +24,8 @@ export type PendingSessionRequest = {
   chainId: string // CAIP-2, e.g. 'eip155:1'
   method: DeferredTxMethod
   params: unknown
+  // WC's per-request domain verification, used by the sheet to render the verify badge.
+  verifyContext?: WalletKitTypes.SessionRequest['verifyContext']
 }
 
 export type PendingItem = PendingSessionProposal | PendingSessionRequest

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitSlice.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitSlice.ts
@@ -32,11 +32,15 @@ export type PendingItem = PendingSessionProposal | PendingSessionRequest
 
 // Tx requests handed off to the review-and-confirm flow, keyed by safeTxHash. We respond
 // to the dApp only after the propose mutation fulfils (user actually signed), not when the
-// sheet's Sign button is tapped.
+// sheet's Sign button is tapped. chainId/safeAddress record the Safe context the draft was
+// composed against, so the safe-switch listener can reject entries that became stale
+// (mirrors draftTxSlice's isSameSafe cleanup).
 export type OutstandingTxRequest = {
   topic: string
   id: number
   method: DeferredTxMethod
+  chainId: string
+  safeAddress: string
 }
 
 type State = {

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitSlice.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitSlice.ts
@@ -24,6 +24,10 @@ export type PendingSessionRequest = {
   chainId: string // CAIP-2, e.g. 'eip155:1'
   method: DeferredTxMethod
   params: unknown
+  // The Safe the request was routed against. The safe-switch listener rejects entries whose
+  // context no longer matches, so Review can't compose a dApp's calls against a different
+  // Safe. Optional only because it may be unknown for requests restored after a restart.
+  safeAddress?: string
   // WC's per-request domain verification, used by the sheet to render the verify badge.
   verifyContext?: WalletKitTypes.SessionRequest['verifyContext']
 }

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitSlice.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitSlice.ts
@@ -114,5 +114,13 @@ export const selectOutstandingRequests = (state: RootState) => state[sliceName].
 export const selectOutstandingRequestByHash = (state: RootState, safeTxHash: string) =>
   state[sliceName].outstandingRequests[safeTxHash]
 
+// Resolve the originating dApp's metadata for a handed-off tx: safeTxHash → outstanding
+// request (topic) → active session → peer metadata. Returns undefined for non-WC txs and
+// after the request is cleared on propose-success.
+export const selectDappMetadataByTxHash = (state: RootState, safeTxHash: string) => {
+  const topic = state[sliceName].outstandingRequests[safeTxHash]?.topic
+  return topic ? state[sliceName].sessions[topic]?.peer.metadata : undefined
+}
+
 export default walletKitSlice.reducer
 export const walletKitSliceName = sliceName

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitSlice.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitSlice.ts
@@ -45,6 +45,10 @@ export type OutstandingTxRequest = {
   method: DeferredTxMethod
   chainId: string
   safeAddress: string
+  // True while the /propose mutation is in flight (set from its pending/rejected actions).
+  // WcRejectOnBack must not reject during this window — the draft still exists, but a
+  // reject would race the propose-fulfilled success response.
+  proposing?: boolean
 }
 
 type State = {
@@ -91,6 +95,12 @@ const walletKitSlice = createSlice({
       const { safeTxHash, ...req } = action.payload
       state.outstandingRequests[safeTxHash] = req
     },
+    setOutstandingProposing(state, action: PayloadAction<{ safeTxHash: string; proposing: boolean }>) {
+      const req = state.outstandingRequests[action.payload.safeTxHash]
+      if (req) {
+        req.proposing = action.payload.proposing
+      }
+    },
     clearOutstandingRequest(state, action: PayloadAction<string>) {
       const { [action.payload]: _removed, ...rest } = state.outstandingRequests
       state.outstandingRequests = rest
@@ -109,6 +119,7 @@ export const {
   pushPending,
   removePending,
   setOutstandingRequest,
+  setOutstandingProposing,
   clearOutstandingRequest,
   clear: clearWalletKitState,
 } = walletKitSlice.actions

--- a/apps/mobile/src/services/tx/draft.ts
+++ b/apps/mobile/src/services/tx/draft.ts
@@ -1,0 +1,104 @@
+import { cgwApi, type Operation } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import type { SafeTransaction } from '@safe-global/types-kit'
+import { getSafeSDK } from '@/src/hooks/coreSDK/safeCoreSDK'
+import { setDraft, type DraftTx } from '@/src/store/draftTxSlice'
+import { synthesizeDraftTxDetails } from '@/src/features/ConfirmTx/utils/synthesizeDraftTxDetails'
+import { asError } from '@safe-global/utils/services/exceptions/utils'
+import type { AppDispatch } from '@/src/store'
+
+type SafeSDK = NonNullable<ReturnType<typeof getSafeSDK>>
+
+/**
+ * Returns the protocol-kit SDK singleton, verified to be bound to the expected chain.
+ * Composing on a mismatched SDK would produce a draft for the wrong chain, so this throws
+ * instead — shared by the Send flow and the WalletConnect tx-request flow.
+ */
+export async function getVerifiedSafeSDK(chainId: string): Promise<SafeSDK> {
+  const safeSDK = getSafeSDK()
+  if (!safeSDK) {
+    throw new Error('Safe SDK is not initialized')
+  }
+
+  const sdkChainId = await safeSDK.getChainId()
+  if (sdkChainId.toString() !== chainId) {
+    throw new Error(`Chain mismatch: SDK on chain ${sdkChainId}, expected ${chainId}`)
+  }
+
+  return safeSDK
+}
+
+export type PreviewAndStashDraftArgs = {
+  safeSDK: SafeSDK
+  safeTx: SafeTransaction
+  chainId: string
+  safeAddress: string
+  safe: Pick<SafeState, 'owners' | 'threshold'>
+  dispatch: AppDispatch
+}
+
+/**
+ * Shared tail of the local draft pipeline: hash the composed SafeTransaction, ask CGW for a
+ * /preview, synthesize a TransactionDetails shape, and stash a DraftTx so the existing
+ * sign/review screens render it without a /propose round-trip. The /propose call only
+ * happens when the user signs.
+ *
+ * Throws (without stashing anything) when the preview fails.
+ *
+ * Returns the `safeTxHash` (used as the synthetic txId for the downstream review screens).
+ */
+export const previewAndStashDraft = async ({
+  safeSDK,
+  safeTx,
+  chainId,
+  safeAddress,
+  safe,
+  dispatch,
+}: PreviewAndStashDraftArgs): Promise<string> => {
+  const safeTxHash = await safeSDK.getTransactionHash(safeTx)
+
+  const previewPromise = dispatch(
+    cgwApi.endpoints.transactionsPreviewTransactionV1.initiate({
+      chainId,
+      safeAddress,
+      previewTransactionDto: {
+        to: safeTx.data.to,
+        data: safeTx.data.data || null,
+        value: safeTx.data.value?.toString() ?? '0',
+        operation: (safeTx.data.operation ?? 0) as Operation,
+      },
+    }),
+  )
+
+  let txDetails
+  try {
+    const previewResult = await previewPromise
+
+    if ('error' in previewResult || !previewResult.data) {
+      throw asError('error' in previewResult ? previewResult.error : new Error('Preview unavailable'))
+    }
+
+    txDetails = synthesizeDraftTxDetails({
+      safeAddress,
+      safeTxHash,
+      buildParams: safeTx.data,
+      owners: safe.owners,
+      threshold: safe.threshold,
+      preview: previewResult.data,
+    })
+  } finally {
+    previewPromise.reset()
+  }
+
+  const draft: DraftTx = {
+    chainId,
+    safeAddress,
+    buildParams: safeTx.data,
+    safeTxHash,
+    txDetails,
+  }
+
+  dispatch(setDraft(draft))
+
+  return safeTxHash
+}

--- a/packages/utils/src/features/walletconnect/__tests__/utils.test.ts
+++ b/packages/utils/src/features/walletconnect/__tests__/utils.test.ts
@@ -6,4 +6,14 @@ describe('chainIdToHex', () => {
     expect(chainIdToHex('137')).toBe('0x89')
     expect(chainIdToHex(11155111)).toBe('0xaa36a7')
   })
+
+  it('normalizes a 0x-hex input to a canonical quantity', () => {
+    expect(chainIdToHex('0x010')).toBe('0x10')
+    expect(chainIdToHex('0x0')).toBe('0x0')
+  })
+
+  it('preserves precision above 2^53 (BigInt, not Number)', () => {
+    // 0x20000000000001 = 2^53 + 1 — Number would round this down to 2^53.
+    expect(chainIdToHex('0x20000000000001')).toBe('0x20000000000001')
+  })
 })

--- a/packages/utils/src/features/walletconnect/utils.ts
+++ b/packages/utils/src/features/walletconnect/utils.ts
@@ -13,3 +13,8 @@ export const getEip155ChainId = (chainId: string): `${typeof EIP155}:${string}` 
 export const chainIdToHex = (chainId: string | number): string => {
   return '0x' + Number(chainId).toString(16)
 }
+
+// CAIP-2 / CAIP-10 -> trailing segment, e.g. 'eip155:1' -> '1', 'eip155:1:0xabc' -> '0xabc'.
+export const stripEip155Prefix = (eip155Address: string): string => {
+  return eip155Address.split(':').pop() ?? ''
+}

--- a/packages/utils/src/features/walletconnect/utils.ts
+++ b/packages/utils/src/features/walletconnect/utils.ts
@@ -9,9 +9,10 @@ export const getEip155ChainId = (chainId: string): `${typeof EIP155}:${string}` 
   return `${EIP155}:${chainId}`
 }
 
-// Numeric chain id -> hex, e.g. '137' -> '0x89'
+// Integer (decimal or 0x-hex string, or number) -> canonical hex quantity, e.g. '137' -> '0x89'.
+// Uses BigInt so values above 2^53 (e.g. block numbers / gas) don't lose precision.
 export const chainIdToHex = (chainId: string | number): string => {
-  return '0x' + Number(chainId).toString(16)
+  return '0x' + BigInt(chainId).toString(16)
 }
 
 // CAIP-2 / CAIP-10 -> trailing segment, e.g. 'eip155:1' -> '1', 'eip155:1:0xabc' -> '0xabc'.


### PR DESCRIPTION
> Read-only calls now proxy to the chain,
> capabilities and call-status answer in kind,
> switch-chain flips the active Safe —
> the dApp's RPC surface, no longer blind.

## What it solves

Resolves: [WA-2322](https://linear.app/safe-global/issue/WA-2322/read-only-rpc-proxy-wallet-control-methods)

WA-2321 trimmed the mobile WalletKit `methodRouter` to the tx-request flow only, so every other dApp RPC call (read-only methods, EIP-5792 capability/status, `wallet_switchEthereumChain`) fell through to `UNSUPPORTED_METHODS`. dApps like Uniswap (`eth_call`/`eth_estimateGas` pre-flight) and CowSwap (`wallet_getCapabilities`) couldn't operate against a connected Safe.

## How this PR fixes it

Fills in the deferred router branches (ported from `origin/mobile/walletconnect-dapps-poc`, adapted to WA-2321's `RouteContext`):

- **Read-only proxy** (`services/readRpcProxy.ts`, new) — allow-listed reads forwarded to the active chain's JSON-RPC via a per-chain cached provider.
- **`wallet_switchEthereumChain`** — switches the active chain when the Safe is deployed there, else `4901`.
- **`wallet_getCapabilities`** — atomic-batch support, scoped to the Safe's deployed chains.
- **`wallet_getCallsStatus`** — CGW status enriched with the on-chain receipt; envelope logic extracted to a pure, tested `getCallsStatus.ts#buildGetCallsResult`.
- **`wallet_showCallsStatus`** — navigates to the pending-transactions queue.

`RouteContext` gains `deployedChainIds` + 3 callbacks, wired in `WalletKitProvider`. Numeric/shape contracts verified against web's `safe-wallet-provider`.

## How to test it

```bash
yarn workspace @safe-global/mobile test src/features/WalletConnect/Wallet
```

Manual: a dApp using `eth_call` + `wallet_switchEthereumChain` resolves reads and switches chain; a dApp firing `personal_sign` gets `UNSUPPORTED_METHODS` with no wallet UI.

## Affected flows

- dApp read-only RPC → proxied to the active chain.
- dApp `wallet_switchEthereumChain` → flips the active Safe's chain.
- dApp EIP-5792 capability / call-status queries.
- WA-2321 tx flow — unchanged (new branches are additive, ordered ahead of it).

## Blast radius

- **`routeSessionRequest`** — every WC `session_request` routes through it; new branches additive, existing paths untouched.
- **`RouteContext` / `SessionRequestHandlerDeps`** — 4 additive fields.
- **`WalletKitProvider`** — 3 new callbacks + a `safes`-slice selector.
- **`readRpcProxy` `providerCache`** — process-lifetime, keyed by chainId.
- Mobile-only; no API/persistence/flag/route/shared-package changes.

## Risks / not checked

Deliberate derivations (POC-verbatim unless noted):

- `wallet_switchEthereumChain` returns `4901` for a non-deployed chain (ticket/EIP-3326 say `4902`) — kept per POC.
- Read-only proxy and `wallet_getCallsStatus` target the **active** chain, not the request's `chainId` (they coincide via send-time binding).
- Receipt-fetch errors are swallowed (envelope returned without `receipts`); web throws.
- `wallet_getCapabilities` isn't gated on the queried address (web returns `{}` unless it matches); chain scoping was added to match web, address gate left off for the POC's multichain intent.
- `wallet_showCallsStatus` lands on the queue, not the specific tx (params not yet read) — follow-up.

Not verified:

- No provider-level integration test for `switchActiveChainByCaip2` / `getCallsStatus` I/O (chains RTK-Query cache is brittle to seed); router→dep contract and `buildGetCallsResult` are unit-tested instead.
- E2E against live dApps (separate ticket).

## Visual summary

```mermaid
flowchart TD
  R[session_request] --> NS{eip155 namespace?}
  NS -- no --> X1[UNAUTHORIZED_METHOD]
  NS -- yes --> SIG{rejected signing / safe_setSettings?}
  SIG -- yes --> X2[UNSUPPORTED_METHODS]
  SIG -- no --> LOCAL{eth_accounts / eth_chainId / net_version?}
  LOCAL -- yes --> A1[answer locally]
  LOCAL -- no --> SW{wallet_switchEthereumChain?}
  SW -- yes --> A2["switch active chain → null, else 4901"]
  SW -- no --> CAP{wallet_getCapabilities?}
  CAP -- yes --> A3["atomicBatch for deployed chains only"]
  CAP -- no --> CS{wallet_getCallsStatus / showCallsStatus?}
  CS -- yes --> A4["CGW status + receipt / navigate to queue"]
  CS -- no --> RO{read-only allow-list?}
  RO -- yes --> A5["proxy to active chain RPC"]
  RO -- no --> TX{eth_sendTransaction / wallet_sendCalls?}
  TX -- yes --> A6["guards → __DEFERRED__ sheet (WA-2321)"]
  TX -- no --> X3[UNSUPPORTED_METHODS]

  style A2 fill:#d6f5d6
  style A3 fill:#d6f5d6
  style A4 fill:#d6f5d6
  style A5 fill:#d6f5d6
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] Analytics impact documented — none 📊
- [x] Unit tests written 🧑‍💻
- [x] Affected flows, blast radius, and unverified risks listed 🎯
- [ ] Playwright one-shot — N/A (mobile-only) 🎬

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
