### PR TITLE
fix: resolve zero-address MultiSend sub-calls to the executing Safe

### DIFF
--- a/apps/mobile/src/features/TransactionActions/components/TxActionsList.test.tsx
+++ b/apps/mobile/src/features/TransactionActions/components/TxActionsList.test.tsx
@@ -6,10 +6,20 @@ import { Operation } from '@safe-global/store/gateway/types'
 import { ZERO_ADDRESS } from '@safe-global/utils/utils/constants'
 import { faker } from '@faker-js/faker'
 import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { multiSendDefaultsToSelf } from '@safe-global/utils/utils/multiSend'
 
 jest.mock('expo-router', () => ({
   useLocalSearchParams: () => ({ txId: 'multisig_0x_0x' }),
   router: { push: jest.fn() },
+}))
+
+jest.mock('@/src/store/hooks/activeSafe', () => ({
+  useDefinedActiveSafe: () => ({ address: '0x0000000000000000000000000000000000000001', chainId: '1' }),
+}))
+
+jest.mock('@safe-global/utils/utils/multiSend', () => ({
+  ...jest.requireActual('@safe-global/utils/utils/multiSend'),
+  multiSendDefaultsToSelf: jest.fn(),
 }))
 
 const buildTxDetails = (safeAddress: string, to: string): TransactionDetails =>
@@ -17,6 +27,7 @@ const buildTxDetails = (safeAddress: string, to: string): TransactionDetails =>
     safeAddress,
     txId: 'multisig_0x_0x',
     txData: {
+      to: { value: faker.finance.ethereumAddress() },
       addressInfoIndex: {},
       dataDecoded: {
         method: 'multiSend',
@@ -41,6 +52,11 @@ const buildTxDetails = (safeAddress: string, to: string): TransactionDetails =>
   }) as unknown as TransactionDetails
 
 describe('TxActionsList', () => {
+  beforeEach(() => {
+    // Default: the batch's MultiSend version defaults a zero `to` to the Safe (v1.5.0+)
+    ;(multiSendDefaultsToSelf as jest.Mock).mockReturnValue(true)
+  })
+
   afterEach(() => {
     jest.clearAllMocks()
   })
@@ -67,6 +83,19 @@ describe('TxActionsList', () => {
     // A real target is passed through verbatim, not rewritten to the Safe
     const pushArg = (router.push as jest.Mock).mock.calls[0][0]
     expect(pushArg.params.action).toContain(contract)
+    expect(pushArg.params.action).not.toContain(safeAddress)
+  })
+
+  it('does NOT resolve the zero address for a pre-1.5.0 MultiSend', () => {
+    ;(multiSendDefaultsToSelf as jest.Mock).mockReturnValue(false)
+    const safeAddress = faker.finance.ethereumAddress()
+    render(<TxActionsList txDetails={buildTxDetails(safeAddress, ZERO_ADDRESS)} />)
+
+    fireEvent.press(screen.getByTestId('tx-action-item-0'))
+
+    // The raw zero address is preserved (older MultiSend does not default it to the Safe)
+    const pushArg = (router.push as jest.Mock).mock.calls[0][0]
+    expect(pushArg.params.action).toContain(ZERO_ADDRESS)
     expect(pushArg.params.action).not.toContain(safeAddress)
   })
 })

