### PR TITLE
feat(web): show transaction note in nonce replacement label

### DIFF
--- a/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.test.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@/tests/test-utils'
+import { fireEvent, render, screen, within } from '@/tests/test-utils'
 import TxNonce from '../index'
 import { SafeTxContext, type SafeTxContextParams } from '@/components/tx-flow/SafeTxProvider'
 import { TxFlowContext, initialContext as initialTxFlowContext } from '@/components/tx-flow/TxFlowProvider'
@@ -192,6 +192,78 @@ describe('TxNonce', () => {
       renderTxNonce({ nonce: 5, recommendedNonce: 5, isReadOnly: false }, false)
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
       expect(screen.getByText('5')).toBeInTheDocument()
+    })
+  })
+
+  describe('replace existing nonce label', () => {
+    const buildQueuedTx = (overrides: { note?: string | null; humanDescription?: string | null } = {}) => ({
+      type: 'TRANSACTION' as const,
+      conflictType: 'None' as const,
+      transaction: {
+        id: 'tx-1',
+        timestamp: Date.now(),
+        txStatus: 'AWAITING_CONFIRMATIONS' as const,
+        note: overrides.note ?? null,
+        txInfo: {
+          type: 'Custom' as const,
+          humanDescription: overrides.humanDescription ?? null,
+          to: { value: '0x0000000000000000000000000000000000000000' },
+          dataSize: '0',
+          value: '0',
+          isCancellation: false,
+          methodName: null,
+          actionCount: null,
+        },
+      },
+    })
+
+    const openNonceDropdown = () => {
+      const combobox = screen.getByRole('combobox')
+      fireEvent.mouseDown(combobox)
+      return screen.getByRole('listbox')
+    }
+
+    const mockQueueByNonce = (nonce: number, tx: ReturnType<typeof buildQueuedTx> | null) => {
+      mockUseQueuedTxByNonce.mockImplementation((n: number) => (n === nonce && tx ? [tx] : []))
+    }
+
+    const getPreviousNonceOption = (listbox: HTMLElement) => within(listbox).getByRole('option', { selected: false })
+
+    it('shows the transaction note when present', () => {
+      mockUsePreviousNonces.mockReturnValue([4])
+      mockQueueByNonce(4, buildQueuedTx({ note: 'Treasury payout', humanDescription: 'fallback' }))
+      renderTxNonce({ nonce: 5, recommendedNonce: 5 })
+
+      const option = getPreviousNonceOption(openNonceDropdown())
+      expect(option).toHaveTextContent(/Treasury payout/)
+      expect(option).not.toHaveTextContent(/fallback/)
+    })
+
+    it('falls back to humanDescription when note is missing', () => {
+      mockUsePreviousNonces.mockReturnValue([4])
+      mockQueueByNonce(4, buildQueuedTx({ note: null, humanDescription: 'Send to alice.eth' }))
+      renderTxNonce({ nonce: 5, recommendedNonce: 5 })
+
+      const option = getPreviousNonceOption(openNonceDropdown())
+      expect(option).toHaveTextContent(/Send to alice\.eth/)
+    })
+
+    it('treats a whitespace-only note as missing and falls back', () => {
+      mockUsePreviousNonces.mockReturnValue([4])
+      mockQueueByNonce(4, buildQueuedTx({ note: '   ', humanDescription: 'Send to alice.eth' }))
+      renderTxNonce({ nonce: 5, recommendedNonce: 5 })
+
+      const option = getPreviousNonceOption(openNonceDropdown())
+      expect(option).toHaveTextContent(/Send to alice\.eth/)
+    })
+
+    it('shows "New transaction" when no queued txs exist for that nonce', () => {
+      mockUsePreviousNonces.mockReturnValue([4])
+      mockQueueByNonce(4, null)
+      renderTxNonce({ nonce: 5, recommendedNonce: 5 })
+
+      const option = getPreviousNonceOption(openNonceDropdown())
+      expect(option).toHaveTextContent(/New transaction/)
     })
   })
 

--- a/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.test.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@/tests/test-utils'
+import { act, render, screen, waitFor, within } from '@/tests/test-utils'
 import { userEvent } from '@testing-library/user-event'
 import TxNonce from '../index'
 import { SafeTxContext, type SafeTxContextParams } from '@/components/tx-flow/SafeTxProvider'
