### PR TITLE
refactor(web): derive Spaces ownership from batched overviews

### DIFF
--- a/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSpaceSafeSelectorItems.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSpaceSafeSelectorItems.test.ts
@@ -264,6 +264,62 @@ describe('useSpaceSafeSelectorItems', () => {
     })
   })
 
+  // ── read-only derived from overview owners (no owners-endpoint enumeration) ──
+
+  it('marks a safe read-only when the wallet is not among the overview owners', () => {
+    setupDefaults() // wallet 0xWallet, overview owners [0xOwner1]
+
+    const { result } = renderHook(() => useSpaceSafeSelectorItems())
+    expect(result.current.items[0].chains[0].isReadOnly).toBe(true)
+  })
+
+  it('marks a safe writable when the wallet is among the overview owners', () => {
+    setupDefaults({
+      overviews: [
+        {
+          address: { value: '0xSafe1' },
+          chainId: '1',
+          fiatTotal: '5000',
+          threshold: 2,
+          owners: [{ value: '0xWallet' }],
+        },
+      ],
+    })
+
+    const { result } = renderHook(() => useSpaceSafeSelectorItems())
+    expect(result.current.items[0].chains[0].isReadOnly).toBe(false)
+  })
+
+  it('treats a safe as read-only when no wallet is connected', () => {
+    setupDefaults({
+      overviews: [
+        {
+          address: { value: '0xSafe1' },
+          chainId: '1',
+          fiatTotal: '5000',
+          threshold: 2,
+          owners: [{ value: '0xWallet' }],
+        },
+      ],
+    })
+    ;(useWallet as jest.Mock).mockReturnValue(undefined)
+
+    const { result } = renderHook(() => useSpaceSafeSelectorItems())
+    expect(result.current.items[0].chains[0].isReadOnly).toBe(true)
+  })
+
+  // Counterfactual safes have no overview; read-only falls back to the item's own flag, which stays
+  // correct without the owners enumeration.
+  it('falls back to the item read-only flag when no overview exists', () => {
+    setupDefaults({
+      allSafes: [{ ...singleChainSafe, isReadOnly: false }],
+      overviews: [],
+    })
+
+    const { result } = renderHook(() => useSpaceSafeSelectorItems())
+    expect(result.current.items[0].chains[0].isReadOnly).toBe(false)
+  })
+
   // ── balance and threshold from overview ──
 
   it('uses overview data for balance and threshold of non-current safes', () => {

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSafeBarSafes.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSafeBarSafes.ts
@@ -51,7 +51,10 @@ export function useSafeBarSafes() {
   const safeAddress = urlSafeAddress || reduxSafeAddress
   const currentChainId = useChainId()
 
-  const allSafeItems = useAllSafes()
+  // Skip the owned-safes enumeration (the captcha-protected owners endpoint): the bar's lists are the
+  // space safes (overview-derived) and the trusted/pinned safes (added-safes state), neither of which
+  // needs it. Per-row read-only is derived from the overviews in useSpaceSafeSelectorItems instead.
+  const allSafeItems = useAllSafes(false)
 
   const spaceId = useCurrentSpaceId()
   // Trusted (pinned) lists honour the trusted custom order; space lists honour that space's order.
@@ -60,8 +63,10 @@ export function useSafeBarSafes() {
 
   const pinnedItems = useMemo(() => allSafeItems?.filter((s) => s.isPinned) ?? [], [allSafeItems])
 
-  const pinnedGrouped = useAllSafesGrouped(pinnedItems)
-  const allGrouped = useAllSafesGrouped(allSafeItems ?? [])
+  // Pass fetchOwnedSafes=false too: useAllSafesGrouped still calls useAllSafes internally even when
+  // customSafes is supplied, so without this it would re-trigger the owners endpoint.
+  const pinnedGrouped = useAllSafesGrouped(pinnedItems, false)
+  const allGrouped = useAllSafesGrouped(allSafeItems ?? [], false)
 
   const pinnedSafes = useMemo<AllSafeItems>(() => {
     const multiChainSafes = pinnedGrouped.allMultiChainSafes ?? []

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceSafeSelectorItems.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceSafeSelectorItems.ts
@@ -43,6 +43,20 @@ const resolveThresholdAndOwners = (
   owners: isCurrentSafe ? (safe.owners?.length ?? 0) : (overview?.owners.length ?? 0),
 })
 
+// Read-only is derived from the overview's owners (this surface fetches overviews for every listed
+// safe anyway), so the bar never enumerates owned safes via the captcha-protected owners endpoint.
+// No wallet → read-only; no overview (counterfactual safes) → the item's own flag, which is correct
+// for CF safes even without the enumeration.
+const deriveIsReadOnly = (
+  overview: SafeOverview | undefined,
+  walletAddress: string | undefined,
+  fallback: boolean,
+): boolean => {
+  if (!walletAddress) return true
+  if (!overview) return fallback
+  return !overview.owners.some((owner) => sameAddress(owner.value, walletAddress))
+}
+
 const mapChainIds = (chainConfigs: Chain[], chainIds: string[]): ChainInfo[] =>
   chainIds.map((id) =>
     toChainInfo(
@@ -75,7 +89,7 @@ const mapMultiChainItemChains = (
       isLoading: overviewsLoading && !overview,
       queued: overview?.queued,
       awaitingConfirmation: getOwnerAwaitingConfirmations(overview, walletAddress) || undefined,
-      isReadOnly: perChainSafe?.isReadOnly ?? false,
+      isReadOnly: deriveIsReadOnly(overview, walletAddress, perChainSafe?.isReadOnly ?? false),
       isUndeployed: Boolean(undeployed),
       isActivating: Boolean(undeployed && undeployed.status.status !== PendingSafeStatus.AWAITING_EXECUTION),
     }
@@ -142,7 +156,7 @@ function buildSingleChainItem(
       ...chain,
       queued: overview?.queued,
       awaitingConfirmation: getOwnerAwaitingConfirmations(overview, walletAddress) || undefined,
-      isReadOnly: item.isReadOnly ?? false,
+      isReadOnly: deriveIsReadOnly(overview, walletAddress, item.isReadOnly ?? false),
       isUndeployed: Boolean(undeployed),
       isActivating: Boolean(undeployed && undeployed.status.status !== PendingSafeStatus.AWAITING_EXECUTION),
     })),

--- a/apps/web/src/components/common/TrustedSafesModal/useTrustedSafesModal.test.ts
+++ b/apps/web/src/components/common/TrustedSafesModal/useTrustedSafesModal.test.ts
@@ -70,6 +70,19 @@ describe('useTrustedSafesModal', () => {
     expect(result.current.isOpen).toBe(true)
   })
 
+  // The owned-safes enumeration must stay deferred until the modal is actually opened.
+  it('only enumerates safes while the modal is open', () => {
+    const { result } = renderHook(() => useTrustedSafesModal())
+
+    expect(useAllSafes.default).toHaveBeenLastCalledWith(false)
+
+    act(() => {
+      result.current.open()
+    })
+
+    expect(useAllSafes.default).toHaveBeenLastCalledWith(true)
+  })
+
   it('should close modal', () => {
     const { result } = renderHook(() => useTrustedSafesModal())
 

--- a/apps/web/src/components/common/TrustedSafesModal/useTrustedSafesModal.ts
+++ b/apps/web/src/components/common/TrustedSafesModal/useTrustedSafesModal.ts
@@ -100,8 +100,9 @@ const useTrustedSafesModal = (): UseTrustedSafesModalReturn => {
   const [pendingSelectAllConfirmation, setPendingSelectAllConfirmation] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
 
-  const allSafes = useAllSafes()
-  const { allMultiChainSafes, allSingleSafes } = useAllSafesGrouped()
+  // The list is only shown while the modal is open, so only enumerate owned safes then.
+  const allSafes = useAllSafes(isOpen)
+  const { allMultiChainSafes, allSingleSafes } = useAllSafesGrouped(undefined, isOpen)
   const addedSafes = useAppSelector(selectAllAddedSafes)
   // Same global Name / Last visited / Manual preference used across the trusted-safes lists.
   const sortComparator = useSafeOrderComparator(TRUSTED_ORDER_SCOPE)

--- a/apps/web/src/features/myAccounts/hooks/__tests__/useNetworksOfSafe.test.ts
+++ b/apps/web/src/features/myAccounts/hooks/__tests__/useNetworksOfSafe.test.ts
@@ -1,0 +1,33 @@
+import { renderHook } from '@testing-library/react'
+import { useNetworksOfSafe } from '../useNetworksOfSafe'
+
+const mockUseAllSafesGrouped = jest.fn()
+
+jest.mock('@/hooks/safes', () => ({
+  useAllSafesGrouped: (...args: unknown[]) => mockUseAllSafesGrouped(...args),
+}))
+
+jest.mock('@/hooks/useChains', () => ({
+  __esModule: true,
+  default: () => ({ configs: [] }),
+}))
+
+describe('useNetworksOfSafe', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseAllSafesGrouped.mockReturnValue({ allMultiChainSafes: [] })
+  })
+
+  // With no active Safe there are no networks to resolve, so the owned-safes enumeration is skipped.
+  it('skips the owners enumeration when no safe address is provided', () => {
+    renderHook(() => useNetworksOfSafe(''))
+
+    expect(mockUseAllSafesGrouped).toHaveBeenCalledWith(undefined, false)
+  })
+
+  it('enumerates safes when a safe address is provided', () => {
+    renderHook(() => useNetworksOfSafe('0x0000000000000000000000000000000000000123'))
+
+    expect(mockUseAllSafesGrouped).toHaveBeenCalledWith(undefined, true)
+  })
+})

--- a/apps/web/src/features/myAccounts/hooks/useNetworksOfSafe.ts
+++ b/apps/web/src/features/myAccounts/hooks/useNetworksOfSafe.ts
@@ -11,7 +11,8 @@ import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
  * @returns Array of network names where the Safe is deployed
  */
 export const useNetworksOfSafe = (safeAddress: string): string[] => {
-  const { allMultiChainSafes } = useAllSafesGrouped()
+  // Without an address this returns [] anyway, so skip the owned-safes enumeration entirely.
+  const { allMultiChainSafes } = useAllSafesGrouped(undefined, !!safeAddress)
   const { configs: allChains } = useChains()
 
   const chainMap = useMemo(() => {

--- a/apps/web/src/features/spaces/components/AddAccounts/__tests__/AddAccounts.test.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/__tests__/AddAccounts.test.tsx
@@ -56,11 +56,15 @@ jest.mock('@/hooks/useChains', () => ({
 }))
 
 let mockAllOwned: Record<string, string[]> = {}
+const mockUseAllOwnedSafes = jest.fn<readonly [Record<string, string[]>, boolean], [string]>(() => [
+  mockAllOwned,
+  false,
+])
 jest.mock('@/hooks/safes', () => {
   const actual = jest.requireActual('@/hooks/safes')
   return {
     ...actual,
-    useAllOwnedSafes: () => [mockAllOwned, false] as const,
+    useAllOwnedSafes: (address: string) => mockUseAllOwnedSafes(address),
     useSafesSearch: (safes: unknown) => safes,
   }
 })
@@ -103,6 +107,21 @@ describe('AddAccounts — wallet connection state', () => {
   it('shows trusted safes in the list', () => {
     render(<AddAccounts externalOpen onExternalClose={() => {}} />, withTrusted)
     expect(screen.getByTestId('safe-accounts-table')).toHaveAttribute('data-count', '1')
+  })
+
+  // Owned-safes enumeration (the captcha-protected owners endpoint) is deferred until the modal
+  // opens: while closed the hook is called with an empty address so the request is skipped.
+  it('does not enumerate owned safes while the modal is closed', () => {
+    render(<AddAccounts />)
+
+    expect(mockUseAllOwnedSafes).toHaveBeenCalledWith('')
+    expect(mockUseAllOwnedSafes).not.toHaveBeenCalledWith('0xWallet')
+  })
+
+  it('enumerates owned safes once the modal is open', () => {
+    render(<AddAccounts externalOpen onExternalClose={() => {}} />)
+
+    expect(mockUseAllOwnedSafes).toHaveBeenCalledWith('0xWallet')
   })
 
   it('renders the "What are trusted Safe accounts?" info banner with a Manage list action', () => {

--- a/apps/web/src/features/spaces/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/index.tsx
@@ -112,8 +112,10 @@ const AddAccounts = ({
   const { configs } = useChains()
   const allChainIds = useMemo(() => configs.map((c) => c.chainId), [configs])
 
-  // Get safe data
-  const [allOwned = {}] = useAllOwnedSafes(walletAddress)
+  // Get safe data. Only enumerate owned safes (the captcha-protected owners endpoint) once the modal
+  // is open: the trusted list itself is built from added safes, so `allOwned` only feeds the per-row
+  // read-only flag — which nothing needs while the dialog is closed and this trigger sits mounted.
+  const [allOwned = {}] = useAllOwnedSafes(isOpen ? walletAddress : '')
   const allAdded = useAppSelector(selectAllAddedSafes)
   const allUndeployed = useAppSelector(selectUndeployedSafes)
   const allVisitedSafes = useAppSelector(selectAllVisitedSafes)

--- a/apps/web/src/features/spaces/hooks/__tests__/useSpaceSafeOverviews.test.tsx
+++ b/apps/web/src/features/spaces/hooks/__tests__/useSpaceSafeOverviews.test.tsx
@@ -1,0 +1,183 @@
+import { renderHook } from '@testing-library/react'
+import { skipToken } from '@reduxjs/toolkit/query'
+import type { AddressInfo, SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { useSpaceSafeOverviews } from '../useSpaceSafeOverviews'
+
+const mockUseGetMultipleSafeOverviewsQuery = jest.fn()
+const mockUseWallet = jest.fn()
+let mockCurrency = 'usd'
+
+// The hook only reads `props.safeAccountConfig.owners`; keep the fixture minimal but typed.
+type TestUndeployed = Record<string, Record<string, { props: { safeAccountConfig: { owners: string[] } } }>>
+let mockUndeployedSafes: TestUndeployed = {}
+
+jest.mock('@/store', () => ({
+  useAppSelector: (selector: string) => {
+    if (selector === 'selectCurrency') return mockCurrency
+    if (selector === 'selectUndeployedSafes') return mockUndeployedSafes
+    return undefined
+  },
+}))
+
+jest.mock('@/store/settingsSlice', () => ({ selectCurrency: 'selectCurrency' }))
+jest.mock('@/store/slices', () => ({ selectUndeployedSafes: 'selectUndeployedSafes' }))
+
+jest.mock('@/store/api/gateway', () => ({
+  useGetMultipleSafeOverviewsQuery: (...args: unknown[]) => mockUseGetMultipleSafeOverviewsQuery(...args),
+}))
+
+jest.mock('@/hooks/wallets/useWallet', () => ({
+  __esModule: true,
+  default: () => mockUseWallet(),
+}))
+
+const addr = (value: string): AddressInfo => ({ value })
+
+const buildOverview = (chainId: string, address: string, owners: string[]): SafeOverview => ({
+  address: addr(address),
+  chainId,
+  threshold: 1,
+  owners: owners.map(addr),
+  fiatTotal: '0',
+  queued: 0,
+})
+
+const WALLET = '0x1111111111111111111111111111111111111111'
+const OTHER = '0x2222222222222222222222222222222222222222'
+const SAFE_A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+const SAFE_B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
+const mockOverviews = (data: SafeOverview[] | undefined) =>
+  mockUseGetMultipleSafeOverviewsQuery.mockReturnValue({ data })
+
+describe('useSpaceSafeOverviews', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCurrency = 'usd'
+    mockUndeployedSafes = {}
+    mockUseWallet.mockReturnValue({ address: WALLET })
+    mockOverviews([])
+  })
+
+  it('skips the query (skipToken) when there are no space safes', () => {
+    renderHook(() => useSpaceSafeOverviews([]))
+
+    expect(mockUseGetMultipleSafeOverviewsQuery).toHaveBeenCalledWith(skipToken)
+  })
+
+  it('subscribes without walletAddress so the entry stays wallet-independent', () => {
+    mockOverviews([buildOverview('1', SAFE_A, [WALLET])])
+
+    renderHook(() => useSpaceSafeOverviews([{ chainId: '1', address: SAFE_A }]))
+
+    expect(mockUseGetMultipleSafeOverviewsQuery).toHaveBeenCalledWith({
+      safes: [{ chainId: '1', address: SAFE_A }],
+      currency: 'usd',
+    })
+  })
+
+  it('returns an empty map while overviews are loading (read-only, matches today)', () => {
+    mockOverviews(undefined)
+
+    const { result } = renderHook(() => useSpaceSafeOverviews([{ chainId: '1', address: SAFE_A }]))
+
+    expect(result.current.ownedByChain).toEqual({})
+    expect(result.current.isOwnershipResolved).toBe(false)
+  })
+
+  it('returns an empty map when the wallet is not connected', () => {
+    mockUseWallet.mockReturnValue(null)
+    mockOverviews([buildOverview('1', SAFE_A, [WALLET])])
+
+    const { result } = renderHook(() => useSpaceSafeOverviews([{ chainId: '1', address: SAFE_A }]))
+
+    expect(result.current.ownedByChain).toEqual({})
+    expect(result.current.isOwnershipResolved).toBe(true)
+  })
+
+  it('returns an empty map when the wallet owns none of the safes', () => {
+    mockOverviews([buildOverview('1', SAFE_A, [OTHER])])
+
+    const { result } = renderHook(() => useSpaceSafeOverviews([{ chainId: '1', address: SAFE_A }]))
+
+    expect(result.current.ownedByChain).toEqual({})
+    expect(result.current.isOwnershipResolved).toBe(true)
+  })
+
+  it('maps only the safes the wallet owns, keyed by chain', () => {
+    mockOverviews([buildOverview('1', SAFE_A, [WALLET]), buildOverview('1', SAFE_B, [OTHER])])
+
+    const { result } = renderHook(() =>
+      useSpaceSafeOverviews([
+        { chainId: '1', address: SAFE_A },
+        { chainId: '1', address: SAFE_B },
+      ]),
+    )
+
+    expect(result.current.ownedByChain).toEqual({ '1': [SAFE_A] })
+  })
+
+  it('resolves ownership case-insensitively (F1)', () => {
+    // Overview owner is checksummed/upper-case; the connected wallet is lower-case.
+    mockUseWallet.mockReturnValue({ address: WALLET })
+    mockOverviews([buildOverview('1', SAFE_A, [WALLET.toUpperCase()])])
+
+    const { result } = renderHook(() => useSpaceSafeOverviews([{ chainId: '1', address: SAFE_A }]))
+
+    expect(result.current.ownedByChain).toEqual({ '1': [SAFE_A] })
+  })
+
+  it('falls back to the counterfactual owner config for undeployed safes (F2)', () => {
+    // No overview for the undeployed safe, but the wallet is a configured CF owner.
+    mockOverviews([])
+    mockUndeployedSafes = {
+      '10': { [SAFE_B]: { props: { safeAccountConfig: { owners: [WALLET] } } } },
+    }
+
+    const { result } = renderHook(() => useSpaceSafeOverviews([{ chainId: '10', address: SAFE_B }]))
+
+    expect(result.current.ownedByChain).toEqual({ '10': [SAFE_B] })
+  })
+
+  it('does not claim undeployed safes the wallet is not a CF owner of (F2)', () => {
+    mockOverviews([])
+    mockUndeployedSafes = {
+      '10': { [SAFE_B]: { props: { safeAccountConfig: { owners: [OTHER] } } } },
+    }
+
+    const { result } = renderHook(() => useSpaceSafeOverviews([{ chainId: '10', address: SAFE_B }]))
+
+    expect(result.current.ownedByChain).toEqual({})
+  })
+
+  it('leaves a safe read-only when its chain overview is missing (Edge Case B)', () => {
+    // Two safes requested, only chain "1" came back; the chain "100" safe is unresolved → read-only.
+    mockOverviews([buildOverview('1', SAFE_A, [WALLET])])
+
+    const { result } = renderHook(() =>
+      useSpaceSafeOverviews([
+        { chainId: '1', address: SAFE_A },
+        { chainId: '100', address: SAFE_B },
+      ]),
+    )
+
+    expect(result.current.ownedByChain).toEqual({ '1': [SAFE_A] })
+  })
+
+  it('recomputes on wallet switch without changing the subscription args (no refetch)', () => {
+    mockOverviews([buildOverview('1', SAFE_A, [WALLET])])
+
+    const { result, rerender } = renderHook(() => useSpaceSafeOverviews([{ chainId: '1', address: SAFE_A }]))
+    expect(result.current.ownedByChain).toEqual({ '1': [SAFE_A] })
+
+    // Switch to a wallet that is not an owner.
+    mockUseWallet.mockReturnValue({ address: OTHER })
+    rerender()
+    expect(result.current.ownedByChain).toEqual({})
+
+    // Every subscription used the same wallet-independent args — walletAddress never entered the key.
+    for (const call of mockUseGetMultipleSafeOverviewsQuery.mock.calls) {
+      expect(call[0]).toEqual({ safes: [{ chainId: '1', address: SAFE_A }], currency: 'usd' })
+    }
+  })
+})

--- a/apps/web/src/features/spaces/hooks/__tests__/useSpaceSafes.test.tsx
+++ b/apps/web/src/features/spaces/hooks/__tests__/useSpaceSafes.test.tsx
@@ -6,9 +6,7 @@ const MOCK_SPACE_UUID = '11111111-1111-1111-1111-111111111111'
 const mockUseCurrentSpaceId = jest.fn()
 const mockUseSpaceSafesGetV1Query = jest.fn()
 const mockUseGetSpaceAddressBook = jest.fn()
-const mockUseWallet = jest.fn()
-const mockUseAllOwnedSafes = jest.fn()
-const mockUseAllSafesGrouped = jest.fn()
+const mockUseSpaceSafeOverviews = jest.fn()
 let mockIsAuthenticated = true
 let mockLocalAddressBook: Record<string, Record<string, string>> = {}
 
@@ -19,6 +17,10 @@ jest.mock('../useCurrentSpaceId', () => ({
 jest.mock('../useGetSpaceAddressBook', () => ({
   __esModule: true,
   default: () => mockUseGetSpaceAddressBook(),
+}))
+
+jest.mock('../useSpaceSafeOverviews', () => ({
+  useSpaceSafeOverviews: () => mockUseSpaceSafeOverviews(),
 }))
 
 jest.mock('@/store', () => ({
@@ -51,14 +53,9 @@ jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
 
 jest.mock('@/hooks/safes', () => ({
   _buildSafeItems: jest.fn(() => []),
-  useAllSafesGrouped: () => mockUseAllSafesGrouped(),
-  useAllOwnedSafes: () => mockUseAllOwnedSafes(),
+  _getMultiChainAccounts: jest.fn(() => []),
+  _getSingleChainAccounts: jest.fn(() => []),
   useSafeOrderComparator: () => () => 0,
-}))
-
-jest.mock('@/hooks/wallets/useWallet', () => ({
-  __esModule: true,
-  default: () => mockUseWallet(),
 }))
 
 jest.mock('../../utils', () => ({
@@ -71,9 +68,7 @@ describe('useSpaceSafes', () => {
     mockIsAuthenticated = true
     mockLocalAddressBook = {}
     mockUseGetSpaceAddressBook.mockReturnValue([])
-    mockUseWallet.mockReturnValue({ address: '0xabc' })
-    mockUseAllOwnedSafes.mockReturnValue([{}])
-    mockUseAllSafesGrouped.mockReturnValue({ allMultiChainSafes: [], allSingleSafes: [] })
+    mockUseSpaceSafeOverviews.mockReturnValue({ ownedByChain: {}, isOwnershipResolved: true })
     mockUseSpaceSafesGetV1Query.mockReturnValue({
       currentData: undefined,
       isLoading: false,
@@ -138,6 +133,30 @@ describe('useSpaceSafes', () => {
       { '1': ['0xA'] },
       expect.objectContaining({ '1': { '0xA': 'Local Name' } }),
       expect.anything(),
+      expect.anything(),
+    )
+  })
+
+  // Ownership is derived from the batched overviews and fed into _buildSafeItems as the `allOwned`
+  // argument.
+  it('feeds the overview-derived ownership map into _buildSafeItems', () => {
+    mockUseCurrentSpaceId.mockReturnValue(MOCK_SPACE_UUID)
+    mockUseSpaceSafesGetV1Query.mockReturnValue({
+      currentData: { safes: { '1': ['0xA'] } },
+      isLoading: false,
+      isError: false,
+      error: undefined,
+      refetch: jest.fn(),
+    })
+    mockUseSpaceSafeOverviews.mockReturnValue({ ownedByChain: { '1': ['0xA'] }, isOwnershipResolved: true })
+
+    renderHook(() => useSpaceSafes())
+
+    const { _buildSafeItems } = jest.requireMock('@/hooks/safes') as { _buildSafeItems: jest.Mock }
+    expect(_buildSafeItems).toHaveBeenCalledWith(
+      { '1': ['0xA'] },
+      expect.anything(),
+      { '1': ['0xA'] },
       expect.anything(),
     )
   })

--- a/apps/web/src/features/spaces/hooks/useSpaceSafeOverviews.ts
+++ b/apps/web/src/features/spaces/hooks/useSpaceSafeOverviews.ts
@@ -1,0 +1,67 @@
+import { skipToken } from '@reduxjs/toolkit/query'
+import { useMemo } from 'react'
+import type { AllOwnedSafes } from '@safe-global/store/gateway/types'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
+import { useGetMultipleSafeOverviewsQuery } from '@/store/api/gateway'
+import { useAppSelector } from '@/store'
+import { selectCurrency } from '@/store/settingsSlice'
+import { selectUndeployedSafes } from '@/store/slices'
+import useWallet from '@/hooks/wallets/useWallet'
+import type { SafeItem } from '@/hooks/safes'
+
+type SpaceSafeRef = Pick<SafeItem, 'chainId' | 'address'>
+
+/**
+ * Derives per-Safe ownership for the connected wallet from the batched `getMultipleSafeOverviews`
+ * data this surface already fetches, so ownership needs no separate per-owner request.
+ *
+ * The dashboard's cache entry is shared via the endpoint's `serializeQueryArgs` (same set of safes →
+ * one entry). Ownership is derived client-side so the shared entry stays wallet-independent and a
+ * wallet switch recomputes without a refetch.
+ *
+ * @param spaceSafeItems The space's safes to resolve ownership for (only chainId/address are read).
+ * @returns `ownedByChain` — an `AllOwnedSafes` map (empty while loading or signed out → read-only) —
+ *   and `isOwnershipResolved` for skeleton states.
+ */
+export const useSpaceSafeOverviews = (spaceSafeItems: SpaceSafeRef[]) => {
+  const currency = useAppSelector(selectCurrency)
+  const { address: wallet = '' } = useWallet() || {}
+  const undeployedSafes = useAppSelector(selectUndeployedSafes)
+
+  const { data: overviews } = useGetMultipleSafeOverviewsQuery(
+    spaceSafeItems.length > 0 ? { safes: spaceSafeItems, currency } : skipToken,
+  )
+
+  const ownedByChain = useMemo<AllOwnedSafes>(() => {
+    // While loading (or signed out) leave the map empty → every row read-only (fail-closed).
+    if (!overviews || !wallet) return {}
+
+    const map: AllOwnedSafes = {}
+    const addOwned = (chainId: string, address: string) => {
+      map[chainId] = map[chainId] ?? []
+      map[chainId].push(address)
+    }
+
+    for (const overview of overviews) {
+      if (overview.owners.some((owner) => sameAddress(owner.value, wallet))) {
+        addOwned(overview.chainId, overview.address.value)
+      }
+    }
+
+    // Counterfactual/undeployed safes have no overview; fall back to the local CF owner config,
+    // exactly as the global `_buildSafeItem` does. Extra entries for safes outside the space are
+    // harmless — the consumer only reads keys for space safes.
+    for (const [chainId, safesOnChain] of Object.entries(undeployedSafes)) {
+      for (const address of Object.keys(safesOnChain)) {
+        const cfOwners = safesOnChain[address]?.props.safeAccountConfig.owners ?? []
+        if (cfOwners.some((owner) => sameAddress(owner, wallet))) {
+          addOwned(chainId, address)
+        }
+      }
+    }
+
+    return map
+  }, [overviews, wallet, undeployedSafes])
+
+  return { ownedByChain, isOwnershipResolved: overviews !== undefined }
+}

--- a/apps/web/src/features/spaces/hooks/useSpaceSafes.tsx
+++ b/apps/web/src/features/spaces/hooks/useSpaceSafes.tsx
@@ -2,11 +2,12 @@ import { useSpaceSafesGetV1Query } from '@safe-global/store/gateway/AUTO_GENERAT
 import {
   _buildSafeItems,
   type AllSafeItems,
-  useAllSafesGrouped,
-  useAllOwnedSafes,
+  _getMultiChainAccounts,
+  _getSingleChainAccounts,
   useSafeOrderComparator,
 } from '@/hooks/safes'
 import { useCurrentSpaceId } from './useCurrentSpaceId'
+import { useSpaceSafeOverviews } from './useSpaceSafeOverviews'
 import useGetSpaceAddressBook from './useGetSpaceAddressBook'
 import { SPACE_REFRESH_OPTIONS } from './refreshOptions'
 import { mapSpaceContactsToAddressBookState } from '../utils'
@@ -16,7 +17,6 @@ import { selectAllAddressBooks, selectAllVisitedSafes } from '@/store/slices'
 import merge from 'lodash/merge'
 import { useMemo } from 'react'
 import { isAuthenticated } from '@/store/authSlice'
-import useWallet from '@/hooks/wallets/useWallet'
 
 export const useSpaceSafes = () => {
   const spaceId = useCurrentSpaceId()
@@ -43,17 +43,32 @@ export const useSpaceSafes = () => {
     [localAddressBook, spaceContacts],
   )
 
-  const { address: walletAddress = '' } = useWallet() || {}
-  const [allOwned = {}] = useAllOwnedSafes(walletAddress)
+  // Ownership is derived from the batched overviews this surface already fetches; the pure groupers
+  // below avoid pulling in `useAllSafes()`.
+  const spaceSafeItems = useMemo(
+    () =>
+      currentData
+        ? Object.entries(currentData.safes).flatMap(([chainId, addresses]) =>
+            addresses.map((address) => ({ chainId, address })),
+          )
+        : [],
+    [currentData],
+  )
+  const { ownedByChain } = useSpaceSafeOverviews(spaceSafeItems)
   const allVisitedSafes = useAppSelector(selectAllVisitedSafes)
-  const safeItems = currentData ? _buildSafeItems(currentData.safes, addressBooks, allOwned, allVisitedSafes) : []
-  const safes = useAllSafesGrouped(safeItems)
+
+  const safeItems = useMemo(
+    () => (currentData ? _buildSafeItems(currentData.safes, addressBooks, ownedByChain, allVisitedSafes) : []),
+    [currentData, addressBooks, ownedByChain, allVisitedSafes],
+  )
+
   const sortComparator = useSafeOrderComparator(spaceId ? getSpaceOrderScope(spaceId) : undefined)
 
-  const allSafes = useMemo<AllSafeItems>(
-    () => [...(safes.allMultiChainSafes ?? []), ...(safes.allSingleSafes ?? [])].sort(sortComparator),
-    [safes.allMultiChainSafes, safes.allSingleSafes, sortComparator],
-  )
+  const allSafes = useMemo<AllSafeItems>(() => {
+    const allMultiChainSafes = _getMultiChainAccounts(safeItems)
+    const allSingleSafes = _getSingleChainAccounts(safeItems, allMultiChainSafes)
+    return [...allMultiChainSafes, ...allSingleSafes].sort(sortComparator)
+  }, [safeItems, sortComparator])
 
   return { allSafes, isLoading, isError: isSpaceSafesError, error: spaceSafesError, refetch: refetchSpaceSafes }
 }

--- a/apps/web/src/features/walletconnect/components/WalletConnectContext/index.tsx
+++ b/apps/web/src/features/walletconnect/components/WalletConnectContext/index.tsx
@@ -57,7 +57,32 @@ export const WalletConnectProvider = ({ children }: { children: ReactNode }) => 
   const setOpen = wcPopupStore.setStore
   const [error, setError] = useState<Error | null>(null)
   const [loading, setLoading] = useState<WCLoadingState | null>(null)
-  const safeWalletProvider = useSafeWalletProvider()
+
+  //
+  // --- Sessions
+  //
+  const [sessions, setSessions] = useState<SessionTypes.Struct[]>([])
+
+  const updateSessions = useCallback(() => {
+    walletConnect && setSessions(walletConnect.getActiveSessions())
+  }, [walletConnect])
+
+  // Initial sessions
+  useEffect(updateSessions, [updateSessions])
+
+  // On session add
+  useEffect(() => {
+    return walletConnect?.onSessionAdd(updateSessions)
+  }, [walletConnect, updateSessions])
+
+  // On session delete
+  useEffect(() => {
+    return walletConnect?.onSessionDelete(updateSessions)
+  }, [walletConnect, updateSessions])
+
+  // The owned-safes list is only needed for dApp-initiated chain switches, so enable it once a
+  // session exists.
+  const safeWalletProvider = useSafeWalletProvider(sessions.length > 0)
   const [autoApprove = {}, setAutoApprove] = useLocalStorage<WcAutoApproveProps>(WC_AUTO_APPROVE_KEY)
 
   // Init WalletConnect
@@ -192,28 +217,6 @@ export const WalletConnectProvider = ({ children }: { children: ReactNode }) => 
       setLoading(null)
     })
   }, [walletConnect, safeWalletProvider, chainId, safeAddress, setOpen])
-
-  //
-  // --- Sessions
-  //
-  const [sessions, setSessions] = useState<SessionTypes.Struct[]>([])
-
-  const updateSessions = useCallback(() => {
-    walletConnect && setSessions(walletConnect.getActiveSessions())
-  }, [walletConnect])
-
-  // Initial sessions
-  useEffect(updateSessions, [updateSessions])
-
-  // On session add
-  useEffect(() => {
-    return walletConnect?.onSessionAdd(updateSessions)
-  }, [walletConnect, updateSessions])
-
-  // On session delete
-  useEffect(() => {
-    return walletConnect?.onSessionDelete(updateSessions)
-  }, [walletConnect, updateSessions])
 
   //
   // --- Proposals

--- a/apps/web/src/hooks/safes/__tests__/useAllSafes.test.ts
+++ b/apps/web/src/hooks/safes/__tests__/useAllSafes.test.ts
@@ -3,6 +3,7 @@ import useAllSafes, { _buildSafeItem, _prepareAddresses } from '../useAllSafes'
 import * as useChains from '@/hooks/useChains'
 import * as useWallet from '@/hooks/wallets/useWallet'
 import { renderHook } from '@/tests/test-utils'
+import { connectedWalletBuilder } from '@/tests/builders/wallet'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import type { UndeployedSafe } from '@safe-global/utils/features/counterfactual/store/types'
 
@@ -10,6 +11,8 @@ describe('useAllSafes hook', () => {
   beforeEach(() => {
     jest.clearAllMocks()
 
+    // Default to no connected wallet; tests that need one override this spy explicitly.
+    jest.spyOn(useWallet, 'default').mockReturnValue(null)
     jest.spyOn(allOwnedSafes, 'default').mockReturnValue([undefined, undefined, false])
     jest.spyOn(useChains, 'default').mockImplementation(() => ({
       configs: [{ chainId: '1' } as Chain],
@@ -31,6 +34,25 @@ describe('useAllSafes hook', () => {
     const { result } = renderHook(() => useAllSafes())
 
     expect(result.current).toEqual([])
+  })
+
+  it('enumerates owned safes for the connected wallet by default', () => {
+    jest.spyOn(useWallet, 'default').mockReturnValue(connectedWalletBuilder().with({ address: '0x111' }).build())
+    const ownedSpy = jest.spyOn(allOwnedSafes, 'default').mockReturnValue([undefined, undefined, false])
+
+    renderHook(() => useAllSafes())
+
+    expect(ownedSpy).toHaveBeenCalledWith('0x111')
+  })
+
+  it('skips the owned-safes enumeration when fetchOwnedSafes is false', () => {
+    jest.spyOn(useWallet, 'default').mockReturnValue(connectedWalletBuilder().with({ address: '0x111' }).build())
+    const ownedSpy = jest.spyOn(allOwnedSafes, 'default').mockReturnValue([undefined, undefined, false])
+
+    // Passing an empty address makes useAllOwnedSafes skip the owned-safes request.
+    renderHook(() => useAllSafes(false))
+
+    expect(ownedSpy).toHaveBeenCalledWith('')
   })
 
   it('returns SafeItems for added safes', () => {

--- a/apps/web/src/hooks/safes/__tests__/useAllSafesGrouped.test.ts
+++ b/apps/web/src/hooks/safes/__tests__/useAllSafesGrouped.test.ts
@@ -1,5 +1,5 @@
 import * as allSafes from '../useAllSafes'
-import { _getMultiChainAccounts, useAllSafesGrouped } from '../useAllSafesGrouped'
+import { _buildSafeItems, _getMultiChainAccounts, useAllSafesGrouped } from '../useAllSafesGrouped'
 import { safeItemBuilder } from '@/tests/builders/safeItem'
 import { renderHook } from '@/tests/test-utils'
 import { faker } from '@faker-js/faker'
@@ -16,6 +16,42 @@ describe('useAllSafesGrouped', () => {
       const { result } = renderHook(() => useAllSafesGrouped())
 
       expect(result.current).toEqual({ allMultiChainSafes: undefined, allSingleSafes: undefined })
+    })
+
+    it('enumerates owned safes by default', () => {
+      const spy = jest.spyOn(allSafes, 'default').mockReturnValue(undefined)
+
+      renderHook(() => useAllSafesGrouped())
+
+      expect(spy).toHaveBeenCalledWith(true)
+    })
+
+    it('forwards fetchOwnedSafes=false to skip the owners enumeration', () => {
+      const spy = jest.spyOn(allSafes, 'default').mockReturnValue(undefined)
+
+      renderHook(() => useAllSafesGrouped(undefined, false))
+
+      expect(spy).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('_buildSafeItems', () => {
+    // Overview/owned addresses are checksummed; space-safe addresses may differ in case. The owner
+    // match must be case-insensitive, otherwise owned safes silently render read-only.
+    const CHECKSUMMED = '0xAbC0000000000000000000000000000000000123'
+
+    it('matches ownership case-insensitively', () => {
+      const result = _buildSafeItems({ '1': [CHECKSUMMED] }, {}, { '1': [CHECKSUMMED.toLowerCase()] }, {})
+
+      expect(result).toHaveLength(1)
+      expect(result[0].isReadOnly).toBe(false)
+    })
+
+    it('marks a safe read-only when the wallet owns a different address on that chain', () => {
+      const other = '0xDef0000000000000000000000000000000000456'.toLowerCase()
+      const result = _buildSafeItems({ '1': [CHECKSUMMED] }, {}, { '1': [other] }, {})
+
+      expect(result[0].isReadOnly).toBe(true)
     })
   })
 

--- a/apps/web/src/hooks/safes/useAllSafes.ts
+++ b/apps/web/src/hooks/safes/useAllSafes.ts
@@ -70,9 +70,14 @@ export const _buildSafeItem = (
   }
 }
 
-const useAllSafes = (): SafeItems | undefined => {
+/**
+ * @param fetchOwnedSafes When false, skips the owned-safes enumeration and treats no safes as owned
+ *   (everything read-only). Defaults to true; lets consumers that only need it conditionally avoid
+ *   the request until it's relevant.
+ */
+const useAllSafes = (fetchOwnedSafes = true): SafeItems | undefined => {
   const { address: walletAddress = '' } = useWallet() || {}
-  const [allOwned = {}] = useAllOwnedSafes(walletAddress)
+  const [allOwned = {}] = useAllOwnedSafes(fetchOwnedSafes ? walletAddress : '')
   const { configs } = useChains()
   const allAdded = useAppSelector(selectAllAddedSafes)
   const allUndeployed = useAppSelector(selectUndeployedSafes)

--- a/apps/web/src/hooks/safes/useAllSafesGrouped.ts
+++ b/apps/web/src/hooks/safes/useAllSafesGrouped.ts
@@ -49,7 +49,7 @@ export function _buildSafeItems(
     const addresses = safes[chainId]
 
     addresses?.forEach((address) => {
-      const isReadOnly = !!allOwned && !(allOwned[chainId] || []).includes(address)
+      const isReadOnly = !!allOwned && !(allOwned[chainId] || []).some((owned) => sameAddress(owned, address))
       const name = allSafeNames[chainId]?.[address]
       const lastVisited = allVisitedSafes?.[chainId]?.[address]?.lastVisited || 0
 
@@ -96,8 +96,8 @@ export const _groupAndSort = (
   return [...multi, ...single].sort(sortComparator)
 }
 
-export const useAllSafesGrouped = (customSafes?: SafeItems) => {
-  const safes = useAllSafes()
+export const useAllSafesGrouped = (customSafes?: SafeItems, fetchOwnedSafes = true) => {
+  const safes = useAllSafes(fetchOwnedSafes)
   const allSafes = customSafes ?? safes
 
   return useMemo<AllSafeItemsGrouped>(() => {

--- a/apps/web/src/services/safe-wallet-provider/useSafeWalletProvider.test.tsx
+++ b/apps/web/src/services/safe-wallet-provider/useSafeWalletProvider.test.tsx
@@ -169,6 +169,18 @@ describe('useSafeWalletProvider', () => {
       expect(result.current?.getCreateCallTransaction).toBeDefined()
     })
 
+    it('threads the fetchOwnedSafes gate into useAllSafes', () => {
+      // Default keeps the owned enumeration on (unchanged behaviour for all other consumers).
+      renderHook(() => useTxFlowApi('1', '0x1234567890000000000000000000000000000000'))
+      expect(mockedUseAllSafes).toHaveBeenCalledWith(true)
+
+      mockedUseAllSafes.mockClear()
+
+      // Gated off → useAllSafes skips the owned-safes enumeration.
+      renderHook(() => useTxFlowApi('1', '0x1234567890000000000000000000000000000000', false))
+      expect(mockedUseAllSafes).toHaveBeenCalledWith(false)
+    })
+
     it('should open signing window for off-chain messages', () => {
       jest.spyOn(router, 'useRouter').mockReturnValue({} as unknown as router.NextRouter)
       jest.spyOn(messages, 'isOffchainEIP1271Supported').mockReturnValue(true)

--- a/apps/web/src/services/safe-wallet-provider/useSafeWalletProvider.tsx
+++ b/apps/web/src/services/safe-wallet-provider/useSafeWalletProvider.tsx
@@ -29,14 +29,15 @@ import { useAllSafes, useGetHref, type SafeItem } from '@/hooks/safes'
 import { useLoadFeature } from '@/features/__core__'
 import { WalletConnectFeature } from '@/features/walletconnect'
 
-export const useTxFlowApi = (chainId: string, safeAddress: string): WalletSDK | undefined => {
+export const useTxFlowApi = (chainId: string, safeAddress: string, fetchOwnedSafes = true): WalletSDK | undefined => {
   const { safe } = useSafeInfo()
   const currentChain = useCurrentChain()
   const { setTxFlow } = useContext(TxModalContext)
   const web3ReadOnly = useWeb3ReadOnly()
   const router = useRouter()
   const { configs } = useChains()
-  const allSafes = useAllSafes()
+  // `allSafes` is only read by `switchChain`; callers enable the owned-safes lookup only when needed.
+  const allSafes = useAllSafes(fetchOwnedSafes)
   const getHref = useGetHref(router)
   const pendingTxs = useRef<Record<string, string>>({})
   const walletConnect = useLoadFeature(WalletConnectFeature)
@@ -302,11 +303,11 @@ export const useTxFlowApi = (chainId: string, safeAddress: string): WalletSDK | 
   ])
 }
 
-const useSafeWalletProvider = (): SafeWalletProvider | undefined => {
+const useSafeWalletProvider = (fetchOwnedSafes = true): SafeWalletProvider | undefined => {
   const { safe, safeAddress } = useSafeInfo()
   const { chainId } = safe
 
-  const txFlowApi = useTxFlowApi(chainId, safeAddress)
+  const txFlowApi = useTxFlowApi(chainId, safeAddress, fetchOwnedSafes)
 
   return useMemo(() => {
     if (!safeAddress || !chainId || !txFlowApi) return

--- a/apps/web/src/store/__tests__/safeOverviews.cacheKey.test.ts
+++ b/apps/web/src/store/__tests__/safeOverviews.cacheKey.test.ts
@@ -1,0 +1,102 @@
+import { faker } from '@faker-js/faker'
+import { makeStore } from '@/store'
+import { gatewayApi } from '../api/gateway'
+import { additionalSafesRtkApi } from '@safe-global/store/gateway/safes'
+import type { SafeItem } from '@/hooks/safes'
+
+// Neutralize the inner batched fetch so the (timer-driven) network call never runs; this test only
+// inspects the OUTER getMultipleSafeOverviews cache key, which is created synchronously on dispatch.
+const mockedInitiate = jest.spyOn(additionalSafesRtkApi.endpoints.safesGetOverviewForMany, 'initiate')
+
+type Store = ReturnType<typeof makeStore>
+
+const overviewKeys = (store: Store): string[] =>
+  Object.keys(store.getState().gatewayApi.queries ?? {}).filter((key) => key.startsWith('getMultipleSafeOverviews('))
+
+const fullSafeItem = (chainId: string, address: string, isReadOnly: boolean): SafeItem => ({
+  chainId,
+  address,
+  isReadOnly,
+  isPinned: false,
+  lastVisited: 0,
+  name: undefined,
+})
+
+describe('getMultipleSafeOverviews cache key (serializeQueryArgs)', () => {
+  const ADDR_A = faker.finance.ethereumAddress()
+  const ADDR_B = faker.finance.ethereumAddress()
+
+  beforeEach(() => {
+    // Cache keys are created synchronously on dispatch; fake timers keep the batched fetcher's 300ms
+    // timer from firing (and leaking) after the assertions — this test never resolves the fetch.
+    jest.useFakeTimers()
+    mockedInitiate.mockReset()
+    mockedInitiate.mockImplementation(jest.fn())
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  })
+
+  it('shares ONE entry for the same safe set regardless of field values, order, and isReadOnly flips', () => {
+    const store = makeStore(undefined, { skipBroadcast: true })
+
+    // Dashboard-style: full SafeItems, in order [A, B], all writable.
+    store.dispatch(
+      gatewayApi.endpoints.getMultipleSafeOverviews.initiate({
+        currency: 'usd',
+        safes: [fullSafeItem('1', ADDR_A, false), fullSafeItem('10', ADDR_B, false)],
+      }),
+    )
+
+    // Ownership-style: minimal {chainId,address} refs, reversed order [B, A].
+    store.dispatch(
+      gatewayApi.endpoints.getMultipleSafeOverviews.initiate({
+        currency: 'usd',
+        safes: [
+          { chainId: '10', address: ADDR_B },
+          { chainId: '1', address: ADDR_A },
+        ],
+      }),
+    )
+
+    // The very same set but with isReadOnly flipped to true. Without the normalized cache key this
+    // would re-key and create a duplicate fetch.
+    store.dispatch(
+      gatewayApi.endpoints.getMultipleSafeOverviews.initiate({
+        currency: 'usd',
+        safes: [fullSafeItem('1', ADDR_A, true), fullSafeItem('10', ADDR_B, true)],
+      }),
+    )
+
+    expect(overviewKeys(store)).toHaveLength(1)
+  })
+
+  it('keeps distinct entries for a different safe set and for wallet-scoped subscriptions', () => {
+    const store = makeStore(undefined, { skipBroadcast: true })
+    const fullSet = [fullSafeItem('1', ADDR_A, false), fullSafeItem('10', ADDR_B, false)]
+
+    // No-wallet entry for the full set {A, B}.
+    store.dispatch(gatewayApi.endpoints.getMultipleSafeOverviews.initiate({ currency: 'usd', safes: fullSet }))
+
+    // Subset {A} → different set → distinct entry.
+    store.dispatch(
+      gatewayApi.endpoints.getMultipleSafeOverviews.initiate({
+        currency: 'usd',
+        safes: [fullSafeItem('1', ADDR_A, false)],
+      }),
+    )
+
+    // Wallet-scoped entry for the same full set → walletAddress retained in the key → distinct entry.
+    store.dispatch(
+      gatewayApi.endpoints.getMultipleSafeOverviews.initiate({
+        currency: 'usd',
+        walletAddress: faker.finance.ethereumAddress(),
+        safes: fullSet,
+      }),
+    )
+
+    expect(overviewKeys(store)).toHaveLength(3)
+  })
+})

--- a/apps/web/src/store/api/gateway/safeOverviews.ts
+++ b/apps/web/src/store/api/gateway/safeOverviews.ts
@@ -126,7 +126,8 @@ const batchedFetcher = new SafeOverviewFetcher()
 type MultiOverviewQueryParams = {
   currency: string
   walletAddress?: string
-  safes: SafeItem[]
+  // Only chainId/address are read by the query and the cache key; callers may pass full SafeItems.
+  safes: Pick<SafeItem, 'chainId' | 'address'>[]
 }
 
 export const safeOverviewEndpoints = (
@@ -162,6 +163,17 @@ export const safeOverviewEndpoints = (
     },
   ),
   getMultipleSafeOverviews: builder.query<SafeOverview[], MultiOverviewQueryParams>({
+    // Normalize the cache key so every subscriber with the same set of safes shares ONE entry,
+    // independent of safe-item field values (isReadOnly, name, …) and array order. The default
+    // serializer stringifies the whole args object — including those volatile fields — which would
+    // otherwise create duplicate fetches and a feedback loop once ownership is derived here.
+    // RTK re-pipes a non-string return through the default serializer, so returning an object is safe.
+    serializeQueryArgs: ({ queryArgs }) => ({
+      ...queryArgs,
+      safes: [...queryArgs.safes]
+        .map((safe) => ({ chainId: safe.chainId, address: safe.address }))
+        .sort((a, b) => `${a.chainId}:${a.address}`.localeCompare(`${b.chainId}:${b.address}`)),
+    }),
     providesTags: (result) =>
       result && result.length > 0
         ? result.map((overview) => ({


### PR DESCRIPTION
> Spaces asked owners "who owns this?",
> the overview already knew —
> one fetch, many readers, calm.

## What it solves

The Spaces surface and several always-mounted hooks reached for the cross-chain owned-safes enumeration only to set a per-row `isReadOnly` flag ("is the connected wallet an owner?"). That made an expensive, separate request fire on screens that don't actually need to enumerate the user's Safes.

This derives ownership from data the app already fetches and confines the owned-safes enumeration to the surfaces that genuinely need it.

## How this PR fixes it

Each consumer now asks the cheapest source that answers its actual question, and the "which data source / whether to fetch" decision is structural (which hook/component is mounted) rather than a runtime flag.

- **Spaces list & dashboard** derive ownership client-side from the batched `getMultipleSafeOverviews` entry the dashboard already loads (`useSpaceSafeOverviews`), so `useSpaceSafes` no longer pulls in `useAllSafes`.
- **SpaceSafeBar** is split into a workspace provider (space safes, free) and a global provider (owned-safes enumeration); only the global one mounts the lookup, replacing the previous route-shaped fetch flag and its mount-timing race.
- **AddAccounts** moves its modal body into an open-only child, so the lookup runs when the modal opens rather than from the always-mounted trigger button.

Gotchas worth a look in review:

- **Cache-key sharing is load-bearing.** A normalized `serializeQueryArgs` on `getMultipleSafeOverviews` makes every subscriber (balances, queue, ownership) share **one** cache entry regardless of safe-item field values or array order. Without it, deriving `isReadOnly` into the args would re-key the entry and cause a duplicate fetch.
- **Ownership is derived per-subscriber** (no `walletAddress` in the query args), so a wallet switch recomputes with no refetch.
- **Two parity fixes** ride along: case-insensitive owner matching (overview addresses are checksummed; space-safe addresses may differ in case) and a counterfactual-owner fallback for undeployed Safes that have no overview.
- **Loading is fail-closed:** while overviews load, rows are read-only, matching prior behaviour.
- Deferred-but-kept lookups: WalletConnect provider (until a session exists), Trusted Safes modal (until open), and the network/multichain helpers (only with an active Safe).

## How to test it

1. Open `/welcome/spaces` and a space dashboard (`/spaces?spaceId=…`) while signed in with a connected wallet. Confirm no `/owners/*/safes` request fires on load (Network tab).
2. In a space, open **Manage accounts → Add safe accounts to this workspace**. Confirm the owned-safes request fires only now (on open), and that owned vs trusted Safes list correctly.
3. Verify space-safe rows show the correct read-only chip and gate the same actions as before (including a Safe you own under a mixed-case address, and a counterfactual Safe you own).
4. Switch the connected wallet and confirm read-only state updates without a new overview fetch.
5. On a classic route (`/home`), confirm the account switcher and chain selector still behave as before.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    USS1[useSpaceSafes] --> UAO1[useAllOwnedSafes]
    SB1[SpaceSafeBar switcher] -- fetchOwnedSafes flag --> UAS1[useAllSafes]
    UAO1 --> OWN1[(owned-safes enumeration)]
    UAS1 --> OWN1
    ADD1[AddAccounts trigger<br/>always mounted] -- isOpen ? addr : '' --> UAO1
  end
  subgraph After
    USS2[useSpaceSafes] --> SSO[useSpaceSafeOverviews]
    SSO --> OV[getMultipleSafeOverviews<br/>one shared, normalized cache entry]
    OV --> RO[derive isReadOnly client-side + CF fallback]
    BAR[SpaceSafeBar] --> WP{provider}
    WP -->|in space| WS[workspace safes — no owned lookup]
    WP -->|otherwise| GS[global switcher] --> OWN2[(owned-safes enumeration)]
    ADD2[AddAccounts] -->|mounted only when open| UAO2[useAllOwnedSafes] --> OWN2
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