--- a/apps/mobile/src/features/TransactionActions/components/TxActionsList.test.tsx
+++ b/apps/mobile/src/features/TransactionActions/components/TxActionsList.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { router } from 'expo-router'
+import { render, screen, fireEvent } from '@/src/tests/test-utils'
+import { TxActionsList } from './TxActionsList'
+import { Operation } from '@safe-global/store/gateway/types'
+import { ZERO_ADDRESS } from '@safe-global/utils/utils/constants'
+import { faker } from '@faker-js/faker'
+import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ txId: 'multisig_0x_0x' }),
+  router: { push: jest.fn() },
+}))
+
+const buildTxDetails = (safeAddress: string, to: string): TransactionDetails =>
+  ({
+    safeAddress,
+    txId: 'multisig_0x_0x',
+    txData: {
+      addressInfoIndex: {},
+      dataDecoded: {
+        method: 'multiSend',
+        parameters: [
+          {
+            name: 'transactions',
+            type: 'bytes',
+            value: '0x',
+            valueDecoded: [
+              {
+                operation: Operation.CALL,
+                to,
+                value: '0',
+                data: '0x610b5925',
+                dataDecoded: { method: 'enableModule', parameters: [] },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  }) as unknown as TransactionDetails
+
+describe('TxActionsList', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('resolves a zero-address sub-transaction to the executing Safe', () => {
+    const safeAddress = faker.finance.ethereumAddress()
+    render(<TxActionsList txDetails={buildTxDetails(safeAddress, ZERO_ADDRESS)} />)
+
+    fireEvent.press(screen.getByTestId('tx-action-item-0'))
+
+    // The action handed to the details screen targets the Safe, not the zero address
+    const pushArg = (router.push as jest.Mock).mock.calls[0][0]
+    expect(pushArg.params.action).toContain(safeAddress)
+    expect(pushArg.params.action).not.toContain(ZERO_ADDRESS)
+  })
+
+  it('leaves a non-zero sub-transaction target unchanged', () => {
+    const safeAddress = faker.finance.ethereumAddress()
+    const contract = faker.finance.ethereumAddress()
+    render(<TxActionsList txDetails={buildTxDetails(safeAddress, contract)} />)
+
+    fireEvent.press(screen.getByTestId('tx-action-item-0'))
+
+    // A real target is passed through verbatim, not rewritten to the Safe
+    const pushArg = (router.push as jest.Mock).mock.calls[0][0]
+    expect(pushArg.params.action).toContain(contract)
+    expect(pushArg.params.action).not.toContain(safeAddress)
+  })
+})

--- a/apps/mobile/src/features/TransactionActions/components/TxActionsList.tsx
+++ b/apps/mobile/src/features/TransactionActions/components/TxActionsList.tsx
@@ -11,6 +11,7 @@ import { useTxTokenInfo } from '@safe-global/utils/hooks/useTxTokenInfo'
 import { useAppSelector } from '@/src/store/hooks'
 import { selectActiveChainCurrency } from '@/src/store/chains'
 import { HashDisplay } from '@/src/components/HashDisplay'
+import { resolveMultiSendToAddress } from '@safe-global/utils/utils/multiSend'
 
 interface TxActionsListProps {
   txDetails: TransactionDetails
@@ -32,17 +33,20 @@ interface TxActionItemProps {
   index: number
   addressInfoIndex?: AddressInfoIndex
   txData: TransactionDetails['txData']
+  safeAddress: string
 }
 
-const TxActionItem = ({ action, index, addressInfoIndex, txData }: TxActionItemProps) => {
+const TxActionItem = ({ action, index, addressInfoIndex, txData, safeAddress }: TxActionItemProps) => {
   const valueDecoded = txData?.dataDecoded?.parameters?.[0].valueDecoded
   const tx = Array.isArray(valueDecoded) ? valueDecoded[index] : undefined
+  // MultiSend rewrites a zero-address sub-transaction `to` to the executing Safe.
+  const to = tx ? resolveMultiSendToAddress(tx.to, safeAddress) : ''
   const nativeCurrency = useAppSelector(selectActiveChainCurrency)
 
   const transferTokenInfo = useTxTokenInfo(
     tx?.data?.toString() || undefined,
     tx?.value || undefined,
-    tx?.to || '',
+    to,
     nativeCurrency as NativeToken,
     txData?.tokenInfoIndex ?? {},
   )
@@ -64,7 +68,7 @@ const TxActionItem = ({ action, index, addressInfoIndex, txData }: TxActionItemP
                 Send {formatVisualAmount(transferTokenInfo.transferValue, transferTokenInfo?.tokenInfo?.decimals, 6)}{' '}
                 {transferTokenInfo.tokenInfo.symbol} to
               </Text>
-              <HashDisplay value={tx.to as `0x${string}`} showCopy={false} showExternalLink={false} />
+              <HashDisplay value={to as `0x${string}`} showCopy={false} showExternalLink={false} />
             </View>
           ) : (
             <Text fontSize="$4" flexShrink={1} flexWrap="wrap">
@@ -83,6 +87,7 @@ export function TxActionsList({ txDetails }: TxActionsListProps) {
   const { txId } = useLocalSearchParams<{ txId: string }>()
 
   const { dataDecoded, addressInfoIndex } = txDetails.txData || {}
+  const safeAddress = txDetails.safeAddress
 
   const onActionPress = (action: MultiSend) => {
     router.push({
@@ -97,8 +102,14 @@ export function TxActionsList({ txDetails }: TxActionsListProps) {
 
   const transaction = dataDecoded?.parameters?.find((action) => action.name === 'transactions' && action.valueDecoded)
   const actions = useMemo(() => {
-    return Array.isArray(transaction?.valueDecoded) ? transaction?.valueDecoded : [transaction?.valueDecoded]
-  }, [transaction])
+    const rawActions = Array.isArray(transaction?.valueDecoded)
+      ? transaction?.valueDecoded
+      : [transaction?.valueDecoded]
+    // MultiSend rewrites a zero-address sub-transaction `to` to the executing Safe.
+    return rawActions?.map((action) =>
+      action && 'to' in action ? { ...action, to: resolveMultiSendToAddress(action.to, safeAddress) } : action,
+    )
+  }, [transaction, safeAddress])
 
   return (
     <YStack gap="$2" padding="$4">
@@ -116,7 +127,7 @@ export function TxActionsList({ txDetails }: TxActionsListProps) {
             testID={`tx-action-item-${index}`}
             collapsable={false}
           >
-            <TxActionItem txData={txDetails.txData} action={action} index={index} />
+            <TxActionItem txData={txDetails.txData} action={action} index={index} safeAddress={safeAddress} />
           </Container>
         )
       })}

--- a/apps/mobile/src/features/TransactionActions/components/TxActionsList.tsx
+++ b/apps/mobile/src/features/TransactionActions/components/TxActionsList.tsx
@@ -11,7 +11,8 @@ import { useTxTokenInfo } from '@safe-global/utils/hooks/useTxTokenInfo'
 import { useAppSelector } from '@/src/store/hooks'
 import { selectActiveChainCurrency } from '@/src/store/chains'
 import { HashDisplay } from '@/src/components/HashDisplay'
-import { resolveMultiSendToAddress } from '@safe-global/utils/utils/multiSend'
+import { multiSendDefaultsToSelf, resolveMultiSendToAddress } from '@safe-global/utils/utils/multiSend'
+import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 
 interface TxActionsListProps {
   txDetails: TransactionDetails
@@ -34,13 +35,14 @@ interface TxActionItemProps {
   addressInfoIndex?: AddressInfoIndex
   txData: TransactionDetails['txData']
   safeAddress: string
+  defaultsToSelf: boolean
 }
 
-const TxActionItem = ({ action, index, addressInfoIndex, txData, safeAddress }: TxActionItemProps) => {
+const TxActionItem = ({ action, index, addressInfoIndex, txData, safeAddress, defaultsToSelf }: TxActionItemProps) => {
   const valueDecoded = txData?.dataDecoded?.parameters?.[0].valueDecoded
   const tx = Array.isArray(valueDecoded) ? valueDecoded[index] : undefined
-  // MultiSend rewrites a zero-address sub-transaction `to` to the executing Safe.
-  const to = tx ? resolveMultiSendToAddress(tx.to, safeAddress) : ''
+  // MultiSend v1.5.0+ rewrites a zero-address sub-transaction `to` to the executing Safe.
+  const to = tx ? (defaultsToSelf ? resolveMultiSendToAddress(tx.to, safeAddress) : tx.to) : ''
   const nativeCurrency = useAppSelector(selectActiveChainCurrency)
 
   const transferTokenInfo = useTxTokenInfo(
@@ -88,6 +90,10 @@ export function TxActionsList({ txDetails }: TxActionsListProps) {
 
   const { dataDecoded, addressInfoIndex } = txDetails.txData || {}
   const safeAddress = txDetails.safeAddress
+  const { chainId } = useDefinedActiveSafe()
+  // Only MultiSend v1.5.0+ defaults a zero-address sub-transaction `to` to the executing Safe.
+  const multiSendAddress = txDetails.txData?.to?.value
+  const defaultsToSelf = !!multiSendAddress && multiSendDefaultsToSelf(multiSendAddress, chainId)
 
   const onActionPress = (action: MultiSend) => {
     router.push({
@@ -105,11 +111,13 @@ export function TxActionsList({ txDetails }: TxActionsListProps) {
     const rawActions = Array.isArray(transaction?.valueDecoded)
       ? transaction?.valueDecoded
       : [transaction?.valueDecoded]
-    // MultiSend rewrites a zero-address sub-transaction `to` to the executing Safe.
+    // MultiSend v1.5.0+ rewrites a zero-address sub-transaction `to` to the executing Safe.
     return rawActions?.map((action) =>
-      action && 'to' in action ? { ...action, to: resolveMultiSendToAddress(action.to, safeAddress) } : action,
+      defaultsToSelf && action && 'to' in action
+        ? { ...action, to: resolveMultiSendToAddress(action.to, safeAddress) }
+        : action,
     )
-  }, [transaction, safeAddress])
+  }, [transaction, safeAddress, defaultsToSelf])
 
   return (
     <YStack gap="$2" padding="$4">
@@ -127,7 +135,13 @@ export function TxActionsList({ txDetails }: TxActionsListProps) {
             testID={`tx-action-item-${index}`}
             collapsable={false}
           >
-            <TxActionItem txData={txDetails.txData} action={action} index={index} safeAddress={safeAddress} />
+            <TxActionItem
+              txData={txDetails.txData}
+              action={action}
+              index={index}
+              safeAddress={safeAddress}
+              defaultsToSelf={defaultsToSelf}
+            />
           </Container>
         )
       })}

--- a/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.test.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.test.tsx
@@ -5,8 +5,13 @@ import { faker } from '@faker-js/faker'
 import { Safe__factory } from '@safe-global/utils/types/contracts'
 import { ZERO_ADDRESS } from '@safe-global/utils/utils/constants'
 import useSafeAddress from '@/hooks/useSafeAddress'
+import { multiSendDefaultsToSelf } from '@safe-global/utils/utils/multiSend'
 
 jest.mock('@/hooks/useSafeAddress')
+jest.mock('@safe-global/utils/utils/multiSend', () => ({
+  ...jest.requireActual('@safe-global/utils/utils/multiSend'),
+  multiSendDefaultsToSelf: jest.fn(),
+}))
 
 const safeInterface = Safe__factory.createInterface()
 const encodeEnableModule = (module: string) => safeInterface.encodeFunctionData('enableModule', [module])
@@ -43,9 +48,11 @@ describe('Multisend', () => {
 
   beforeEach(() => {
     ;(useSafeAddress as jest.Mock).mockReturnValue(safeAddress)
+    // Default: the batch's MultiSend version defaults a zero `to` to the Safe (v1.5.0+)
+    ;(multiSendDefaultsToSelf as jest.Mock).mockReturnValue(true)
   })
 
-  it('resolves a zero-address inner action to the Safe (MultiSend defaults `to` to address(this))', () => {
+  it('resolves a zero-address inner action to the Safe (MultiSend v1.5.0+ defaults `to` to address(this))', () => {
     const moduleAddress = faker.finance.ethereumAddress()
     const result = render(<Multisend txData={buildMultisendTxData([{ to: ZERO_ADDRESS, module: moduleAddress }])} />)
 
@@ -64,6 +71,18 @@ describe('Multisend', () => {
     fireEvent.click(result.getByTestId('expande-all-btn'))
 
     // A real target is not rewritten to the Safe
+    expect(result.queryByText('This Safe Account')).not.toBeInTheDocument()
+  })
+
+  it('does NOT resolve the zero address for a pre-1.5.0 MultiSend (keeps the raw zero address)', () => {
+    // Older MultiSend versions call the zero address as-is — no zero->Safe default
+    ;(multiSendDefaultsToSelf as jest.Mock).mockReturnValue(false)
+    const moduleAddress = faker.finance.ethereumAddress()
+    const result = render(<Multisend txData={buildMultisendTxData([{ to: ZERO_ADDRESS, module: moduleAddress }])} />)
+
+    fireEvent.click(result.getByTestId('expande-all-btn'))
+
+    expect(result.getByText('0x0000...0000')).toBeInTheDocument()
     expect(result.queryByText('This Safe Account')).not.toBeInTheDocument()
   })
 

--- a/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.test.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render } from '@/tests/test-utils'
+import Multisend from '.'
+import { Operation } from '@safe-global/store/gateway/types'
+import { faker } from '@faker-js/faker'
+import { Safe__factory } from '@safe-global/utils/types/contracts'
+import { ZERO_ADDRESS } from '@safe-global/utils/utils/constants'
+import useSafeAddress from '@/hooks/useSafeAddress'
+
+jest.mock('@/hooks/useSafeAddress')
+
+const safeInterface = Safe__factory.createInterface()
+const encodeEnableModule = (module: string) => safeInterface.encodeFunctionData('enableModule', [module])
+
+const buildMultisendTxData = (innerTxs: Array<{ to: string; module: string }>) => ({
+  to: { value: faker.finance.ethereumAddress() },
+  value: '0',
+  operation: Operation.DELEGATE,
+  addressInfoIndex: {},
+  dataDecoded: {
+    method: 'multiSend',
+    parameters: [
+      {
+        name: 'transactions',
+        type: 'bytes',
+        value: '0x',
+        valueDecoded: innerTxs.map(({ to, module }) => ({
+          operation: Operation.CALL,
+          to,
+          value: '0',
+          data: encodeEnableModule(module),
+          dataDecoded: {
+            method: 'enableModule',
+            parameters: [{ name: 'module', type: 'address', value: module }],
+          },
+        })),
+      },
+    ],
+  },
+})
+
+describe('Multisend', () => {
+  const safeAddress = faker.finance.ethereumAddress()
+
+  beforeEach(() => {
+    ;(useSafeAddress as jest.Mock).mockReturnValue(safeAddress)
+  })
+
+  it('resolves a zero-address inner action to the Safe (MultiSend defaults `to` to address(this))', () => {
+    const moduleAddress = faker.finance.ethereumAddress()
+    const result = render(<Multisend txData={buildMultisendTxData([{ to: ZERO_ADDRESS, module: moduleAddress }])} />)
+
+    fireEvent.click(result.getByTestId('expande-all-btn'))
+
+    // The action is shown as targeting the Safe, not a bare call to the zero address
+    expect(result.getByText('This Safe Account')).toBeInTheDocument()
+    expect(result.queryByText('0x0000...0000')).not.toBeInTheDocument()
+  })
+
+  it('leaves a non-zero inner action target unchanged', () => {
+    const contract = faker.finance.ethereumAddress()
+    const moduleAddress = faker.finance.ethereumAddress()
+    const result = render(<Multisend txData={buildMultisendTxData([{ to: contract, module: moduleAddress }])} />)
+
+    fireEvent.click(result.getByTestId('expande-all-btn'))
+
+    // A real target is not rewritten to the Safe
+    expect(result.queryByText('This Safe Account')).not.toBeInTheDocument()
+  })
+
+  it('resolves a zero-address inner action to the executing Safe when overridden (nested Safe)', () => {
+    // Nested Safe: the batch executes in a different Safe than the connected one
+    const nestedSafe = faker.finance.ethereumAddress()
+    const moduleAddress = faker.finance.ethereumAddress()
+    const result = render(
+      <Multisend
+        txData={buildMultisendTxData([{ to: ZERO_ADDRESS, module: moduleAddress }])}
+        executingSafeAddress={nestedSafe}
+      />,
+    )
+
+    fireEvent.click(result.getByTestId('expande-all-btn'))
+
+    // Resolves to the nested Safe, not the connected one ("This Safe Account" is the connected Safe)
+    expect(result.queryByText('This Safe Account')).not.toBeInTheDocument()
+    expect(result.queryByText('0x0000...0000')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -7,11 +7,16 @@ import SingleTxDecoded from '@/components/transactions/TxDetails/TxData/DecodedD
 import { Button, Divider, Stack } from '@mui/material'
 import css from './styles.module.css'
 import classnames from 'classnames'
+import useSafeAddress from '@/hooks/useSafeAddress'
+import { resolveMultiSendToAddress } from '@safe-global/utils/utils/multiSend'
 
 type MultisendProps = {
   txData?: TransactionData | null
   compact?: boolean
   isExecuted?: boolean
+  // The Safe executing the batch, i.e. MultiSend's `address(this)`. Defaults to the connected Safe;
+  // pass explicitly when rendering a nested Safe's batch where it is not the connected Safe.
+  executingSafeAddress?: string
 }
 
 export const MultisendActionsHeader = ({
@@ -44,9 +49,16 @@ export const MultisendActionsHeader = ({
   )
 }
 
-const Multisend = ({ txData, compact = false, isExecuted = false }: MultisendProps): ReactElement | null => {
+const Multisend = ({
+  txData,
+  compact = false,
+  isExecuted = false,
+  executingSafeAddress,
+}: MultisendProps): ReactElement | null => {
   const [openMap, setOpenMap] = useState<Record<number, boolean>>()
   const isOpenMapUndefined = openMap == null
+  const connectedSafeAddress = useSafeAddress()
+  const safeAddress = executingSafeAddress || connectedSafeAddress
 
   // multiSend method receives one parameter `transactions`
   const multiSendTransactions = txData?.dataDecoded?.parameters?.[0].valueDecoded
@@ -70,7 +82,10 @@ const Multisend = ({ txData, compact = false, isExecuted = false }: MultisendPro
 
       <div className={compact ? css.compact : ''}>
         {Array.isArray(multiSendTransactions) &&
-          multiSendTransactions.map(({ dataDecoded, data, value, to, operation }, index) => {
+          multiSendTransactions.map(({ dataDecoded, data, value, to: rawTo, operation }, index) => {
+            // MultiSend rewrites a zero-address sub-transaction `to` to the executing Safe.
+            const to = resolveMultiSendToAddress(rawTo, safeAddress)
+
             const onChange: AccordionProps['onChange'] = (_, expanded) => {
               setOpenMap((prev) => ({
                 ...prev,

--- a/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -8,7 +8,8 @@ import { Button, Divider, Stack } from '@mui/material'
 import css from './styles.module.css'
 import classnames from 'classnames'
 import useSafeAddress from '@/hooks/useSafeAddress'
-import { resolveMultiSendToAddress } from '@safe-global/utils/utils/multiSend'
+import useChainId from '@/hooks/useChainId'
+import { multiSendDefaultsToSelf, resolveMultiSendToAddress } from '@safe-global/utils/utils/multiSend'
 
 type MultisendProps = {
   txData?: TransactionData | null
@@ -59,6 +60,10 @@ const Multisend = ({
   const isOpenMapUndefined = openMap == null
   const connectedSafeAddress = useSafeAddress()
   const safeAddress = executingSafeAddress || connectedSafeAddress
+  const chainId = useChainId()
+  // Only MultiSend v1.5.0+ defaults a zero-address sub-transaction `to` to the executing Safe.
+  const multiSendAddress = txData?.to?.value
+  const defaultsToSelf = !!multiSendAddress && multiSendDefaultsToSelf(multiSendAddress, chainId)
 
   // multiSend method receives one parameter `transactions`
   const multiSendTransactions = txData?.dataDecoded?.parameters?.[0].valueDecoded
@@ -83,8 +88,7 @@ const Multisend = ({
       <div className={compact ? css.compact : ''}>
         {Array.isArray(multiSendTransactions) &&
           multiSendTransactions.map(({ dataDecoded, data, value, to: rawTo, operation }, index) => {
-            // MultiSend rewrites a zero-address sub-transaction `to` to the executing Safe.
-            const to = resolveMultiSendToAddress(rawTo, safeAddress)
+            const to = defaultsToSelf ? resolveMultiSendToAddress(rawTo, safeAddress) : rawTo
 
             const onChange: AccordionProps['onChange'] = (_, expanded) => {
               setOpenMap((prev) => ({

--- a/apps/web/src/components/transactions/TxDetails/TxData/NestedTransaction/ExecTransaction/index.test.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/NestedTransaction/ExecTransaction/index.test.tsx
@@ -9,6 +9,10 @@ import { ZERO_ADDRESS } from '@safe-global/utils/utils/constants'
 import useSafeAddress from '@/hooks/useSafeAddress'
 
 jest.mock('@/hooks/useSafeAddress')
+jest.mock('@safe-global/utils/utils/multiSend', () => ({
+  ...jest.requireActual('@safe-global/utils/utils/multiSend'),
+  multiSendDefaultsToSelf: jest.fn(() => true),
+}))
 
 const mockUseTxPreview = jest.spyOn(useTxPreviewHook, 'default')
 const safeInterface = Safe__factory.createInterface()

--- a/apps/web/src/components/transactions/TxDetails/TxData/NestedTransaction/ExecTransaction/index.test.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/NestedTransaction/ExecTransaction/index.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render } from '@/tests/test-utils'
+import { ExecTransaction } from '.'
+import * as useTxPreviewHook from '@/components/tx/confirmation-views/useTxPreview'
+import { Operation, TransactionInfoType } from '@safe-global/store/gateway/types'
+import type { TransactionData, TransactionPreview } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { faker } from '@faker-js/faker'
+import { Safe__factory } from '@safe-global/utils/types/contracts'
+import { ZERO_ADDRESS } from '@safe-global/utils/utils/constants'
+import useSafeAddress from '@/hooks/useSafeAddress'
+
+jest.mock('@/hooks/useSafeAddress')
+
+const mockUseTxPreview = jest.spyOn(useTxPreviewHook, 'default')
+const safeInterface = Safe__factory.createInterface()
+
+describe('ExecTransaction (nested Safe MultiSend)', () => {
+  const connectedSafe = faker.finance.ethereumAddress()
+  const nestedSafe = faker.finance.ethereumAddress()
+  const moduleAddress = faker.finance.ethereumAddress()
+
+  beforeEach(() => {
+    ;(useSafeAddress as jest.Mock).mockReturnValue(connectedSafe)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('resolves a zero-address sub-transaction to the nested Safe, not the connected Safe', () => {
+    // Outer tx: the connected Safe calls nestedSafe.execTransaction(...) targeting a MultiSend batch
+    const execTransactionHexData = safeInterface.encodeFunctionData('execTransaction', [
+      faker.finance.ethereumAddress(),
+      '0',
+      '0x',
+      Operation.DELEGATE,
+      0,
+      0,
+      0,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      '0x',
+    ])
+
+    const execTxData: TransactionData = {
+      to: { value: nestedSafe, name: 'Nested Safe B' },
+      value: '0',
+      operation: Operation.CALL,
+      trustedDelegateCallTarget: false,
+      hexData: execTransactionHexData,
+      dataDecoded: { method: 'execTransaction', parameters: [] },
+      addressInfoIndex: {},
+    }
+
+    // Preview of the nested batch: a single enableModule sub-action targeting the zero address,
+    // which the MultiSend contract rewrites to the executing (nested) Safe.
+    const nestedBatchTxData: TransactionData = {
+      to: { value: faker.finance.ethereumAddress() },
+      value: '0',
+      operation: Operation.DELEGATE,
+      trustedDelegateCallTarget: false,
+      addressInfoIndex: {
+        [nestedSafe]: { value: nestedSafe, name: 'Nested Safe B' },
+      },
+      dataDecoded: {
+        method: 'multiSend',
+        parameters: [
+          {
+            name: 'transactions',
+            type: 'bytes',
+            value: '0x',
+            valueDecoded: [
+              {
+                operation: Operation.CALL,
+                to: ZERO_ADDRESS,
+                value: '0',
+                data: safeInterface.encodeFunctionData('enableModule', [moduleAddress]),
+                dataDecoded: {
+                  method: 'enableModule',
+                  parameters: [{ name: 'module', type: 'address', value: moduleAddress }],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    }
+
+    const txPreview: TransactionPreview = {
+      txData: nestedBatchTxData,
+      txInfo: {
+        type: TransactionInfoType.CUSTOM,
+        humanDescription: undefined,
+        to: { value: nestedBatchTxData.to.value },
+        dataSize: '0',
+        value: '0',
+        isCancellation: false,
+        methodName: 'multiSend',
+        actionCount: 1,
+      },
+    }
+
+    mockUseTxPreview.mockReturnValue([txPreview, undefined, false])
+
+    const result = render(<ExecTransaction data={execTxData} />)
+
+    fireEvent.click(result.getByTestId('expande-all-btn'))
+
+    // Resolves to the nested Safe, not the connected Safe ("This Safe Account") nor the zero address
+    expect(result.getAllByText(/Nested Safe B/).length).toBeGreaterThan(0)
+    expect(result.queryByText('This Safe Account')).not.toBeInTheDocument()
+    expect(result.queryByText('0x0000...0000')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/transactions/TxDetails/TxData/NestedTransaction/ExecTransaction/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/NestedTransaction/ExecTransaction/index.tsx
@@ -68,7 +68,13 @@ export const ExecTransaction = ({
   )
 
   const decodedNestedTxDataBlock = txPreview ? (
-    <TxData txData={txPreview.txData} txInfo={txPreview.txInfo} trusted imitation={false} />
+    <TxData
+      txData={txPreview.txData}
+      txInfo={txPreview.txInfo}
+      trusted
+      imitation={false}
+      executingSafeAddress={data?.to.value}
+    />
   ) : null
 
   return (

--- a/apps/web/src/components/transactions/TxDetails/TxData/index.test.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/index.test.tsx
@@ -8,6 +8,10 @@ import { ZERO_ADDRESS } from '@safe-global/utils/utils/constants'
 import useSafeAddress from '@/hooks/useSafeAddress'
 
 jest.mock('@/hooks/useSafeAddress')
+jest.mock('@safe-global/utils/utils/multiSend', () => ({
+  ...jest.requireActual('@safe-global/utils/utils/multiSend'),
+  multiSendDefaultsToSelf: jest.fn(() => true),
+}))
 
 const safeInterface = Safe__factory.createInterface()
 

--- a/apps/web/src/components/transactions/TxDetails/TxData/index.test.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/index.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render } from '@/tests/test-utils'
+import TxData from '.'
+import { Operation, TransactionInfoType } from '@safe-global/store/gateway/types'
+import type { TransactionData, TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { faker } from '@faker-js/faker'
+import { Safe__factory } from '@safe-global/utils/types/contracts'
+import { ZERO_ADDRESS } from '@safe-global/utils/utils/constants'
+import useSafeAddress from '@/hooks/useSafeAddress'
+
+jest.mock('@/hooks/useSafeAddress')
+
+const safeInterface = Safe__factory.createInterface()
+
+describe('TxData — MultiSend executing-Safe resolution', () => {
+  const connectedSafe = faker.finance.ethereumAddress()
+
+  beforeEach(() => {
+    ;(useSafeAddress as jest.Mock).mockReturnValue(connectedSafe)
+  })
+
+  it("resolves a zero-address sub-action to the tx's own Safe (txDetails.safeAddress), not the connected Safe", () => {
+    // Mirrors the nested approveHash/OnChainConfirmation case: the rendered batch belongs to a
+    // child Safe (txDetails.safeAddress) that is NOT the connected (parent) Safe.
+    const childSafe = faker.finance.ethereumAddress()
+    const multisendLib = faker.finance.ethereumAddress()
+    const moduleAddress = faker.finance.ethereumAddress()
+
+    const txData = {
+      to: { value: multisendLib },
+      operation: Operation.DELEGATE,
+      addressInfoIndex: { [childSafe]: { value: childSafe, name: 'Child Safe' } },
+      dataDecoded: {
+        method: 'multiSend',
+        parameters: [
+          {
+            name: 'transactions',
+            type: 'bytes',
+            value: '0x',
+            valueDecoded: [
+              {
+                operation: Operation.CALL,
+                to: ZERO_ADDRESS,
+                value: '0',
+                data: safeInterface.encodeFunctionData('enableModule', [moduleAddress]),
+                dataDecoded: {
+                  method: 'enableModule',
+                  parameters: [{ name: 'module', type: 'address', value: moduleAddress }],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    } as unknown as TransactionData
+
+    const txInfo = {
+      type: TransactionInfoType.CUSTOM,
+      methodName: 'multiSend',
+      to: { value: multisendLib },
+      dataSize: '0',
+      value: '0',
+      isCancellation: false,
+      actionCount: 1,
+      humanDescription: undefined,
+    } as unknown as TransactionDetails['txInfo']
+
+    const txDetails = { safeAddress: childSafe } as unknown as TransactionDetails
+
+    const result = render(<TxData txInfo={txInfo} txData={txData} txDetails={txDetails} trusted imitation={false} />)
+
+    fireEvent.click(result.getByTestId('expande-all-btn'))
+
+    // Resolves to the child Safe (the tx's own Safe), not "This Safe Account" (connected parent) nor 0x0
+    expect(result.getAllByText(/Child Safe/).length).toBeGreaterThan(0)
+    expect(result.queryByText('This Safe Account')).not.toBeInTheDocument()
+    expect(result.queryByText('0x0000...0000')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/transactions/TxDetails/TxData/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/index.tsx
@@ -49,6 +49,7 @@ const TxData = ({
   txDetails,
   trusted,
   imitation,
+  executingSafeAddress,
   children,
 }: PropsWithChildren<{
   txInfo: TransactionDetails['txInfo']
@@ -56,6 +57,9 @@ const TxData = ({
   txDetails?: TransactionDetails
   trusted: boolean
   imitation: boolean
+  // Safe whose context the txData executes in. Only needed when it can't be derived from
+  // `txDetails.safeAddress` (e.g. ExecTransaction, which renders a preview without txDetails).
+  executingSafeAddress?: string
 }>): ReactElement => {
   const chainId = useChainId()
   const { SwapOrder } = useLoadFeature(SwapFeature)
@@ -145,7 +149,11 @@ const TxData = ({
 
       {(isMultiSendTxInfo(txInfo) || isOrderTxInfo(txInfo)) && (
         <ObservabilityErrorBoundary fallback={<div>Error parsing data</div>}>
-          <Multisend txData={txData} isExecuted={!!txDetails?.executedAt} />
+          <Multisend
+            txData={txData}
+            isExecuted={!!txDetails?.executedAt}
+            executingSafeAddress={executingSafeAddress ?? txDetails?.safeAddress}
+          />
         </ObservabilityErrorBoundary>
       )}
     </>

--- a/packages/utils/src/utils/__tests__/multiSend.test.ts
+++ b/packages/utils/src/utils/__tests__/multiSend.test.ts
@@ -1,0 +1,21 @@
+import { faker } from '@faker-js/faker'
+import { resolveMultiSendToAddress } from '../multiSend'
+import { ZERO_ADDRESS } from '../constants'
+
+describe('resolveMultiSendToAddress', () => {
+  it('resolves the zero address to the executing Safe (MultiSend defaults `to` to address(this))', () => {
+    const safeAddress = faker.finance.ethereumAddress()
+    expect(resolveMultiSendToAddress(ZERO_ADDRESS, safeAddress)).toBe(safeAddress)
+  })
+
+  it('leaves a non-zero target unchanged', () => {
+    const to = faker.finance.ethereumAddress()
+    const safeAddress = faker.finance.ethereumAddress()
+    expect(resolveMultiSendToAddress(to, safeAddress)).toBe(to)
+  })
+
+  it('leaves the zero address unchanged when the Safe is unknown', () => {
+    expect(resolveMultiSendToAddress(ZERO_ADDRESS, undefined)).toBe(ZERO_ADDRESS)
+    expect(resolveMultiSendToAddress(ZERO_ADDRESS, '')).toBe(ZERO_ADDRESS)
+  })
+})

--- a/packages/utils/src/utils/__tests__/multiSend.test.ts
+++ b/packages/utils/src/utils/__tests__/multiSend.test.ts
@@ -1,6 +1,17 @@
 import { faker } from '@faker-js/faker'
-import { resolveMultiSendToAddress } from '../multiSend'
+import { getMultiSendCallOnlyDeployments, getMultiSendDeployments } from '@safe-global/safe-deployments'
+import type { SingletonDeploymentV2 } from '@safe-global/safe-deployments'
+import { multiSendDefaultsToSelf, resolveMultiSendToAddress } from '../multiSend'
 import { ZERO_ADDRESS } from '../constants'
+
+const networkAddress = (deployment: SingletonDeploymentV2 | undefined, chainId: string): string => {
+  const addresses = deployment?.networkAddresses?.[chainId]
+  const address = Array.isArray(addresses) ? addresses[0] : addresses
+  if (!address) {
+    throw new Error('No deployment address found')
+  }
+  return address
+}
 
 describe('resolveMultiSendToAddress', () => {
   it('resolves the zero address to the executing Safe (MultiSend defaults `to` to address(this))', () => {
@@ -17,5 +28,28 @@ describe('resolveMultiSendToAddress', () => {
   it('leaves the zero address unchanged when the Safe is unknown', () => {
     expect(resolveMultiSendToAddress(ZERO_ADDRESS, undefined)).toBe(ZERO_ADDRESS)
     expect(resolveMultiSendToAddress(ZERO_ADDRESS, '')).toBe(ZERO_ADDRESS)
+  })
+})
+
+describe('multiSendDefaultsToSelf', () => {
+  const chainId = '1'
+
+  it('returns true for a v1.5.0 MultiSendCallOnly deployment', () => {
+    const address = networkAddress(getMultiSendCallOnlyDeployments({ version: '1.5.0', network: chainId }), chainId)
+    expect(multiSendDefaultsToSelf(address, chainId)).toBe(true)
+  })
+
+  it('returns true for a v1.5.0 MultiSend deployment', () => {
+    const address = networkAddress(getMultiSendDeployments({ version: '1.5.0', network: chainId }), chainId)
+    expect(multiSendDefaultsToSelf(address, chainId)).toBe(true)
+  })
+
+  it('returns false for a pre-1.5.0 (v1.4.1) MultiSendCallOnly deployment', () => {
+    const address = networkAddress(getMultiSendCallOnlyDeployments({ version: '1.4.1', network: chainId }), chainId)
+    expect(multiSendDefaultsToSelf(address, chainId)).toBe(false)
+  })
+
+  it('returns false for an unknown address', () => {
+    expect(multiSendDefaultsToSelf(faker.finance.ethereumAddress(), chainId)).toBe(false)
   })
 })

--- a/packages/utils/src/utils/multiSend.ts
+++ b/packages/utils/src/utils/multiSend.ts
@@ -1,0 +1,17 @@
+import { sameAddress } from './addresses'
+import { ZERO_ADDRESS } from './constants'
+
+/**
+ * Resolves the target address of a MultiSend batched sub-transaction.
+ *
+ * `MultiSend` and `MultiSendCallOnly` rewrite a sub-transaction `to` of the zero address to
+ * `address(this)` at execution time — the Safe running the batch via `delegatecall`. Transaction
+ * decoders faithfully report the raw `0x0`, so any presentation layer that needs the *effective*
+ * target (e.g. to label or warn about a self-call) must apply the same resolution.
+ *
+ * @param to - decoded sub-transaction target (possibly the zero address)
+ * @param safeAddress - the Safe executing the batch (MultiSend's `address(this)`)
+ * @returns `safeAddress` when `to` is the zero address and `safeAddress` is known, otherwise `to`
+ */
+export const resolveMultiSendToAddress = (to: string, safeAddress?: string): string =>
+  safeAddress && sameAddress(to, ZERO_ADDRESS) ? safeAddress : to

--- a/packages/utils/src/utils/multiSend.ts
+++ b/packages/utils/src/utils/multiSend.ts
@@ -1,17 +1,35 @@
+import { getMultiSendCallOnlyDeployments, getMultiSendDeployments } from '@safe-global/safe-deployments'
+import type { SafeVersion } from '@safe-global/types-kit'
+import { hasMatchingDeployment } from '../services/contracts/deployments'
 import { sameAddress } from './addresses'
 import { ZERO_ADDRESS } from './constants'
 
+// MultiSend / MultiSendCallOnly versions that default a sub-transaction `to` of the zero address to
+// `address(this)`. Introduced in 1.5.0; earlier deployments (1.3.0, 1.4.1, …) forward the zero
+// address as-is, so a zero `to` there is a real call to the zero address and must be left untouched.
+const ZERO_ADDRESS_DEFAULT_VERSIONS: SafeVersion[] = ['1.5.0']
+
 /**
- * Resolves the target address of a MultiSend batched sub-transaction.
+ * Whether the given MultiSend / MultiSendCallOnly deployment defaults a zero-address sub-transaction
+ * `to` to the executing Safe (`address(this)`). True only for v1.5.0+ deployments.
  *
- * `MultiSend` and `MultiSendCallOnly` rewrite a sub-transaction `to` of the zero address to
- * `address(this)` at execution time — the Safe running the batch via `delegatecall`. Transaction
- * decoders faithfully report the raw `0x0`, so any presentation layer that needs the *effective*
- * target (e.g. to label or warn about a self-call) must apply the same resolution.
+ * @param multiSendAddress - the MultiSend library the batch is delegatecalled into (the batch's `to`)
+ * @param chainId - the chain the batch executes on
+ */
+export const multiSendDefaultsToSelf = (multiSendAddress: string, chainId: string): boolean =>
+  hasMatchingDeployment(getMultiSendDeployments, multiSendAddress, chainId, ZERO_ADDRESS_DEFAULT_VERSIONS) ||
+  hasMatchingDeployment(getMultiSendCallOnlyDeployments, multiSendAddress, chainId, ZERO_ADDRESS_DEFAULT_VERSIONS)
+
+/**
+ * Resolves the target of a MultiSend batched sub-transaction to the executing Safe when its `to` is
+ * the zero address.
+ *
+ * MultiSend v1.5.0+ rewrites a zero-address `to` to `address(this)` — the Safe executing the batch
+ * via `delegatecall`. Older deployments call the zero address as-is, so callers MUST gate this on
+ * {@link multiSendDefaultsToSelf}; this helper only performs the substitution.
  *
  * @param to - decoded sub-transaction target (possibly the zero address)
  * @param safeAddress - the Safe executing the batch (MultiSend's `address(this)`)
- * @returns `safeAddress` when `to` is the zero address and `safeAddress` is known, otherwise `to`
  */
 export const resolveMultiSendToAddress = (to: string, safeAddress?: string): string =>
   safeAddress && sameAddress(to, ZERO_ADDRESS) ? safeAddress : to


### PR DESCRIPTION
## What it solves

In a MultiSend batch, a sub-transaction whose target is the zero address actually
executes against the Safe itself — MultiSend rewrites `address(0)` to `address(this)`.
The wallet displayed the raw zero address, so the action wasn't clearly shown as
targeting the Safe, making batches harder to review accurately.

Resolves: [SEC-216](https://linear.app/safe-global/issue/SEC-216/multisend-self-call-toaddress0-displayed-as-a-zero-address-call-in)

## How this PR fixes it

The zero→Safe rule is a MultiSend execution semantic, so it's applied at the **display
layer only** — the gateway's decoded data stays faithful to the calldata (it's also
consumed by the security scanner and other clients). A shared `@safe-global/utils`
helper resolves a zero-address sub-target to the executing Safe; web and mobile both use it.

Notes:
- The executing Safe = the Safe running the batch (`address(this)`). For a nested-Safe
  view that's the child, not the connected Safe, so it's derived from the rendered tx's
  own `safeAddress` (with an explicit override for the one path that renders a preview
  without it).
- Nothing that signs / proposes / verifies / executes a transaction reads the decoded
  `to`, so this is display-only — the `safeTxHash` and on-chain behaviour are unchanged.

## How to test it

1. In the Transaction Builder, create a batch with two `enableModule` actions: one
   targeting your Safe, one targeting `0x0000000000000000000000000000000000000000`.
2. Open "All actions" — both should now display as targeting your Safe (the zero one as
   "This Safe Account"), not a nameless zero address.
3. (Nested) With a parent Safe that owns a child Safe, propose the same batch on the
   child and review it via the parent — it resolves to the child Safe, not the parent.

## Screenshots

Display-only change. Before: the zero-address action showed `0x0000…0000` with no name.
After: it shows the Safe, consistent with an explicit self-call. 
<img width="1080" height="907" alt="image" src="https://github.com/user-attachments/assets/9b4e7bb7-f9c0-401a-b40d-2323090d49d2" />

<img width="1207" height="743" alt="image" src="https://github.com/user-attachments/assets/14a4dad7-3bd9-4cc8-b77d-b9237c67a677" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