@@ -226,6 +226,78 @@ describe('TxNonce', () => {
       await waitFor(() => {
         expect(screen.getByRole('listbox')).toBeInTheDocument()
       })
+    })
+  })
+
+  describe('replace existing nonce label', () => {
+    const buildQueuedTx = (overrides: { note?: string | null; humanDescription?: string | null } = {}) => ({
+      type: 'TRANSACTION' as const,
+      conflictType: 'None' as const,
+      transaction: {
+        id: 'tx-1',
+        timestamp: Date.now(),
+        txStatus: 'AWAITING_CONFIRMATIONS' as const,
+        note: overrides.note ?? null,
+        txInfo: {
+          type: 'Custom' as const,
+          humanDescription: overrides.humanDescription ?? null,
+          to: { value: '0x0000000000000000000000000000000000000000' },
+          dataSize: '0',
+          value: '0',
+          isCancellation: false,
+          methodName: null,
+          actionCount: null,
+        },
+      },
+    })
+
+    const openNonceDropdown = async () => {
+      const user = userEvent.setup()
+      await user.click(screen.getByRole('combobox'))
+      return screen.findByRole('listbox')
+    }
+
+    const mockQueueByNonce = (nonce: number, tx: ReturnType<typeof buildQueuedTx> | null) => {
+      mockUseQueuedTxByNonce.mockImplementation((n: number) => (n === nonce && tx ? [tx] : []))
+    }
+
+    const getPreviousNonceOption = (listbox: HTMLElement) => within(listbox).getByRole('option', { selected: false })
+
+    it('shows the transaction note when present', async () => {
+      mockUsePreviousNonces.mockReturnValue([4])
+      mockQueueByNonce(4, buildQueuedTx({ note: 'Treasury payout', humanDescription: 'fallback' }))
+      renderTxNonce({ nonce: 5, recommendedNonce: 5 })
+
+      const option = getPreviousNonceOption(await openNonceDropdown())
+      expect(option).toHaveTextContent(/Treasury payout/)
+      expect(option).not.toHaveTextContent(/fallback/)
+    })
+
+    it('falls back to humanDescription when note is missing', async () => {
+      mockUsePreviousNonces.mockReturnValue([4])
+      mockQueueByNonce(4, buildQueuedTx({ note: null, humanDescription: 'Send to alice.eth' }))
+      renderTxNonce({ nonce: 5, recommendedNonce: 5 })
+
+      const option = getPreviousNonceOption(await openNonceDropdown())
+      expect(option).toHaveTextContent(/Send to alice\.eth/)
+    })
+
+    it('treats a whitespace-only note as missing and falls back', async () => {
+      mockUsePreviousNonces.mockReturnValue([4])
+      mockQueueByNonce(4, buildQueuedTx({ note: '   ', humanDescription: 'Send to alice.eth' }))
+      renderTxNonce({ nonce: 5, recommendedNonce: 5 })
+
+      const option = getPreviousNonceOption(await openNonceDropdown())
+      expect(option).toHaveTextContent(/Send to alice\.eth/)
+    })
+
+    it('shows "New transaction" when no queued txs exist for that nonce', async () => {
+      mockUsePreviousNonces.mockReturnValue([4])
+      mockQueueByNonce(4, null)
+      renderTxNonce({ nonce: 5, recommendedNonce: 5 })
+
+      const option = getPreviousNonceOption(await openNonceDropdown())
+      expect(option).toHaveTextContent(/New transaction/)
     })
   })
 

--- a/apps/web/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/index.tsx
@@ -67,7 +67,10 @@ const NonceFormOption = memo(function NonceFormOption({
     }
 
     const [{ transaction }] = latestTransactions
-    return transaction.txInfo.humanDescription || `${getTransactionType(transaction, addressBook).text} transaction`
+    const note = transaction.note?.trim()
+    return (
+      note || transaction.txInfo.humanDescription || `${getTransactionType(transaction, addressBook).text} transaction`
+    )
   }, [addressBook, transactions])
 
   const label = txLabel || 'New transaction'

--- a/apps/web/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/index.tsx
@@ -41,7 +41,10 @@ const NonceFormOption = memo(function NonceFormOption({ nonce }: { nonce: string
     }
 
     const [{ transaction }] = latestTransactions
-    return transaction.txInfo.humanDescription || `${getTransactionType(transaction, addressBook).text} transaction`
+    const note = transaction.note?.trim()
+    return (
+      note || transaction.txInfo.humanDescription || `${getTransactionType(transaction, addressBook).text} transaction`
+    )
   }, [addressBook, transactions])
 
   const label = txLabel || 'New transaction'


### PR DESCRIPTION
## What it solves

Resolves: #7517

When the user opens the nonce selector to replace an existing transaction, queued transactions are labeled generically (e.g. "Transaction Builder transaction"). The issue requests preferring the transaction's note (from `origin['note']`) so users can identify what they're about to overwrite.

## How this PR fixes it

In `apps/web/src/components/tx-flow/common/TxNonce/index.tsx`, the `txLabel` derivation now prefers `transaction.note` (trimmed) when present, then falls back to the existing `humanDescription`, then the transaction-type label. Whitespace-only notes are treated as missing so a stray space doesn't replace a useful label with blanks.

## How to test it

1. Create a transaction via Transaction Builder with a note (e.g. "Treasury payout") and queue it for some nonce N.
2. Start a new transaction and open the nonce selector.
3. The entry for nonce N should display "Treasury payout" instead of "Transaction Builder transaction".
4. Remove the note and confirm the label falls back to the previous behavior.

Unit tests in `TxNonce.test.tsx` cover: note present, note missing (fallback to human description), whitespace-only note, and no queued tx for the nonce.

## Affected flows

- New transaction → nonce selector → "Replace existing nonce" option labels

## Blast radius

- `apps/web/src/components/tx-flow/common/TxNonce/index.tsx` — purely label-derivation change inside `NonceFormOption`. No consumers, no API/store/route changes. `transaction.note` already exists on the `TransactionSummary` type from `@safe-global/safe-gateway-typescript-sdk`.

## Risks / not checked

- Did not test on mobile (web-only component).
- Did not exercise localization of the fallback strings (none added/changed).
- Did not verify behavior across every `txInfo.type` variant — only the label string is affected, no behavior changes.

## Visual summary

Label resolution order: `transaction.note?.trim()` → `transaction.txInfo.humanDescription` → `"<type> transaction"`.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