### PR TITLE
chore(web): rename "Most recent" sort label to "Last visited" (WA-2631)

### DIFF
--- a/apps/web/src/components/common/SafeListSortToggle/index.test.tsx
+++ b/apps/web/src/components/common/SafeListSortToggle/index.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@/tests/test-utils'
+import { ORDER_BY_RESET_VERSION, OrderByOption } from '@/store/orderByPreferenceSlice'
 import SafeListSortToggle from '.'
 
 // The popup/menu open state is verified in the browser: base-ui menus don't open in jsdom
@@ -11,5 +12,16 @@ describe('SafeListSortToggle', () => {
     const trigger = screen.getByTestId('safe-list-sort-toggle')
     expect(trigger).toBeInTheDocument()
     expect(trigger).toHaveTextContent('Name')
+  })
+
+  it('labels the last-visited sort as "Last visited"', () => {
+    render(<SafeListSortToggle />, {
+      // resetVersion must match or the store's hydration reducer reverts to the default order.
+      initialReduxState: {
+        orderByPreference: { orderBy: OrderByOption.LAST_VISITED, resetVersion: ORDER_BY_RESET_VERSION },
+      },
+    })
+
+    expect(screen.getByTestId('safe-list-sort-toggle')).toHaveTextContent('Last visited')
   })
 })

--- a/apps/web/src/components/common/SafeListSortToggle/index.tsx
+++ b/apps/web/src/components/common/SafeListSortToggle/index.tsx
@@ -14,7 +14,7 @@ import { OrderByOption, selectOrderByPreference, setOrderByPreference } from '@/
 
 const labels: Record<OrderByOption, string> = {
   [OrderByOption.NAME]: 'Name',
-  [OrderByOption.LAST_VISITED]: 'Most recent',
+  [OrderByOption.LAST_VISITED]: 'Last visited',
 }
 
 /**
@@ -32,7 +32,7 @@ const SafeListSortToggle = () => {
           <Button
             variant="outline"
             // Match the adjacent search InputGroup exactly: h-9, rounded-md, border-gray-100, shadow-none.
-            // Fixed width so the trigger doesn't grow/shrink between "Name" and "Most recent".
+            // Fixed width so the trigger doesn't grow/shrink between "Name" and "Last visited".
             size="default"
             className="h-9 w-[160px] shrink-0 justify-between gap-1.5 rounded-md border-gray-100 shadow-none text-muted-foreground"
             data-testid="safe-list-sort-toggle"

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.ts
@@ -36,7 +36,7 @@ const EMPTY_SAFES: SafeItems = []
  *   useAllSafesGrouped()                              otherSafes → useAllSafesGrouped()
  *     ▼                                                 ▼
  *   allItems  (merge, sort by order               otherSafeItems  (merge, sort by order
- *     ▼  preference — Name or Most recent)           ▼  preference — Name or Most recent)
+ *     ▼  preference — Name or Last visited)          ▼  preference — Name or Last visited)
  *     ▼  search + isPinned                            ▼  search + !isPinned
  *   trustedItems                                    otherItems
  *

--- a/apps/web/src/features/myAccounts/components/OrderByButton/index.tsx
+++ b/apps/web/src/features/myAccounts/components/OrderByButton/index.tsx
@@ -12,7 +12,7 @@ type OrderByButtonProps = {
 }
 
 const orderByLabels = {
-  [OrderByOption.LAST_VISITED]: 'Most recent',
+  [OrderByOption.LAST_VISITED]: 'Last visited',
   [OrderByOption.NAME]: 'Name',
 }
 


### PR DESCRIPTION
> "Most recent" was vague — recent what?
> Now the label reads "Last visited",
> same sort underneath, copy matching the enum.

## What it solves

Resolves: [WA-2631](https://linear.app/safe-global/issue/WA-2631/rename-most-recent-sort-label-to-last-visited)

The Safe-list sort option is internally `OrderByOption.LAST_VISITED`, but the UI showed it as **"Most recent"** — ambiguous (most recent _what_: created? added? used?). This renames the visible label to **"Last visited"**, which names the actual sort axis (the time you last opened the Safe) and matches the underlying enum.

## How this PR fixes it

Pure copy change in both sort controls — no logic touched:

- [`SafeListSortToggle`](apps/web/src/components/common/SafeListSortToggle/index.tsx) — the new design-system control used by the **Safe selector dropdown** + the **All accounts modal**.
- [`OrderByButton`](apps/web/src/features/myAccounts/components/OrderByButton/index.tsx) — the legacy My accounts list sort button.
- Updated two stale code comments that referenced the old label.

The sort comparator (`lastVisitedComparator`) and the persisted preference value (the enum `lastVisited`) are unchanged.

## How to test it

1. Open the **Safe selector dropdown** (or **All accounts** modal) → open the **Sort by** control.
2. Confirm the option that was "Most recent" now reads **"Last visited"**.
3. Select it → list still orders by most-recently-opened first (no behavior change).
4. Repeat on the legacy **My accounts** page sort button.

## Affected flows

- Sorting the Safe list in the **Safe selector dropdown / All accounts modal** (`SafeListSortToggle`).
- Sorting the Safe list on the legacy **My accounts** page (`OrderByButton`).

## Blast radius

- **`SafeListSortToggle`** (new DS) — consumed by the Safe selector dropdown + All accounts modal.
- **`OrderByButton`** (legacy MUI) — My accounts list.
- **`orderByPreferenceSlice`** (shared, persisted) — **value unchanged** (stores the enum `lastVisited`, not the label), so existing user preferences need no migration.
- **Analytics** — the `SORT_SAFES` event `label` emitted from `OrderByButton` changes `"Most recent"` → `"Last visited"`. `SafeListSortToggle` emits no event.
- **Mobile** — not affected (both components are web-only).

## Risks / not checked

- Mixpanel dashboards/filters keyed on `label="Most recent"` will see `"Last visited"` going forward — minor, intentional continuity break.
- No unit test added to the legacy `OrderByButton` (the label is covered via `SafeListSortToggle`'s test); did not capture a live browser screenshot (before/after mockup below).
- No Playwright one-shot added — copy-only change with no behavior change.

## Visual summary

Before → after (sort control trigger + menu):

```
        BEFORE                              AFTER
  ┌────────────────────┐            ┌────────────────────┐
  │ ⇅  Most recent   ▾ │            │ ⇅  Last visited  ▾ │
  └────────────────────┘            └────────────────────┘
     Sort by                           Sort by
     • Name                            • Name
     • Most recent   ✓                 • Last visited  ✓
```

```mermaid
flowchart LR
  E["OrderByOption.LAST_VISITED<br/>(enum — unchanged)"] --> L["UI label: 'Most recent' → 'Last visited'"]
  L --> A["SafeListSortToggle<br/>(Safe selector dropdown + All accounts modal)"]
  L --> B["OrderByButton<br/>(legacy My accounts list)"]
  E --> S["lastVisitedComparator<br/>(sort logic — unchanged)"]
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — _N/A, web-only components_
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
- [ ] For web feature/bugfix PRs, I've added a Playwright one-shot happy-path clickthrough under apps/web/e2e/tests/one-shots/ and run it locally — CI records and posts the clickthrough GIF 🎬 — _N/A, copy-only, no behavior change_

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
