### PR TITLE
fix(security-hub): rework guard check UX and wire Hypernative nudge (WA-2673)

### DIFF
--- a/apps/web/src/features/security/data/scanners/__tests__/defaultValues.test.ts
+++ b/apps/web/src/features/security/data/scanners/__tests__/defaultValues.test.ts
@@ -47,11 +47,11 @@ describe('scanner accuracy with real vs default data', () => {
       expect(result.partner).toBe('hypernative')
     })
 
-    it('correctly distinguishes 0 balance (clear) from high balance (partial) on supported chain', async () => {
+    it('correctly distinguishes 0 balance (not_applicable) from high balance (partial) on supported chain', async () => {
       const base = { guard: null, chainSupportsHypernative: true }
-      const clearResult = await guardScanner.scan(createMockContext({ ...base, balanceUsd: 0 }))
+      const naResult = await guardScanner.scan(createMockContext({ ...base, balanceUsd: 0 }))
       const partialResult = await guardScanner.scan(createMockContext({ ...base, balanceUsd: 2_000_000 }))
-      expect(clearResult.status).toBe('clear')
+      expect(naResult.status).toBe('not_applicable')
       expect(partialResult.status).toBe('partial')
     })
   })

--- a/apps/web/src/features/security/data/scanners/__tests__/guard.test.ts
+++ b/apps/web/src/features/security/data/scanners/__tests__/guard.test.ts
@@ -77,7 +77,7 @@ describe('guardScanner', () => {
       expect(result.status).toBe('partial')
       expect(result.severity).toBe('Medium')
       expect(result.partner).toBe('hypernative')
-      expect(result.ctaLabelOverride).toBe('Learn more')
+      expect(result.ctaLabelOverride).toBe('Set up protection')
     })
 
     it('does not recommend for balance at threshold', async () => {
@@ -87,13 +87,14 @@ describe('guardScanner', () => {
         balanceUsd: HIGH_VALUE_THRESHOLD_USD,
       })
       const result = await guardScanner.scan(ctx)
-      expect(result.status).toBe('clear')
+      expect(result.status).toBe('not_applicable')
       expect(result.partner).toBeUndefined()
     })
 
