### PR TITLE
feat: add copy address button to account cards (WA-2681)

### DIFF
--- a/apps/web/src/components/common/AddressWithCopy/index.tsx
+++ b/apps/web/src/components/common/AddressWithCopy/index.tsx
@@ -1,0 +1,19 @@
+import { Typography } from '@/components/ui/typography'
+import { shortenAddress } from '@safe-global/utils/utils/formatters'
+import CopyAddressIconButton from '../CopyAddressIconButton'
+
+/**
+ * Shortened address + inline copy button, laid out consistently for shadcn
+ * account rows/cards. Keeps spacing, truncation, and typography aligned across
+ * the surfaces that show a Safe address.
+ */
+const AddressWithCopy = ({ address, 'data-testid': testId }: { address: string; 'data-testid'?: string }) => (
+  <div className="flex min-w-0 items-center gap-1.5">
+    <Typography data-testid={testId} variant="paragraph-mini" color="muted" className="truncate">
+      {shortenAddress(address)}
+    </Typography>
+    <CopyAddressIconButton address={address} />
+  </div>
+)
+
+export default AddressWithCopy

--- a/apps/web/src/components/common/CopyAddressIconButton/index.test.tsx
+++ b/apps/web/src/components/common/CopyAddressIconButton/index.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from '@/tests/test-utils'
+import CopyAddressIconButton from '.'
+
+const ADDRESS = '0xA98ABC1234567890123456789012345678932F8'
+
+describe('CopyAddressIconButton', () => {
+  const writeText = jest.fn()
+
+  beforeAll(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders a copy button labelled with the address action', () => {
+    render(<CopyAddressIconButton address={ADDRESS} />)
+    expect(screen.getByRole('button', { name: 'Copy address' })).toBeInTheDocument()
+  })
+
+  it('copies the address to the clipboard on click', () => {
+    render(<CopyAddressIconButton address={ADDRESS} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy address' }))
+
+    expect(writeText).toHaveBeenCalledWith(ADDRESS)
+  })
+
+  it('does not trigger the surrounding link/click handler', () => {
+    const onParentClick = jest.fn()
+
+    render(
+      <a href="/somewhere" onClick={onParentClick}>
+        <CopyAddressIconButton address={ADDRESS} />
+      </a>,
+    )
+
+    const event = fireEvent.click(screen.getByRole('button', { name: 'Copy address' }))
+
+    // The click is consumed by the copy button (preventDefault + stopPropagation)
+    expect(event).toBe(false)
+    expect(onParentClick).not.toHaveBeenCalled()
+    expect(writeText).toHaveBeenCalledWith(ADDRESS)
+  })
+})

