### PR TITLE
fix(web): Switch to hard drive icon

### DIFF
--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -9,7 +9,7 @@ import EthHashInfo from '@/components/common/EthHashInfo'
 import EmailInfo from '@/components/common/EmailInfo'
 import { NetworkLogosList } from '@/features/multichain'
 import ChainIndicator from '@/components/common/ChainIndicator'
-import { BookUser, ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
+import { HardDrive, ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
 import type { SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import SpaceAddressBookActions from './SpaceAddressBookActions'
 import LocalContactActions from './LocalContactActions'
@@ -98,7 +98,7 @@ function SpaceAddressBookTable({
                       />
                     }
                   >
-                    {entry.isLocal && <BookUser className="text-muted-foreground size-4 flex-shrink-0" />}
+                    {entry.isLocal && <HardDrive className="text-muted-foreground size-4 flex-shrink-0" />}
                     <span className="min-w-0 truncate">{entry.name}</span>
                   </TooltipTrigger>
                   <TooltipContent>{entry.name}</TooltipContent>


### PR DESCRIPTION
How it will look like
<img width="967" height="287" alt="Screenshot 2026-06-15 at 14 35 54" src="https://github.com/user-attachments/assets/59fb2525-1ee0-4ed1-b60f-93ce678f6380" />

Use the proper icon for local contacts, the one that we also use in the address picker