### PR TITLE
fix(web): address book resets from All networks on new network launch (WA-2243)

### DIFF
--- a/apps/web/src/components/common/NetworkSelector/NetworkMultiSelectorInput.tsx
+++ b/apps/web/src/components/common/NetworkSelector/NetworkMultiSelectorInput.tsx
@@ -14,6 +14,7 @@ type NetworkMultiSelectorInputProps = {
   error?: boolean
   helperText?: string
   showSelectAll?: boolean
+  maxVisibleTags?: number
 }
 
 const SELECT_ALL_OPTION = { chainId: 'select-all', chainName: 'Select All' } as Chain
@@ -26,6 +27,7 @@ const NetworkMultiSelectorInput = ({
   error,
   helperText,
   showSelectAll = false,
+  maxVisibleTags,
 }: NetworkMultiSelectorInputProps): ReactElement => {
   const { configs } = useChains()
   const { setValue } = useFormContext()
@@ -79,18 +81,29 @@ const NetworkMultiSelectorInput = ({
         )
       }
 
-      return selectedOptions.map((chain) => (
-        <Chip
-          variant="outlined"
-          key={chain.chainId}
-          avatar={<ChainIndicator chainId={chain.chainId} onlyLogo inline />}
-          label={chain.chainName}
-          onDelete={() => handleDelete(chain.chainId)}
-          className={css.multiChainChip}
-        />
-      ))
+      const visibleOptions =
+        maxVisibleTags != null && selectedOptions.length > maxVisibleTags
+          ? selectedOptions.slice(0, maxVisibleTags)
+          : selectedOptions
+      const hiddenCount = selectedOptions.length - visibleOptions.length
+
+      return (
+        <>
+          {visibleOptions.map((chain) => (
+            <Chip
+              variant="outlined"
+              key={chain.chainId}
+              avatar={<ChainIndicator chainId={chain.chainId} onlyLogo inline />}
+              label={chain.chainName}
+              onDelete={() => handleDelete(chain.chainId)}
+              className={css.multiChainChip}
+            />
+          ))}
+          {hiddenCount > 0 && <Chip variant="outlined" label={`+${hiddenCount} more`} className={css.multiChainChip} />}
+        </>
+      )
     },
