### PR TITLE
fix(spaces): show member display name in activity log filter

### DIFF
--- a/apps/web/src/features/spaces/components/SpaceActivityLog/ActivityLogFilters.tsx
+++ b/apps/web/src/features/spaces/components/SpaceActivityLog/ActivityLogFilters.tsx
@@ -3,6 +3,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import useGetSpaceAuditLogActors from '../../hooks/useGetSpaceAuditLogActors'
+import { useMemberNameResolver } from '../../hooks/useMemberNameResolver'
 
 export type ActivityLogFilterState = {
   actorUserId?: number
@@ -44,6 +45,11 @@ function ActivityLogFilters({
 }) {
   // Includes former and deleted members — their events stay filterable.
   const actors = useGetSpaceAuditLogActors()
+  const resolveMemberName = useMemberNameResolver()
+
+  // Prefer the Team-page display name; fall back to the server label (a raw
+  // address for wallet members, an email otherwise) for non-members.
+  const getActorLabel = (actorUserId: number, fallback: string) => resolveMemberName(actorUserId) ?? fallback
 
   const selectedActor = actors.find((actor) => actor.actorUserId === filters.actorUserId)
   const sortDirection = filters.sortDirection ?? 'desc'
@@ -62,14 +68,16 @@ function ActivityLogFilters({
         >
           <SelectTrigger id="activity-actor-filter" className="bg-card w-48 cursor-pointer rounded-lg">
             <SelectValue placeholder={ALL_ACTORS_LABEL}>
-              <span className="truncate">{selectedActor ? selectedActor.actor : ALL_ACTORS_LABEL}</span>
+              <span className="truncate">
+                {selectedActor ? getActorLabel(selectedActor.actorUserId, selectedActor.actor) : ALL_ACTORS_LABEL}
+              </span>
             </SelectValue>
           </SelectTrigger>
           <SelectContent alignItemWithTrigger={false} align="start">
             <SelectItem value={ALL_ACTORS}>{ALL_ACTORS_LABEL}</SelectItem>
             {actors.map((actor) => (
               <SelectItem key={actor.actorUserId} value={String(actor.actorUserId)}>
-                {actor.actor}
+                {getActorLabel(actor.actorUserId, actor.actor)}
               </SelectItem>
             ))}
           </SelectContent>

--- a/apps/web/src/features/spaces/components/SpaceActivityLog/__tests__/ActivityLogFilters.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceActivityLog/__tests__/ActivityLogFilters.test.tsx
@@ -4,11 +4,17 @@ import useGetSpaceAuditLogActors from '../../../hooks/useGetSpaceAuditLogActors'
 
 jest.mock('../../../hooks/useGetSpaceAuditLogActors')
 
+const mockResolveMemberName = jest.fn()
+jest.mock('../../../hooks/useMemberNameResolver', () => ({
+  useMemberNameResolver: () => mockResolveMemberName,
+}))
+
 const mockUseActors = useGetSpaceAuditLogActors as jest.MockedFunction<typeof useGetSpaceAuditLogActors>
 
 describe('ActivityLogFilters', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockResolveMemberName.mockReturnValue(undefined)
     // Includes a former/deleted member — the dropdown is fed from the audit
     // log itself, not from current members.
     mockUseActors.mockReturnValue([
@@ -64,5 +70,20 @@ describe('ActivityLogFilters', () => {
     expect(mockUseActors).toHaveBeenCalled()
     expect(screen.getByLabelText('Member')).toBeInTheDocument()
     expect(screen.getByLabelText('Sort')).toBeInTheDocument()
+  })
+
+  it('shows the Team-page display name for a wallet member instead of the address', () => {
+    mockResolveMemberName.mockImplementation((userId) => (userId === 1 ? 'Liliya (wallet)' : undefined))
+
+    render(<ActivityLogFilters filters={{ actorUserId: 1 }} onFiltersChange={jest.fn()} />)
+
+    expect(screen.getByText('Liliya (wallet)')).toBeInTheDocument()
+    expect(screen.queryByText('0x1234567890abcdef1234567890abcdef12345678')).not.toBeInTheDocument()
+  })
+
+  it('falls back to the server label when no member name resolves', () => {
+    render(<ActivityLogFilters filters={{ actorUserId: 2 }} onFiltersChange={jest.fn()} />)
+
+    expect(screen.getByText('Former member')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
> Wallet members named at last,
> no raw hex address in the cast—
> the filter speaks in human tongue.

## What it solves

In the Spaces Activity log, the **Member** filter dropdown showed SIWE (wallet) members by their raw Ethereum address instead of the display name set on the Team page, while email members correctly showed their email. This made it impossible to filter activity by a wallet member without knowing their address.

Resolves: https://linear.app/safe-global/issue/WA-2619/

## How this PR fixes it

The audit event **rows** already resolve the Team-page display name via `useMemberNameResolver` (space member name → address → server label), but the filter **dropdown** rendered the raw server-resolved `actor.actor` string — which is the wallet address for SIWE members. The fix applies the same resolver in the dropdown.

Gotcha: the filter **value** stays keyed on `actorUserId`, so only the displayed label changes — filtering behavior and the query are untouched. Former/deleted members and wallet members with no display name set fall back to the server label/address (consistent with the row behavior).

## How to test it

1. Open a Space with both email-auth and SIWE (wallet) members that have display names set on the Team page (requires the `SPACE_AUDIT_LOG` flag).
2. Navigate to the Activity page and open the **Member** filter dropdown.
3. Confirm wallet members now show their Team-page display name (not their `0x…` address); email members are unchanged.
4. Select a wallet member and confirm the activity list filters correctly to that member.

## Affected flows

- Spaces Activity log → Member filter: dropdown item labels and the selected-value label now resolve to the Team-page display name.

## Blast radius

- `ActivityLogFilters.tsx` — only consumer changed.
- Reuses the existing shared hook `useMemberNameResolver` (already used by `AuditEventRow` and `SpaceAddressBookTable`); the hook itself is unchanged, so its other consumers are unaffected.
- No change to the audit-log query, the `actorUserId` filter value, or any RTK Query endpoint/API contract.
- No feature-flag, persistence, route, or shared-package (mobile) impact — change is web-only and display-only.

## Risks / not checked

- Backend (CGW) actor resolution is unchanged — this is a client-side display fix only.
- Duplicate display names in the dropdown are not disambiguated with the address (matches the existing row behavior; the issue marks secondary text optional).
- Not tested on mobile (web-only feature).
- Verified via unit tests; not exercised manually in a running app.

## Visual summary

UI effect: the **Member** dropdown label for a wallet member changes from `0x4c3c38a4…` to e.g. `Liliya (wallet)`.

```mermaid
flowchart LR
  A["actor from audit-log endpoint<br/>(actorUserId, actor)"] --> B{"useMemberNameResolver(actorUserId)"}
  B -->|"name found (Team page)"| C["Display name<br/>e.g. 'Liliya (wallet)'"]
  B -->|"no name (former / unnamed wallet)"| D["Fallback: actor.actor<br/>(address or email)"]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
- [ ] For web feature/bugfix PRs, I've added a Playwright one-shot happy-path clickthrough under apps/web/e2e/tests/one-shots/ and run it locally — CI records and posts the clickthrough GIF 🎬

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
