### PR TITLE
feat: new memberCount field

### DIFF
--- a/apps/web/src/features/spaces/components/InviteBanner/index.tsx
+++ b/apps/web/src/features/spaces/components/InviteBanner/index.tsx
@@ -1,7 +1,6 @@
 import { Card, Box, Typography, Stack } from '@mui/material'
 import type { GetSpaceResponse } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { SpaceSummary } from '../SpaceCard'
-import { MemberStatus } from '@/features/spaces'
 import InitialsAvatar from '@/components/common/InitialsAvatar'
 import css from './styles.module.css'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
@@ -16,8 +15,7 @@ type SpaceListInvite = {
 }
 
 const SpaceListInvite = ({ space, invitedByName }: SpaceListInvite) => {
-  const { name, members, safeCount } = space
-  const numberOfMembers = members.filter((member) => member.status === MemberStatus.ACTIVE).length
+  const { name, safeCount, memberCount } = space
 
   return (
     <Card sx={{ p: 2, mb: 2 }} data-testid="space-invite-banner">
@@ -39,7 +37,7 @@ const SpaceListInvite = ({ space, invitedByName }: SpaceListInvite) => {
             </Box>
 
             <Box>
-              <SpaceSummary name={name} numberOfAccounts={safeCount} numberOfMembers={numberOfMembers} />
+              <SpaceSummary name={name} numberOfAccounts={safeCount} numberOfMembers={memberCount} />
             </Box>
           </Stack>
 

--- a/apps/web/src/features/spaces/components/SpaceCard/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceCard/index.tsx
@@ -6,7 +6,6 @@ import css from './styles.module.css'
 import type { GetSpaceResponse } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import classNames from 'classnames'
 import { isUserActiveAdmin } from '@/features/spaces/utils'
-import { MemberStatus } from '@/features/spaces'
 import InitialsAvatar from '@/components/common/InitialsAvatar'
 import SpaceContextMenu from './SpaceContextMenu'
 import { maybePlural } from '@safe-global/utils/utils/formatters'
@@ -56,8 +55,7 @@ const SpaceCard = ({
   isLink?: boolean
   currentUserId?: number
 }) => {
-  const { uuid, name, members, safeCount } = space
-  const numberOfMembers = members.filter((member) => member.status === MemberStatus.ACTIVE).length
+  const { uuid, name, members, safeCount, memberCount } = space
   const isAdmin = isUserActiveAdmin(members, currentUserId)
 
   const handleClick = () => {
@@ -84,7 +82,7 @@ const SpaceCard = ({
 
       <InitialsAvatar name={name} size={isCompact ? 'medium' : 'large'} />
 
-      <SpaceSummary name={name} numberOfAccounts={safeCount} numberOfMembers={numberOfMembers} isCompact={isCompact} />
+      <SpaceSummary name={name} numberOfAccounts={safeCount} numberOfMembers={memberCount} isCompact={isCompact} />
 
       {isAdmin && <SpaceContextMenu space={space} />}
     </Card>

--- a/apps/web/src/features/spaces/components/SpaceCardNew/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceCardNew/index.tsx
@@ -1,7 +1,7 @@
 import { AppRoutes } from '@/config/routes'
 import Link from 'next/link'
 import type { GetSpaceResponse } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
-import { MemberStatus, useIsAdmin } from '../../hooks/useSpaceMembers'
+import { useIsAdmin } from '../../hooks/useSpaceMembers'
 import { maybePlural } from '@safe-global/utils/utils/formatters'
 import { getDeterministicColor } from '@/utils/colors'
 import { Card } from '@/components/ui/card'
@@ -38,9 +38,7 @@ export const SpaceSummaryNew = ({
 }
 
 const SpaceCardNew = ({ space, isLink = true }: { space: GetSpaceResponse; isLink?: boolean }) => {
-  const { uuid, name, members, safeCount } = space
-  const numberOfMembers = members.filter((member) => member.status === MemberStatus.ACTIVE).length
-  const numberOfAccounts = safeCount
+  const { uuid, name, safeCount, memberCount } = space
   const isAdmin = useIsAdmin(uuid)
 
   const logoColor = getDeterministicColor(name)
@@ -66,7 +64,7 @@ const SpaceCardNew = ({ space, isLink = true }: { space: GetSpaceResponse; isLin
         </AvatarFallback>
       </Avatar>
 
-      <SpaceSummaryNew name={name} numberOfAccounts={numberOfAccounts} numberOfMembers={numberOfMembers} />
+      <SpaceSummaryNew name={name} numberOfAccounts={safeCount} numberOfMembers={memberCount} />
 
       {isAdmin && (
         <div className="relative z-10 col-start-3 flex items-start">

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/DangerZoneSection.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/DangerZoneSection.test.tsx
@@ -33,8 +33,8 @@ describe('DangerZoneSection', () => {
       uuid: MOCK_SPACE_UUID,
       name: 'Other Workspace',
       members: [],
-      safeCount: 0,
       memberCount: 0,
+      safeCount: 0,
     }
 
     renderSection(space)
@@ -55,8 +55,8 @@ describe('DangerZoneSection', () => {
       uuid: MOCK_SPACE_UUID_ALT,
       name: 'Viewed',
       members: [],
-      safeCount: 0,
       memberCount: 0,
+      safeCount: 0,
     }
 
     renderSection(viewedSpace)


### PR DESCRIPTION
> Invite banner counted itself,
> a guest sees only their own row —
> so ask the backend: how many ACTIVE?

## What it solves [WA-2626](https://linear.app/safe-global/issue/WA-2626/invitation-shows-0-count-for-membersaccounts) 
Space summaries (cards + invite banner) derived the member count client-side via `members.filter(status === ACTIVE).length`. Introduce a new dedicated field `memberCount` to

## How this PR fixes it

- Adds a new backend-provided `memberCount` field to `GetSpaceResponse`, defined as the **total count of ACTIVE members** — semantically identical to the old client-side filter, but computed server-side so it's correct even when the `members` array is partial.
- Replaces the local `members.filter(ACTIVE).length` computation with `space.memberCount` in:
  - `SpaceCard` (legacy MUI card)
  - `SpaceCardNew` (shadcn card)
  - `InviteBanner` (the surface that actually exhibited the bug)
- Removes the now-unused `MemberStatus` imports and intermediate alias variables.
- `members` is still read for membership/role/inviter logic (`isUserActiveAdmin`, `getInvitedByName`, `AuthState`, `AcceptInviteDialog`) — only the *counting* usage was replaced.
- Updates the `spaceBuilder` test helper, the `SpaceCardNew` story, and four `SpaceSettings` test mocks to supply the now-required `memberCount`.

## How to test it

1. As a user with a **pending invite** to a space that has multiple active members, open the invite banner.
2. Confirm the banner shows the **real** active-member count, not "1".
3. On the spaces list, confirm member counts on `SpaceCard` / `SpaceCardNew` are unchanged for spaces you're already an active member of.
<img width="765" height="210" alt="Screenshot 2026-06-19 at 12 44 32 PM" src="https://github.com/user-attachments/assets/a9f2e89c-4c23-40d1-b6b8-c5782a5063b1" />

## Affected flows

- Spaces list cards (`SpaceCard`, `SpaceCardNew`) — member count display
- Invitation banner — member count display (the bug)

## Blast radius

- `GetSpaceResponse` consumers across `apps/web/src/features/spaces`. Only the three count surfaces changed behavior; all other `members` reads (admin check, inviter name, current-membership lookup) are untouched.

## Risks / not checked

- `memberCount` semantics depend on the backend returning **ACTIVE-only** counts (confirmed in the regenerated schema doc comment). If the backend definition drifts to include INVITED/DECLINED, counts would diverge from the old behavior.

## Visual summary

```mermaid
flowchart LR
  A[GetSpaceResponse] -->|before| B["members.filter(ACTIVE).length"]
  B --> C{Invited user?}
  C -->|members array = own row only| D["Wrong count (e.g. 1)"]
  A -->|after| E[space.memberCount]
  E --> F["Correct ACTIVE count (server-side)"]
```

## Checklist

- [x] Code follows the style guidelines of this project
- [x] Tests updated (builder, story, SpaceSettings mocks) and passing
- [x] `type-check`, `lint`, `prettier` clean
- [x] No new `any` types
