### PR TITLE
fix(web): align signer badge in pending transactions widget (WA-2489)

### DIFF
--- a/apps/web/src/components/dashboard/PendingTxs/PendingTxListItem.test.tsx
+++ b/apps/web/src/components/dashboard/PendingTxs/PendingTxListItem.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@/tests/test-utils'
+import { DetailedExecutionInfoType } from '@safe-global/store/gateway/types'
+import type { Transaction } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import PendingTxListItem from './PendingTxListItem'
+
+// Child components rely on the address book / chain config; mock them so the test
+// stays focused on what PendingTxListItem itself renders (link target + signer badge).
+jest.mock('@/components/transactions/TxType', () => ({
+  TxTypeIcon: () => <span data-testid="tx-type-icon" />,
+  TxTypeText: () => <span>Transaction Builder</span>,
+}))
+
+jest.mock('@/components/transactions/TxInfo', () => ({
+  __esModule: true,
+  default: () => <span>2 actions</span>,
+}))
+
+const createTransaction = (overrides: Partial<Transaction> = {}): Transaction =>
+  ({
+    id: 'multisig_0xabc',
+    timestamp: 1705852800000,
+    txStatus: 'AWAITING_CONFIRMATIONS',
+    txInfo: { type: 'Custom', methodName: 'multiSend', actionCount: 2 },
+    executionInfo: {
+      type: DetailedExecutionInfoType.MULTISIG,
+      nonce: 1,
+      confirmationsRequired: 2,
+      confirmationsSubmitted: 1,
+      missingSigners: [],
+    },
+    ...overrides,
+  }) as unknown as Transaction
+
+describe('PendingTxListItem', () => {
+  it('links to the transaction details with the tx id', () => {
+    render(<PendingTxListItem transaction={createTransaction()} />)
+
+    const link = screen.getByTestId('tx-pending-item')
+    expect(link).toHaveAttribute('href', expect.stringContaining('/transactions/tx'))
+    expect(link).toHaveAttribute('href', expect.stringContaining('multisig_0xabc'))
+  })
+
+  it('renders the type, info and signer confirmations badge', () => {
+    render(<PendingTxListItem transaction={createTransaction()} />)
+
+    expect(screen.getByText('Transaction Builder')).toBeInTheDocument()
+    expect(screen.getByText('2 actions')).toBeInTheDocument()
+    expect(screen.getByText('1/2')).toBeInTheDocument()
+  })
+
+  it('does not render a confirmations badge for non-multisig execution info', () => {
+    render(<PendingTxListItem transaction={createTransaction({ executionInfo: undefined })} />)
+
+    expect(screen.queryByText('1/2')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/dashboard/PendingTxs/PendingTxListItem.tsx
+++ b/apps/web/src/components/dashboard/PendingTxs/PendingTxListItem.tsx
@@ -34,11 +34,11 @@ const PendingTx = ({ transaction }: PendingTxType): ReactElement => {
   return (
     <NextLink data-testid="tx-pending-item" href={url} passHref>
       <Box className={css.container}>
-        <Stack direction="row" gap={1.5} alignItems="center">
+        <Stack direction="row" gap={1.5} alignItems="center" sx={{ minWidth: 0 }}>
           <Box className={css.iconWrapper}>
             <TxTypeIcon tx={transaction} />
           </Box>
-          <Box>
+          <Box sx={{ minWidth: 0 }}>
             <Typography className={css.txDescription}>
               <TxTypeText tx={transaction} />
               <TxInfo info={transaction.txInfo} />

--- a/apps/web/src/components/dashboard/PendingTxs/PendingTxsList.stories.tsx
+++ b/apps/web/src/components/dashboard/PendingTxs/PendingTxsList.stories.tsx
@@ -53,15 +53,82 @@ const createMockQueueResponse = (txCount: number, confirmations: number = 1, thr
 
 // Create handlers for tx queue
 const createTxQueueHandlers = (txCount: number, confirmations: number = 1, threshold: number = 2) => {
+  return createQueueResponseHandlers(createMockQueueResponse(txCount, confirmations, threshold))
+}
+
+// Create handlers that serve a pre-built queue response (for custom scenarios)
+const createQueueResponseHandlers = (response: object) => {
   const chainData = createChainData()
   return [
     http.get(/\/v1\/chains\/\d+$/, () => HttpResponse.json(chainData)),
     http.get(/\/v1\/chains$/, () => HttpResponse.json({ ...chainFixtures.all, results: [chainData] })),
     http.get(/\/v1\/chains\/\d+\/safes\/0x[a-fA-F0-9]+$/, () => HttpResponse.json(safeFixtures.efSafe)),
-    http.get(/\/v1\/chains\/\d+\/safes\/0x[a-fA-F0-9]+\/transactions\/queued/, () =>
-      HttpResponse.json(createMockQueueResponse(txCount, confirmations, threshold)),
-    ),
+    http.get(/\/v1\/chains\/\d+\/safes\/0x[a-fA-F0-9]+\/transactions\/queued/, () => HttpResponse.json(response)),
   ]
+}
+
+// WA-2489: rows with very different description lengths (a long contract method
+// name vs. a short "N actions" Transaction Builder row) must keep their signer
+// badge aligned to the right. This mixed-type queue reproduces that scenario.
+const createCustomContractTx = (nonce: number, methodName: string, name: string) => ({
+  type: 'TRANSACTION',
+  transaction: {
+    id: `multisig_custom_0x${nonce.toString(16).padStart(8, '0')}`,
+    timestamp: Date.now() - nonce * 3600000,
+    txStatus: 'AWAITING_CONFIRMATIONS',
+    txInfo: {
+      type: 'Custom',
+      to: { value: '0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67', name },
+      dataSize: '100',
+      isCancellation: false,
+      methodName,
+    },
+    executionInfo: {
+      type: 'MULTISIG',
+      nonce,
+      confirmationsRequired: 2,
+      confirmationsSubmitted: 1,
+      missingSigners: [{ value: '0xowner1111111111111111111111111111111111' }],
+    },
+  },
+  conflictType: 'None',
+})
+
+const createTxBuilderTx = (nonce: number, actionCount: number) => ({
+  type: 'TRANSACTION',
+  transaction: {
+    id: `multisig_txbuilder_0x${nonce.toString(16).padStart(8, '0')}`,
+    timestamp: Date.now() - nonce * 3600000,
+    txStatus: 'AWAITING_CONFIRMATIONS',
+    txInfo: {
+      type: 'Custom',
+      to: { value: '0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67' },
+      dataSize: '500',
+      isCancellation: false,
+      methodName: 'multiSend',
+      actionCount,
+    },
+    safeAppInfo: { name: 'Transaction Builder', url: 'https://apps-portal.safe.global/tx-builder' },
+    executionInfo: {
+      type: 'MULTISIG',
+      nonce,
+      confirmationsRequired: 2,
+      confirmationsSubmitted: 1,
+      missingSigners: [{ value: '0xowner1111111111111111111111111111111111' }],
+    },
+  },
+  conflictType: 'None',
+})
+
+const mixedQueueResponse = {
+  count: 3,
+  next: null,
+  previous: null,
+  results: [
+    createCustomContractTx(1, 'createProxyWithNonce', 'SafeProxyFactory 1.4.1'),
+    createCustomContractTx(2, 'createProxyWithNonce', 'SafeProxyFactory 1.4.1'),
+    createTxBuilderTx(3, 2),
+  ],
 }
 
 const defaultSetup = createMockStory({
@@ -222,6 +289,31 @@ export const Loading: Story = (() => {
         return HttpResponse.json({})
       }),
     ],
+  })
+  return {
+    parameters: { ...setup.parameters },
+    decorators: [setup.decorator],
+  }
+})()
+
+/**
+ * Mixed transaction types with different description lengths (WA-2489).
+ * The signer badge ("1/2") must stay aligned to the right on every row,
+ * including the shorter Transaction Builder row.
+ */
+export const MixedTransactionTypes: Story = (() => {
+  const setup = createMockStory({
+    scenario: 'efSafe',
+    wallet: 'owner',
+    layout: 'paper',
+    store: {
+      txQueue: {
+        data: mixedQueueResponse,
+        loading: false,
+        error: undefined,
+      },
+    },
+    handlers: createQueueResponseHandlers(mixedQueueResponse),
   })
   return {
     parameters: { ...setup.parameters },

--- a/apps/web/src/components/dashboard/PendingTxs/styles.module.css
+++ b/apps/web/src/components/dashboard/PendingTxs/styles.module.css
@@ -7,7 +7,7 @@
   border-radius: 8px;
   flex-wrap: nowrap;
   display: grid;
-  grid-template-columns: 1fr 100px;
+  grid-template-columns: minmax(0, 1fr) 100px;
   align-items: center;
   gap: var(--space-2);
   min-height: 50px;
@@ -130,7 +130,7 @@
     flex-direction: column;
     align-items: flex-start;
     flex-wrap: wrap;
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     gap: var(--space-1);
   }
 


### PR DESCRIPTION
## What it solves

Resolves: [WA-2489](https://linear.app/safe-global/issue/WA-2489/unaligned-transaction-builder-row-in-pending-transaction-component)

In the dashboard **Pending transactions** widget, the signer badge (e.g. `1/2`) on the **Transaction Builder** row was not aligned with the other rows' badges that float to the right. It's most visible on narrower widths (e.g. the two‑column dashboard layout), where the badge appeared shifted to the left of the rows above it.

## How this PR fixes it

**Root cause (measured in the browser):** the row container uses `grid-template-columns: 1fr 100px`. Since `1fr` resolves to `minmax(auto, 1fr)`, the first track's _auto minimum_ is its content's **min-content**. Rows that contain a long unbreakable token (e.g. the contract method name `createProxyWithNonce`, ≈170px) force the first column past its fair share (214.5px vs 178px), so the grid overflows the container and pushes the fixed 100px badge column ~37px to the right. Rows whose content is all short words (Transaction Builder → `2 actions`) keep the fair‑share width, so their badge sits at the correct padded‑right position — making it the visual odd‑one‑out.

**Fix:**

- `grid-template-columns: minmax(0, 1fr) …` (desktop + the `≤600px` media query) so the flexible column can never exceed its track.
- `min-width: 0` on the first column's `Stack` and inner description `Box`, so long text truncates **inside** its track — this finally engages the existing `.txInfo { text-overflow: ellipsis }` rule (it never fired before because the column kept growing) instead of overflowing toward the badge.

## How to test it

1. Open a Safe whose queue has mixed transaction types — at least one contract interaction with a long method name (e.g. `createProxyWithNonce`) **and** a Transaction Builder (multiSend) transaction. Example: `eth:0x7B45F456d8bA33FA6e8Ab38320542F4489970d16` on the dev environment.
2. Make the **Pending transactions** widget narrow (resize the window so the dashboard uses its two‑column layout).
3. ✅ Every signer badge (`1/2`, `2/2`, …) should be flush‑right on **every** row, including the Transaction Builder row.
4. ✅ Long method names should truncate with an ellipsis (`createProxyWithNon…`) rather than overflowing toward the badge.
5. ✅ At `≤600px` the layout stays single‑column with the badge stacked below each row, no horizontal overflow.
6. Storybook: **Dashboard/PendingTxsList → MixedTransactionTypes**.

## Affected flows

- Dashboard **Pending transactions** widget — signer-badge alignment across all queued transaction rows (Send/transfer, contract interaction, Transaction Builder / batch).

## Blast radius

- **`PendingTxs/styles.module.css` (`.container`, `≤600px` rule)** — consumers:
  - `PendingTxListItem` (changed here).
  - `PendingRecoveryListItem` (uses `.container` + `.recoveryContainer`). Its `.recoveryContainer { grid-template-columns: 1fr 170px }` overrides the desktop rule, so it's **unaffected on desktop**; at `≤600px` it now inherits `minmax(0, 1fr)`, which is harmless for its short content.
- **`RecoveryType`** reuses only `.iconWrapper` from this module → unaffected.
- No RTK Query endpoints / API contracts, feature flags, chain configs, routes, or persisted state touched.
- No shared‑package (`packages/**`) changes → **no React‑Native mobile impact**. The `≤600px` change is web responsive CSS only.

## Risks / not checked

- **Live recovery widget not exercised** (needs an active recovery queue). Reasoned safe: `.recoveryContainer` overrides the desktop grid and its content is short, so the blow‑out can't occur there.
- **No automated pixel/layout assertion** — jsdom can't compute layout, so alignment is verified manually in the browser (before/after) and via the new Storybook story. The unit test covers render output + the badge's multisig conditional only.
- Left `.recoveryContainer`'s desktop `1fr 170px` unchanged (out of scope; same latent pattern, but not reported and not reproducible without an active recovery).
- **Analytics:** no change.

## Visual summary

```mermaid
flowchart TB
  subgraph Before["Before — grid-template-columns: 1fr 100px"]
    A1["Row w/ long token<br/>createProxyWithNonce"] --> B1["1fr = minmax(auto,1fr)<br/>col 1 grows to min-content ≈214px"]
    B1 --> C1["grid overflows container<br/>badge column pushed right"]
    A2["Transaction Builder<br/>short: 2 actions"] --> B2["col 1 stays fair-share 178px"]
    B2 --> C2["badge at correct padded-right"]
    C1 --> D1["❌ badges misaligned"]
    C2 --> D1
  end
  subgraph After["After — minmax(0,1fr) + min-width:0"]
    E1["Any row"] --> F1["col 1 capped at fair-share 178px"]
    F1 --> G1["long text truncates with ellipsis"]
    G1 --> H1["✅ all badges flush-right"]
  end
```
<img width="385" height="438" alt="Screenshot 2026-06-19 at 17 47 07" src="https://github.com/user-attachments/assets/46721007-bbff-410d-b37c-23c54622498c" />


Measured (widget container 355px, two‑column dashboard):

| Row | Before — grid columns | Badge right edge |
| --- | --- | --- |
| SafeProxyFactory (long method) | `214.5px 100px` | 1337 (overflowed) |
| SafeProxyFactory (long method) | `214.5px 100px` | 1337 (overflowed) |
| Transaction Builder | `178px 100px` | 1300 |
| **After (every row)** | **`207.3px 100px`** | **1388 — all aligned** |

## Checklist

- [x] I've tested the branch on mobile 📱 _(verified the `≤600px` web layout — single column, badge stacked, no horizontal overflow; no shared‑package/RN change)_
- [x] I've documented how it affects the analytics (if at all) 📊 _(no analytics impact)_
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 _(added `PendingTxListItem.test.tsx` + `MixedTransactionTypes` Storybook story)_
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).