--- a/apps/web/src/components/common/CopyAddressIconButton/index.test.tsx
+++ b/apps/web/src/components/common/CopyAddressIconButton/index.test.tsx
@@ -1,20 +1,14 @@
-import { fireEvent, render, screen } from '@/tests/test-utils'
+import { fireEvent, render, screen, mockClipboard } from '@/tests/test-utils'
 import CopyAddressIconButton from '.'
 
 const ADDRESS = '0xA98ABC1234567890123456789012345678932F8'
 
 describe('CopyAddressIconButton', () => {
-  const writeText = jest.fn()
-
-  beforeAll(() => {
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    })
-  })
+  let writeText: jest.Mock
 
   beforeEach(() => {
     jest.clearAllMocks()
+    writeText = mockClipboard()
   })
 
   it('renders a copy button labelled with the address action', () => {
@@ -30,10 +24,10 @@ describe('CopyAddressIconButton', () => {
     expect(writeText).toHaveBeenCalledWith(ADDRESS)
   })
 
-  it('copies the address when activated via the keyboard', () => {
+  it.each(['Enter', ' '])('copies the address when activated via the keyboard (%s)', (key) => {
     render(<CopyAddressIconButton address={ADDRESS} />)
 
-    fireEvent.keyDown(screen.getByRole('button', { name: 'Copy address' }), { key: 'Enter' })
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Copy address' }), { key })
 
     expect(writeText).toHaveBeenCalledWith(ADDRESS)
   })

--- a/apps/web/src/components/common/CopyAddressIconButton/index.test.tsx
+++ b/apps/web/src/components/common/CopyAddressIconButton/index.test.tsx
@@ -30,6 +30,14 @@ describe('CopyAddressIconButton', () => {
     expect(writeText).toHaveBeenCalledWith(ADDRESS)
   })
 
+  it('copies the address when activated via the keyboard', () => {
+    render(<CopyAddressIconButton address={ADDRESS} />)
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Copy address' }), { key: 'Enter' })
+
+    expect(writeText).toHaveBeenCalledWith(ADDRESS)
+  })
+
   it('does not trigger the surrounding link/click handler', () => {
     const onParentClick = jest.fn()
 

--- a/apps/web/src/components/common/CopyAddressIconButton/index.tsx
+++ b/apps/web/src/components/common/CopyAddressIconButton/index.tsx
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Tooltip } from '@mui/material'
+import { Check, Copy } from 'lucide-react'
+import { cn } from '@/utils/cn'
+
+const RESET_DELAY = 2000
+
+/**
+ * Inline icon button that copies an address to the clipboard. Designed to sit
+ * next to a (shortened) address inside clickable rows/cards — it stops click
+ * propagation and prevents default so it never triggers the parent link.
+ */
+const CopyAddressIconButton = ({ address, className }: { address: string; className?: string }) => {
+  const [copied, setCopied] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  useEffect(() => () => clearTimeout(timeoutRef.current), [])
+
+  const handleCopy = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      navigator.clipboard.writeText(address)
+      setCopied(true)
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = setTimeout(() => setCopied(false), RESET_DELAY)
+    },
+    [address],
+  )
+
+  return (
+    <Tooltip title={copied ? 'Copied!' : 'Copy address'} placement="top">
+      <button
+        onClick={handleCopy}
+        className={cn('shrink-0 cursor-pointer rounded p-0.5 transition-colors hover:bg-muted', className)}
+        aria-label="Copy address"
+        type="button"
+      >
+        {copied ? (
+          <Check className="size-3.5 text-green-600" />
+        ) : (
+          <Copy className="size-3.5 text-muted-foreground hover:text-foreground" />
+        )}
+      </button>
+    </Tooltip>
+  )
+}
+
+export default CopyAddressIconButton

--- a/apps/web/src/components/common/CopyAddressIconButton/index.tsx
+++ b/apps/web/src/components/common/CopyAddressIconButton/index.tsx
@@ -1,48 +1,37 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { Tooltip } from '@mui/material'
-import { Check, Copy } from 'lucide-react'
+import type { KeyboardEvent } from 'react'
+import { Copy } from 'lucide-react'
+import CopyTooltip from '../CopyTooltip'
 import { cn } from '@/utils/cn'
 
-const RESET_DELAY = 2000
-
 /**
- * Inline icon button that copies an address to the clipboard. Designed to sit
- * next to a (shortened) address inside clickable rows/cards — it stops click
- * propagation and prevents default so it never triggers the parent link.
+ * Inline copy-address affordance for account rows/cards. Reuses CopyTooltip for
+ * the copy + tooltip logic, and renders a non-`<button>` element so it is safe
+ * to nest inside clickable rows (links, collapsible triggers, selection
+ * buttons) without invalid button-in-button markup.
  */
 const CopyAddressIconButton = ({ address, className }: { address: string; className?: string }) => {
-  const [copied, setCopied] = useState(false)
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
-
-  useEffect(() => () => clearTimeout(timeoutRef.current), [])
-
-  const handleCopy = useCallback(
-    (e: React.MouseEvent) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLSpanElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
-      e.stopPropagation()
-      navigator.clipboard.writeText(address)
-      setCopied(true)
-      clearTimeout(timeoutRef.current)
-      timeoutRef.current = setTimeout(() => setCopied(false), RESET_DELAY)
-    },
-    [address],
-  )
+      e.currentTarget.click()
+    }
+  }
 
   return (
-    <Tooltip title={copied ? 'Copied!' : 'Copy address'} placement="top">
-      <button
-        onClick={handleCopy}
-        className={cn('shrink-0 cursor-pointer rounded p-0.5 transition-colors hover:bg-muted', className)}
+    <CopyTooltip text={address} initialToolTipText="Copy address">
+      <span
+        role="button"
+        tabIndex={0}
         aria-label="Copy address"
-        type="button"
-      >
-        {copied ? (
-          <Check className="size-3.5 text-green-600" />
-        ) : (
-          <Copy className="size-3.5 text-muted-foreground hover:text-foreground" />
+        onKeyDown={handleKeyDown}
+        className={cn(
+          'text-muted-foreground hover:bg-muted hover:text-foreground inline-flex shrink-0 cursor-pointer rounded p-0.5 transition-colors',
+          className,
         )}
-      </button>
-    </Tooltip>
+      >
+        <Copy className="size-3.5" />
+      </span>
+    </CopyTooltip>
   )
 }
 

--- a/apps/web/src/components/sidebar/NestedSafesList/index.tsx
+++ b/apps/web/src/components/sidebar/NestedSafesList/index.tsx
@@ -83,6 +83,7 @@ function NestedSafeItem({
           name={name}
           chainId={safeItem.chainId}
           fullAddress
+          showCopyButton
           highlight4bytes={showSimilarityWarning}
         />
         <AccountItemGroup>
@@ -102,7 +103,7 @@ function NestedSafeItem({
           owners={owners.length}
           chainId={safeItem.chainId}
         />
-        <AccountItemInfo address={safeItem.address} name={name} chainId={safeItem.chainId} />
+        <AccountItemInfo address={safeItem.address} name={name} chainId={safeItem.chainId} showCopyButton />
         <AccountItemBalance fiatTotal={safeOverview?.fiatTotal} isLoading={!safeOverview} />
       </AccountItemLink>
     </Track>

--- a/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
@@ -135,7 +135,6 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, isSpaceSafe = fal
                 chainId={sortedSafes[0]?.chainId ?? '1'}
                 name={multiSafeAccountItem.name}
                 showPrefix={false}
-                showCopyButton
                 addressBookNameSource={isSpaceSafe ? ContactSource.space : undefined}
                 data-testid="group-address"
               />

--- a/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
@@ -135,6 +135,7 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, isSpaceSafe = fal
                 chainId={sortedSafes[0]?.chainId ?? '1'}
                 name={multiSafeAccountItem.name}
                 showPrefix={false}
+                showCopyButton
                 addressBookNameSource={isSpaceSafe ? ContactSource.space : undefined}
                 data-testid="group-address"
               />

--- a/apps/web/src/features/myAccounts/components/AccountsWidget/AccountItemContent.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsWidget/AccountItemContent.tsx
@@ -3,8 +3,7 @@ import { Typography } from '@/components/ui/typography'
 import { AccountItem } from '../AccountItem'
 import type { Account } from './types'
 import Identicon from '@/components/common/Identicon'
-import CopyAddressIconButton from '@/components/common/CopyAddressIconButton'
-import { shortenAddress } from '@safe-global/utils/utils/formatters'
+import AddressWithCopy from '@/components/common/AddressWithCopy'
 import { Avatar } from '@/components/ui/avatar'
 
 interface AccountItemContentProps {
@@ -23,12 +22,7 @@ const AccountItemContent = ({ account, children }: AccountItemContentProps): Rea
           <Typography data-testid="multichain-account-name" variant="paragraph-bold">
             {account.name}
           </Typography>
-          <div className="flex min-w-0 items-center gap-1.5">
-            <Typography data-testid="multichain-account-address" variant="paragraph-mini" color="muted">
-              {shortenAddress(account.address, 4)}
-            </Typography>
-            <CopyAddressIconButton address={account.address} />
-          </div>
+          <AddressWithCopy address={account.address} data-testid="multichain-account-address" />
         </div>
       </div>
 

--- a/apps/web/src/features/myAccounts/components/AccountsWidget/AccountItemContent.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsWidget/AccountItemContent.tsx
@@ -3,6 +3,7 @@ import { Typography } from '@/components/ui/typography'
 import { AccountItem } from '../AccountItem'
 import type { Account } from './types'
 import Identicon from '@/components/common/Identicon'
+import CopyAddressIconButton from '@/components/common/CopyAddressIconButton'
 import { shortenAddress } from '@safe-global/utils/utils/formatters'
 import { Avatar } from '@/components/ui/avatar'
 
@@ -22,9 +23,12 @@ const AccountItemContent = ({ account, children }: AccountItemContentProps): Rea
           <Typography data-testid="multichain-account-name" variant="paragraph-bold">
             {account.name}
           </Typography>
-          <Typography data-testid="multichain-account-address" variant="paragraph-mini" color="muted">
-            {shortenAddress(account.address, 4)}
-          </Typography>
+          <div className="flex min-w-0 items-center gap-1.5">
+            <Typography data-testid="multichain-account-address" variant="paragraph-mini" color="muted">
+              {shortenAddress(account.address, 4)}
+            </Typography>
+            <CopyAddressIconButton address={account.address} />
+          </div>
         </div>
       </div>
 

--- a/apps/web/src/features/myAccounts/components/AccountsWidget/AccountWidgetItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsWidget/AccountWidgetItem.tsx
@@ -7,6 +7,7 @@ import { WidgetItem } from '@/features/spaces'
 import { AccountItem } from '../AccountItem'
 import type { Account } from './types'
 import Identicon from '@/components/common/Identicon'
+import CopyAddressIconButton from '@/components/common/CopyAddressIconButton'
 import { shortenAddress } from '@safe-global/utils/utils/formatters'
 import { NotActivatedBadge } from '@/components/common/SpaceSafeBar/AccountsModal/shared'
 
@@ -34,9 +35,12 @@ const AccountWidgetItem = ({
         </Typography>
       }
       info={
-        <Typography data-testid="single-account-address" variant="paragraph-mini" color="muted">
-          {shortenAddress(account.address, 4)}
-        </Typography>
+        <div className="flex min-w-0 items-center gap-1.5">
+          <Typography data-testid="single-account-address" variant="paragraph-mini" color="muted">
+            {shortenAddress(account.address, 4)}
+          </Typography>
+          <CopyAddressIconButton address={account.address} />
+        </div>
       }
       startNode={
         <Avatar data-testid="single-account-identicon">

--- a/apps/web/src/features/myAccounts/components/AccountsWidget/AccountWidgetItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsWidget/AccountWidgetItem.tsx
@@ -7,8 +7,7 @@ import { WidgetItem } from '@/features/spaces'
 import { AccountItem } from '../AccountItem'
 import type { Account } from './types'
 import Identicon from '@/components/common/Identicon'
-import CopyAddressIconButton from '@/components/common/CopyAddressIconButton'
-import { shortenAddress } from '@safe-global/utils/utils/formatters'
+import AddressWithCopy from '@/components/common/AddressWithCopy'
 import { NotActivatedBadge } from '@/components/common/SpaceSafeBar/AccountsModal/shared'
 
 interface AccountWidgetItemProps {
@@ -34,14 +33,7 @@ const AccountWidgetItem = ({
           {account.name}
         </Typography>
       }
-      info={
-        <div className="flex min-w-0 items-center gap-1.5">
-          <Typography data-testid="single-account-address" variant="paragraph-mini" color="muted">
-            {shortenAddress(account.address, 4)}
-          </Typography>
-          <CopyAddressIconButton address={account.address} />
-        </div>
-      }
+      info={<AddressWithCopy address={account.address} data-testid="single-account-address" />}
       startNode={
         <Avatar data-testid="single-account-identicon">
           <Identicon address={account.address} size={40} />

--- a/apps/web/src/features/myAccounts/components/AccountsWidget/__tests__/AccountsWidget.test.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsWidget/__tests__/AccountsWidget.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@/tests/test-utils'
+import { render, screen, fireEvent } from '@/tests/test-utils'
 import userEvent from '@testing-library/user-event'
 import type { SafeItem } from '@/hooks/safes'
 import type { Account } from '../types'
@@ -74,6 +74,23 @@ describe('AccountsWidget', () => {
 
     expect(screen.getByText('Vault')).toBeInTheDocument()
     expect(screen.getByText('1/1')).toBeInTheDocument()
+  })
+
+  it('renders a copy address button for every account row', () => {
+    render(<AccountsWidget accounts={mockAccounts} />)
+
+    expect(screen.getAllByRole('button', { name: 'Copy address' })).toHaveLength(mockAccounts.length)
+  })
+
+  it('copies the account address when the copy button is clicked', () => {
+    const writeText = jest.fn()
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+
+    render(<AccountsWidget accounts={[mockAccounts[1]]} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy address' }))
+
+    expect(writeText).toHaveBeenCalledWith(mockAccounts[1].address)
   })
 
   it('renders an identicon for each account', () => {

--- a/apps/web/src/features/myAccounts/components/AccountsWidget/__tests__/AccountsWidget.test.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsWidget/__tests__/AccountsWidget.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@/tests/test-utils'
+import { render, screen, fireEvent, mockClipboard } from '@/tests/test-utils'
 import userEvent from '@testing-library/user-event'
 import type { SafeItem } from '@/hooks/safes'
 import type { Account } from '../types'
@@ -83,8 +83,7 @@ describe('AccountsWidget', () => {
   })
 
   it('copies the account address when the copy button is clicked', () => {
-    const writeText = jest.fn()
-    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+    const writeText = mockClipboard()
 
     render(<AccountsWidget accounts={[mockAccounts[1]]} />)
 

--- a/apps/web/src/features/myAccounts/components/MyAccountsV2/components/AccountItem/MultiAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/MyAccountsV2/components/AccountItem/MultiAccountItem.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import NextLink from 'next/link'
 import Identicon from '@/components/common/Identicon'
+import CopyAddressIconButton from '@/components/common/CopyAddressIconButton'
 import { FiatBalance } from '@/features/spaces'
 import MultiAccountContextMenu from '@/components/sidebar/SafeListContextMenu/MultiAccountContextMenu'
 import { AccountItem as BaseAccountItem } from '../../../AccountItem'
@@ -148,9 +149,12 @@ const MultiAccountItem = ({ multiSafeAccountItem, onLinkClick, isSpaceSafe = fal
               <Typography variant="paragraph-medium" className="text-foreground truncate">
                 {displayName}
               </Typography>
-              <Typography variant="paragraph-mini" color="muted" className="truncate">
-                {shortenAddress(address)}
-              </Typography>
+              <div className="flex min-w-0 items-center gap-1.5">
+                <Typography variant="paragraph-mini" color="muted" className="truncate">
+                  {shortenAddress(address)}
+                </Typography>
+                <CopyAddressIconButton address={address} />
+              </div>
             </div>
           </div>
 

--- a/apps/web/src/features/myAccounts/components/MyAccountsV2/components/AccountItem/MultiAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/MyAccountsV2/components/AccountItem/MultiAccountItem.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import NextLink from 'next/link'
 import Identicon from '@/components/common/Identicon'
-import CopyAddressIconButton from '@/components/common/CopyAddressIconButton'
+import AddressWithCopy from '@/components/common/AddressWithCopy'
 import { FiatBalance } from '@/features/spaces'
 import MultiAccountContextMenu from '@/components/sidebar/SafeListContextMenu/MultiAccountContextMenu'
 import { AccountItem as BaseAccountItem } from '../../../AccountItem'
@@ -149,12 +149,7 @@ const MultiAccountItem = ({ multiSafeAccountItem, onLinkClick, isSpaceSafe = fal
               <Typography variant="paragraph-medium" className="text-foreground truncate">
                 {displayName}
               </Typography>
-              <div className="flex min-w-0 items-center gap-1.5">
-                <Typography variant="paragraph-mini" color="muted" className="truncate">
-                  {shortenAddress(address)}
-                </Typography>
-                <CopyAddressIconButton address={address} />
-              </div>
+              <AddressWithCopy address={address} />
             </div>
           </div>
 

--- a/apps/web/src/features/myAccounts/components/MyAccountsV2/components/AccountItem/SingleAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/MyAccountsV2/components/AccountItem/SingleAccountItem.tsx
@@ -1,5 +1,6 @@
 import NextLink from 'next/link'
 import Identicon from '@/components/common/Identicon'
+import CopyAddressIconButton from '@/components/common/CopyAddressIconButton'
 import Track from '@/components/common/Track'
 import { FiatBalance } from '@/features/spaces'
 import { AccountItem as BaseAccountItem } from '../../../AccountItem'
@@ -60,9 +61,12 @@ const SingleAccountItem = ({ safeItem, onLinkClick, isSpaceSafe = false }: Singl
             <Typography variant="paragraph-medium" className="text-foreground truncate">
               {displayName}
             </Typography>
-            <Typography variant="paragraph-mini" color="muted" className="truncate">
-              {shortenAddress(safeItem.address)}
-            </Typography>
+            <div className="flex min-w-0 items-center gap-1.5">
+              <Typography variant="paragraph-mini" color="muted" className="truncate">
+                {shortenAddress(safeItem.address)}
+              </Typography>
+              <CopyAddressIconButton address={safeItem.address} />
+            </div>
 
             <div className="mt-1 flex flex-wrap items-center gap-1">
               <BaseAccountItem.StatusChip

--- a/apps/web/src/features/myAccounts/components/MyAccountsV2/components/AccountItem/SingleAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/MyAccountsV2/components/AccountItem/SingleAccountItem.tsx
@@ -1,6 +1,6 @@
 import NextLink from 'next/link'
 import Identicon from '@/components/common/Identicon'
-import CopyAddressIconButton from '@/components/common/CopyAddressIconButton'
+import AddressWithCopy from '@/components/common/AddressWithCopy'
 import Track from '@/components/common/Track'
 import { FiatBalance } from '@/features/spaces'
 import { AccountItem as BaseAccountItem } from '../../../AccountItem'
@@ -61,12 +61,7 @@ const SingleAccountItem = ({ safeItem, onLinkClick, isSpaceSafe = false }: Singl
             <Typography variant="paragraph-medium" className="text-foreground truncate">
               {displayName}
             </Typography>
-            <div className="flex min-w-0 items-center gap-1.5">
-              <Typography variant="paragraph-mini" color="muted" className="truncate">
-                {shortenAddress(safeItem.address)}
-              </Typography>
-              <CopyAddressIconButton address={safeItem.address} />
-            </div>
+            <AddressWithCopy address={safeItem.address} />
 
             <div className="mt-1 flex flex-wrap items-center gap-1">
               <BaseAccountItem.StatusChip

--- a/apps/web/src/features/myAccounts/components/MyAccountsV2/components/AccountItem/__tests__/MultiAccountItem.test.tsx
+++ b/apps/web/src/features/myAccounts/components/MyAccountsV2/components/AccountItem/__tests__/MultiAccountItem.test.tsx
@@ -132,10 +132,42 @@ const buildSafeItemHookReturn = (overrides: Partial<SafeItemHookReturn> = {}): S
   }) as SafeItemHookReturn
 
 describe('MultiAccountItem (MyAccountsV2)', () => {
+  const writeText = jest.fn()
+
+  beforeAll(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+  })
+
   beforeEach(() => {
     jest.clearAllMocks()
     mockedUseMultiAccountItemData.mockReturnValue(buildMultiAccountHookReturn())
     mockedUseSafeItemData.mockReturnValue(buildSafeItemHookReturn())
+  })
+
+  describe('copy address', () => {
+    it('renders a copy address button in the group header', () => {
+      mockedUseMultiAccountItemData.mockReturnValue(buildMultiAccountHookReturn({ isCurrentSafe: false }))
+
+      render(<MultiAccountItem multiSafeAccountItem={buildMultiChainSafeItem()} />)
+
+      expect(screen.getByRole('button', { name: 'Copy address' })).toBeInTheDocument()
+    })
+
+    it('copies the group address without toggling expansion', () => {
+      const address = '0x1234567890abcdef1234567890abcdef12345678'
+      mockedUseMultiAccountItemData.mockReturnValue(buildMultiAccountHookReturn({ address, isCurrentSafe: false }))
+
+      render(<MultiAccountItem multiSafeAccountItem={buildMultiChainSafeItem({ address })} />)
+
+      fireEvent.click(screen.getByRole('button', { name: 'Copy address' }))
+
+      expect(writeText).toHaveBeenCalledWith(address)
+      // Clicking copy must not expand the collapsible
+      expect(screen.queryByTestId('subacounts-container')).not.toBeInTheDocument()
+    })
   })
 
   describe('display name', () => {

--- a/apps/web/src/features/myAccounts/components/MyAccountsV2/components/AccountItem/__tests__/MultiAccountItem.test.tsx
+++ b/apps/web/src/features/myAccounts/components/MyAccountsV2/components/AccountItem/__tests__/MultiAccountItem.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@/tests/test-utils'
+import { render, screen, fireEvent, mockClipboard } from '@/tests/test-utils'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS, trackEvent } from '@/services/analytics'
 import type { MultiChainSafeItem, SafeItem } from '@/hooks/safes'
 import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
@@ -132,17 +132,11 @@ const buildSafeItemHookReturn = (overrides: Partial<SafeItemHookReturn> = {}): S
   }) as SafeItemHookReturn
 
 describe('MultiAccountItem (MyAccountsV2)', () => {
-  const writeText = jest.fn()
-
-  beforeAll(() => {
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    })
-  })
+  let writeText: jest.Mock
 
   beforeEach(() => {
     jest.clearAllMocks()
+    writeText = mockClipboard()
     mockedUseMultiAccountItemData.mockReturnValue(buildMultiAccountHookReturn())
     mockedUseSafeItemData.mockReturnValue(buildSafeItemHookReturn())
   })

--- a/apps/web/src/features/myAccounts/components/MyAccountsV2/components/AccountItem/__tests__/SingleAccountItem.test.tsx
+++ b/apps/web/src/features/myAccounts/components/MyAccountsV2/components/AccountItem/__tests__/SingleAccountItem.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, fireEvent, mockClipboard } from '@/tests/test-utils'
+import { OVERVIEW_LABELS } from '@/services/analytics'
+import type { SafeItem } from '@/hooks/safes'
+import SingleAccountItem from '../SingleAccountItem'
+import { useSafeItemData } from '../../../../../hooks/useSafeItemData'
+
+jest.mock('../../../../../hooks/useSafeItemData')
+
+jest.mock('@/components/common/Track', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+jest.mock('@/components/common/Identicon', () => ({
+  __esModule: true,
+  default: ({ address }: { address: string }) => <div data-testid="identicon">{address}</div>,
+}))
+
+jest.mock('@/features/spaces', () => ({
+  FiatBalance: ({ value }: { value?: string }) => <div data-testid="fiat-balance">{value ?? ''}</div>,
+}))
+
+jest.mock('@/features/myAccounts/components/AccountItem', () => ({
+  AccountItem: {
+    StatusChip: () => <div data-testid="status-chip" />,
+    QueueActions: () => <div data-testid="queue-actions" />,
+    ChainBadge: () => <div data-testid="chain-badge" />,
+    PinButton: () => <div data-testid="pin-button" />,
+    ContextMenu: () => <div data-testid="context-menu" />,
+  },
+}))
+
+const mockedUseSafeItemData = useSafeItemData as jest.MockedFunction<typeof useSafeItemData>
+type SafeItemHookReturn = ReturnType<typeof useSafeItemData>
+
+const ADDRESS = '0x1234567890abcdef1234567890abcdef12345678'
+
+const buildSafeItem = (overrides: Partial<SafeItem> = {}): SafeItem => ({
+  chainId: '1',
+  address: ADDRESS,
+  isReadOnly: false,
+  isPinned: false,
+  lastVisited: 0,
+  name: '',
+  ...overrides,
+})
+
+const buildHookReturn = (overrides: Partial<SafeItemHookReturn> = {}): SafeItemHookReturn =>
+  ({
+    chain: undefined,
+    name: 'My Safe',
+    href: `/home?safe=eth:${ADDRESS}`,
+    safeOverview: undefined,
+    isCurrentSafe: false,
+    isActivating: false,
+    isReplayable: false,
+    threshold: 1,
+    owners: [{ value: '0xowner' }],
+    undeployedSafe: undefined,
+    elementRef: { current: null },
+    trackingLabel: OVERVIEW_LABELS.login_page,
+    ...overrides,
+  }) as SafeItemHookReturn
+
+describe('SingleAccountItem (MyAccountsV2)', () => {
+  let writeText: jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    writeText = mockClipboard()
+    mockedUseSafeItemData.mockReturnValue(buildHookReturn())
+  })
+
+  it('renders the name and shortened address', () => {
+    render(<SingleAccountItem safeItem={buildSafeItem()} />)
+
+    expect(screen.getByText('My Safe')).toBeInTheDocument()
+    expect(screen.getByText('0x1234...5678')).toBeInTheDocument()
+  })
+
+  it('renders a copy-address button next to the address', () => {
+    render(<SingleAccountItem safeItem={buildSafeItem()} />)
+
+    expect(screen.getByRole('button', { name: 'Copy address' })).toBeInTheDocument()
+  })
+
+  it('copies the address when the copy button is clicked', () => {
+    render(<SingleAccountItem safeItem={buildSafeItem()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy address' }))
+
+    expect(writeText).toHaveBeenCalledWith(ADDRESS)
+  })
+})

--- a/apps/web/src/features/myAccounts/components/SafesList/SafeListItem.tsx
+++ b/apps/web/src/features/myAccounts/components/SafesList/SafeListItem.tsx
@@ -69,12 +69,7 @@ export const SafeListItem = ({ safeItem, onLinkClick, isSpaceSafe = false }: Saf
         threshold={threshold}
         owners={owners.length}
       />
-      <AccountItem.Info
-        address={safeItem.address}
-        chainId={safeItem.chainId}
-        name={isSpaceSafe ? safeItem.name : name}
-        showCopyButton
-      >
+      <AccountItem.Info address={safeItem.address} chainId={safeItem.chainId} name={isSpaceSafe ? safeItem.name : name}>
         {!isMobile && statusChips}
       </AccountItem.Info>
       <AccountItem.ChainBadge chainId={safeItem.chainId} />

--- a/apps/web/src/features/myAccounts/components/SafesList/SafeListItem.tsx
+++ b/apps/web/src/features/myAccounts/components/SafesList/SafeListItem.tsx
@@ -69,7 +69,12 @@ export const SafeListItem = ({ safeItem, onLinkClick, isSpaceSafe = false }: Saf
         threshold={threshold}
         owners={owners.length}
       />
-      <AccountItem.Info address={safeItem.address} chainId={safeItem.chainId} name={isSpaceSafe ? safeItem.name : name}>
+      <AccountItem.Info
+        address={safeItem.address}
+        chainId={safeItem.chainId}
+        name={isSpaceSafe ? safeItem.name : name}
+        showCopyButton
+      >
         {!isMobile && statusChips}
       </AccountItem.Info>
       <AccountItem.ChainBadge chainId={safeItem.chainId} />

--- a/apps/web/src/features/spaces/components/SafeAccounts/SafeCardReadOnly.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/SafeCardReadOnly.tsx
@@ -5,8 +5,8 @@ import Identicon from '@/components/common/Identicon'
 import NotActivatedBadge from '@/components/common/NotActivatedBadge'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
-import { TriangleAlert, Copy, Check, RotateCw } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { TriangleAlert, RotateCw } from 'lucide-react'
+import { useMemo } from 'react'
 import { Tooltip } from '@mui/material'
 import FiatBalance from '../SelectSafesOnboarding/components/FiatBalance'
 import ThresholdBadge from '../SelectSafesOnboarding/components/ThresholdBadge'
@@ -22,6 +22,7 @@ import useWallet from '@/hooks/wallets/useWallet'
 import { useAppSelector } from '@/store'
 import { selectCurrency } from '@/store/settingsSlice'
 import { cn } from '@/utils/cn'
+import CopyAddressIconButton from '@/components/common/CopyAddressIconButton'
 
 interface SafeCardReadOnlyProps {
   safe: SafeItem | MultiChainSafeItem
@@ -44,7 +45,6 @@ const SafeCardReadOnly = ({
   disabled = false,
   disabledTooltip,
 }: SafeCardReadOnlyProps) => {
-  const [copied, setCopied] = useState(false)
   const router = useRouter()
   const isMultiChain = isMultiChainSafeItem(safe)
   const { name, fiatValue, threshold, ownersCount, elementRef, isUndeployed, isActivating } = useSafeCardData(safe)
@@ -76,13 +76,6 @@ const SafeCardReadOnly = ({
 
   const isClickable = Boolean(singleSafe) && !disabled
   const tooltipTitle = disabled ? (disabledTooltip ?? '') : !singleSafe ? 'Safe data is not available' : ''
-
-  const handleCopyAddress = (e: React.MouseEvent) => {
-    e.stopPropagation()
-    navigator.clipboard.writeText(safe.address)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
-  }
 
   const handleCardClick = () => {
     if (!singleSafe || !chain?.shortName) return
@@ -140,20 +133,7 @@ const SafeCardReadOnly = ({
                   shortenAddress(safe.address)
                 )}
               </span>
-              <Tooltip title={copied ? 'Copied!' : 'Copy address'} placement="top">
-                <button
-                  onClick={handleCopyAddress}
-                  className="shrink-0 p-0.5 rounded hover:bg-muted transition-colors cursor-pointer"
-                  aria-label="Copy address"
-                  type="button"
-                >
-                  {copied ? (
-                    <Check className="size-3.5 text-green-600" />
-                  ) : (
-                    <Copy className="size-3.5 text-muted-foreground hover:text-foreground" />
-                  )}
-                </button>
-              </Tooltip>
+              <CopyAddressIconButton address={safe.address} />
             </div>
           </div>
         </div>

--- a/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SafeCardReadOnly.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SafeCardReadOnly.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@/tests/test-utils'
+import { render, screen, fireEvent, mockClipboard } from '@/tests/test-utils'
 import SafeCardReadOnly from '../SafeCardReadOnly'
 import { safeItemBuilder } from '@/tests/builders/safeItem'
 import { chainBuilder } from '@/tests/builders/chains'
@@ -70,6 +70,19 @@ describe('SafeCardReadOnly', () => {
     render(<SafeCardReadOnly safe={safe} />)
 
     expect(screen.queryByTestId('pending-activation-chip')).toBeNull()
+  })
+
+  it('renders a copy-address button and copies the address', () => {
+    const writeText = mockClipboard()
+    const safe = safeItemBuilder().with({ chainId: '1', address: '0xDEADBEEF' }).build()
+
+    render(<SafeCardReadOnly safe={safe} />)
+
+    const copyButton = screen.getByRole('button', { name: 'Copy address' })
+    expect(copyButton).toBeInTheDocument()
+
+    fireEvent.click(copyButton)
+    expect(writeText).toHaveBeenCalledWith(safe.address)
   })
 
   it('renders the Not activated chip for an undeployed safe', () => {

--- a/apps/web/src/features/spaces/components/SecurityHub/__tests__/SecuritySafesTable.test.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/__tests__/SecuritySafesTable.test.tsx
@@ -148,6 +148,23 @@ describe('SecuritySafesTable', () => {
     expect(screen.getByTestId('chain-1')).toBeInTheDocument()
   })
 
+  it('renders a copy-address button on the safe row', () => {
+    renderTable()
+    expect(screen.getByRole('button', { name: 'Copy address' })).toBeInTheDocument()
+  })
+
+  it('copying the address does not trigger the row click', () => {
+    const writeText = jest.fn()
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+    const onViewReport = jest.fn()
+    renderTable({ onViewReport })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy address' }))
+
+    expect(writeText).toHaveBeenCalledWith(singleSafe.address)
+    expect(onViewReport).not.toHaveBeenCalled()
+  })
+
   it('calls onViewReport when a deployed row is clicked', () => {
     const onViewReport = jest.fn()
     renderTable({ onViewReport })

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/MultichainSafeRow.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/MultichainSafeRow.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion'
 import { ChevronDown, ChevronRight, TriangleAlert } from 'lucide-react'
 import type { ScanResult } from '@/features/security/types'
 import Identicon from '@/components/common/Identicon'
+import CopyAddressIconButton from '@/components/common/CopyAddressIconButton'
 import ChainIndicator from '@/components/common/ChainIndicator'
 import { NetworkLogosList } from '@/features/multichain'
 import { shortenAddress } from '@safe-global/utils/utils/formatters'
@@ -216,9 +217,12 @@ const MultichainSafeRow = ({
                   </Tooltip>
                 )}
               </div>
-              <span className="truncate text-[0.6875rem] leading-none text-muted-foreground">
-                {shortenAddress(safe.address)}
-              </span>
+              <div className="flex min-w-0 items-center gap-1.5">
+                <span className="truncate text-[0.6875rem] leading-none text-muted-foreground">
+                  {shortenAddress(safe.address)}
+                </span>
+                <CopyAddressIconButton address={safe.address} />
+              </div>
             </div>
           </div>
         </div>

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/SingleSafeRow.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/SingleSafeRow.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion'
 import ChevronRightRoundedIcon from '@mui/icons-material/ChevronRightRounded'
 import type { ScanResult } from '@/features/security/types'
 import Identicon from '@/components/common/Identicon'
+import CopyAddressIconButton from '@/components/common/CopyAddressIconButton'
 import ChainIndicator from '@/components/common/ChainIndicator'
 import { shortenAddress } from '@safe-global/utils/utils/formatters'
 import { cn } from '@/utils/cn'
@@ -90,9 +91,12 @@ const SingleSafeRow = ({
             >
               {safe.name || shortenAddress(safe.address)}
             </Typography>
-            <Typography sx={{ fontSize: '0.6875rem', color: 'text.secondary', lineHeight: 1 }}>
-              {shortenAddress(safe.address)}
-            </Typography>
+            <Stack direction="row" alignItems="center" spacing={0.5} sx={{ minWidth: 0 }}>
+              <Typography noWrap sx={{ fontSize: '0.6875rem', color: 'text.secondary', lineHeight: 1 }}>
+                {shortenAddress(safe.address)}
+              </Typography>
+              <CopyAddressIconButton address={safe.address} />
+            </Stack>
           </Stack>
         </Stack>
       </div>

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/SafeCard.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/SafeCard.tsx
@@ -40,7 +40,7 @@ const SafeCard = ({ safe, isSimilar, isAtLimit = false }: SafeCardProps) => {
   if (isMultiChain) {
     return (
       <SafeCardLayout
-        ref={elementRef as React.Ref<HTMLButtonElement>}
+        ref={elementRef as React.Ref<HTMLDivElement>}
         checked={allSubSafesChecked}
         onToggle={handleMultiChainToggle}
         disabled={isAtLimit && noSubSafesChecked}
@@ -63,7 +63,7 @@ const SafeCard = ({ safe, isSimilar, isAtLimit = false }: SafeCardProps) => {
       control={control}
       render={({ field }) => (
         <SafeCardLayout
-          ref={elementRef as React.Ref<HTMLButtonElement>}
+          ref={elementRef as React.Ref<HTMLDivElement>}
           checked={Boolean(field.value)}
           onToggle={() => field.onChange(!field.value)}
           onCheckedChange={(checked) => field.onChange(checked)}

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/SafeCardLayout.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/SafeCardLayout.tsx
@@ -3,6 +3,7 @@ import { shortenAddress } from '@safe-global/utils/utils/formatters'
 import { Checkbox } from '@/components/ui/checkbox'
 import { AccountItem } from '@/features/myAccounts'
 import Identicon from '@/components/common/Identicon'
+import CopyAddressIconButton from '@/components/common/CopyAddressIconButton'
 import { Badge } from '@/components/ui/badge'
 import { TriangleAlert } from 'lucide-react'
 import NotActivatedBadge from '@/components/common/NotActivatedBadge'
@@ -81,18 +82,21 @@ export const SafeCardLayout = ({
         <div className="flex min-w-0 items-center gap-2">
           <span className="truncate text-base font-medium text-foreground">{name || shortenAddress(address)}</span>
         </div>
-        <span className="block min-w-0 break-all text-xs text-muted-foreground">
-          {isSimilar ? (
-            <>
-              {address.slice(0, 2)}
-              <b>{address.slice(2, 6)}</b>
-              {address.slice(6, -4)}
-              <b>{address.slice(-4)}</b>
-            </>
-          ) : (
-            shortenAddress(address)
-          )}
-        </span>
+        <div className="flex min-w-0 items-center gap-1.5">
+          <span className="block min-w-0 break-all text-xs text-muted-foreground">
+            {isSimilar ? (
+              <>
+                {address.slice(0, 2)}
+                <b>{address.slice(2, 6)}</b>
+                {address.slice(6, -4)}
+                <b>{address.slice(-4)}</b>
+              </>
+            ) : (
+              shortenAddress(address)
+            )}
+          </span>
+          <CopyAddressIconButton address={address} />
+        </div>
       </div>
     </div>
 

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/SafeCardLayout.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/SafeCardLayout.tsx
@@ -12,7 +12,7 @@ import FiatBalance from './FiatBalance'
 import ThresholdBadge from './ThresholdBadge'
 
 interface SafeCardLayoutProps {
-  ref?: React.Ref<HTMLButtonElement>
+  ref?: React.Ref<HTMLDivElement>
   checked: boolean
   onToggle: () => void
   onCheckedChange?: (checked: boolean) => void
@@ -44,15 +44,14 @@ export const SafeCardLayout = ({
   isActivating = false,
   disabled = false,
 }: SafeCardLayoutProps) => (
-  <button
+  <div
     ref={ref}
-    type="button"
-    role="checkbox"
-    aria-checked={checked}
-    onClick={onToggle}
-    disabled={disabled}
+    data-testid="safe-card"
+    onClick={disabled ? undefined : onToggle}
+    data-disabled={disabled || undefined}
     className={cn(
-      'box-border flex w-full min-w-0 max-w-full cursor-pointer items-center gap-1.5 rounded-3xl border-2 py-4 pl-2 pr-3 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60 sm:gap-2 sm:pr-6',
+      'box-border flex w-full min-w-0 max-w-full items-center gap-1.5 rounded-3xl border-2 py-4 pl-2 pr-3 text-left transition-colors sm:gap-2 sm:pr-6',
+      disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
       checked
         ? 'border-[var(--color-secondary-light)] bg-[var(--color-secondary-background)]'
         : 'border-card bg-card hover:bg-muted/50',
@@ -64,6 +63,7 @@ export const SafeCardLayout = ({
         disabled={disabled}
         onCheckedChange={onCheckedChange ?? (() => onToggle())}
         onClick={(e) => e.stopPropagation()}
+        aria-label={`Select ${name || shortenAddress(address)}`}
       />
     </div>
 
@@ -115,5 +115,5 @@ export const SafeCardLayout = ({
       {!isUndeployed && <FiatBalance value={fiatValue} />}
       {threshold > 0 && <ThresholdBadge threshold={threshold} owners={ownersCount} />}
     </div>
-  </button>
+  </div>
 )

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/__tests__/SafeCard.test.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/__tests__/SafeCard.test.tsx
@@ -135,11 +135,9 @@ describe('SafeCard', () => {
       </FormWrapper>,
     )
 
-    const checkboxes = screen.getAllByRole('checkbox')
-    const cardButton = checkboxes.find((el) => el.tagName === 'BUTTON')!
-    fireEvent.click(cardButton)
+    fireEvent.click(screen.getByTestId('safe-card'))
 
-    expect(cardButton).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-checked', 'true')
   })
 
   it('renders multi-chain safe with chain badge', () => {
@@ -159,14 +157,13 @@ describe('SafeCard', () => {
       </FormWrapper>,
     )
 
-    const checkboxes = screen.getAllByRole('checkbox')
-    const cardButton = checkboxes.find((el) => el.tagName === 'BUTTON')!
-    fireEvent.click(cardButton)
+    fireEvent.click(screen.getByTestId('safe-card'))
 
-    expect(cardButton).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-checked', 'true')
   })
 
-  const getCardButton = () => screen.getAllByRole('checkbox').find((el) => el.tagName === 'BUTTON')!
+  const getCard = () => screen.getByTestId('safe-card')
+  const getCheckbox = () => screen.getByRole('checkbox')
 
   it('disables an unselected single-chain safe when at limit', () => {
     render(
@@ -175,7 +172,7 @@ describe('SafeCard', () => {
       </FormWrapper>,
     )
 
-    expect(getCardButton()).toBeDisabled()
+    expect(getCheckbox()).toHaveAttribute('data-disabled')
   })
 
   it('keeps a selected single-chain safe enabled when at limit so it can be deselected', () => {
@@ -185,10 +182,9 @@ describe('SafeCard', () => {
       </FormWrapper>,
     )
 
-    const cardButton = getCardButton()
-    expect(cardButton).not.toBeDisabled()
-    fireEvent.click(cardButton)
-    expect(cardButton).toHaveAttribute('aria-checked', 'false')
+    expect(getCheckbox()).not.toHaveAttribute('data-disabled')
+    fireEvent.click(getCard())
+    expect(getCheckbox()).toHaveAttribute('aria-checked', 'false')
   })
 
   it('does not disable single-chain safes when not at limit', () => {
@@ -198,7 +194,7 @@ describe('SafeCard', () => {
       </FormWrapper>,
     )
 
-    expect(getCardButton()).not.toBeDisabled()
+    expect(getCheckbox()).not.toHaveAttribute('data-disabled')
   })
 
   it('disables an unselected multi-chain safe when at limit', () => {
@@ -208,7 +204,7 @@ describe('SafeCard', () => {
       </FormWrapper>,
     )
 
-    expect(getCardButton()).toBeDisabled()
+    expect(getCheckbox()).toHaveAttribute('data-disabled')
   })
 
   it('keeps a fully-selected multi-chain safe enabled when at limit', () => {
@@ -218,7 +214,7 @@ describe('SafeCard', () => {
       </FormWrapper>,
     )
 
-    expect(getCardButton()).not.toBeDisabled()
+    expect(getCheckbox()).not.toHaveAttribute('data-disabled')
   })
 
   it('keeps a partially-selected multi-chain safe enabled when at limit so it can be deselected', () => {
@@ -228,7 +224,7 @@ describe('SafeCard', () => {
       </FormWrapper>,
     )
 
-    expect(getCardButton()).not.toBeDisabled()
+    expect(getCheckbox()).not.toHaveAttribute('data-disabled')
   })
 
   it('clicking a disabled single-chain safe does not select it', () => {
@@ -238,10 +234,9 @@ describe('SafeCard', () => {
       </FormWrapper>,
     )
 
-    const cardButton = getCardButton()
-    expect(cardButton).toHaveAttribute('aria-checked', 'false')
-    fireEvent.click(cardButton)
-    expect(cardButton).toHaveAttribute('aria-checked', 'false')
+    expect(getCheckbox()).toHaveAttribute('aria-checked', 'false')
+    fireEvent.click(getCard())
+    expect(getCheckbox()).toHaveAttribute('aria-checked', 'false')
   })
 
   it('clicking a disabled multi-chain safe does not select it', () => {
@@ -251,9 +246,8 @@ describe('SafeCard', () => {
       </FormWrapper>,
     )
 
-    const cardButton = getCardButton()
-    expect(cardButton).toHaveAttribute('aria-checked', 'false')
-    fireEvent.click(cardButton)
-    expect(cardButton).toHaveAttribute('aria-checked', 'false')
+    expect(getCheckbox()).toHaveAttribute('aria-checked', 'false')
+    fireEvent.click(getCard())
+    expect(getCheckbox()).toHaveAttribute('aria-checked', 'false')
   })
 })

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/__tests__/SafeCardLayout.test.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/__tests__/SafeCardLayout.test.tsx
@@ -45,8 +45,8 @@ describe('SafeCardLayout', () => {
     const onToggle = jest.fn()
     render(<SafeCardLayout {...baseProps} onToggle={onToggle} disabled />)
 
-    const card = screen.getAllByRole('checkbox').find((el) => el.tagName === 'BUTTON') as HTMLButtonElement
-    expect(card).toBeDisabled()
+    const card = screen.getByTestId('safe-card')
+    expect(card).toHaveAttribute('data-disabled')
     fireEvent.click(card)
     expect(onToggle).not.toHaveBeenCalled()
   })
@@ -65,8 +65,8 @@ describe('SafeCardLayout', () => {
     const onToggle = jest.fn()
     render(<SafeCardLayout {...baseProps} onToggle={onToggle} />)
 
-    const card = screen.getAllByRole('checkbox').find((el) => el.tagName === 'BUTTON') as HTMLButtonElement
-    expect(card).not.toBeDisabled()
+    const card = screen.getByTestId('safe-card')
+    expect(card).not.toHaveAttribute('data-disabled')
     fireEvent.click(card)
     expect(onToggle).toHaveBeenCalled()
   })

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/__tests__/SafeCardLayout.test.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/__tests__/SafeCardLayout.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@/tests/test-utils'
+import { render, screen, fireEvent, mockClipboard } from '@/tests/test-utils'
 import { SafeCardLayout } from '../SafeCardLayout'
 import { safeItemBuilder } from '@/tests/builders/safeItem'
 import { chainBuilder } from '@/tests/builders/chains'
@@ -72,8 +72,7 @@ describe('SafeCardLayout', () => {
   })
 
   it('copies the address without toggling the card selection', () => {
-    const writeText = jest.fn()
-    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+    const writeText = mockClipboard()
     const onToggle = jest.fn()
     render(<SafeCardLayout {...baseProps} onToggle={onToggle} />)
 

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/__tests__/SafeCardLayout.test.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/__tests__/SafeCardLayout.test.tsx
@@ -70,4 +70,16 @@ describe('SafeCardLayout', () => {
     fireEvent.click(card)
     expect(onToggle).toHaveBeenCalled()
   })
+
+  it('copies the address without toggling the card selection', () => {
+    const writeText = jest.fn()
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+    const onToggle = jest.fn()
+    render(<SafeCardLayout {...baseProps} onToggle={onToggle} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy address' }))
+
+    expect(writeText).toHaveBeenCalledWith(baseProps.address)
+    expect(onToggle).not.toHaveBeenCalled()
+  })
 })

--- a/apps/web/src/tests/test-utils.tsx
+++ b/apps/web/src/tests/test-utils.tsx
@@ -106,6 +106,16 @@ function customRenderHook<Result, Props>(
 
 export const fakerChecksummedAddress = () => checksumAddress(faker.finance.ethereumAddress())
 
+/**
+ * Stub `navigator.clipboard.writeText` and return the mock so tests can assert
+ * what was copied. Keeps clipboard mocking consistent across test files.
+ */
+export const mockClipboard = (): jest.Mock => {
+  const writeText = jest.fn().mockResolvedValue(undefined)
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+  return writeText
+}
+
 // https://testing-library.com/docs/user-event/intro#writing-tests-with-userevent
 export const renderWithUserEvent = (
   ui: React.ReactElement,


### PR DESCRIPTION
## What it solves

Resolves: [WA-2681](https://linear.app/safe-global/issue/WA-2681/add-copy-address-button-on-home-account-list)

Account list rows across the app were missing a copy-address button, while the Spaces **Safe accounts** cards already showed one. This adds the same copy action to every account card/row that displays an address.

## How this PR fixes it

The copy button that lived inline in `SafeCardReadOnly` is extracted into a shared, reusable component and wired into every account card/row that shows an address:

- **New** `components/common/CopyAddressIconButton` — lucide copy/check icon + tooltip, copies to clipboard, and `stopPropagation`/`preventDefault` so it never triggers the surrounding link, row click, expand toggle, or selection checkbox.
- `SafeCardReadOnly` now consumes the shared component (DRY, no behaviour change).

Surfaces that gained the copy button:

| Surface | Component | Mechanism |
| --- | --- | --- |
| Spaces dashboard accounts widget (`/spaces?spaceId=…`) | `AccountWidgetItem`, `AccountItemContent` | `CopyAddressIconButton` |
| My accounts page – redesign / V2 | `SingleAccountItem`, `MultiAccountItem` | `CopyAddressIconButton` |
| Security Hub safes table | `SingleSafeRow`, `MultichainSafeRow` (parent row) | `CopyAddressIconButton` |
| Add-accounts onboarding | `SafeCardLayout` | `CopyAddressIconButton` |
| Nested safes list (manage + read-only) | `NestedSafesList` | `EthHashInfo showCopyButton` |

Parent rows only — per-chain sub-rows in multichain expansions show a chain name (not an address), so they are intentionally left unchanged.

## How to test it

1. Open a workspace dashboard (`/spaces?spaceId=…`) → the Accounts widget rows show a copy icon next to each truncated address.
2. Open the My accounts page (redesign on), the Security Hub safes table, the add-accounts onboarding, and the nested-safes list → each account row shows the copy icon.
3. Click a copy icon → the address is copied (tooltip: "Copied!") and the row does **not** navigate, expand, or toggle its selection.

## Affected flows

- View account list on the Spaces dashboard → copy a Safe's address.
- View / browse the My accounts (V2) list → copy a Safe's address.
- View the Security Hub safes table → copy a Safe's address (single + multichain parent rows).
- Select Safes in the add-accounts onboarding → copy an address without toggling the selection.
- Open the nested-safes list (manage + read-only) → copy a nested Safe's address.
- Spaces "Safe accounts" cards (`SafeCardReadOnly`) — unchanged behaviour, now backed by the shared component.

## Blast radius

- **New shared component** `CopyAddressIconButton` (`@/components/common`) — consumed by `AccountWidgetItem`, `AccountItemContent`, `SingleAccountItem`, `MultiAccountItem` (V2), `SingleSafeRow`, `MultichainSafeRow`, `SafeCardLayout`, and `SafeCardReadOnly`.
- **`SafeCardReadOnly` refactor** — the inline copy button was replaced by the shared component; same markup/behaviour. Consumers: Spaces Safe accounts page, `SelectSafeModal`, global search (Accounts / Trusted safes).
- **`EthHashInfo showCopyButton`** enabled on `NestedSafesList` (via `AccountItem.Info`) — existing, well-used prop; no API change.
- **Feature flags:** `WELCOME_ACCOUNTS_REDESIGN` gates V1 vs V2 of the My accounts page. V2 rows are covered here; the deprecated V1 sidebar list (`SafeListItem` / `AccountItems/MultiAccountItem`) is intentionally left unchanged and is **not** marked `@deprecated` because `/welcome/accounts` (flag off) still renders it.
- **No** RTK Query / API contract, persistence, migration, or shared-package (`packages/**`) changes.

## Risks / not checked

- Did not test on **mobile** — this is a web-only change (`apps/web`), no shared-package code touched.
- Did not manually verify the **deprecated V1 sidebar** list (left unchanged by design).
- Nested-list copy buttons were verified via unit-level reasoning + type/lint/tests, not a full manual click-through of every modal state.
- Visual placement was reasoned from the code/screenshots; final pixel placement should be confirmed on the preview deploy.

## Visual summary
<img width="553" height="284" alt="Screenshot 2026-06-19 at 16 01 45" src="https://github.com/user-attachments/assets/443864c2-c87e-47b3-b9d8-4449c26b96f6" />
<img width="523" height="509" alt="Screenshot 2026-06-19 at 16 01 55" src="https://github.com/user-attachments/assets/50f0740e-9367-4757-8d8a-56e9e7aba5cf" />
<img width="558" height="532" alt="Screenshot 2026-06-19 at 16 02 06" src="https://github.com/user-attachments/assets/e562314e-2a80-45b1-b7a0-25c538c1ff66" />
<img width="520" height="595" alt="Screenshot 2026-06-19 at 16 02 17" src="https://github.com/user-attachments/assets/711c374d-21e9-4d10-9e0e-d751a45a003b" />
<img width="349" height="358" alt="Screenshot 2026-06-19 at 16 02 49" src="https://github.com/user-attachments/assets/2e8cdf6f-66f3-4214-bcc8-07043acd2664" />
<img width="792" height="589" alt="Screenshot 2026-06-19 at 16 03 41" src="https://github.com/user-attachments/assets/0a223d59-4010-40a3-bf14-9b35392a9851" />


```mermaid
flowchart LR
  SCRO[SafeCardReadOnly - Spaces Safe accounts] -->|extract| CAB[CopyAddressIconButton - shared]
  CAB -.reused.-> SCRO
  CAB --> AWI[AccountWidgetItem / AccountItemContent - Spaces dashboard]
  CAB --> SAI[SingleAccountItem / MultiAccountItem - My accounts V2]
  CAB --> SEC[SingleSafeRow / MultichainSafeRow - Security Hub]
  CAB --> SCL[SafeCardLayout - Add accounts]
  NSL[NestedSafesList] -->|showCopyButton| EHI[EthHashInfo CopyAddressButton]
```

Before: account row = avatar + name + `0xA98A…32F8` (no copy). After: same row + a copy icon next to the address.



## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact (presentational copy button only)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).