### PR TITLE
fix(web): Add workspace name char limit

### DIFF
--- a/apps/web/src/features/spaces/components/CreateSpaceOnboarding/index.tsx
+++ b/apps/web/src/features/spaces/components/CreateSpaceOnboarding/index.tsx
@@ -20,6 +20,7 @@ import { useOnboardingStepCount } from '../../hooks/useOnboardingStepCount'
 import useExistingSpace from './hooks/useExistingSpace'
 import useSpaceSubmit from './hooks/useSpaceSubmit'
 import useOnboardingExit from './hooks/useOnboardingExit'
+import { SPACE_NAME_MAX_LENGTH } from '@/features/spaces/constants'
 
 const ONBOARDING_STEP = 1
 const FORM_ID = 'create-space-form'
@@ -49,7 +50,10 @@ const CreateSpaceOnboarding = (): ReactElement => {
   const [hasUserEdited, setHasUserEdited] = useState(false)
   const nameReg = register('name', {
     required: true,
-    maxLength: { value: 30, message: 'Workspace name must be 30 characters or less' },
+    maxLength: {
+      value: SPACE_NAME_MAX_LENGTH,
+      message: `Workspace name must be ${SPACE_NAME_MAX_LENGTH} characters or less`,
+    },
     pattern: { value: /^[a-zA-Z0-9 ]+$/, message: 'Workspace name must not contain special characters' },
     validate: (value) => value?.trim() !== '',
   })

--- a/apps/web/src/features/spaces/components/SpaceSettings/UpdateSpaceForm.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/UpdateSpaceForm.tsx
@@ -4,6 +4,7 @@ import ErrorAlert from './ErrorAlert'
 import { Button, TextField } from '@mui/material'
 import { type GetSpaceResponse } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useIsAdmin } from '@/features/spaces'
+import { SPACE_NAME_MAX_LENGTH } from '@/features/spaces/constants'
 
 const UpdateSpaceForm = ({ space }: { space: GetSpaceResponse | undefined }) => {
   const { handleUpdate, error } = useUpdateSpace(space)
@@ -36,7 +37,7 @@ const UpdateSpaceForm = ({ space }: { space: GetSpaceResponse | undefined }) => 
               label="Workspace name"
               fullWidth
               value={field.value || ''}
-              slotProps={{ inputLabel: { shrink: true } }}
+              slotProps={{ inputLabel: { shrink: true }, htmlInput: { maxLength: SPACE_NAME_MAX_LENGTH } }}
               onKeyDown={(e) => e.stopPropagation()}
             />
           )}

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/UpdateSpaceForm.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/UpdateSpaceForm.test.tsx
@@ -5,6 +5,7 @@ import UpdateSpaceForm from '../UpdateSpaceForm'
 
 import type { GetSpaceResponse } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { spaceBuilder } from '@/tests/builders/space'
+import { SPACE_NAME_MAX_LENGTH } from '@/features/spaces/constants'
 const MOCK_SPACE_UUID = '11111111-1111-1111-1111-111111111111'
 
 const mockUnwrap = jest.fn()
@@ -76,6 +77,13 @@ describe('UpdateSpaceForm', () => {
       const { input } = getFormElements()
       expect(input).toHaveValue('Updated Space Name')
     })
+  })
+
+  it('should cap the workspace name input length', () => {
+    setupForm(mockSpace, true)
+
+    const { input } = getFormElements()
+    expect(input).toHaveAttribute('maxlength', String(SPACE_NAME_MAX_LENGTH))
   })
 
   it('should disable save button when name is unchanged', () => {

--- a/apps/web/src/features/spaces/constants.ts
+++ b/apps/web/src/features/spaces/constants.ts
@@ -11,6 +11,9 @@ export const SAFE_ACCOUNTS_LIMIT = !Number.isNaN(safeAccountsLimitRaw) ? safeAcc
 
 export const SPACES_LIMIT = 10
 
+/** Maximum length of a workspace name. Enforced on both create and rename. */
+export const SPACE_NAME_MAX_LENGTH = 30
+
 /** Friendly notice shown when a workspace is already at the Safe accounts cap. */
 export const safeAccountsLimitReachedText = (limit: number = SAFE_ACCOUNTS_LIMIT) =>
   `You've reached the maximum of ${limit} Safe accounts per workspace`


### PR DESCRIPTION
Fixes https://linear.app/safe-global/issue/WA-2642/when-renaming-a-workspace-on-welcomespaces-the-workspace-name-input#comment-83d6c5f6