### PR TITLE
chore: cleanup for legacy spaceId

### DIFF
--- a/apps/web/src/features/spaces/components/AuthState/index.test.tsx
+++ b/apps/web/src/features/spaces/components/AuthState/index.test.tsx
@@ -77,7 +77,7 @@ describe('AuthState', () => {
     mockIsUnauthorized.mockReturnValue(false)
     mockUseHasFeature.mockReturnValue(true)
     mockUseSpacesGetOneV1Query.mockReturnValue({
-      currentData: { id: 1, members: [{ user: { id: 'u1' }, status: 'ACTIVE' }] },
+      currentData: { uuid: 'uuid-1', members: [{ user: { id: 'u1' }, status: 'ACTIVE' }] },
       error: undefined,
       isLoading: false,
       isFetching: false,
@@ -89,7 +89,7 @@ describe('AuthState', () => {
     mockIsAuthenticated = false
 
     render(
-      <AuthState spaceId="7">
+      <AuthState spaceId="11111111-1111-1111-1111-111111111111">
         <div />
       </AuthState>,
     )
@@ -104,11 +104,10 @@ describe('AuthState', () => {
       </AuthState>,
     )
 
-    // Without the guard, Number('') would be 0 and the query would hit /v1/spaces/0
     expect(mockUseSpacesGetOneV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true, ...SPACE_REFRESH_OPTIONS })
   })
 
-  it('skips the space query when spaceId is null at runtime (Number(null) is 0)', () => {
+  it('skips the space query when spaceId is null at runtime', () => {
     render(
       <AuthState spaceId={null as unknown as string}>
         <div />
@@ -143,7 +142,7 @@ describe('AuthState', () => {
 
   it('renders the children for an active member', () => {
     render(
-      <AuthState spaceId="7">
+      <AuthState spaceId="11111111-1111-1111-1111-111111111111">
         <div data-testid="children" />
       </AuthState>,
     )
@@ -157,7 +156,7 @@ describe('AuthState', () => {
     mockUseSpacesGetOneV1Query.mockReturnValue({ currentData: undefined, error: { status: 404 }, isLoading: false })
 
     const { queryByTestId } = render(
-      <AuthState spaceId="7">
+      <AuthState spaceId="11111111-1111-1111-1111-111111111111">
         <div data-testid="children" />
       </AuthState>,
     )
@@ -176,7 +175,7 @@ describe('AuthState', () => {
     })
 
     const { queryByTestId } = render(
-      <AuthState spaceId="7">
+      <AuthState spaceId="11111111-1111-1111-1111-111111111111">
         <div data-testid="children" />
       </AuthState>,
     )
@@ -200,7 +199,7 @@ describe('AuthState', () => {
     })
 
     const { queryByTestId } = render(
-      <AuthState spaceId="7">
+      <AuthState spaceId="11111111-1111-1111-1111-111111111111">
         <div data-testid="children" />
       </AuthState>,
     )
@@ -220,7 +219,7 @@ describe('AuthState', () => {
     })
 
     const { queryByTestId } = render(
-      <AuthState spaceId="7">
+      <AuthState spaceId="11111111-1111-1111-1111-111111111111">
         <div data-testid="children" />
       </AuthState>,
     )
@@ -233,7 +232,7 @@ describe('AuthState', () => {
     mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: undefined })
 
     render(
-      <AuthState spaceId="7">
+      <AuthState spaceId="11111111-1111-1111-1111-111111111111">
         <div data-testid="children" />
       </AuthState>,
     )
@@ -246,7 +245,7 @@ describe('AuthState', () => {
     mockUseSpacesGetOneV1Query.mockReturnValue({ currentData: undefined, error: undefined, isLoading: true })
 
     const { queryByTestId } = render(
-      <AuthState spaceId="7">
+      <AuthState spaceId="11111111-1111-1111-1111-111111111111">
         <div data-testid="children" />
       </AuthState>,
     )
@@ -260,7 +259,7 @@ describe('AuthState', () => {
     mockIsUnauthorized.mockReturnValue(true)
 
     const { queryByTestId } = render(
-      <AuthState spaceId="7">
+      <AuthState spaceId="11111111-1111-1111-1111-111111111111">
         <div data-testid="children" />
       </AuthState>,
     )
@@ -271,7 +270,7 @@ describe('AuthState', () => {
 
   it('does not redirect when the user is still authorized', () => {
     const { queryByTestId } = render(
-      <AuthState spaceId="7">
+      <AuthState spaceId="11111111-1111-1111-1111-111111111111">
         <div data-testid="children" />
       </AuthState>,
     )

--- a/apps/web/src/features/spaces/components/SpaceActivityLog/__tests__/index.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceActivityLog/__tests__/index.test.tsx
@@ -121,7 +121,7 @@ describe('SpaceActivityLog', () => {
     mockPages({
       '': {
         results: [buildEvent('3'), buildEvent('2')],
-        next: 'https://gw/v1/spaces/1/audit-log?cursor=limit%3D2%26offset%3D2',
+        next: 'https://gw/v1/spaces/uuid-1/audit-log?cursor=limit%3D2%26offset%3D2',
         previous: null,
         count: 3,
       },
@@ -144,7 +144,7 @@ describe('SpaceActivityLog', () => {
     mockPages({
       '': {
         results: [buildEvent('1')],
-        next: 'https://gw/v1/spaces/1/audit-log?cursor=limit%3D1%26offset%3D1',
+        next: 'https://gw/v1/spaces/uuid-1/audit-log?cursor=limit%3D1%26offset%3D1',
         previous: null,
         count: 2,
       },
@@ -162,7 +162,7 @@ describe('SpaceActivityLog', () => {
     mockPages({
       '': {
         results: [buildEvent('1')],
-        next: 'https://gw/v1/spaces/1/audit-log?cursor=limit%3D1%26offset%3D1',
+        next: 'https://gw/v1/spaces/uuid-1/audit-log?cursor=limit%3D1%26offset%3D1',
         previous: null,
         count: 2,
       },
@@ -185,7 +185,7 @@ describe('SpaceActivityLog', () => {
     mockPages({
       '': {
         results: [buildEvent('1')],
-        next: 'https://gw/v1/spaces/1/audit-log?cursor=limit%3D1%26offset%3D1',
+        next: 'https://gw/v1/spaces/uuid-1/audit-log?cursor=limit%3D1%26offset%3D1',
         previous: null,
         count: 2,
       },

--- a/apps/web/src/features/spaces/hooks/useCurrentSpaceId.ts
+++ b/apps/web/src/features/spaces/hooks/useCurrentSpaceId.ts
@@ -5,8 +5,7 @@ import { useSpacesGetV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/s
 
 /**
  * Returns the current space UUID by checking (in priority order):
- * 1. `spaceId` query param (UUID; legacy numeric strings from older URLs are also
- *    accepted by the backend's `LegacySpaceIdPipe` during the deprecation window)
+ * 1. `spaceId` query param (UUID)
  * 2. Last used space stored in Redux
  * 3. First space from the user's spaces list
  */

--- a/apps/web/src/stories/mocks/handlers.ts
+++ b/apps/web/src/stories/mocks/handlers.ts
@@ -315,9 +315,9 @@ export const mockSafeOverviews = [
 /**
  * Mock space data for spaces feature
  */
-export function createMockSpace(spaceId: number = 1) {
+export function createMockSpace(spaceId: string = 'uuid-1') {
   return {
-    id: spaceId,
+    uuid: spaceId,
     name: 'Test Space',
     status: 'ACTIVE' as const,
     members: [
@@ -346,16 +346,16 @@ export function spacesHandlers(): RequestHandler[] {
     // User with wallets endpoint
     http.get(/\/v1\/users$/, () => HttpResponse.json(mockUser)),
     // Get space by ID
-    http.get(/\/v1\/spaces\/\d+$/, ({ params }) => {
+    http.get(/\/v1\/spaces\/[^/]+$/, ({ params }) => {
       const url = new URL(params[0] as string, 'https://example.com')
       const pathParts = url.pathname.split('/')
-      const spaceId = parseInt(pathParts[pathParts.length - 1], 10) || 1
+      const spaceId = pathParts[pathParts.length - 1] || 'uuid-1'
       return HttpResponse.json(createMockSpace(spaceId))
     }),
     // List all spaces for user
-    http.get(/\/v1\/spaces$/, () => HttpResponse.json([createMockSpace(1)])),
+    http.get(/\/v1\/spaces$/, () => HttpResponse.json([createMockSpace('uuid-1')])),
     // Get space safes
-    http.get(/\/v1\/spaces\/\d+\/safes$/, () => HttpResponse.json({ safes: {} })),
+    http.get(/\/v1\/spaces\/[^/]+\/safes$/, () => HttpResponse.json({ safes: {} })),
     // Get all safes owned by address (used by useOwnedSafesGrouped)
     http.get(/\/v2\/owners\/0x[a-fA-F0-9]+\/safes$/, () => HttpResponse.json(mockOwnedSafes)),
     // Safe overviews v1 (batch endpoint for safe card data)
@@ -363,11 +363,11 @@ export function spacesHandlers(): RequestHandler[] {
     // Safe overviews v2 (batch endpoint for safe card data)
     http.get(/\/v2\/safes$/, () => HttpResponse.json(mockSafeOverviews)),
     // Add safes to space (mutation)
-    http.post(/\/v1\/spaces\/\d+\/safes$/, () => HttpResponse.json({ success: true })),
+    http.post(/\/v1\/spaces\/[^/]+\/safes$/, () => HttpResponse.json({ success: true })),
     // Invite members to space (mutation)
-    http.post(/\/v1\/spaces\/\d+\/members\/invite$/, () => HttpResponse.json({ success: true })),
+    http.post(/\/v1\/spaces\/[^/]+\/members\/invite$/, () => HttpResponse.json({ success: true })),
     // Get space members
-    http.get(/\/v1\/spaces\/\d+\/members$/, () =>
+    http.get(/\/v1\/spaces\/[^/]+\/members$/, () =>
       HttpResponse.json([
         {
           id: 1,

--- a/apps/web/src/utils/spaces.ts
+++ b/apps/web/src/utils/spaces.ts
@@ -1,10 +1,7 @@
 /**
- * Normalize the persisted `lastUsedSpace` value (string | null) for use as
- * a Space identifier. Returns null for missing/whitespace-only inputs so
- * callers can skip space-scoped requests rather than passing an empty id.
- * The identifier is a UUID; legacy numeric strings are still accepted by
- * the backend's LegacySpaceIdPipe during the deprecation window, so we
- * pass any non-empty string through unchanged.
+ * Normalize a Space UUID (string | null) for use as a Space identifier.
+ * Returns null for missing/whitespace-only inputs so callers can skip
+ * space-scoped requests rather than passing an empty id.
  */
 export const normalizeSpaceId = (spaceId: string | null): string | null => {
   if (spaceId === null || spaceId.trim() === '') return null


### PR DESCRIPTION
## What it solves

Resolves: [WA-2687](https://linear.app/safe-global/issue/WA-2687/legacy-spaceid-cleanup)

The backend no longer serves or accepts the legacy numeric `spaceId` (it now uses UUIDs only, via `GetSpaceResponse.uuid`). Several spots still modelled the old numeric shape: a stale `LegacySpaceIdPipe` deprecation comment, a Storybook mock that built spaces with `id: <number>`, and test fixtures using numeric-style space ids / dead `Number()`-coercion comments.

## How this PR fixes it

- **Docs (prod code, no behavior change):** removed the obsolete `LegacySpaceIdPipe` / "legacy numeric strings" wording from `normalizeSpaceId` ([utils/spaces.ts](apps/web/src/utils/spaces.ts)) and `useCurrentSpaceId` ([useCurrentSpaceId.ts](apps/web/src/features/spaces/hooks/useCurrentSpaceId.ts)). Kept `normalizeSpaceId` itself — it still does a real job (empty/whitespace → `null` guard so callers skip space-scoped requests).
- **Storybook mock:** `createMockSpace` now emits `uuid: string` instead of `id: number`, and the MSW route regexes for `/v1/spaces/...` match a UUID-shaped segment (`[^/]+`) instead of `\d+` ([handlers.ts](apps/web/src/stories/mocks/handlers.ts)).
- **Tests:** `AuthState` test now passes a UUID and mocks `currentData.uuid`; dropped stale `Number('')`/`Number(null)` comments and test-name. Activity-log pagination cursor URLs use a UUID segment ([AuthState test](apps/web/src/features/spaces/components/AuthState/index.test.tsx), [SpaceActivityLog test](apps/web/src/features/spaces/components/SpaceActivityLog/__tests__/index.test.tsx)).

## How to test it

- `yarn workspace @safe-global/web type-check`
- `yarn workspace @safe-global/web test --testPathPattern "AuthState|SpaceActivityLog"`
- Open Storybook spaces stories and confirm they still render (the mock now returns `uuid`).

## Affected flows

- Space resolution from `lastUsedSpace` / query param (`normalizeSpaceId` callers: create-safe review step, create-safe-on-new-chain, counterfactual safe sync/persist, safe-limit check) — UUID-only now.
- Spaces feature Storybook stories driven by the shared MSW mock.

## Blast radius

- `normalizeSpaceId` ([utils/spaces.ts](apps/web/src/utils/spaces.ts)) — comment-only change; consumers: `useIsCurrentSpaceAtSafeLimit`, `CreateSafeOnNewChain`, `useCounterfactualSafeSync`, `persistCounterfactualSafe`, `ReviewStep`. No signature/behavior change.
- `createMockSpace` ([handlers.ts](apps/web/src/stories/mocks/handlers.ts)) — Storybook-only; param type changed `number → string`. No production code imports it.
- No RTK Query endpoint, feature flag, route, persisted state, or shared package changed. No mobile impact.

## Risks / not checked

- Did not exhaustively render every spaces Storybook story; relied on type-check + targeted unit tests.
- Did not test on mobile (no shared-package changes; web-only mocks/tests + web util comments).
- Did not change runtime `normalizeSpaceId` behavior, so no functional path was altered to verify.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1["createMockSpace(): { id: number }"] --> M1["MSW regex /spaces/\d+/"]
    B1["normalizeSpaceId — 'LegacySpaceIdPipe / numeric accepted'"]
    C1["AuthState test: spaceId='7', currentData.id"]
  end
  subgraph After
    A2["createMockSpace(): { uuid: string }"] --> M2["MSW regex /spaces/[^/]+/"]
    B2["normalizeSpaceId — UUID-only, empty→null guard"]
    C2["AuthState test: spaceId=UUID, currentData.uuid"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