-    [showSelectAll, isAllSelected, handleDelete],
+    [showSelectAll, isAllSelected, handleDelete, maxVisibleTags],
   )
 
   const renderOption = useCallback(

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddContactDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddContactDialog.tsx
@@ -169,6 +169,7 @@ const AddContactDialog = ({
                       <NetworkMultiSelectorInput
                         name="networks"
                         showSelectAll
+                        maxVisibleTags={6}
                         value={field.value || []}
                         error={!!errors.networks}
                         helperText={errors.networks ? 'Select at least one network' : ''}

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/EditContactDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/EditContactDialog.tsx
@@ -151,6 +151,7 @@ const EditContactDialog = ({ entry, onClose }: EditContactDialogProps) => {
                     <NetworkMultiSelectorInput
                       name="networks"
                       showSelectAll
+                      maxVisibleTags={6}
                       value={field.value || []}
                       error={!!errors.networks}
                       helperText={errors.networks ? 'Select at least one network' : ''}

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/SpaceAddressBookTable.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/SpaceAddressBookTable.test.tsx
@@ -7,7 +7,9 @@ import { faker } from '@faker-js/faker'
 const mockUseIsMobile = jest.fn(() => false)
 jest.mock('@/hooks/use-mobile', () => ({ useIsMobile: () => mockUseIsMobile() }))
 
-jest.mock('@/hooks/useChains', () => () => ({ configs: [] }))
+jest.mock('@/hooks/useChains', () => () => ({
+  configs: [],
+}))
 jest.mock('@/components/common/EthHashInfo', () => {
   const EthHashInfo = ({ address, shortAddress }: { address: string; shortAddress?: boolean }) => (
     <span data-testid="eth-hash-info" data-short-address={String(Boolean(shortAddress))}>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/utils.test.ts
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/utils.test.ts
@@ -3,11 +3,17 @@ import {
   createContactItems,
   flattenAddressBook,
   getRenameContactTooltip,
+    getNetworkAvailabilityText,
   getSelectedAddresses,
   validateContactName,
+    getSupportedChainIds,
 } from '../utils'
 import type { ImportContactsFormValues } from '../Import/ImportAddressBookDialog'
 import { EMPTY_NAME_MESSAGE } from '@safe-global/utils/validation/names'
+import { chainBuilder } from '@/tests/builders/chains'
+import { maybePlural } from '@safe-global/utils/utils/formatters'
+
+const buildChain = (chainId: string, chainName: string) => chainBuilder().with({ chainId, chainName }).build()
 
 describe('space address book utils', () => {
   describe('flattenAddressBook', () => {
@@ -234,6 +240,132 @@ describe('space address book utils', () => {
       expect(getRenameContactTooltip('Invalid characters')).toBe(
         'Rename this contact to add it to the workspace. Invalid characters',
       )
+    })
+  })
+
+  describe('getSupportedChainIds', () => {
+    const configs = [buildChain('1', 'Ethereum'), buildChain('137', 'Polygon'), buildChain('10', 'Optimism')]
+
+    it('keeps only chain ids that are still in the config', () => {
+      expect(getSupportedChainIds(['1', '99999', '137'], configs)).toEqual(['1', '137'])
+    })
+
+    it('preserves the original order of the supported chain ids', () => {
+      expect(getSupportedChainIds(['137', '10', '1'], configs)).toEqual(['137', '10', '1'])
+    })
+
+    it('returns an empty array when every stored chain has been delisted', () => {
+      expect(getSupportedChainIds(['99998', '99999'], configs)).toEqual([])
+    })
+
+    it('returns an empty array when no chains are configured', () => {
+      expect(getSupportedChainIds(['1', '137'], [])).toEqual([])
+    })
+  })
+
+  describe('getNetworkAvailabilityText', () => {
+    const configs = [
+      buildChain('1', 'Ethereum'),
+      buildChain('137', 'Polygon'),
+      buildChain('10', 'Optimism'),
+      buildChain('42161', 'Arbitrum'),
+      buildChain('100', 'Gnosis'),
+    ]
+
+    it('returns "all networks" when the entry covers every configured chain', () => {
+      expect(getNetworkAvailabilityText(['1', '137', '10', '42161', '100'], configs)).toBe(
+        'Available on all supported networks',
+      )
+    })
+
+    it('lists the missing networks when only a few are not covered', () => {
+      expect(getNetworkAvailabilityText(['1', '137', '10'], configs)).toBe(
+        'Available on all supported networks except Arbitrum, Gnosis',
+      )
+    })
+
+    it('uses a single missing network name without a separator', () => {
+      expect(getNetworkAvailabilityText(['1', '137', '10', '42161'], configs)).toBe(
+        'Available on all supported networks except Gnosis',
+      )
+    })
+
+    it('summarises as "X of Y" when many networks are missing', () => {
+      expect(getNetworkAvailabilityText(['1'], configs)).toBe(`Available on 1 of 5 supported network${maybePlural(5)}`)
+    })
+
+    it('ignores stored chain ids that are no longer in the config', () => {
+      expect(getNetworkAvailabilityText(['1', '137', '10', '42161', '100', '999'], configs)).toBe(
+        'Available on all supported networks',
+      )
+    })
+
+    it('falls back to the raw count when no chains are configured', () => {
+      expect(getNetworkAvailabilityText(['1', '137'], [])).toBe(`Available on 2 supported network${maybePlural(2)}`)
+      expect(getNetworkAvailabilityText(['1'], [])).toBe(`Available on 1 supported network${maybePlural(1)}`)
+    })
+  })
+
+  describe('getSupportedChainIds', () => {
+    const configs = [buildChain('1', 'Ethereum'), buildChain('137', 'Polygon'), buildChain('10', 'Optimism')]
+
+    it('keeps only chain ids that are still in the config', () => {
+      expect(getSupportedChainIds(['1', '99999', '137'], configs)).toEqual(['1', '137'])
+    })
+
+    it('preserves the original order of the supported chain ids', () => {
+      expect(getSupportedChainIds(['137', '10', '1'], configs)).toEqual(['137', '10', '1'])
+    })
+
+    it('returns an empty array when every stored chain has been delisted', () => {
+      expect(getSupportedChainIds(['99998', '99999'], configs)).toEqual([])
+    })
+
+    it('returns an empty array when no chains are configured', () => {
+      expect(getSupportedChainIds(['1', '137'], [])).toEqual([])
+    })
+  })
+
+  describe('getNetworkAvailabilityText', () => {
+    const configs = [
+      buildChain('1', 'Ethereum'),
+      buildChain('137', 'Polygon'),
+      buildChain('10', 'Optimism'),
+      buildChain('42161', 'Arbitrum'),
+      buildChain('100', 'Gnosis'),
+    ]
+
+    it('returns "all networks" when the entry covers every configured chain', () => {
+      expect(getNetworkAvailabilityText(['1', '137', '10', '42161', '100'], configs)).toBe(
+        'Available on all supported networks',
+      )
+    })
+
+    it('lists the missing networks when only a few are not covered', () => {
+      expect(getNetworkAvailabilityText(['1', '137', '10'], configs)).toBe(
+        'Available on all supported networks except Arbitrum, Gnosis',
+      )
+    })
+
+    it('uses a single missing network name without a separator', () => {
+      expect(getNetworkAvailabilityText(['1', '137', '10', '42161'], configs)).toBe(
+        'Available on all supported networks except Gnosis',
+      )
+    })
+
+    it('summarises as "X of Y" when many networks are missing', () => {
+      expect(getNetworkAvailabilityText(['1'], configs)).toBe(`Available on 1 of 5 supported network${maybePlural(5)}`)
+    })
+
+    it('ignores stored chain ids that are no longer in the config', () => {
+      expect(getNetworkAvailabilityText(['1', '137', '10', '42161', '100', '999'], configs)).toBe(
+        'Available on all supported networks',
+      )
+    })
+
+    it('falls back to the raw count when no chains are configured', () => {
+      expect(getNetworkAvailabilityText(['1', '137'], [])).toBe(`Available on 2 supported network${maybePlural(2)}`)
+      expect(getNetworkAvailabilityText(['1'], [])).toBe(`Available on 1 supported network${maybePlural(1)}`)
     })
   })
 })

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/utils.test.ts
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/utils.test.ts
@@ -3,10 +3,10 @@ import {
   createContactItems,
   flattenAddressBook,
   getRenameContactTooltip,
-    getNetworkAvailabilityText,
+  getNetworkAvailabilityText,
   getSelectedAddresses,
   validateContactName,
-    getSupportedChainIds,
+  getSupportedChainIds,
 } from '../utils'
 import type { ImportContactsFormValues } from '../Import/ImportAddressBookDialog'
 import { EMPTY_NAME_MESSAGE } from '@safe-global/utils/validation/names'
@@ -240,69 +240,6 @@ describe('space address book utils', () => {
       expect(getRenameContactTooltip('Invalid characters')).toBe(
         'Rename this contact to add it to the workspace. Invalid characters',
       )
-    })
-  })
-
-  describe('getSupportedChainIds', () => {
-    const configs = [buildChain('1', 'Ethereum'), buildChain('137', 'Polygon'), buildChain('10', 'Optimism')]
-
-    it('keeps only chain ids that are still in the config', () => {
-      expect(getSupportedChainIds(['1', '99999', '137'], configs)).toEqual(['1', '137'])
-    })
-
-    it('preserves the original order of the supported chain ids', () => {
-      expect(getSupportedChainIds(['137', '10', '1'], configs)).toEqual(['137', '10', '1'])
-    })
-
-    it('returns an empty array when every stored chain has been delisted', () => {
-      expect(getSupportedChainIds(['99998', '99999'], configs)).toEqual([])
-    })
-
-    it('returns an empty array when no chains are configured', () => {
-      expect(getSupportedChainIds(['1', '137'], [])).toEqual([])
-    })
-  })
-
-  describe('getNetworkAvailabilityText', () => {
-    const configs = [
-      buildChain('1', 'Ethereum'),
-      buildChain('137', 'Polygon'),
-      buildChain('10', 'Optimism'),
-      buildChain('42161', 'Arbitrum'),
-      buildChain('100', 'Gnosis'),
-    ]
-
-    it('returns "all networks" when the entry covers every configured chain', () => {
-      expect(getNetworkAvailabilityText(['1', '137', '10', '42161', '100'], configs)).toBe(
-        'Available on all supported networks',
-      )
-    })
-
-    it('lists the missing networks when only a few are not covered', () => {
-      expect(getNetworkAvailabilityText(['1', '137', '10'], configs)).toBe(
-        'Available on all supported networks except Arbitrum, Gnosis',
-      )
-    })
-
-    it('uses a single missing network name without a separator', () => {
-      expect(getNetworkAvailabilityText(['1', '137', '10', '42161'], configs)).toBe(
-        'Available on all supported networks except Gnosis',
-      )
-    })
-
-    it('summarises as "X of Y" when many networks are missing', () => {
-      expect(getNetworkAvailabilityText(['1'], configs)).toBe(`Available on 1 of 5 supported network${maybePlural(5)}`)
-    })
-
-    it('ignores stored chain ids that are no longer in the config', () => {
-      expect(getNetworkAvailabilityText(['1', '137', '10', '42161', '100', '999'], configs)).toBe(
-        'Available on all supported networks',
-      )
-    })
-
-    it('falls back to the raw count when no chains are configured', () => {
-      expect(getNetworkAvailabilityText(['1', '137'], [])).toBe(`Available on 2 supported network${maybePlural(2)}`)
-      expect(getNetworkAvailabilityText(['1'], [])).toBe(`Available on 1 supported network${maybePlural(1)}`)
     })
   })
 

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/utils.ts
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/utils.ts
@@ -8,6 +8,42 @@ import {
   sanitizeName,
   validateName,
 } from '@safe-global/utils/validation/names'
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import { maybePlural } from '@safe-global/utils/utils/formatters'
+
+const MAX_LISTED_MISSING_NETWORKS = 3
+
+// Stored chain ids can outlive the chain config when a network is delisted.
+// Those ids resolve to an "unknown network" logo, so callers should display
+// only the chains that are still supported.
+export const getSupportedChainIds = (chainIds: string[], configs: Chain[]): string[] => {
+  const supportedIds = new Set(configs.map((chain) => chain.chainId))
+  return chainIds.filter((chainId) => supportedIds.has(chainId))
+}
+
+// Human-readable summary of which networks a contact applies to, shown instead
+// of listing every chain. "All networks" is derived from the current chain
+// config rather than a stored flag, so it reflects what is supported now. The
+// evergreen, intent-based version is tracked in WA-2695.
+export const getNetworkAvailabilityText = (chainIds: string[], configs: Chain[]): string => {
+  const total = configs.length
+  if (total === 0) {
+    return `Available on ${chainIds.length} supported network${maybePlural(chainIds.length)}`
+  }
+
+  const selectedIds = new Set(chainIds)
+  const missing = configs.filter((chain) => !selectedIds.has(chain.chainId))
+
+  if (missing.length === 0) {
+    return 'Available on all supported networks'
+  }
+
+  if (missing.length <= MAX_LISTED_MISSING_NETWORKS) {
+    return `Available on all supported networks except ${missing.map((chain) => chain.chainName).join(', ')}`
+  }
+
+  return `Available on ${total - missing.length} of ${total} supported network${maybePlural(total)}`
+}
 
 export const flattenAddressBook = (allAddressBooks: AddressBookState): ContactItem[] => {
   return Object.entries(allAddressBooks).flatMap(([chainId, addressBook]) => {


### PR DESCRIPTION
## What it solves

Resolves: [WA-2695 ](<https://linear.app/safe-global/issue/WA-2243/address-book-resets-from-all-networks-on-new-network-launch>)(interim)

Space address book entries persist a list of chain IDs. When a network is delisted, those stored IDs outlive the chain config, so the table rendered<br>  "unknown network" logos and a tooltip listing every raw chain ID — including ones that no longer exist. The network multi-selector in the add/edit dialogs<br>  also rendered one chip per selected network, which overflowed for contacts on many chains.

## How this PR fixes it

* **Filter delisted chains:** `getSupportedChainIds()` intersects an entry's stored chain IDs with the current chain config, so `NetworkLogosList` only<br>renders chains that are still supported.
* **Readable availability tooltip:** `getNetworkAvailabilityText()` replaces the per-chain `ChainIndicator` list with a derived summary — `"Available on all supported networks"`, `"...except X, Y"` (≤3 missing), or `"Available on N of M supported networks"`. "All networks" is derived from the live config, not a<br>stored flag.
* **Chip overflow:** `NetworkMultiSelectorInput` gains an optional `maxVisibleTags` prop that caps visible chips and appends a `+N more` chip. Wired up at<br>`6` in `AddContactDialog` and `EditContactDialog`.

## How to test it

1. Open a Space with an address book containing a contact whose stored chain IDs include a delisted/unknown chain → its logo and tooltip should only show<br>currently-supported networks.
2. Hover the networks cell for: a contact on every chain (→ "all supported networks"), a contact missing 1–3 chains (→ "...except …"), and a contact on few<br>chains (→ "N of M supported networks").
3. Open Add contact / Edit contact, select more than 6 networks → only 6 chips show, plus a `+N more` chip.

## Affected flows

* Space address book — viewing the networks column (logos + tooltip) for a contact.
* Space address book — adding a contact (network multi-select chips).
* Space address book — editing a contact (network multi-select chips).

## Blast radius

* `NetworkMultiSelectorInput` (shared component, `components/common/NetworkSelector/`): new optional prop only; default behavior unchanged for all other<br>consumers. Confirm other call sites still render all chips (no `maxVisibleTags` passed).
* `SpaceAddressBookTable`: now calls `useChains()` and the two new utils; dropped the `ChainIndicator` import.
* `utils.ts` (`SpaceAddressBook/`): two new pure exports (`getSupportedChainIds`, `getNetworkAvailabilityText`); existing exports untouched.
* No RTK Query endpoints, feature flags, persistence, or routes touched. No shared `packages/**` changes → no mobile impact.

## Risks / not checked

* No test for the `maxVisibleTags` / `+N more` behavior in `NetworkMultiSelectorInput`, `AddContactDialog`, or `EditContactDialog` (verify flagged these as<br>missing coverage).
* Not tested on mobile (web-only surfaces).
* ESLint not confirmed in this session (run was interrupted); type-check, prettier, and unit tests pass.
* Did not exhaustively audit every other `NetworkMultiSelectorInput` consumer at runtime — relying on the prop being optional/defaulted.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    E1[entry.chainIds] --> L1[NetworkLogosList<br/>incl. delisted]
    E1 --> T1[Tooltip: ChainIndicator per chainId]
  end
  subgraph After
    E2[entry.chainIds] --> S[getSupportedChainIds<br/>configs]
    S --> L2[NetworkLogosList<br/>supported only]
    E2 --> A[getNetworkAvailabilityText<br/>configs]
    A --> T2[Tooltip: 'all networks' /<br/>'…except X,Y' / 'N of M']
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [X] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](<https://safe.global/cla>).