### PR TITLE
fix(web): readable disabled address fields & align Request to add contact dialog

### DIFF
--- a/apps/web/src/components/common/AddressInput/index.test.tsx
+++ b/apps/web/src/components/common/AddressInput/index.test.tsx
@@ -309,6 +309,14 @@ describe('AddressInput tests', () => {
     await waitFor(() => expect(utils.getByText(mockSafeName)).toBeInTheDocument())
   })
 
+  it('should render a readable read-only field when disabled even if the address is not in the address book', async () => {
+    // Address book is empty (mocked in beforeEach), mirroring a contact shown under a source
+    // (e.g. spaceOnly) that does not contain it. The disabled field must still be readable.
+    const { utils } = setup(TEST_ADDRESS_A, undefined, true)
+
+    await waitFor(() => expect(utils.getByTestId('address-book-recipient')).toBeInTheDocument())
+  })
+
   it('should clear the input on click if the address is in the address book and not disabled', async () => {
     const mockChainId = '11155111'
     const mockSafeName = 'Test Safe'

--- a/apps/web/src/components/common/AddressInput/index.tsx
+++ b/apps/web/src/components/common/AddressInput/index.tsx
@@ -68,6 +68,10 @@ const AddressInput = ({
 
   const addressBook = useAddressBook()
 
+  // A disabled field is a read-only display, so render the readable EthHashInfo instead of the
+  // greyed-out input — even when the address isn't in the (source-scoped) address book.
+  const isReadOnly = Boolean(addressBook[watchedValue]) || Boolean(props.disabled)
+
   // Fetch an ENS resolution for the current address
   const isDomainLookupEnabled = !!currentChain && hasFeature(currentChain, FEATURES.DOMAIN_LOOKUP)
   const { address, resolverError, resolving } = useNameResolver(isDomainLookupEnabled ? watchedValue : '')
@@ -170,9 +174,9 @@ const AddressInput = ({
         spellCheck={false}
         InputProps={{
           ...(props.InputProps || {}),
-          className: addressBook[watchedValue] ? css.readOnly : undefined,
+          className: isReadOnly ? css.readOnly : undefined,
 
-          startAdornment: addressBook[watchedValue] ? (
+          startAdornment: isReadOnly ? (
             <AddressInputReadOnly address={watchedValue} showPrefix={showPrefix} chainId={chain?.chainId} />
           ) : (
             // Display the current short name in the adornment, unless the value contains the same prefix

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/RequestToAddButton.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/RequestToAddButton.tsx
@@ -1,8 +1,17 @@
 import { useState } from 'react'
-import { Alert, Button as MuiButton, DialogActions, DialogContent, Tooltip } from '@mui/material'
+import {
+  Alert,
+  Box,
+  Button as MuiButton,
+  CircularProgress,
+  DialogActions,
+  DialogContent,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { Spinner } from '@/components/ui/spinner'
 import ModalDialog from '@/components/common/ModalDialog'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import ChainIndicator from '@/components/common/ChainIndicator'
@@ -103,56 +112,54 @@ const RequestToAddButton = ({ address, name, chainIds, alreadyRequested }: Reque
 
       <ModalDialog open={open} onClose={() => setOpen(false)} dialogTitle="Request to add contact" hideChainIndicator>
         <DialogContent sx={{ py: 2 }}>
-          <div className="flex flex-col gap-4">
-            <p className="text-muted-foreground text-sm">
+          <Stack spacing={2}>
+            <Typography variant="body2" color="text.secondary">
               An admin has to approve the request before the contact appears in the workspace address book.
-            </p>
+            </Typography>
 
-            <div>
-              <p className="text-sm font-bold">Name</p>
-              <p className="text-sm">{name}</p>
-            </div>
+            <Box>
+              <Typography variant="body2" color="text.secondary" mb={0.5}>
+                Name
+              </Typography>
+              <Typography variant="body1">{name}</Typography>
+            </Box>
 
-            <div>
-              <p className="mb-1 text-sm font-bold">Address</p>
-              <div className="text-[0.8em]">
-                <EthHashInfo
-                  address={address}
-                  shortAddress={false}
-                  showPrefix={false}
-                  showName={false}
-                  avatarSize={24}
-                />
-              </div>
-            </div>
+            <Box>
+              <Typography variant="body2" color="text.secondary" mb={0.5}>
+                Address
+              </Typography>
+              <EthHashInfo address={address} shortAddress={false} showPrefix={false} showName={false} avatarSize={24} />
+            </Box>
 
-            <div>
-              <p className="mb-1 text-sm font-bold">Networks</p>
+            <Box>
+              <Typography variant="body2" color="text.secondary" mb={1}>
+                Networks
+              </Typography>
               {chains.configs.length === chainIds.length ? (
-                <p className="text-sm">All networks</p>
+                <Typography variant="body1">All networks</Typography>
               ) : (
                 <Tooltip
                   title={
-                    <div className="flex flex-col gap-1">
+                    <Stack spacing={0.5}>
                       {chainIds.map((chainId) => (
                         <ChainIndicator key={chainId} chainId={chainId} />
                       ))}
-                    </div>
+                    </Stack>
                   }
                   placement="top"
                   arrow
                 >
-                  <span className="inline-flex">
+                  <Box display="inline-flex">
                     <NetworkLogosList networks={chainIds.map((chainId) => ({ chainId }))} showHasMore maxVisible={6} />
-                  </span>
+                  </Box>
                 </Tooltip>
               )}
-            </div>
+            </Box>
 
             {nameError && (
               <Alert severity="warning">Rename this contact to share it with the workspace. {nameError}.</Alert>
             )}
-          </div>
+          </Stack>
         </DialogContent>
 
         <DialogActions>
@@ -167,7 +174,7 @@ const RequestToAddButton = ({ address, name, chainIds, alreadyRequested }: Reque
             disabled={!!nameError || isSubmitting}
             disableElevation
           >
-            {isSubmitting ? <Spinner className="size-5" /> : 'Request to add'}
+            {isSubmitting ? <CircularProgress size={20} /> : 'Request to add'}
           </MuiButton>
         </DialogActions>
       </ModalDialog>


### PR DESCRIPTION
> Greyed address, now read clear—
> disabled fields show their truth;
> the request dialog, kin to its siblings.

## What it solves

Two UI-consistency issues in the Spaces address book:

1. **The address was grey and barely readable** when editing a contact under a space, while the per-Safe address book showed it clearly.
2. **The "Request to add contact" dialog** used ad-hoc Tailwind markup and the custom UI-kit spinner instead of the standard Safe dialog primitives, so it looked off next to sibling dialogs.

## How this PR fixes it

The grey address was the non-obvious one. A disabled `AddressInput` is a read-only display, but it only used the readable `EthHashInfo` rendering when the address resolved in the **source-scoped** address book. The Spaces address book runs under `source="spaceOnly"`, so a **local** contact never resolves there → the field fell through to a disabled MUI `TextField`, whose greyed text was the "barely readable" part. Fix: treat any disabled field as read-only so it always renders the readable address, regardless of resolution. This only affects disabled fields (every one goes through `EntryDialog`); all editable `AddressInput` flows are unchanged.

The dialog restyle swaps raw `<p>`/Tailwind and the custom `Spinner` for MUI `Typography`/`Stack`/`CircularProgress`, matching `AcceptInviteDialog`/`EntryDialog`. The trigger button and "Requested" badge intentionally stay on the custom kit to match the surrounding table actions.

## How to test it

1. Open a Space → **Address book** → **My contacts** tab, with a local contact saved on a network other than the currently connected one.
2. Click **edit** on that contact → the address in the **Edit entry** dialog should be fully readable (not greyed out), like the per-Safe address book edit dialog.
3. On the **My contacts** tab as a non-admin/member, click **Request to add** on a local contact → the **Request to add contact** dialog should match other Safe dialogs (MUI typography, spacing, and a spinner in the submit button while pending).


## Screenshots

before
<img width="621" height="542" alt="image" src="https://github.com/user-attachments/assets/35ac7851-4dcb-4391-ab09-277b39253007" />

<img width="601" height="350" alt="image" src="https://github.com/user-attachments/assets/e1aac3ed-e51f-43f8-804a-c212775ad261" />

after
<img width="620" height="428" alt="image" src="https://github.com/user-attachments/assets/7fef3a1f-5411-4ce3-95af-63a998a91630" />
<img width="625" height="364" alt="image" src="https://github.com/user-attachments/assets/c04036f4-db53-4139-b2b2-08915193a449" />



## Visual summary

Address field render path (the readability fix):

```mermaid
flowchart TB
  subgraph Before
    A1[Disabled AddressInput] --> B1{address in source-scoped book?}
    B1 -->|yes| C1[AddressInputReadOnly - readable]
    B1 -->|no, e.g. local contact under spaceOnly| D1[Disabled MUI TextField - greyed, barely readable]
  end
  subgraph After
    A2[Disabled AddressInput] --> C2[AddressInputReadOnly - always readable]
  end
```

_UI change — reviewers may want to attach before/after screenshots of the Edit entry and Request to add contact dialogs._

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
