### PR TITLE
feat(web/Spaces): remove Beta tag; layout fixes

### DIFF
--- a/apps/web/src/components/common/PageLayout/index.test.tsx
+++ b/apps/web/src/components/common/PageLayout/index.test.tsx
@@ -206,6 +206,30 @@ describe('PageLayout', () => {
     })
   })
 
+  describe('accounts page topbar gating (/welcome/accounts)', () => {
+    const useIsRequireLoginEnabledModule = jest.requireMock('@/hooks/useIsRequireLoginEnabled') as {
+      useIsRequireLoginEnabled: jest.Mock
+    }
+
+    afterEach(() => {
+      useIsRequireLoginEnabledModule.useIsRequireLoginEnabled.mockReturnValue(false)
+    })
+
+    it('renders Topbar on /welcome/accounts when the user is signed in', () => {
+      useIsRequireLoginEnabledModule.useIsRequireLoginEnabled.mockReturnValue(false)
+      mockUseIsSignedIn.mockReturnValue(true)
+      renderLayout(AppRoutes.welcome.accounts)
+      expect(screen.getByTestId('topbar')).toBeInTheDocument()
+    })
+
+    it('hides Topbar on /welcome/accounts when the user is signed out (mirrors /welcome/spaces)', () => {
+      useIsRequireLoginEnabledModule.useIsRequireLoginEnabled.mockReturnValue(false)
+      mockUseIsSignedIn.mockReturnValue(false)
+      renderLayout(AppRoutes.welcome.accounts)
+      expect(screen.queryByTestId('topbar')).not.toBeInTheDocument()
+    })
+  })
+
   describe('auth gate blocking', () => {
     beforeEach(() => {
       mockUseIsAuthGateBlocking.mockReturnValue(true)

--- a/apps/web/src/components/common/PageLayout/index.tsx
+++ b/apps/web/src/components/common/PageLayout/index.tsx
@@ -62,11 +62,14 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
   // legacy workspaces list when signed in — only the list needs the Topbar.
   const isLoginPath = pathname === AppRoutes.welcome.spaces || pathname === AppRoutes.index
   const isWelcomeWorskpacePage = pathname === AppRoutes.welcome.spaces
+  // The Accounts and Workspaces tabs share a header row; keep the Topbar gating in sync
+  // so switching tabs while signed out doesn't shift the row vertically.
+  const isWelcomeAccountsPage = pathname === AppRoutes.welcome.accounts
   const hideHeader =
     NO_HEADER_ROUTES.includes(pathname) ||
     Boolean(isRequireLoginEnabled && isLoginPath) ||
     Boolean(isRequireLoginEnabled && isWelcomeWorskpacePage) ||
-    (pathname === AppRoutes.welcome.spaces && !isSignedIn) ||
+    ((isWelcomeWorskpacePage || isWelcomeAccountsPage) && !isSignedIn) ||
     // While the gate is still resolving, keep the Topbar off the login paths so it
     // can't flash an empty safe-selector skeleton before it (often) gets hidden.
     (isRequireLoginEnabled === undefined && isLoginPath)

--- a/apps/web/src/features/myAccounts/components/AccountsNavigation/index.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsNavigation/index.tsx
@@ -1,7 +1,6 @@
 import { AppRoutes } from '@/config/routes'
 import css from './styles.module.css'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
-import { Chip } from '@mui/material'
 import classNames from 'classnames'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
@@ -13,7 +12,6 @@ type Item = {
   label: string
   url: string
   trackEvent?: AnalyticsEvent
-  beta?: boolean
 }
 
 type NavItems = Item[]
@@ -27,7 +25,6 @@ const navItems: NavItems = [
     label: 'Workspaces',
     url: AppRoutes.welcome.spaces,
     trackEvent: { ...SPACE_EVENTS.OPEN_SPACE_LIST_PAGE, label: SPACE_LABELS.accounts_page },
-    beta: true,
   },
 ]
 
@@ -56,10 +53,7 @@ const AccountsNavigation = () => {
           onClick={handleClick(item)}
           className={classNames(css.tab, { [css.active]: isActiveNavigation(item.url) })}
         >
-          <span className={css.label}>
-            {item.label}
-            {item.beta && <Chip label="Beta" size="small" sx={{ ml: 1, fontWeight: 'normal', borderRadius: '4px' }} />}
-          </span>
+          <span className={css.label}>{item.label}</span>
         </Link>
       ))}
     </nav>

--- a/apps/web/src/features/myAccounts/components/MyAccounts/index.tsx
+++ b/apps/web/src/features/myAccounts/components/MyAccounts/index.tsx
@@ -6,6 +6,7 @@ import { Box, Divider, Paper } from '@mui/material'
 import madProps from '@/utils/mad-props'
 import css from '../../styles.module.css'
 import useWallet from '@/hooks/wallets/useWallet'
+import { useIsSignedIn } from '@/hooks/useIsSignedIn'
 import { type AllSafeItemsGrouped, useAllSafesGrouped } from '@/hooks/safes'
 import classNames from 'classnames'
 import useTrackSafesCount from '../../hooks/useTrackedSafesCount'
@@ -19,12 +20,18 @@ type MyAccountsProps = {
 
 const MyAccounts = ({ safes, onLinkClick, isSidebar = false }: MyAccountsProps) => {
   const wallet = useWallet()
+  const isSignedIn = useIsSignedIn()
   const [searchQuery, setSearchQuery] = useState('')
   useTrackSafesCount(safes, wallet)
 
   return (
     <Box data-testid="sidebar-safe-container" className={css.container}>
-      <Box className={classNames(css.myAccounts, { [css.sidebarAccounts]: isSidebar })}>
+      <Box
+        className={classNames(css.myAccounts, {
+          [css.sidebarAccounts]: isSidebar,
+          [css.headerSpacer]: !isSignedIn,
+        })}
+      >
         <AccountsHeader isSidebar={isSidebar} onLinkClick={onLinkClick} />
 
         <Paper sx={{ padding: 0 }}>

--- a/apps/web/src/features/myAccounts/components/MyAccountsV2/MyAccountsV2.tsx
+++ b/apps/web/src/features/myAccounts/components/MyAccountsV2/MyAccountsV2.tsx
@@ -5,6 +5,7 @@ import AccountsSearch from './components/AccountsSearch'
 import madProps from '@/utils/mad-props'
 import css from '../../styles.module.css'
 import useWallet from '@/hooks/wallets/useWallet'
+import { useIsSignedIn } from '@/hooks/useIsSignedIn'
 import { type AllSafeItemsGrouped, useAllSafesGrouped } from '@/hooks/safes'
 import classNames from 'classnames'
 import useTrackSafesCount from '../../hooks/useTrackedSafesCount'
@@ -19,12 +20,18 @@ type MyAccountsProps = {
 
 const MyAccountsV2 = ({ safes, onLinkClick, isSidebar = false }: MyAccountsProps) => {
   const wallet = useWallet()
+  const isSignedIn = useIsSignedIn()
   const [searchQuery, setSearchQuery] = useState('')
   useTrackSafesCount(safes, wallet)
 
   return (
     <div data-testid="sidebar-safe-container" className={css.container}>
-      <div className={classNames(css.myAccounts, { [css.sidebarAccounts]: isSidebar })}>
+      <div
+        className={classNames(css.myAccounts, {
+          [css.sidebarAccounts]: isSidebar,
+          [css.headerSpacer]: !isSignedIn,
+        })}
+      >
         <AccountsHeader isSidebar={isSidebar} onLinkClick={onLinkClick} />
 
         <div className="bg-background/50 text-card-foreground overflow-hidden rounded-xl">

--- a/apps/web/src/features/myAccounts/styles.module.css
+++ b/apps/web/src/features/myAccounts/styles.module.css
@@ -15,6 +15,17 @@
   margin: 0 !important;
 }
 
+/* Signed-out top spacing, kept in sync with the Workspaces page. */
+.headerSpacer {
+  padding-top: calc(var(--topbar-height) / 2);
+}
+
+@media (max-width: 899.95px) {
+  .headerSpacer {
+    padding-top: 0;
+  }
+}
+
 .safeList {
   padding: var(--space-2) var(--space-2) var(--space-3);
   margin-bottom: var(--space-1);

--- a/apps/web/src/features/spaces/components/SpacesList/styles.module.css
+++ b/apps/web/src/features/spaces/components/SpacesList/styles.module.css
@@ -11,13 +11,9 @@
   margin: var(--space-2);
 }
 
-/* When signed out, /welcome/spaces hides the Topbar while /welcome/accounts keeps
-   it (PageLayout adds .mainSpace { padding-top: var(--topbar-height) } there). Reserve
-   the same top space here so the Accounts/Workspaces tabs don't jump vertically when
-   switching between the two pages. Mirrors the 900px breakpoint where the Topbar stops
-   being absolutely positioned. */
+/* Signed-out top spacing, kept in sync with the Accounts page. */
 .headerSpacer {
-  padding-top: var(--topbar-height);
+  padding-top: calc(var(--topbar-height) / 2);
 }
 
 @media (max-width: 899.95px) {


### PR DESCRIPTION
## What it solves

Resolves:[ WA-2698](https://linear.app/safe-global/issue/WA-2698/remove-beta-tag-from-spaces)

Resolves two issues on the signed-out welcome pages (Classic / non-redesign view):

1. The **"Beta"** badge on the **Workspaces** navigation tab is no longer wanted.
2. Switching between the **Accounts** and **Workspaces** tabs while signed out made the tab row **jump vertically** — the Topbar showed on `/welcome/accounts` but was hidden on `/welcome/spaces`, so the two pages did not align.

## How this PR fixes it

- **Remove the Beta tag** — drop the `Chip` and the `beta` flag from `AccountsNavigation`.
- **Align the Topbar gating** — in `PageLayout`, hide the Topbar on `/welcome/accounts` when signed out, mirroring the existing `/welcome/spaces` behaviour. Signed-in behaviour is unchanged (Topbar still shows on both).
- **Reserve consistent top spacing when signed out** — both pages now apply a `headerSpacer` (`calc(var(--topbar-height) / 2)` ≈ 50px, dropping to `0` below the 900px breakpoint), gated on `!isSignedIn`, so the tab row keeps its breathing room and stays aligned across both tabs. The old one-sided `headerSpacer` workaround on the Workspaces page (which reserved full Topbar height to compensate for the Accounts page keeping its Topbar) is replaced by this symmetric spacing.

## How to test it

1. Sign out (disconnect / no authenticated session).
2. Open `/welcome/accounts` and `/welcome/spaces` and switch between the **Accounts** and **Workspaces** tabs.
   - The tab row should **not jump** vertically — both pages sit at the same height with breathing room at the top.
   - The **Workspaces** tab should **no longer** show a "Beta" badge.
3. Sign in and confirm the Topbar still appears on both pages and layout is unaffected.
4. Verify at a narrow viewport (< 900px) that the top spacer collapses to 0.

## Affected flows

- Signed-out welcome navigation — switching between the Accounts and Workspaces tabs (Classic / non-redesign view).
- `/welcome/accounts` Topbar visibility (now hidden when signed out, shown when signed in).
- Workspaces tab label rendering (Beta badge removed).

## Blast radius

- **`PageLayout`** (`components/common/PageLayout/index.tsx`) — changed the `hideHeader` condition for `/welcome/accounts`. This drives `css.mainNoHeader` / `css.mainSpace` (top padding) and `Breadcrumbs` gating. Verified no other `/welcome/*` or app route changes behaviour; existing tests for `/welcome/spaces` and `/` gating still pass.
- **`AccountsNavigation`** (`features/myAccounts/components/AccountsNavigation/index.tsx`) — removed `Chip` import, the `beta` field on `Item`, and the badge render. No other consumer of the `beta` flag existed.
- **`MyAccounts` and `MyAccountsV2`** (both `/welcome/accounts` variants, behind `WELCOME_ACCOUNTS_REDESIGN`) — added `useIsSignedIn` and the `headerSpacer` class on the page wrapper.
- **`SpacesList`** — `headerSpacer` repurposed to the new shared spacing value; gating unchanged (`!isUserSignedIn`, which only reaches this branch when the require-login gate is off).
- **Shared CSS** — `headerSpacer` added to `features/myAccounts/styles.module.css` and updated in `SpacesList/styles.module.css`; both use the same `--topbar-height` token.
- **Feature flag**: `WELCOME_ACCOUNTS_REDESIGN` — both the on (`MyAccountsV2`) and off (`MyAccounts`) variants updated.
- **Mobile**: no shared `packages/**` touched — web-only change.

## Risks / not checked

- Pixel-level visual alignment was not verified by running the app; confirmed via the shared signed-in signal and the symmetric spacing, but a visual pass in the browser is recommended.
- Did not exercise the require-login-gate-ON path for `/welcome/accounts` beyond the existing gating logic (that path was already covered by `/welcome/spaces` behaviour).
- Did not test on mobile (web-only surfaces; no shared packages changed).
- Left the orphaned `components/sidebar/Sidebar` component and the broader `isSidebar` prop chain untouched — out of scope for this fix (noted for a future cleanup).

## Visual summary

Before:

https://github.com/user-attachments/assets/43d4da53-b7b3-4eac-b289-8ab8a478bd8d


After:

https://github.com/user-attachments/assets/7bf48485-e667-4adc-a719-a8fba099101e


```mermaid
flowchart TB
  subgraph Before["Before — signed out"]
    A1["/welcome/accounts<br/>Topbar VISIBLE"] -->|switch tab| B1["/welcome/spaces<br/>Topbar hidden + one-sided headerSpacer"]
    B1 -.->|tab row jumps| J["❌ vertical jump<br/>+ Beta badge on Workspaces"]
  end
  subgraph After["After — signed out"]
    A2["/welcome/accounts<br/>Topbar hidden + headerSpacer (½ topbar height)"] -->|switch tab| B2["/welcome/spaces<br/>Topbar hidden + headerSpacer (½ topbar height)"]
    B2 -->|aligned| OK["✅ no jump<br/>no Beta badge"]
  end
```

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics change; the Workspaces tab `trackEvent` is unchanged
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — added `/welcome/accounts` Topbar-gating cases to `PageLayout/index.test.tsx`
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
