### PR TITLE
fix(web): resolve ENS in Spaces address book and clarify ENS errors

### DIFF
--- a/apps/web/src/components/common/AddressInput/index.test.tsx
+++ b/apps/web/src/components/common/AddressInput/index.test.tsx
@@ -17,6 +17,11 @@ const mockChain = chainBuilder()
   .with({ chainId: '11155111' })
   .build()
 
+const mockMainnetChain = chainBuilder()
+  .with({ features: [FEATURES.DOMAIN_LOOKUP] })
+  .with({ chainId: '1', shortName: 'eth' })
+  .build()
+
 // mock useCurrentChain
 jest.mock('@/hooks/useChains', () => ({
   useCurrentChain: jest.fn(() => mockChain),
@@ -27,8 +32,11 @@ jest.mock('@/hooks/useChains', () => ({
 // mock useNameResolver
 jest.mock('@/components/common/AddressInput/useNameResolver', () => ({
   __esModule: true,
+  getEnsNotAvailableError: (chain?: { chainName?: string }) =>
+    `ENS name not available on ${chain?.chainName || 'this network'}`,
   default: jest.fn((val: string) => ({
     address: val === 'zero.eth' ? '0x0000000000000000000000000000000000000000' : undefined,
+    name: val === 'zero.eth' ? 'zero.eth' : undefined,
     resolverError: val === 'bogus.eth' ? new Error('Failed to resolve') : undefined,
     resolving: false,
   })),
@@ -38,10 +46,12 @@ const TestForm = ({
   address,
   validate,
   disabled,
+  chain,
 }: {
   address: string
   validate?: AddressInputProps['validate']
   disabled?: boolean
+  chain?: AddressInputProps['chain']
 }) => {
   const name = 'recipient'
 
@@ -57,15 +67,20 @@ const TestForm = ({
   return (
     <FormProvider {...methods}>
       <form onSubmit={methods.handleSubmit(() => null)}>
-        <AddressInput name={name} label="Recipient address" validate={validate} disabled={disabled} />
+        <AddressInput name={name} label="Recipient address" validate={validate} disabled={disabled} chain={chain} />
         <button type="submit">Submit</button>
       </form>
     </FormProvider>
   )
 }
 
-const setup = (address: string, validate?: AddressInputProps['validate'], disabled?: boolean) => {
-  const utils = render(<TestForm address={address} validate={validate} disabled={disabled} />)
+const setup = (
+  address: string,
+  validate?: AddressInputProps['validate'],
+  disabled?: boolean,
+  chain?: AddressInputProps['chain'],
+) => {
+  const utils = render(<TestForm address={address} validate={validate} disabled={disabled} chain={chain} />)
   const input = utils.getByLabelText('Recipient address', { exact: false })
 
   return {
@@ -185,7 +200,60 @@ describe('AddressInput tests', () => {
 
     await waitFor(() => {
       expect(input.value).toBe('0x0000000000000000000000000000000000000000')
-      expect(useNameResolver).toHaveBeenCalledWith('zero.eth')
+      expect(useNameResolver).toHaveBeenCalledWith('zero.eth', undefined)
+    })
+  })
+
+  it('should label the field with the ENS name it resolved from', async () => {
+    const { input, utils } = setup('')
+
+    act(() => {
+      fireEvent.change(input, { target: { value: 'zero.eth' } })
+    })
+
+    await waitFor(() => {
+      expect(input.value).toBe('0x0000000000000000000000000000000000000000')
+      expect(utils.getByLabelText('Address resolved from zero.eth', { exact: false })).toBeDefined()
+    })
+  })
+
+  it('should revert the label when the resolved address is edited', async () => {
+    const { input, utils } = setup('')
+
+    act(() => {
+      fireEvent.change(input, { target: { value: 'zero.eth' } })
+    })
+
+    await waitFor(() => expect(utils.getByLabelText('Address resolved from zero.eth', { exact: false })).toBeDefined())
+
+    act(() => {
+      fireEvent.change(input, { target: { value: TEST_ADDRESS_B } })
+    })
+
+    await waitFor(() => {
+      expect(utils.queryByLabelText('Address resolved from zero.eth', { exact: false })).toBeNull()
+    })
+  })
+
+  it('should resolve ENS names against the given chain even if the current chain lacks the feature', async () => {
+    // The Spaces address book is chain-agnostic, so it passes mainnet to resolve .eth names while
+    // the connected/current chain (here without DOMAIN_LOOKUP) would otherwise gate resolution off.
+    ;(useCurrentChain as jest.Mock).mockImplementation(() => ({
+      shortName: 'gno',
+      chainId: '100',
+      chainName: 'Gnosis Chain',
+      features: [],
+    }))
+
+    const { input } = setup('', undefined, undefined, mockMainnetChain)
+
+    act(() => {
+      fireEvent.change(input, { target: { value: 'zero.eth' } })
+    })
+
+    await waitFor(() => {
+      expect(input.value).toBe('0x0000000000000000000000000000000000000000')
+      expect(useNameResolver).toHaveBeenCalledWith('zero.eth', mockMainnetChain)
     })
   })
 
@@ -197,7 +265,7 @@ describe('AddressInput tests', () => {
       jest.advanceTimersByTime(1000)
     })
 
-    expect(useNameResolver).toHaveBeenCalledWith('bogus.eth')
+    expect(useNameResolver).toHaveBeenCalledWith('bogus.eth', undefined)
     await waitFor(() => expect(utils.getByLabelText(`Failed to resolve`, { exact: false })).toBeDefined())
   })
 
@@ -216,9 +284,31 @@ describe('AddressInput tests', () => {
       jest.advanceTimersByTime(1000)
     })
 
-    expect(useNameResolver).toHaveBeenCalledWith('')
+    expect(useNameResolver).toHaveBeenCalledWith('', undefined)
     await waitFor(() => expect(input.value).toBe('zero.eth'))
-    await waitFor(() => expect(utils.getByLabelText('Invalid address format', { exact: false })).toBeDefined())
+    await waitFor(() =>
+      expect(utils.getByLabelText('ENS name not available on Goerli', { exact: false })).toBeDefined(),
+    )
+  })
+
+  it('shows a domain-specific error when an ENS name cannot be resolved on the chain', async () => {
+    ;(useCurrentChain as jest.Mock).mockImplementation(() => ({
+      shortName: 'matic',
+      chainId: '137',
+      chainName: 'Polygon',
+      features: [],
+    }))
+
+    const { input, utils } = setup('')
+
+    act(() => {
+      fireEvent.change(input, { target: { value: 'vitalik.eth' } })
+      jest.advanceTimersByTime(1000)
+    })
+
+    await waitFor(() =>
+      expect(utils.getByLabelText('ENS name not available on Polygon', { exact: false })).toBeDefined(),
+    )
   })
 
   it('should show chain prefix in an adornment', async () => {

--- a/apps/web/src/components/common/AddressInput/index.tsx
+++ b/apps/web/src/components/common/AddressInput/index.tsx
@@ -2,7 +2,7 @@ import AddressInputReadOnly from '@/components/common/AddressInputReadOnly'
 import useAddressBook from '@/hooks/useAddressBook'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import type { ReactElement } from 'react'
-import { useEffect, useCallback, useRef, useMemo } from 'react'
+import { useEffect, useCallback, useRef, useMemo, useState } from 'react'
 import {
   InputAdornment,
   TextField,
@@ -16,8 +16,9 @@ import {
 import { useFormContext, useWatch, type Validate, get } from 'react-hook-form'
 import { validatePrefixedAddress } from '@safe-global/utils/utils/validation'
 import { useCurrentChain } from '@/hooks/useChains'
-import useNameResolver from './useNameResolver'
-import { cleanInputValue, parsePrefixedAddress } from '@safe-global/utils/utils/addresses'
+import useNameResolver, { getEnsNotAvailableError } from './useNameResolver'
+import { isDomain } from '@/services/ens'
+import { cleanInputValue, parsePrefixedAddress, sameAddress } from '@safe-global/utils/utils/addresses'
 import useDebounce from '@safe-global/utils/hooks/useDebounce'
 import CaretDownIcon from '@/public/images/common/caret-down.svg'
 import SaveAddressIcon from '@/public/images/common/save-address.svg'
@@ -72,9 +73,20 @@ const AddressInput = ({
   // greyed-out input — even when the address isn't in the (source-scoped) address book.
   const isReadOnly = Boolean(addressBook[watchedValue]) || Boolean(props.disabled)
 
-  // Fetch an ENS resolution for the current address
-  const isDomainLookupEnabled = !!currentChain && hasFeature(currentChain, FEATURES.DOMAIN_LOOKUP)
-  const { address, resolverError, resolving } = useNameResolver(isDomainLookupEnabled ? watchedValue : '')
+  // Resolve ENS against the given chain when provided (e.g. mainnet for the chain-agnostic Spaces
+  // address book), otherwise fall back to the app's current chain.
+  const ensChain = chain ?? currentChain
+  const isDomainLookupEnabled = !!ensChain && hasFeature(ensChain, FEATURES.DOMAIN_LOOKUP)
+  const {
+    address,
+    name: resolvedName,
+    resolverError,
+    resolving,
+  } = useNameResolver(isDomainLookupEnabled ? watchedValue : '', chain)
+
+  // Remember which ENS name produced the current address so the field can show "Address resolved
+  // from <name>" until the user edits the address away from it.
+  const [resolvedFrom, setResolvedFrom] = useState<{ name: string; address: string }>()
 
   // errors[name] doesn't work with nested field names like 'safe.address', need to use the lodash get
   const fieldError = resolverError || get(errors, name)
@@ -110,12 +122,19 @@ const AddressInput = ({
     [setValue, name],
   )
 
-  // On ENS resolution, update the input value
+  // On ENS resolution, update the input value and remember the name it resolved from
   useEffect(() => {
     if (address) {
+      if (resolvedName) setResolvedFrom({ name: resolvedName, address })
       setAddressValue(`${currentShortName}:${address}`)
     }
-  }, [address, currentShortName, setAddressValue])
+  }, [address, resolvedName, currentShortName, setAddressValue])
+
+  // Label the field with the source ENS name while it still holds that resolved address
+  const resolvedFromLabel =
+    resolvedFrom && sameAddress(watchedValue, resolvedFrom.address)
+      ? `Address resolved from ${resolvedFrom.name}`
+      : undefined
 
   // Retransform the value when chain changes
   useEffect(() => {
@@ -167,7 +186,14 @@ const AddressInput = ({
         className={inputCss.input}
         autoComplete="off"
         autoFocus={props.focused}
-        label={<>{error?.message || props.label || `Recipient address${isDomainLookupEnabled ? ' or ENS' : ''}`}</>}
+        label={
+          <>
+            {error?.message ||
+              resolvedFromLabel ||
+              props.label ||
+              `Recipient address${isDomainLookupEnabled ? ' or ENS' : ''}`}
+          </>
+        }
         error={!!error}
         fullWidth
         onClick={resetName}
@@ -208,9 +234,18 @@ const AddressInput = ({
 
           validate: async () => {
             const value = rawValueRef.current
-            if (value) {
-              return validatePrefixed(value) || (await validate?.(parsePrefixedAddress(value).address))
+            if (!value) return
+
+            const { address } = parsePrefixedAddress(value)
+
+            // An ENS-style name keeps the field invalid until it resolves (the value is replaced by
+            // the resolved address). If it can't be resolved on the lookup chain, say so explicitly
+            // instead of the generic "Invalid address format".
+            if (isDomain(address)) {
+              return getEnsNotAvailableError(ensChain)
             }
+
+            return validatePrefixed(value) || (await validate?.(address))
           },
 
           // Workaround for a bug in react-hook-form that it restores a cached error state on blur

--- a/apps/web/src/components/common/AddressInput/useNameResolver.test.ts
+++ b/apps/web/src/components/common/AddressInput/useNameResolver.test.ts
@@ -1,0 +1,103 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import useNameResolver, { getEnsNotAvailableError } from './useNameResolver'
+import { chainBuilder } from '@/tests/builders/chains'
+import { FEATURES } from '@safe-global/store/gateway/types'
+
+const globalProvider = { id: 'global' }
+const dedicatedProvider = { id: 'dedicated', destroy: jest.fn() }
+
+const mockCreateWeb3ReadOnly = jest.fn<typeof dedicatedProvider, unknown[]>(() => dedicatedProvider)
+const mockResolveName = jest.fn<Promise<string>, unknown[]>(() =>
+  Promise.resolve('0x1234567890123456789012345678901234567890'),
+)
+const mockUseCurrentChain = jest.fn()
+
+jest.mock('@/hooks/wallets/web3ReadOnly', () => ({
+  useWeb3ReadOnly: () => globalProvider,
+}))
+
+jest.mock('@/hooks/wallets/web3', () => ({
+  createWeb3ReadOnly: (...args: unknown[]) => mockCreateWeb3ReadOnly(...args),
+}))
+
+jest.mock('@/hooks/useChains', () => ({
+  useCurrentChain: () => mockUseCurrentChain(),
+}))
+
+jest.mock('@/store', () => ({
+  useAppSelector: () => undefined,
+}))
+
+jest.mock('@/services/ens', () => ({
+  isDomain: (value: string) => value.includes('.'),
+  resolveName: (...args: unknown[]) => mockResolveName(...args),
+}))
+
+const currentChain = chainBuilder().with({ chainId: '100', features: [] }).build()
+const mainnetChain = chainBuilder()
+  .with({ chainId: '1', shortName: 'eth', features: [FEATURES.DOMAIN_LOOKUP] })
+  .build()
+
+describe('useNameResolver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseCurrentChain.mockReturnValue(currentChain)
+  })
+
+  it('resolves via the global provider when no chain is given', async () => {
+    const { result } = renderHook(() => useNameResolver('vitalik.eth'))
+
+    await waitFor(() => {
+      expect(result.current.address).toBe('0x1234567890123456789012345678901234567890')
+    })
+
+    expect(result.current.name).toBe('vitalik.eth')
+    expect(mockResolveName).toHaveBeenCalledWith(globalProvider, 'vitalik.eth')
+    expect(mockCreateWeb3ReadOnly).not.toHaveBeenCalled()
+  })
+
+  it('resolves via the global provider when the given chain matches the current chain', async () => {
+    mockUseCurrentChain.mockReturnValue(mainnetChain)
+
+    const { result } = renderHook(() => useNameResolver('vitalik.eth', mainnetChain))
+
+    await waitFor(() => {
+      expect(result.current.address).toBe('0x1234567890123456789012345678901234567890')
+    })
+
+    expect(mockResolveName).toHaveBeenCalledWith(globalProvider, 'vitalik.eth')
+    expect(mockCreateWeb3ReadOnly).not.toHaveBeenCalled()
+  })
+
+  it('creates a dedicated provider for the given chain when it differs from the current chain', async () => {
+    const { result } = renderHook(() => useNameResolver('vitalik.eth', mainnetChain))
+
+    await waitFor(() => {
+      expect(result.current.address).toBe('0x1234567890123456789012345678901234567890')
+    })
+
+    expect(mockCreateWeb3ReadOnly).toHaveBeenCalledWith(mainnetChain, undefined)
+    expect(mockResolveName).toHaveBeenCalledWith(dedicatedProvider, 'vitalik.eth')
+  })
+
+  it('reports a chain-specific error when the name does not resolve', async () => {
+    mockResolveName.mockResolvedValueOnce(undefined as unknown as string)
+
+    const { result } = renderHook(() => useNameResolver('vitalik.eth'))
+
+    await waitFor(() => {
+      expect(result.current.resolverError?.message).toBe(getEnsNotAvailableError(currentChain))
+    })
+    expect(result.current.address).toBeUndefined()
+  })
+
+  it('tears down the dedicated provider on unmount', async () => {
+    const { unmount } = renderHook(() => useNameResolver('vitalik.eth', mainnetChain))
+
+    await waitFor(() => expect(mockCreateWeb3ReadOnly).toHaveBeenCalled())
+
+    unmount()
+
+    expect(dedicatedProvider.destroy).toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/common/AddressInput/useNameResolver.ts
+++ b/apps/web/src/components/common/AddressInput/useNameResolver.ts
@@ -1,13 +1,39 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3ReadOnly'
+import { createWeb3ReadOnly } from '@/hooks/wallets/web3'
+import { useCurrentChain } from '@/hooks/useChains'
+import { useAppSelector } from '@/store'
+import { selectRpc } from '@/store/settingsSlice'
 import useAsync from '@safe-global/utils/hooks/useAsync'
 import { isDomain, resolveName } from '@/services/ens'
 import useDebounce from '@safe-global/utils/hooks/useDebounce'
 
+// Shown when the user enters an ENS-style name that can't be resolved to an address on the chain it
+// was looked up on — either because that chain has no domain lookup, or the name isn't set there.
+// Names the chain (e.g. "Ethereum" in the chain-agnostic Spaces address book) so it isn't ambiguous.
+export const getEnsNotAvailableError = (chain?: Chain): string =>
+  `ENS name not available on ${chain?.chainName || 'this network'}`
+
 const useNameResolver = (
   value?: string,
-): { address: string | undefined; resolverError?: Error; resolving: boolean } => {
-  const ethersProvider = useWeb3ReadOnly()
+  chain?: Chain,
+): { address: string | undefined; name: string | undefined; resolverError?: Error; resolving: boolean } => {
+  const globalProvider = useWeb3ReadOnly()
+  const currentChain = useCurrentChain()
+  const customRpc = useAppSelector(selectRpc)
+
+  // ENS lives on a specific chain. When the field resolves against a chain other than the app's
+  // current one — e.g. the chain-agnostic Spaces address book resolves names on mainnet — use a
+  // dedicated read-only provider for it, since the global provider follows the connected chain.
+  const needsOwnProvider = !!chain && chain.chainId !== currentChain?.chainId
+  const ownProvider = useMemo(
+    () => (needsOwnProvider && chain ? createWeb3ReadOnly(chain, customRpc?.[chain.chainId]) : undefined),
+    [needsOwnProvider, chain, customRpc],
+  )
+  useEffect(() => () => ownProvider?.destroy(), [ownProvider])
+
+  const ethersProvider = needsOwnProvider ? ownProvider : globalProvider
   const debouncedValue = useDebounce((value || '').trim(), 200)
 
   // Fetch an ENS resolution for the current address
@@ -15,21 +41,22 @@ const useNameResolver = (
     if (!ethersProvider || !debouncedValue || !isDomain(debouncedValue)) return
 
     return resolveName(ethersProvider, debouncedValue).then((address) => {
-      if (!address) throw Error('Failed to resolve the address')
+      if (!address) throw Error(getEnsNotAvailableError(chain ?? currentChain))
       return { name: debouncedValue, address }
     })
-  }, [debouncedValue, ethersProvider])
+  }, [debouncedValue, ethersProvider, chain, currentChain])
 
   const resolving = isResolving && !!ethersProvider && !!debouncedValue
-  const address = ens && ens.name === value ? ens.address : undefined
+  const resolved = ens && ens.name === value ? ens : undefined
 
   return useMemo(
     () => ({
-      address,
+      address: resolved?.address,
+      name: resolved?.name,
       resolverError,
       resolving,
     }),
-    [address, resolverError, resolving],
+    [resolved, resolverError, resolving],
   )
 }
 

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddContactDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddContactDialog.tsx
@@ -10,6 +10,7 @@ import NameInput from '@/components/common/NameInput'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import NetworkMultiSelectorInput from '@/components/common/NetworkSelector/NetworkMultiSelectorInput'
 import useChains from '@/hooks/useChains'
+import { DEFAULT_MAINNET_CHAIN_ID } from '@/config/constants'
 import { useCurrentSpaceId } from '@/features/spaces'
 import { showNotification } from '@/store/notificationsSlice'
 import { useAppDispatch } from '@/store'
@@ -55,6 +56,9 @@ const AddContactDialog = ({
   const { configs: allNetworks } = useChains()
   const dispatch = useAppDispatch()
   const spaceId = useCurrentSpaceId()
+
+  // Contacts are chain-agnostic, so resolve ENS names on mainnet regardless of the connected chain
+  const ensChain = allNetworks.find((chain) => chain.chainId === String(DEFAULT_MAINNET_CHAIN_ID))
 
   const defaultValues = {
     name: '',
@@ -134,7 +138,7 @@ const AddContactDialog = ({
                 {intro && <p className="text-muted-foreground text-sm">{intro}</p>}
 
                 <NameInput name="name" label="Name" required />
-                <AddressInput name="address" label="Address or ENS" required showPrefix={false} />
+                <AddressInput name="address" label="Address or ENS" required showPrefix={false} chain={ensChain} />
 
                 <div>
                   <p className="mb-1 inline-flex items-center gap-1 text-sm font-bold">Select networks</p>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/AddContactDialog.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/AddContactDialog.test.tsx
@@ -47,9 +47,9 @@ jest.mock('@/components/common/NameInput', () => ({
 
 jest.mock('@/components/common/AddressInput', () => ({
   __esModule: true,
-  default: ({ name, label }: { name: string; label: string }) => {
+  default: ({ name, label, chain }: { name: string; label: string; chain?: { chainId: string } }) => {
     const { register } = (jest.requireActual('react-hook-form') as typeof ReactHookForm).useFormContext()
-    return <input aria-label={label} {...register(name, { required: true })} />
+    return <input aria-label={label} data-ens-chain={chain?.chainId ?? ''} {...register(name, { required: true })} />
   },
 }))
 
@@ -204,5 +204,12 @@ describe('AddContactDialog', () => {
     openDialog()
 
     expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+  })
+
+  it('resolves ENS on mainnet by passing the mainnet chain to the address input', () => {
+    render(<AddContactDialog {...baseProps} submit={jest.fn()} />)
+    openDialog()
+
+    expect(screen.getByLabelText('Address or ENS')).toHaveAttribute('data-ens-chain', '1')
   })
 })


### PR DESCRIPTION
## What it solves

Adding an ENS name (e.g. `vitalik.eth`) as a contact in the Spaces address book no longer worked — it showed "Invalid address format". More broadly, ENS-style input that can't be resolved on the active chain gave a confusing generic error with no hint about why.

Resolves: https://linear.app/safe-global/issue/WA-2677/cannot-add-ens-as-a-contact

## How this PR fixes it

ENS resolution in `AddressInput` was gated on the **current** chain having `DOMAIN_LOOKUP` and resolved via the current-chain provider. The Spaces address book is chain-agnostic (no Safe in the URL), so the "current chain" follows the connected wallet — on a chain without ENS (e.g. Polygon) `.eth` names silently fail.

Three layered changes, all in the shared `AddressInput`:

1. **Resolve on the right chain.** `AddressInput` now honours its `chain` prop for both the `DOMAIN_LOOKUP` gate and the resolver; the Spaces dialog passes mainnet, so `.eth` names resolve there regardless of the connected chain. A dedicated read-only provider is created only when the lookup chain differs from the current one (the common paths keep using the global provider unchanged).
2. **Chain-named error.** ENS-style input that can't be resolved now reads e.g. "ENS name not available on Polygon" / "...on Ethereum" instead of "Invalid address format" — naming the chain ENS was looked up on, which also disambiguates the chain-agnostic Spaces case.
3. **Provenance label.** Once a name resolves, the field label becomes "Address resolved from `<name>`", reverting if the user edits the address.

Gotcha: the field stays invalid while a domain is entered until it resolves (the value is swapped for the resolved address), so a bare ENS string can never be submitted.

## How to test it

1. Connect a wallet on a non-mainnet chain (e.g. Polygon).
2. Open a Space → Address book → **Add contact**. Enter a name and `vitalik.eth` → it resolves to the address and the field label reads "Address resolved from vitalik.eth". Save succeeds.
3. In **Send tokens** on Polygon, type `vitalik.eth` → the field shows "ENS name not available on Polygon" (not "Invalid address format").
4. On a mainnet Safe, type `vitalik.eth` in any recipient field → resolves as before, with the provenance label.

## Screenshots

https://github.com/user-attachments/assets/89ae3aa0-53c1-47d5-ba50-6e2727e8bbcb


UI changes are the field label/error copy — screenshots to be added. Resolution logic:

```mermaid
flowchart TD
    A[User types vitalik.eth] --> B{chain prop given?}
    B -->|Spaces: mainnet| C[Resolve via mainnet provider]
    B -->|no: use current chain| D{DOMAIN_LOOKUP on chain?}
    D -->|yes| C
    D -->|no| E[Error: 'ENS name not available on chainName']
    C -->|resolved| F[Set address + label 'Address resolved from vitalik.eth']
    C -->|not found| E
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).