-    // Regression: WA-2369 — small non-zero balances must not trigger the recommendation.
-    it.each([2, 20, 999, 999_999])(
-      'returns clear for low non-zero balance ($%i) on supported chain',
+    // Regression: WA-2369 — non-zero balances below the threshold must not trigger the
+    // recommendation. Derived from the constant so it stays correct if the threshold moves.
+    it.each([1, 2, HIGH_VALUE_THRESHOLD_USD - 1])(
+      'returns not_applicable for low non-zero balance ($%i) on supported chain',
       async (balanceUsd) => {
         const ctx = createMockContext({
           guard: null,
@@ -101,32 +102,32 @@ describe('guardScanner', () => {
           balanceUsd,
         })
         const result = await guardScanner.scan(ctx)
-        expect(result.status).toBe('clear')
+        expect(result.status).toBe('not_applicable')
         expect(result.partner).toBeUndefined()
       },
     )
   })
 
   describe('Tier 4: no guard needed', () => {
-    it('returns clear for no guard on unsupported chain', async () => {
+    it('returns not_applicable for no guard on unsupported chain', async () => {
       const ctx = createMockContext({
         guard: null,
         chainSupportsHypernative: false,
       })
       const result = await guardScanner.scan(ctx)
-      expect(result.status).toBe('clear')
+      expect(result.status).toBe('not_applicable')
       expect(result.severity).toBe('Low')
       expect(result.partner).toBeUndefined()
     })
 
-    it('returns clear for low-value Safe on supported chain', async () => {
+    it('returns not_applicable for low-value Safe on supported chain', async () => {
       const ctx = createMockContext({
         guard: null,
         chainSupportsHypernative: true,
         balanceUsd: 0,
       })
       const result = await guardScanner.scan(ctx)
-      expect(result.status).toBe('clear')
+      expect(result.status).toBe('not_applicable')
     })
 
     it('treats zero address guard as no guard', async () => {
@@ -134,7 +135,7 @@ describe('guardScanner', () => {
         guard: { value: ZERO_ADDRESS, name: null },
       })
       const result = await guardScanner.scan(ctx)
-      expect(result.status).toBe('clear')
+      expect(result.status).toBe('not_applicable')
     })
   })
 })

--- a/apps/web/src/features/security/data/scanners/__tests__/modules.test.ts
+++ b/apps/web/src/features/security/data/scanners/__tests__/modules.test.ts
@@ -16,16 +16,16 @@ describe('modulesScanner', () => {
     mockIsAffected.mockResolvedValue(false)
   })
 
-  it('returns clear when no modules are installed', async () => {
+  it('returns not_applicable when no modules are installed', async () => {
     const result = await modulesScanner.scan(createMockContext({ modules: null }))
-    expect(result.status).toBe('clear')
+    expect(result.status).toBe('not_applicable')
     expect(result.severity).toBe('Low')
     expect(result.score).toBe(100)
   })
 
-  it('returns clear for empty modules array', async () => {
+  it('returns not_applicable for empty modules array', async () => {
     const result = await modulesScanner.scan(createMockContext({ modules: [] }))
-    expect(result.status).toBe('clear')
+    expect(result.status).toBe('not_applicable')
     expect(result.score).toBe(100)
   })
 
@@ -127,7 +127,7 @@ describe('modulesScanner', () => {
         modules: [{ value: '0x0000000000000000000000000000000000000000' }],
       }),
     )
-    expect(result.status).toBe('clear')
+    expect(result.status).toBe('not_applicable')
     expect(result.score).toBe(100)
   })
 

--- a/apps/web/src/features/security/data/scanners/guard.ts
+++ b/apps/web/src/features/security/data/scanners/guard.ts
@@ -108,9 +108,9 @@ export const guardScanner: SecurityScanner = {
         score,
         evidence: [{ label: 'Status', value: 'No transaction guard configured' }],
         remediation:
-          'For high-value accounts, a transaction guard adds pre-execution validation. Enterprise-grade protection is available.',
+          'For high-value accounts, a transaction guard adds pre-execution validation. Enterprise-grade protection is available via Hypernative.',
         lastChecked: now,
-        ctaLabelOverride: 'Learn more',
+        ctaLabelOverride: 'Set up protection',
         partner: 'hypernative',
       }
     }
@@ -118,8 +118,8 @@ export const guardScanner: SecurityScanner = {
     // Tier 4: No guard — normal (low-value Safe or unsupported chain)
     const score = 100
     return {
-      status: 'clear',
-      severity: getSeverityFromScore(score),
+      status: 'not_applicable',
+      severity: getSeverityFromScore(score, { excluded: true }),
       score,
       evidence: [{ label: 'Status', value: 'No guard required' }],
       remediation: '',

--- a/apps/web/src/features/security/data/scanners/modules.ts
+++ b/apps/web/src/features/security/data/scanners/modules.ts
@@ -111,8 +111,8 @@ export const modulesScanner: SecurityScanner = {
     if (activeModules.length === 0) {
       const score = 100
       return {
-        status: 'clear',
-        severity: getSeverityFromScore(score),
+        status: 'not_applicable',
+        severity: getSeverityFromScore(score, { excluded: true }),
         score,
         evidence: [{ label: 'Status', value: 'No modules installed' }],
         remediation: '',

--- a/apps/web/src/features/spaces/components/SecurityHub/__tests__/SecurityChecksSection.test.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/__tests__/SecurityChecksSection.test.tsx
@@ -158,6 +158,43 @@ describe('SecurityChecksSection', () => {
       expect(screen.getByRole('link', { name: /review modules/i })).toBeInTheDocument()
     })
 
+    it('opens the Hypernative signup flow for a partner-tagged guard nudge', () => {
+      const onHnSignupClick = jest.fn()
+      renderPanel({
+        results: {
+          ...allClearResults,
+          guard: mkResult({
+            status: 'partial',
+            severity: 'Medium',
+            remediation: 'Guard recommended.',
+            ctaLabelOverride: 'Set up protection',
+            partner: 'hypernative',
+          }),
+        },
+        onHnSignupClick,
+      })
+      fireEvent.click(screen.getByText('Transaction guard is recommended'))
+      fireEvent.click(screen.getByRole('button', { name: /set up protection/i }))
+      expect(onHnSignupClick).toHaveBeenCalled()
+    })
+
+    it('falls back to a deep-link for a partner nudge when no signup handler is provided', () => {
+      renderPanel({
+        results: {
+          ...allClearResults,
+          guard: mkResult({
+            status: 'partial',
+            severity: 'Medium',
+            remediation: 'Guard recommended.',
+            ctaLabelOverride: 'Set up protection',
+            partner: 'hypernative',
+          }),
+        },
+      })
+      fireEvent.click(screen.getByText('Transaction guard is recommended'))
+      expect(screen.getByRole('link', { name: /set up protection/i })).toBeInTheDocument()
+    })
+
     it('does not render a CTA when safeQueryParam is missing', () => {
       renderPanel({
         safeQueryParam: undefined,

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityChecks/SecurityChecksSection.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityChecks/SecurityChecksSection.tsx
@@ -9,6 +9,7 @@ export type SecurityChecksSectionProps = {
   results: Record<string, ScanResult>
   safeQueryParam?: string
   onRemoveModule?: (address: string) => void
+  onHnSignupClick?: () => void
 }
 
 /** Severity order of the grade groups; the passing group is always rendered last. */
@@ -19,8 +20,15 @@ const SecurityChecksSection = ({
   results,
   safeQueryParam,
   onRemoveModule,
+  onHnSignupClick,
 }: SecurityChecksSectionProps): ReactElement | null => {
-  const { isReady, failingRows, passingRows } = useSecurityChecks(scanContext, results, safeQueryParam, onRemoveModule)
+  const { isReady, failingRows, passingRows } = useSecurityChecks(
+    scanContext,
+    results,
+    safeQueryParam,
+    onRemoveModule,
+    onHnSignupClick,
+  )
 
   // Feature not yet loaded — render nothing; the panel skeleton covers this state.
   if (!isReady) return null

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityChecks/hooks/useSecurityChecks.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityChecks/hooks/useSecurityChecks.tsx
@@ -239,7 +239,7 @@ export const useSecurityChecks = (
       const title = ok
         ? hasGuard
           ? 'Transaction guard is active'
-          : 'No transaction guard in use'
+          : 'No unsupported guard installed'
         : hasGuard
           ? 'Transaction guard is unverified'
           : 'Transaction guard is recommended'
@@ -310,7 +310,7 @@ export const useSecurityChecks = (
               leadIcon={iconFor(modulesResult)}
               accentTone={toneFor(modulesResult)}
               subtitle={subtitleFor(modulesResult)}
-              title="No modules installed"
+              title="No unsupported module installed"
               expandedContent={buildExpanded(modulesResult, buildCta('modules', modulesResult, safeQueryParam))}
             />
           ),

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityChecks/hooks/useSecurityChecks.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityChecks/hooks/useSecurityChecks.tsx
@@ -68,6 +68,8 @@ export const useSecurityChecks = (
   safeQueryParam: string | undefined,
   /** Launches the remove-module tx flow for a vulnerable module (drawer-provided). */
   onRemoveModule?: (address: string) => void,
+  /** Opens the Hypernative signup flow for a partner-tagged guard nudge (drawer-provided). */
+  onHnSignupClick?: () => void,
 ): UseSecurityChecksResult => {
   const security = useLoadFeature(SecurityFeature)
   const [modulesExpanded, setModulesExpanded] = useState(false)
@@ -241,6 +243,13 @@ export const useSecurityChecks = (
         : hasGuard
           ? 'Transaction guard is unverified'
           : 'Transaction guard is recommended'
+      // A partner-tagged, actionable guard result opens the Hypernative signup flow in place of a
+      // deep-link. Passing results already get no CTA (buildCta returns null), so this only fires
+      // for the Tier-3 nudge (no guard, high-value, Hypernative chain).
+      const guardCta =
+        !ok && guardResult.partner === 'hypernative' && onHnSignupClick
+          ? { label: guardResult.ctaLabelOverride || 'Set up protection', onClick: onHnSignupClick }
+          : buildCta('guard', guardResult, safeQueryParam)
       items.push({
         key: 'guard',
         severity: guardResult.severity,
@@ -251,7 +260,7 @@ export const useSecurityChecks = (
             accentTone={toneFor(guardResult)}
             subtitle={subtitleFor(guardResult)}
             title={title}
-            expandedContent={buildExpanded(guardResult, buildCta('guard', guardResult, safeQueryParam))}
+            expandedContent={buildExpanded(guardResult, guardCta)}
           />
         ),
       })
@@ -451,6 +460,7 @@ export const useSecurityChecks = (
     safeQueryParam,
     modulesExpanded,
     onRemoveModule,
+    onHnSignupClick,
   ])
 
   if (!security.$isReady || !buildCta) {

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/SecurityDrawerContent.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/SecurityDrawerContent.tsx
@@ -11,6 +11,7 @@ type SecurityDrawerContentProps = {
   lastScannedAt: number | null
   safeQueryParam?: string
   onRemoveModule?: (address: string) => void
+  onHnSignupClick?: () => void
 }
 
 /** Tabbed body of the drawer — "Checks" (scan results) and "Details" (placeholder). */
@@ -21,6 +22,7 @@ const SecurityDrawerContent = ({
   lastScannedAt,
   safeQueryParam,
   onRemoveModule,
+  onHnSignupClick,
 }: SecurityDrawerContentProps): ReactElement => (
   <Tabs defaultValue="checks" className="flex min-h-0 flex-1 flex-col gap-4 px-6 pb-6">
     <TabsList className="w-fit gap-2">
@@ -41,6 +43,7 @@ const SecurityDrawerContent = ({
           lastScannedAt={lastScannedAt}
           safeQueryParam={safeQueryParam}
           onRemoveModule={onRemoveModule}
+          onHnSignupClick={onHnSignupClick}
         />
       </TabsContent>
 

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/SecurityReportDrawer.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/SecurityReportDrawer.tsx
@@ -1,10 +1,11 @@
-import { type ReactElement, useCallback, useContext, useEffect, useRef } from 'react'
+import { type ReactElement, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import type { ScanContext, ScanResult } from '@/features/security/types'
 import { useSecurityScan } from '@/features/security'
 import { useChain } from '@/hooks/useChains'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
 import { TxModalContext } from '@/components/tx-flow'
 import { RemoveModuleFlow } from '@/components/tx-flow/flows'
+import { HnSignupFlow } from '@/features/hypernative'
 import SecurityDrawerHeader from './SecurityDrawerHeader'
 import SecurityDrawerContent from './SecurityDrawerContent'
 import type { SelectedSafe, SpaceSafeEntry } from '../../types'
@@ -27,8 +28,16 @@ const SecurityReportDrawer = ({
   const { results, isComplete, lastScannedAt } = useSecurityScan(scanContext)
   const chain = useChain(selectedSafe?.chainId ?? '')
   const { setTxFlow } = useContext(TxModalContext)
+  const [isHnSignupOpen, setIsHnSignupOpen] = useState(false)
   const scanContextRef = useRef(scanContext)
   scanContextRef.current = scanContext
+
+  // Close the drawer before opening the Hypernative signup flow so the MUI dialog owns focus
+  // and isn't dimmed behind the sheet's overlay — mirroring the remove-module action below.
+  const handleHnSignupClick = useCallback(() => {
+    onClose()
+    setIsHnSignupOpen(true)
+  }, [onClose])
 
   // Close the report drawer before launching the remove-module tx flow so the tx modal
   // isn't fighting the sheet for focus, mirroring the Settings → Modules remove action.
@@ -49,36 +58,41 @@ const SecurityReportDrawer = ({
   }, [isComplete, lastScannedAt])
 
   return (
-    <Sheet
-      open={!!selectedSafe}
-      onOpenChange={(open) => {
-        if (!open) onClose()
-      }}
-    >
-      <SheetContent
-        side="right"
-        showCloseButton={false}
-        aria-label="Security report"
-        // Float the sheet with a margin from the viewport, round its corners and use a #fafafa
-        // surface in light mode / `bg-card` in dark mode so the white cards inside stand out.
-        className="inset-y-3! right-3! h-auto! w-[440px]! max-w-[calc(100vw-24px)]! gap-0 overflow-hidden rounded-3xl border-0! bg-zinc-50 p-0 shadow-xl dark:bg-card"
+    <>
+      <Sheet
+        open={!!selectedSafe}
+        onOpenChange={(open) => {
+          if (!open) onClose()
+        }}
       >
-        {selectedSafe && (
-          <div className="flex min-h-0 gap-3 flex-1 flex-col overflow-hidden">
-            <SecurityDrawerHeader address={selectedSafe.address} name={selectedEntry?.name} onClose={onClose} />
+        <SheetContent
+          side="right"
+          showCloseButton={false}
+          aria-label="Security report"
+          // Float the sheet with a margin from the viewport, round its corners and use a #fafafa
+          // surface in light mode / `bg-card` in dark mode so the white cards inside stand out.
+          className="inset-y-3! right-3! h-auto! w-[440px]! max-w-[calc(100vw-24px)]! gap-0 overflow-hidden rounded-3xl border-0! bg-zinc-50 p-0 shadow-xl dark:bg-card"
+        >
+          {selectedSafe && (
+            <div className="flex min-h-0 gap-3 flex-1 flex-col overflow-hidden">
+              <SecurityDrawerHeader address={selectedSafe.address} name={selectedEntry?.name} onClose={onClose} />
 
-            <SecurityDrawerContent
-              scanContext={scanContext}
-              results={results}
-              isComplete={isComplete}
-              lastScannedAt={lastScannedAt}
-              safeQueryParam={chain?.shortName ? `${chain.shortName}:${selectedSafe.address}` : undefined}
-              onRemoveModule={handleRemoveModule}
-            />
-          </div>
-        )}
-      </SheetContent>
-    </Sheet>
+              <SecurityDrawerContent
+                scanContext={scanContext}
+                results={results}
+                isComplete={isComplete}
+                lastScannedAt={lastScannedAt}
+                safeQueryParam={chain?.shortName ? `${chain.shortName}:${selectedSafe.address}` : undefined}
+                onRemoveModule={handleRemoveModule}
+                onHnSignupClick={handleHnSignupClick}
+              />
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
+
+      <HnSignupFlow open={isHnSignupOpen} onClose={() => setIsHnSignupOpen(false)} />
+    </>
   )
 }
 

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/tabs/SecurityDrawerChecks.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/tabs/SecurityDrawerChecks.tsx
@@ -18,6 +18,7 @@ type SecurityDrawerChecksProps = {
   /** The `shortName:address` param used to deep-link a CTA to the correct Safe (e.g., "eth:0x..."). */
   safeQueryParam?: string
   onRemoveModule?: (address: string) => void
+  onHnSignupClick?: () => void
 }
 
 /**
@@ -31,6 +32,7 @@ const SecurityDrawerChecks = ({
   lastScannedAt,
   safeQueryParam,
   onRemoveModule,
+  onHnSignupClick,
 }: SecurityDrawerChecksProps): ReactElement => {
   const security = useLoadFeature(SecurityFeature)
   const header = usePanelHeader(results, isComplete)
@@ -69,6 +71,7 @@ const SecurityDrawerChecks = ({
         results={results}
         safeQueryParam={safeQueryParam}
         onRemoveModule={onRemoveModule}
+        onHnSignupClick={onHnSignupClick}
       />
     </div>
   )


### PR DESCRIPTION
## What it solves

Resolves: [WA-2673](https://linear.app/safe-global/issue/WA-2673/security-hub-guard-ux-and-navigation-issues)

The Security Hub's transaction-guard check produced confusing UX:

- A Safe with **no transaction guard** showed a green "all good" check (status `clear`, score 100), which is misleading while there are no endorsed free guards to recommend.
- The **Hypernative guard setup notification "couldn't be found"**: the guard scanner tagged its high-value result with `partner: 'hypernative'`, but **nothing in the UI ever read that field** — so no Hypernative-specific CTA/notification was rendered anywhere in the Security Hub.

## How this PR fixes it

- **"No guard / no modules" is no longer a passing check.** The `guard` and `modules` scanners now return `not_applicable` (with the documented `{ excluded: true }` severity convention) when nothing is configured, instead of `clear`. `not_applicable` is excluded from the per-Safe grade and the passing/issue counts, so a guard-less Safe is no longer counted as a green "all good" item — matching how `recovery` / `transaction_scanning` / `multichain_setup` already opt out.
- **The Tier-3 high-value nudge is now actionable.** It keeps its `partial` status, but its CTA — relabeled **"Set up protection"** — now opens the existing `HnSignupFlow` (HubSpot → Calendly) in the report drawer, consuming the previously-dead `partner: 'hypernative'` field. The CTA only appears for the non-passing, partner-tagged result (passing rows already get no CTA), so a trusted/installed guard never shows it.
- **Focus fix.** Clicking the CTA closes the drawer before opening the signup modal, so the MUI dialog owns focus and isn't dimmed behind the sheet's overlay — mirroring the existing remove-module flow. The modal is hosted outside the `<Sheet>` so it's decoupled from the sheet's focus-scope.

## How to test it

1. Open the Workspace **Security Hub** and review a Safe with **no transaction guard** on a low-value / non-Hypernative chain → the guard line reads "No transaction guard in use" with a neutral grey icon and does **not** inflate the passing count or the grade.
2. Review a Safe with **no guard, balance > $1M, on a Hypernative-supported chain** → the guard check shows as a `needs attention` finding "Transaction guard is recommended" with a **"Set up protection"** CTA.
3. Click **"Set up protection"** → the drawer closes and the Hypernative signup modal opens, focused and not dimmed.
4. Review a Safe **with a trusted guard installed** → "Transaction guard is active", passing, **no** setup CTA.
5. `yarn workspace @safe-global/web test src/features/security/data/scanners src/features/spaces/components/SecurityHub`.

## Affected flows

- Security Hub per-Safe report drawer → "Transaction guard" check rendering and CTA.
- Security Hub per-Safe grade + the workspace passing/issue counts (guard/modules no-config now excluded).
- New consumer of the Hypernative `HnSignupFlow` from the Spaces Security Hub.

## Blast radius

- **Scanners** (`guard.ts`, `modules.ts`): status change `clear → not_applicable` flows into `getSafeGrade`, `computeSummary`, `WorkspaceHealthCard`, and `SecuritySafesTable` counts — all of which already filter `not_applicable`, so counts/grades reconcile by construction.
- **`useSecurityChecks`** (shared by the drawer's checks tab): new optional `onHnSignupClick` param; guard-row CTA branches on `partner === 'hypernative'`. Backward-compatible (optional).
- **Drawer prop chain** (`SecurityReportDrawer` → `SecurityDrawerContent` → `SecurityDrawerChecks` → `SecurityChecksSection`): threads the new optional callback, mirroring the existing `onRemoveModule` plumbing.
- **`HnSignupFlow`**: imported from the `@/features/hypernative` public barrel (sanctioned entry). Its `setFormCompleted` keys to the *connected* Safe via `useSafeInfo` (see Risks).
- **No** analytics, feature-flag, route, persisted-state, or API-contract changes. Security Hub is web-only — no mobile impact.

## Risks / not checked

- **Modal focus interaction** verified structurally (drawer closes first; modal hosted outside the sheet; MUI Dialog portals at z-1300) but **not** click-tested in a browser in this change.
- `HnSignupFlow.setFormCompleted` keys to the connected Safe (`useSafeInfo`), not the scanned workspace Safe — benign (it governs banner re-display on single-Safe surfaces), but it means completing the form from the Hub won't mark the scanned Safe's banner as done.
- Storybook snapshot job not run locally (excluded from the jest config); a closed dialog renders null, so no drawer-story snapshot change is expected.
- The **back-button navigation** issue from WA-2673 (returns to Home instead of Workspace Security Hub) is **not** addressed here — tracked separately.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    B1[No guard] --> B2["status: clear, score 100<br/>green 'all good' ✅"]
    B3[No guard, >$1M, HN chain] --> B4["partial + partner:'hypernative'<br/>CTA 'Learn more' → settings/security"]
    B4 -.->|partner field read by nothing| B5[(no Hypernative notification)]
  end
  subgraph After
    A1[No guard] --> A2["status: not_applicable<br/>excluded from grade + counts"]
    A3[No guard, >$1M, HN chain] --> A4["partial + partner:'hypernative'<br/>CTA 'Set up protection'"]
    A4 -->|onHnSignupClick| A5[Close drawer → open HnSignupFlow modal]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — N/A (web-only Security Hub feature)
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — scanner status tests updated, 2 new CTA tests in `SecurityChecksSection.test.tsx`
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
