### PR TITLE
fix(web): add back the block explorer link in the safe selector dropdown (WA-2674)

### DIFF
--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/ExplorerLinkButton.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/ExplorerLinkButton.tsx
@@ -1,0 +1,44 @@
+import { type MouseEvent, type PointerEvent } from 'react'
+import { ExternalLink } from 'lucide-react'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { OVERVIEW_EVENTS, trackEvent, MixpanelEventParams } from '@/services/analytics'
+
+// Opens the current safe on its block explorer. Rendered inside the Select trigger next to the copy
+// button, so pointerdown is stopped from reaching the surrounding trigger (which would otherwise
+// toggle the dropdown); the anchor's click still navigates and opens the explorer in a new tab.
+const ExplorerLinkButton = ({ href, title = 'View on block explorer' }: { href: string; title?: string }) => {
+  // preventDefault on pointerdown does not cancel the synthetic click, so navigation still happens.
+  const stopParent = (e: MouseEvent | PointerEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
+  }
+
+  const handleClick = (e: MouseEvent) => {
+    e.stopPropagation()
+    trackEvent(OVERVIEW_EVENTS.OPEN_EXPLORER, { [MixpanelEventParams.SIDEBAR_ELEMENT]: 'Block Explorer' })
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <a
+            href={href}
+            target="_blank"
+            rel="noreferrer"
+            onClick={handleClick}
+            onPointerDown={stopParent}
+            className="shrink-0 rounded p-0.5 hover:bg-muted transition-colors cursor-pointer inline-flex"
+            aria-label={title}
+            data-testid="safe-item-explorer-link"
+          />
+        }
+      >
+        <ExternalLink className="size-3 text-muted-foreground" />
+      </TooltipTrigger>
+      <TooltipContent>{title}</TooltipContent>
+    </Tooltip>
+  )
+}
+
+export default ExplorerLinkButton

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeSelectorTriggerContent.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeSelectorTriggerContent.tsx
@@ -6,9 +6,12 @@ import { useSafeDisplayName } from '@/hooks/useSafeDisplayName'
 import SafeBalanceBlock from './SafeBalanceBlock'
 import ThresholdBadge from './ThresholdBadge'
 import CopyAddressButton from './CopyAddressButton'
+import ExplorerLinkButton from './ExplorerLinkButton'
 import NotActivatedBadge from '@/components/common/NotActivatedBadge'
 import type { SafeItemData } from '../types'
 import EnvHintButton from '@/components/settings/EnvironmentVariables/EnvHintButton'
