### PR TITLE
fix(web): polish workspace onboarding (WA-2660, WA-2657, WA-2655)

### DIFF
--- a/apps/web/src/features/spaces/components/ClassicViewLink/index.test.tsx
+++ b/apps/web/src/features/spaces/components/ClassicViewLink/index.test.tsx
@@ -14,7 +14,7 @@ describe('ClassicViewLink', () => {
     disableClassicView()
   })
 
-  it('renders the "Use the old UI" copy with a trailing arrow icon', () => {
+  it('renders the "Use the old UI" copy with a leading rotate icon', () => {
     render(<ClassicViewLink />, { routerProps: { query: {} } })
 
     const link = screen.getByTestId('classic-view-link')

--- a/apps/web/src/features/spaces/components/ClassicViewLink/index.tsx
+++ b/apps/web/src/features/spaces/components/ClassicViewLink/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import { useRouter } from 'next/router'
-import { ArrowRight } from 'lucide-react'
+import { RotateCcw } from 'lucide-react'
 import { enableClassicView } from '@/hooks/useClassicView'
 import { AppRoutes } from '@/config/routes'
 import { parseNextUrlForRouter } from '@/utils/nextUrl'
@@ -24,15 +24,15 @@ const ClassicViewLink = () => {
   }, [router])
 
   return (
-    <div className="mb-5 mt-2 flex justify-center">
+    <div className="mt-3">
       <button
         type="button"
         onClick={onClick}
         data-testid="classic-view-link"
-        className="inline-flex cursor-pointer items-center gap-1.5 rounded-sm text-[13px] font-medium text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline focus-visible:text-foreground focus-visible:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="flex h-12 w-full cursor-pointer items-center justify-center gap-3 rounded-md border border-border bg-card px-4 text-[15px] font-semibold text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
+        <RotateCcw size={18} />
         Use the old UI
-        <ArrowRight size={13} />
       </button>
     </div>
   )

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
@@ -68,6 +68,15 @@ describe('toInviteName', () => {
   it('falls back to a default when nothing valid remains', () => {
     expect(toInviteName('+++@example.com')).toBe('Member')
   })
+
+  it('falls back to a default when the local part is shorter than the minimum name length', () => {
+    expect(toInviteName('r@cc0x.dev')).toBe('Member')
+    expect(toInviteName('ab@example.com')).toBe('Member')
+  })
+
+  it('keeps a local part at the minimum name length', () => {
+    expect(toInviteName('abc@example.com')).toBe('abc')
+  })
 })
 
 describe('useInviteForm tracking', () => {

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
@@ -18,11 +18,16 @@ export interface InviteMembersFormValues {
   members: MemberInvite[]
 }
 
+// Mirrors the backend's name.schema NAME_MIN_LENGTH: names shorter than this are rejected.
+const NAME_MIN_LENGTH = 3
+
 /**
  * The onboarding flow has no dedicated name field, so a display name is derived from the
  * identifier. Wallet/ENS invites keep using the address as the name (as before); email
  * invites use the email's local part, sanitized to the alphanumeric-ish characters the
- * backend's name validation accepts (the raw email's "@" would be rejected).
+ * backend's name validation accepts (the raw email's "@" would be rejected). A local part
+ * shorter than the backend minimum (e.g. "r@cc0x.dev") falls back to a default name so the
+ * invite isn't rejected for a too-short name.
  */
 export const toInviteName = (identifier: string): string => {
   if (!isEmailAddress(identifier)) return identifier
@@ -33,7 +38,7 @@ export const toInviteName = (identifier: string): string => {
     .replace(/^[^a-zA-Z0-9]+/, '')
     .trim()
 
-  return sanitized || 'Member'
+  return sanitized.length >= NAME_MIN_LENGTH ? sanitized : 'Member'
 }
 
 const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/hooks/__tests__/useOnboardingSubmit.test.ts
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/hooks/__tests__/useOnboardingSubmit.test.ts
@@ -4,6 +4,7 @@ import useOnboardingSubmit from '../useOnboardingSubmit'
 import type { SafeItem } from '@/hooks/safes'
 import type { MultiChainSafeItem } from '@/hooks/safes'
 import { MULTICHAIN_SAFE_KEY_PREFIX } from '../../constants'
+import { getGenericErrorWithStatus } from '@/utils/rtkQuery'
 
 const mockChains: Chain[] = []
 
@@ -274,7 +275,7 @@ describe('useOnboardingSubmit', () => {
       await result.current.onSubmit()
     })
 
-    expect(result.current.error).toBe('Error: 400')
+    expect(result.current.error).toBe(getGenericErrorWithStatus(400))
   })
 
   it('should track analytics event on submit', async () => {

--- a/apps/web/src/features/spaces/components/Sidebar/hooks/__tests__/useAddSafeToSpace.test.ts
+++ b/apps/web/src/features/spaces/components/Sidebar/hooks/__tests__/useAddSafeToSpace.test.ts
@@ -201,7 +201,7 @@ describe('useAddSafeToSpace', () => {
     )
   })
 
-  it('falls back to status code when FetchBaseQueryError has no data message', async () => {
+  it('shows a friendly network message instead of the raw fetch error', async () => {
     mockAddSafeToSpace.mockResolvedValue({
       error: { status: 'FETCH_ERROR', error: 'TypeError: Failed to fetch' },
     })
@@ -214,7 +214,8 @@ describe('useAddSafeToSpace', () => {
     expect(mockDispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         payload: expect.objectContaining({
-          message: 'Failed to add Safe to workspace. TypeError: Failed to fetch',
+          message:
+            "Failed to add Safe to workspace. Couldn't connect to the server. Please check your connection and try again.",
           variant: 'error',
         }),
       }),

--- a/apps/web/src/utils/rtkQuery.test.ts
+++ b/apps/web/src/utils/rtkQuery.test.ts
@@ -1,21 +1,16 @@
 import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import type { SerializedError } from '@reduxjs/toolkit'
-import { getRtkQueryErrorMessage } from './rtkQuery'
-
-const NETWORK_MESSAGE = "Couldn't connect to the server. Please check your connection and try again."
-const TIMEOUT_MESSAGE = 'The request timed out. Please try again.'
-const RATE_LIMIT_MESSAGE = 'Too many requests. Please wait a moment and try again.'
-const GENERIC_MESSAGE = 'Something went wrong. Please try again.'
+import { getRtkQueryErrorMessage, RTK_QUERY_ERROR_MESSAGES } from './rtkQuery'
 
 describe('getRtkQueryErrorMessage', () => {
   it('returns a friendly message for a network failure instead of the raw JS error', () => {
     const error: FetchBaseQueryError = { status: 'FETCH_ERROR', error: 'TypeError: Failed to fetch' }
-    expect(getRtkQueryErrorMessage(error)).toBe(NETWORK_MESSAGE)
+    expect(getRtkQueryErrorMessage(error)).toBe(RTK_QUERY_ERROR_MESSAGES.network)
   })
 
   it('returns a friendly message for a timeout', () => {
     const error: FetchBaseQueryError = { status: 'TIMEOUT_ERROR', error: 'AbortError: timeout' }
-    expect(getRtkQueryErrorMessage(error)).toBe(TIMEOUT_MESSAGE)
+    expect(getRtkQueryErrorMessage(error)).toBe(RTK_QUERY_ERROR_MESSAGES.timeout)
   })
 
   it('maps a non-JSON 429 body to a rate-limit message instead of the SyntaxError', () => {
@@ -25,7 +20,7 @@ describe('getRtkQueryErrorMessage', () => {
       data: 'Rate limit reached',
       error: 'SyntaxError: Unexpected token \'R\', "Rate limit reached" is not valid JSON',
     }
-    expect(getRtkQueryErrorMessage(error)).toBe(RATE_LIMIT_MESSAGE)
+    expect(getRtkQueryErrorMessage(error)).toBe(RTK_QUERY_ERROR_MESSAGES.rateLimit)
   })
 
   it('returns a generic message for a non-429 parsing error', () => {
@@ -35,12 +30,12 @@ describe('getRtkQueryErrorMessage', () => {
       data: 'Internal Server Error',
       error: 'SyntaxError: Unexpected token I',
     }
-    expect(getRtkQueryErrorMessage(error)).toBe(GENERIC_MESSAGE)
+    expect(getRtkQueryErrorMessage(error)).toBe(RTK_QUERY_ERROR_MESSAGES.generic)
   })
 
   it('maps a numeric 429 status to a rate-limit message', () => {
     const error: FetchBaseQueryError = { status: 429, data: {} }
-    expect(getRtkQueryErrorMessage(error)).toBe(RATE_LIMIT_MESSAGE)
+    expect(getRtkQueryErrorMessage(error)).toBe(RTK_QUERY_ERROR_MESSAGES.rateLimit)
   })
 
   it('surfaces the backend message for an HTTP error response', () => {

--- a/apps/web/src/utils/rtkQuery.test.ts
+++ b/apps/web/src/utils/rtkQuery.test.ts
@@ -1,0 +1,70 @@
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
+import type { SerializedError } from '@reduxjs/toolkit'
+import { getRtkQueryErrorMessage } from './rtkQuery'
+
+const NETWORK_MESSAGE = "Couldn't connect to the server. Please check your connection and try again."
+const TIMEOUT_MESSAGE = 'The request timed out. Please try again.'
+const RATE_LIMIT_MESSAGE = 'Too many requests. Please wait a moment and try again.'
+const GENERIC_MESSAGE = 'Something went wrong. Please try again.'
+
+describe('getRtkQueryErrorMessage', () => {
+  it('returns a friendly message for a network failure instead of the raw JS error', () => {
+    const error: FetchBaseQueryError = { status: 'FETCH_ERROR', error: 'TypeError: Failed to fetch' }
+    expect(getRtkQueryErrorMessage(error)).toBe(NETWORK_MESSAGE)
+  })
+
+  it('returns a friendly message for a timeout', () => {
+    const error: FetchBaseQueryError = { status: 'TIMEOUT_ERROR', error: 'AbortError: timeout' }
+    expect(getRtkQueryErrorMessage(error)).toBe(TIMEOUT_MESSAGE)
+  })
+
+  it('maps a non-JSON 429 body to a rate-limit message instead of the SyntaxError', () => {
+    const error: FetchBaseQueryError = {
+      status: 'PARSING_ERROR',
+      originalStatus: 429,
+      data: 'Rate limit reached',
+      error: 'SyntaxError: Unexpected token \'R\', "Rate limit reached" is not valid JSON',
+    }
+    expect(getRtkQueryErrorMessage(error)).toBe(RATE_LIMIT_MESSAGE)
+  })
+
+  it('returns a generic message for a non-429 parsing error', () => {
+    const error: FetchBaseQueryError = {
+      status: 'PARSING_ERROR',
+      originalStatus: 500,
+      data: 'Internal Server Error',
+      error: 'SyntaxError: Unexpected token I',
+    }
+    expect(getRtkQueryErrorMessage(error)).toBe(GENERIC_MESSAGE)
+  })
+
+  it('maps a numeric 429 status to a rate-limit message', () => {
+    const error: FetchBaseQueryError = { status: 429, data: {} }
+    expect(getRtkQueryErrorMessage(error)).toBe(RATE_LIMIT_MESSAGE)
+  })
+
+  it('surfaces the backend message for an HTTP error response', () => {
+    const error: FetchBaseQueryError = { status: 400, data: { message: 'Names must be at least 3 characters long' } }
+    expect(getRtkQueryErrorMessage(error)).toBe('Names must be at least 3 characters long')
+  })
+
+  it('falls back to the status code for an HTTP error with no message', () => {
+    const error: FetchBaseQueryError = { status: 400, data: {} }
+    expect(getRtkQueryErrorMessage(error)).toBe('Error: 400')
+  })
+
+  it('passes through a CUSTOM_ERROR developer message', () => {
+    const error: FetchBaseQueryError = { status: 'CUSTOM_ERROR', error: 'Custom failure' }
+    expect(getRtkQueryErrorMessage(error)).toBe('Custom failure')
+  })
+
+  it('returns the message of a SerializedError', () => {
+    const error: SerializedError = { name: 'Error', message: 'Something serialized' }
+    expect(getRtkQueryErrorMessage(error)).toBe('Something serialized')
+  })
+
+  it('falls back to a generic message for an empty SerializedError', () => {
+    const error: SerializedError = {}
+    expect(getRtkQueryErrorMessage(error)).toBe('Unknown error')
+  })
+})

--- a/apps/web/src/utils/rtkQuery.test.ts
+++ b/apps/web/src/utils/rtkQuery.test.ts
@@ -1,6 +1,6 @@
 import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import type { SerializedError } from '@reduxjs/toolkit'
-import { getRtkQueryErrorMessage, RTK_QUERY_ERROR_MESSAGES } from './rtkQuery'
+import { getRtkQueryErrorMessage, RTK_QUERY_ERROR_MESSAGES, getGenericErrorWithStatus } from './rtkQuery'
 
 describe('getRtkQueryErrorMessage', () => {
   it('returns a friendly message for a network failure instead of the raw JS error', () => {
@@ -43,9 +43,9 @@ describe('getRtkQueryErrorMessage', () => {
     expect(getRtkQueryErrorMessage(error)).toBe('Names must be at least 3 characters long')
   })
 
-  it('falls back to the status code for an HTTP error with no message', () => {
+  it('returns a generic message with the status code for an HTTP error with no message', () => {
     const error: FetchBaseQueryError = { status: 400, data: {} }
-    expect(getRtkQueryErrorMessage(error)).toBe('Error: 400')
+    expect(getRtkQueryErrorMessage(error)).toBe(getGenericErrorWithStatus(400))
   })
 
   it('passes through a CUSTOM_ERROR developer message', () => {
@@ -60,6 +60,6 @@ describe('getRtkQueryErrorMessage', () => {
 
   it('falls back to a generic message for an empty SerializedError', () => {
     const error: SerializedError = {}
-    expect(getRtkQueryErrorMessage(error)).toBe('Unknown error')
+    expect(getRtkQueryErrorMessage(error)).toBe(RTK_QUERY_ERROR_MESSAGES.generic)
   })
 })

--- a/apps/web/src/utils/rtkQuery.ts
+++ b/apps/web/src/utils/rtkQuery.ts
@@ -1,22 +1,53 @@
 import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import type { SerializedError } from '@reduxjs/toolkit'
 
+const HTTP_TOO_MANY_REQUESTS = 429
+
+// User-facing copy for transport-level failures, so raw JS error strings (e.g.
+// "TypeError: Failed to fetch", "SyntaxError: ... is not valid JSON" from a plain-text
+// "Rate limit reached" body) never reach users.
+export const RTK_QUERY_ERROR_MESSAGES = {
+  network: "Couldn't connect to the server. Please check your connection and try again.",
+  timeout: 'The request timed out. Please try again.',
+  rateLimit: 'Too many requests. Please wait a moment and try again.',
+  generic: 'Something went wrong. Please try again.',
+} as const
+
 /**
- * Extract a user-friendly error message from RTK Query errors
+ * Extract a user-friendly error message from RTK Query errors.
+ *
+ * Backend error payloads with a `message` are surfaced as-is (they're written for users,
+ * e.g. validation messages). Transport-level failures (network drop, timeout, a non-JSON
+ * body such as a plain-text "Rate limit reached") are translated to friendly copy instead
+ * of leaking the raw JS error string.
  */
 export const getRtkQueryErrorMessage = (error: FetchBaseQueryError | SerializedError): string => {
   if ('status' in error) {
     // FetchBaseQueryError
-    if ('error' in error) {
-      return error.error
+    const { status } = error
+
+    if (status === 'FETCH_ERROR') return RTK_QUERY_ERROR_MESSAGES.network
+    if (status === 'TIMEOUT_ERROR') return RTK_QUERY_ERROR_MESSAGES.timeout
+    if (status === 'PARSING_ERROR') {
+      return error.originalStatus === HTTP_TOO_MANY_REQUESTS
+        ? RTK_QUERY_ERROR_MESSAGES.rateLimit
+        : RTK_QUERY_ERROR_MESSAGES.generic
     }
+
+    // HTTP error response: prefer the backend's own message when present.
     if ('data' in error && typeof error.data === 'object' && error.data) {
       const data = error.data as Record<string, unknown>
       if ('message' in data && typeof data.message === 'string') {
         return data.message
       }
     }
-    return `Error: ${error.status}`
+
+    if (status === HTTP_TOO_MANY_REQUESTS) return RTK_QUERY_ERROR_MESSAGES.rateLimit
+
+    // CUSTOM_ERROR carries a developer-provided message string.
+    if ('error' in error) return error.error
+
+    return `Error: ${status}`
   }
   // SerializedError
   return error.message || 'Unknown error'

--- a/apps/web/src/utils/rtkQuery.ts
+++ b/apps/web/src/utils/rtkQuery.ts
@@ -10,8 +10,12 @@ export const RTK_QUERY_ERROR_MESSAGES = {
   network: "Couldn't connect to the server. Please check your connection and try again.",
   timeout: 'The request timed out. Please try again.',
   rateLimit: 'Too many requests. Please wait a moment and try again.',
-  generic: 'Something went wrong. Please try again.',
+  generic: 'Something went wrong. Please try again, or contact support if it persists.',
 } as const
+
+// Same general copy as `generic`, but keeps the HTTP status visible so the failure stays debuggable.
+export const getGenericErrorWithStatus = (status: number): string =>
+  `Something went wrong (${status}). Please try again, or contact support if it persists.`
 
 /**
  * Extract a user-friendly error message from RTK Query errors.
@@ -47,8 +51,8 @@ export const getRtkQueryErrorMessage = (error: FetchBaseQueryError | SerializedE
     // CUSTOM_ERROR carries a developer-provided message string.
     if ('error' in error) return error.error
 
-    return `Error: ${status}`
+    return typeof status === 'number' ? getGenericErrorWithStatus(status) : RTK_QUERY_ERROR_MESSAGES.generic
   }
   // SerializedError
-  return error.message || 'Unknown error'
+  return error.message || RTK_QUERY_ERROR_MESSAGES.generic
 }


### PR DESCRIPTION
> Tiny local-part — the invite slips through;
> "Failed to fetch" now speaks in plain words;
> the "old UI" whisper grows into a button.

## What it solves

Resolves:
- [WA-2660](https://linear.app/safe-global/issue/WA-2660) — Email validation rejects short local-part addresses
- [WA-2657](https://linear.app/safe-global/issue/WA-2657) — Polish workspace creation error message
- [WA-2655](https://linear.app/safe-global/issue/WA-2655) — Increase visibility of the "Use the old UI" CTA

Three small, related polish fixes in the workspace onboarding flow.

## How this PR fixes it

- **WA-2660** — In the onboarding invite step there is no name field, so `toInviteName()` derives a display name from the email's local part. A short local part (e.g. `r@cc0x.dev` → `"r"`) was sent as-is and rejected by the backend with _"Names must be at least 3 characters long"_. Now a sanitized local part shorter than the backend minimum falls back to the existing `"Member"` default.
- **WA-2657** — `getRtkQueryErrorMessage` returned the raw JS error string for transport-level failures, leaking _"TypeError: Failed to fetch"_ and _"SyntaxError: … 'Rate limit reached' is not valid JSON"_ (a plain-text 429 the client tried to JSON-parse). It now maps `FETCH_ERROR` / `TIMEOUT_ERROR` / `PARSING_ERROR` (incl. the 429 rate-limit case) to friendly copy, while still surfacing the backend's own `data.message` and the numeric `Error: <status>` fallback.
- **WA-2655** — The classic-view escape hatch was a faint text link that read as "blocked". It's now a full-width secondary button (white fill + border, rotate icon) matching the sign-in buttons' radius (`rounded-md`) and text size (`text-[15px]`), using existing shadcn tokens only. Behaviour unchanged.

## How to test it

Unit tests:

```bash
yarn workspace @safe-global/web test src/utils/rtkQuery.test.ts \
  src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx \
  src/features/spaces/components/ClassicViewLink/index.test.tsx
```

Manual:

- **WA-2660** — Create workspace → invite step → enter `r@cc0x.dev` → invite is accepted (member name shows as `Member`).
- **WA-2657** — Create workspace step 1, set DevTools Network to **Offline**, click Next → friendly _"Couldn't connect to the server…"_ instead of `TypeError: Failed to fetch`.
- **WA-2655** — Signed-out `/welcome/spaces` (with `CLASSIC_VIEW` enabled) → "Use the old UI" renders as a visible button below the sign-in options.

## Affected flows

- Workspace creation → invite-members step (WA-2660)
- Workspace creation → step 1 error handling, and every other RTK-error surface (WA-2657)
- Signed-out sign-in card → classic-view CTA (WA-2655)

## Blast radius

- `getRtkQueryErrorMessage` (`apps/web/src/utils/rtkQuery.ts`) is **shared** — ~10 consumers (workspace create/invite, add-safe, renew invite, chains, accounts). All now show friendly transport-error copy; backend messages and numeric-status fallback preserved. One existing test (`useAddSafeToSpace`) updated to the new copy.
- `toInviteName` — single consumer (`useInviteForm`).
- `ClassicViewLink` — single render site (`SpacesList` signed-out card, behind the `CLASSIC_VIEW` chain flag).
- No API contract, feature-flag, persistence, or routing changes. Web-only files — no shared-package / mobile impact.

## Risks / not checked

- The 429 rate-limit path is unit-tested but not reproduced live (hard to trigger naturally); network-failure path verified live in the browser.
- Not tested on mobile (web-only change).
- No Playwright one-shot clickthrough added in this PR.
- WA-2655 button only renders signed-out with the `CLASSIC_VIEW` flag on; verified in the dev-env.

## Visual summary
<img width="608" height="660" alt="Screenshot 2026-06-17 at 10 28 21" src="https://github.com/user-attachments/assets/03fce402-dc0f-4aa4-bdcb-3153a1324c98" />
<img width="523" height="910" alt="Screenshot 2026-06-17 at 10 31 53" src="https://github.com/user-attachments/assets/eb1041af-1549-4d99-aef6-28f235a96913" />
<img width="401" height="596" alt="Screenshot 2026-06-17 at 10 33 53" src="https://github.com/user-attachments/assets/f0476978-f567-4a05-aa22-60e90fe1fe4e" />

```mermaid
flowchart TB
  subgraph S2660["WA-2660 · short-email invite"]
    A["r@cc0x.dev"] --> B["local part 'r' (1 char)"]
    B --> C{"< 3 chars?"}
    C -->|"before: send 'r'"| D["backend rejects"]
    C -->|"after: 'Member'"| E["invite accepted"]
  end
  subgraph S2657["WA-2657 · friendly errors"]
    F["RTK transport error"] --> G["getRtkQueryErrorMessage"]
    G -->|before| H["raw 'TypeError: Failed to fetch'"]
    G -->|after| I["'Couldn't connect…' / 'Too many requests…'"]
  end
  subgraph S2655["WA-2655 · visible CTA"]
    J["faint text link"] --> K["full-width secondary button"]
  end
```

UI (WA-2655): faint centered "Use the old UI →" text link → full-width 48px secondary button (white + border, rotate icon) matching the sign-in buttons. Verified live in the dev-env. See `wa2655-old-ui-button.png`, `wa2657-offline-message.png`, `wa2660-pending-member.png` in this folder.

## Checklist

- [ ] I've tested the branch on mobile 📱 (web-only change — N/A)
- [x] I've documented how it affects the analytics (no analytics changes) 📊
- [x] I've written a unit/e2e test for it 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
- [ ] For web feature/bugfix PRs, I've added a Playwright one-shot happy-path clickthrough 🎬 (not added)

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
