### PR TITLE
fix(web): keep address actions clickable when the Safe selector is disabled

### DIFF
--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/__tests__/SafeSelectorDropdown.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/__tests__/SafeSelectorDropdown.test.tsx
@@ -368,12 +368,14 @@ describe('SafeSelectorDropdown', () => {
       )
     }
 
-    it('disables the Select and forces it closed when a tx flow is open', () => {
+    it('keeps the Select mounted, not disabled, and forced closed when a tx flow is open', () => {
       renderWithTxFlow(<div data-testid="active-tx-flow" />)
 
       const selectRoot = screen.getByTestId('mock-select-root')
-      expect(selectRoot.getAttribute('data-mock-disabled')).toBe('true')
+      // Not disabled — a disabled <button> would block the nested copy button — but forced closed.
+      expect(selectRoot.getAttribute('data-mock-disabled')).toBe('false')
       expect(selectRoot.getAttribute('data-mock-open')).toBe('false')
+      expect(screen.getByTestId('safe-selector-trigger-content')).toBeInTheDocument()
     })
 
     it('renders the explanatory tooltip when a tx flow is open', () => {
@@ -382,12 +384,14 @@ describe('SafeSelectorDropdown', () => {
       expect(screen.getByTestId('tooltip-content')).toHaveTextContent('Changing the Safe is not allowed in this screen')
     })
 
-    it('applies the disabled styling to the trigger when a tx flow is open', () => {
+    it('keeps the disabled styling but leaves the inline address actions interactive when a tx flow is open', () => {
       renderWithTxFlow(<div data-testid="active-tx-flow" />)
 
-      const trigger = screen.getByTestId('open-safes-icon')
-      expect(trigger.className).toMatch(/cursor-not-allowed/)
-      expect(trigger.className).toMatch(/opacity-50/)
+      const content = screen.getByTestId('open-safes-icon')
+      expect(content.className).toMatch(/cursor-not-allowed/)
+      expect(content.className).toMatch(/opacity-50/)
+      // The trigger isn't turned into a dead button, so copy + explorer + env hint stay clickable.
+      expect(content.className).not.toMatch(/\[&_\*\]:pointer-events-none/)
     })
 
     it('does not disable the Select or render the tooltip when no tx flow is active', () => {
@@ -412,12 +416,13 @@ describe('SafeSelectorDropdown', () => {
       return render(<SafeSelectorDropdown items={[itemA]} selectedItemId={itemA.id} onItemSelect={jest.fn()} />)
     }
 
-    it('disables the Select on /apps/open when an appUrl is present', () => {
+    it('keeps the Select forced closed and shows the tooltip on /apps/open when an appUrl is present', () => {
       jest.mocked(useSafeAppUrl).mockReturnValue('https://example-safe-app.test')
       renderAtRoute(AppRoutes.apps.open, { appUrl: 'https://example-safe-app.test' })
 
       const selectRoot = screen.getByTestId('mock-select-root')
-      expect(selectRoot.getAttribute('data-mock-disabled')).toBe('true')
+      expect(selectRoot.getAttribute('data-mock-disabled')).toBe('false')
+      expect(selectRoot.getAttribute('data-mock-open')).toBe('false')
       expect(screen.getByTestId('tooltip-content')).toHaveTextContent('Changing the Safe is not allowed in this screen')
     })
 

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/__tests__/SafeSelectorDropdown.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/__tests__/SafeSelectorDropdown.test.tsx
@@ -384,14 +384,15 @@ describe('SafeSelectorDropdown', () => {
       expect(screen.getByTestId('tooltip-content')).toHaveTextContent('Changing the Safe is not allowed in this screen')
     })
 
-    it('keeps the disabled styling but leaves the inline address actions interactive when a tx flow is open', () => {
+    it('dims the trigger and marks it aria-disabled (not native disabled) when a tx flow is open', () => {
       renderWithTxFlow(<div data-testid="active-tx-flow" />)
 
       const content = screen.getByTestId('open-safes-icon')
       expect(content.className).toMatch(/cursor-not-allowed/)
       expect(content.className).toMatch(/opacity-50/)
-      // The trigger isn't turned into a dead button, so copy + explorer + env hint stay clickable.
-      expect(content.className).not.toMatch(/\[&_\*\]:pointer-events-none/)
+      // Announced as disabled to assistive tech, but NOT the native `disabled` that would block the
+      // nested copy/explorer buttons. ("Not a dead button" is covered by the data-mock-disabled test.)
+      expect(content.getAttribute('aria-disabled')).toBe('true')
     })
 
     it('does not disable the Select or render the tooltip when no tx flow is active', () => {
@@ -404,6 +405,7 @@ describe('SafeSelectorDropdown', () => {
       const trigger = screen.getByTestId('open-safes-icon')
       expect(trigger.className).not.toMatch(/cursor-not-allowed/)
       expect(trigger.className).not.toMatch(/opacity-50/)
+      expect(trigger.getAttribute('aria-disabled')).toBeNull()
     })
   })
 

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/index.tsx
@@ -127,6 +127,9 @@ function SafeSelectorDropdown({
         )}
         size="default"
         iconWrapperClassName={variants.iconWrapperClass}
+        // Not the native `disabled` (that would kill the nested copy/explorer buttons); aria-disabled
+        // just announces the inert trigger to assistive tech while leaving descendants operable.
+        aria-disabled={isDisabled || undefined}
         data-testid="open-safes-icon"
       >
         <SelectValue>

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/index.tsx
@@ -114,7 +114,8 @@ function SafeSelectorDropdown({
       onValueChange={handleSafeChange}
       open={variants.canOpen && !isDisabled ? dropdownOpen : false}
       onOpenChange={isDisabled ? undefined : handleOpenChange}
-      disabled={isDisabled}
+      // Deliberately not disabled: a disabled <button> blocks the inline address actions (copy,
+      // explorer, env hint). Safe switching is prevented by the forced-closed `open` above instead.
     >
       <SelectTrigger
         className={cn(


### PR DESCRIPTION
## What it solves

Resolves: [WA-2699](https://linear.app/safe-global/issue/WA-2699/enable-copy-button-when-safe-selector-dropdown-is-disabled)

On screens where the Safe-bar is disabled — an open transaction flow, or being inside an opened Safe App (`/apps/open`) — the address copy button (and the block-explorer link next to it) in the Safe selector were not clickable. Users couldn't copy the current Safe's address without first leaving the screen.

The root cause: the selector trigger is a `<button>`, and when the bar is disabled it was rendered with the `disabled` attribute. A disabled `<button>` blocks pointer events on **all** its descendants, so the inline copy and block-explorer buttons nested inside the trigger went dead along with it.

## How this PR fixes it

Stop passing `disabled` to the Select. The trigger stays a normal, enabled `<button>`, so its nested inline actions receive clicks again. Safe **switching** is still blocked the same way it already was — the dropdown's `open` is force-held `false` (with `onOpenChange` left undefined) whenever the bar is disabled, so it can never open. The dimmed look is unchanged (`cursor-not-allowed opacity-50` is still applied), and the "Changing the Safe is not allowed in this screen" tooltip still shows.

Net effect when disabled:

- Copy address ✅ clickable
- Block-explorer link ✅ clickable
- Switch Safe ❌ still blocked (dropdown can't open)

One-line change in `index.tsx` (drop `disabled={isDisabled}`); the rest is a guard comment and updated tests.

## How to test it

1. Open a Safe and either:
   - start a transaction flow (**New transaction**), **or**
   - open a Safe App (**Apps** → open any app; the selector is on the page behind/above it).
2. The top Safe selector is dimmed (disabled) — switching is blocked, and hovering it shows the "Changing the Safe is not allowed in this screen" tooltip.
3. Click the **copy** icon next to the address → address is copied (icon flips to a green check). ✅
4. Click the **block-explorer** icon → opens the address on the explorer in a new tab. ✅
5. Click anywhere else on the selector card → nothing happens (the dropdown stays closed). ✅

## Affected flows

- **Safe selector while a tx flow is open** — copy & block-explorer now usable; switching still blocked.
- **Safe selector while inside an opened Safe App (`/apps/open`)** — same.
- **Safe selector in the normal (enabled) state** — unchanged: dropdown opens, copy works, selection navigates.

## Blast radius

- **Component:** `apps/web/src/features/spaces/components/SafeSelectorDropdown` (`index.tsx`).
- **Consumers:** the top Safe selector rendered by `SpaceSafeBar` and `Header/Topbar`. No prop/API change — purely the disabled-state rendering.
- **Disabled-state source:** `useIsSafeBarControlDisabled` (open tx flow / inside Safe App) — unchanged.
- No RTK Query / API contract, feature-flag, persistence, route, or shared-package changes. Web-only component (no mobile impact).

## Risks / not checked

- **Accessibility:** the trigger is now a focusable combobox that intentionally does nothing on activate (the dropdown is force-closed) rather than being announced as `disabled`. Functionally inert and the tooltip explains why, but it's a minor a11y semantics change.
- The MCP/automation coordinate-click on the 16px copy icon didn't register in the dev browser (the icon has `pointer-events:none` from base trigger styles); verified instead that the copy span resolves via `elementFromPoint`, has `pointer-events:auto`, and that a real DOM click fires the handler (icon → green check). A human click lands on the span and copies.
- Did not test on mobile (component is web-only).

## Visual summary

UI + logic change. The disabled selector looks identical to before (dimmed, chevron present, same layout) — only the inline action buttons regain interactivity.

```mermaid
flowchart TB
  subgraph Before["Before — bar disabled"]
    B1["Select disabled={true}"] --> B2["trigger is &lt;button disabled&gt;"]
    B2 --> B3["copy / block-explorer<br/>all blocked (no pointer events)"]
    B2 --> B4["dropdown can't open"]
  end
  subgraph After["After — bar disabled"]
    A1["Select (not disabled)"] --> A2["trigger is enabled &lt;button&gt;"]
    A2 --> A3["copy / block-explorer<br/>clickable again ✅"]
    A1 --> A4["open forced false<br/>→ dropdown still can't open ✅"]
  end
```

https://github.com/user-attachments/assets/6b202400-a7f7-4f77-914c-64571a7e76e9


## Checklist

- [ ] I've tested the branch on mobile 📱 (N/A — web-only component)
- [x] I've documented how it affects the analytics (if at all) 📊 (no change — existing `COPY_ADDRESS` / `OPEN_EXPLORER` events fire as before)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).