+import { useChain } from '@/hooks/useChains'
+import { getBlockExplorerLink } from '@safe-global/utils/utils/chains'
 
 export interface SafeSelectorTriggerContentProps {
   selectedItem: SafeItemData
@@ -22,6 +25,9 @@ function SafeSelectorTriggerContent({ selectedItem, selectedChainId }: SafeSelec
 
   const resolvedName = useSafeDisplayName(selectedItem.address, selectedChainId)
   const { shortAddress, displayName } = getSafeDisplayInfo(resolvedName, selectedItem.address)
+
+  const chainConfig = useChain(selectedChain?.chainId ?? '')
+  const blockExplorerLink = chainConfig ? getBlockExplorerLink(chainConfig, selectedItem.address) : undefined
 
   return (
     <div className="flex items-center gap-2 sm:gap-4 w-full">
@@ -41,6 +47,7 @@ function SafeSelectorTriggerContent({ selectedItem, selectedChainId }: SafeSelec
             {shortAddress}
           </Typography>
           <CopyAddressButton address={selectedItem.address} />
+          {blockExplorerLink && <ExplorerLinkButton href={blockExplorerLink.href} title={blockExplorerLink.title} />}
           <EnvHintButton chainId={selectedChainId} />
         </div>
       </div>

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/ExplorerLinkButton.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/ExplorerLinkButton.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ExplorerLinkButton from '../ExplorerLinkButton'
+import { OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
+
+jest.mock('@/services/analytics', () => ({
+  __esModule: true,
+  ...jest.requireActual('@/services/analytics'),
+  trackEvent: jest.fn(),
+}))
+
+jest.mock('@/components/ui/tooltip', () => ({
+  __esModule: true,
+  Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({
+    children,
+    render: renderEl,
+  }: {
+    children?: React.ReactNode
+    render?: React.ReactElement<{ children?: React.ReactNode }>
+  }) => (renderEl ? React.cloneElement(renderEl, undefined, children) : <>{children}</>),
+  TooltipContent: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+}))
+
+describe('ExplorerLinkButton', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('renders an external link opening the explorer in a new tab', () => {
+    render(<ExplorerLinkButton href="https://etherscan.io/address/0x123" title="View on Etherscan" />)
+
+    const link = screen.getByTestId('safe-item-explorer-link')
+    expect(link).toHaveAttribute('href', 'https://etherscan.io/address/0x123')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noreferrer')
+    expect(link).toHaveAttribute('aria-label', 'View on Etherscan')
+  })
+
+  it('tracks the open-explorer event and stops propagation on click', async () => {
+    const onParentClick = jest.fn()
+    render(
+      <div onClick={onParentClick}>
+        <ExplorerLinkButton href="https://etherscan.io/address/0x123" />
+      </div>,
+    )
+
+    await userEvent.click(screen.getByTestId('safe-item-explorer-link'))
+
+    expect(trackEvent).toHaveBeenCalledWith(OVERVIEW_EVENTS.OPEN_EXPLORER, expect.any(Object))
+    expect(onParentClick).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeSelectorTriggerContent.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeSelectorTriggerContent.test.tsx
@@ -3,9 +3,15 @@ import SafeSelectorTriggerContent from '../SafeSelectorTriggerContent'
 import type { SafeItemData } from '../../types'
 
 const mockUseSafeDisplayName = jest.fn()
+const mockUseChain = jest.fn()
 
 jest.mock('@/hooks/useSafeDisplayName', () => ({
   useSafeDisplayName: (...args: unknown[]) => mockUseSafeDisplayName(...args),
+}))
+
+jest.mock('@/hooks/useChains', () => ({
+  __esModule: true,
+  useChain: (...args: unknown[]) => mockUseChain(...args),
 }))
 
 jest.mock('../SafeBalanceBlock', () => {
@@ -38,6 +44,7 @@ describe('SafeSelectorTriggerContent', () => {
   beforeEach(() => {
     jest.resetAllMocks()
     mockUseSafeDisplayName.mockReturnValue('')
+    mockUseChain.mockReturnValue(undefined)
   })
 
   it('resolves name per chain without using the cross-chain item name', () => {
@@ -120,5 +127,27 @@ describe('SafeSelectorTriggerContent', () => {
 
     expect(getByTestId('safe-balance-block')).toBeInTheDocument()
     expect(queryByTestId('safe-selector-not-activated-icon')).not.toBeInTheDocument()
+  })
+
+  it('renders a block explorer link for the selected chain when it has an explorer', () => {
+    mockUseChain.mockReturnValue({
+      chainId: '137',
+      blockExplorerUriTemplate: { address: 'https://polygonscan.com/address/{{address}}', txHash: '', api: '' },
+    })
+    const item = createItem()
+
+    const { getByTestId } = render(<SafeSelectorTriggerContent selectedItem={item} selectedChainId="137" />)
+
+    expect(mockUseChain).toHaveBeenCalledWith('137')
+    expect(getByTestId('safe-item-explorer-link')).toHaveAttribute('href', 'https://polygonscan.com/address/0xabc')
+  })
+
+  it('omits the explorer link when the selected chain has no block explorer', () => {
+    mockUseChain.mockReturnValue({ chainId: '1' })
+    const item = createItem()
+
+    const { queryByTestId } = render(<SafeSelectorTriggerContent selectedItem={item} selectedChainId="1" />)
+
+    expect(queryByTestId('safe-item-explorer-link')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## What it solves

Resolves: [WA-2674](https://linear.app/safe-global/issue/WA-2674/add-back-the-link-to-etherscan-gnosisscan)

The Safe account selector dropdown no longer shows a link to the block explorer (Etherscan / Gnosisscan). This PR adds it back.

## How this PR fixes it

The explorer link was dropped when the old sidebar `SafeHeader` (which rendered a QR + copy + **explorer** icon row for the current Safe) was replaced by the new `SpaceSafeBar` → `SafeSelectorDropdown`. The connected-**wallet** dropdown still has its explorer link (via `WalletInfo` → `EthHashInfo hasExplorer`), but the **Safe** account dropdown lost it.

Changes (all in `apps/web/src/features/spaces/components/SafeSelectorDropdown/components/`):

- **New** `ExplorerLinkButton.tsx` — a small external-link icon button styled like the sibling `CopyAddressButton`. Opens the explorer in a new tab, reports `OVERVIEW_EVENTS.OPEN_EXPLORER`, and stops pointer propagation so clicking it doesn't toggle/select the dropdown.
- `SafeSelectorTriggerContent.tsx` — resolves the **currently selected chain** via `useChain`, builds the URL with `getBlockExplorerLink`, and renders the link next to the copy button. Renders nothing when the chain has no block explorer.

## How to test it

1. Open any Safe so the account selector appears in the top header.
2. In the selector trigger (the current Safe row, next to the shortened address and copy icon) you should now see an external-link icon.
3. Click it → opens the current Safe's address on the chain's block explorer in a new tab (e.g. Etherscan for Ethereum, Gnosisscan for Gnosis Chain).
4. Switch the selected chain on a multi-chain Safe → the link points to that chain's explorer.
5. On a chain with no block explorer configured → the icon is not rendered.

## Affected flows

- Safe account selector dropdown trigger — now shows the block explorer link for the current Safe on the selected chain.

## Blast radius

- `SafeSelectorTriggerContent` — the dropdown trigger content rendered by `SafeSelectorDropdown` (used in `SpaceSafeBar` → `Topbar`). The only behavioral change is an extra conditional icon next to the existing copy button.
- New `ExplorerLinkButton` component — local to the `SafeSelectorDropdown/components` folder, no other consumers.
- Reuses existing shared utilities only: `getBlockExplorerLink` (`@safe-global/utils`), `useChain` (`@/hooks/useChains`), and the existing `OVERVIEW_EVENTS.OPEN_EXPLORER` analytics event.
- No RTK Query endpoints, feature flags, chain configs, routes, or persisted state changed.
- No shared `packages/**` changed → no mobile impact.

## Risks / not checked

- **Live browser verification not completed** — the local dev-env backend (CGW) was unreachable (`ERR_CONNECTION_RESET` / `ERR_EMPTY_RESPONSE`) during development, so the dropdown couldn't be exercised in a running app. Covered by unit/RTL tests instead.
- Dropdown **list rows** (`SafeItem` / `SafeInfoDisplay`) and the `AccountsModal` were intentionally left untouched — the old UI only showed the explorer link for the current Safe, and multi-chain list rows have no single explorer to link to.
- Not tested on mobile (web-only components).

## Visual summary

```mermaid
flowchart LR
  A[SafeSelectorTriggerContent] --> B[useChain selectedChainId]
  B --> C{chain has<br/>blockExplorerUriTemplate?}
  C -->|Yes| D[getBlockExplorerLink<br/>chain, safe address]
  D --> E[ExplorerLinkButton<br/>opens explorer in new tab]
  C -->|No| F[no link rendered]
```
<img width="732" height="120" alt="Screenshot 2026-06-18 at 17 44 46" src="https://github.com/user-attachments/assets/406671b5-6c28-4453-b3ab-c7047132abba" />


## Checklist

- [ ] I've tested the branch on mobile 📱 (N/A — web-only components)
- [x] I've documented how it affects the analytics (if at all) 📊 (reuses `OVERVIEW_EVENTS.OPEN_EXPLORER`)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
