### PR TITLE
fix: apply correct button icon

### DIFF
--- a/apps/web/src/features/spaces/components/ClassicViewLink/index.test.tsx
+++ b/apps/web/src/features/spaces/components/ClassicViewLink/index.test.tsx
@@ -14,7 +14,7 @@ describe('ClassicViewLink', () => {
     disableClassicView()
   })
 
-  it('renders the "Use the old UI" copy with a leading rotate icon', () => {
+  it('renders the "Use the old UI" copy with a leading history icon', () => {
     render(<ClassicViewLink />, { routerProps: { query: {} } })
 
     const link = screen.getByTestId('classic-view-link')

--- a/apps/web/src/features/spaces/components/ClassicViewLink/index.tsx
+++ b/apps/web/src/features/spaces/components/ClassicViewLink/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import { useRouter } from 'next/router'
-import { RotateCcw } from 'lucide-react'
+import { History } from 'lucide-react'
 import { enableClassicView } from '@/hooks/useClassicView'
 import { AppRoutes } from '@/config/routes'
 import { parseNextUrlForRouter } from '@/utils/nextUrl'
@@ -31,7 +31,7 @@ const ClassicViewLink = () => {
         data-testid="classic-view-link"
         className="flex h-12 w-full cursor-pointer items-center justify-center gap-3 rounded-md border border-border bg-card px-4 text-[15px] font-semibold text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
-        <RotateCcw size={18} />
+        <History size={18} />
         Use the old UI
       </button>
     </div>


### PR DESCRIPTION
## What it solves

Follow-up polish on the "Use the old UI" CTA from [WA-2655](https://linear.app/safe-global/issue/WA-2655). The button used the `RotateCcw` (↺) icon, which reads as "reload/undo". The `History` (clock) icon communicates "go back to the previous experience" more clearly.

## How this PR fixes it

Swap the lucide icon in `ClassicViewLink` from `RotateCcw` to `History`. No behaviour, layout, sizing, or token changes — icon only.

## How to test it

```bash
yarn workspace @safe-global/web test src/features/spaces/components/ClassicViewLink/index.test.tsx
```

Or signed-out on `/welcome/spaces` (with `CLASSIC_VIEW` enabled): the "Use the old UI" button shows the history (clock) icon.

## Affected flows

- Signed-out sign-in card → "Use the old UI" CTA (icon only)

## Blast radius

- `ClassicViewLink` — single render site (`SpacesList` signed-out card, behind the `CLASSIC_VIEW` flag). `SpacesList` mocks `ClassicViewLink`, so no other consumer asserts the icon.
- No logic, props, routing, API, or token changes. Web-only.

## Risks / not checked

- Not tested on mobile (web-only change).

## Visual summary
<img width="442" height="97" alt="Screenshot 2026-06-19 at 12 15 58" src="https://github.com/user-attachments/assets/eb1d9816-a054-4e10-8997-c8efa78947bd" />


## Checklist

- [ ] I've tested the branch on mobile 📱 (web-only — N/A)
- [x] I've documented how it affects the analytics (none) 📊
- [x] I've written a unit/e2e test for it (updated existing) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
- [ ] For web feature/bugfix PRs, I've added a Playwright one-shot clickthrough 🎬 (not added)

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
