### PR TITLE
fix(mobile): keep navigation tree stable across WalletKitGate flag flip

### DIFF
--- a/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitGate.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitGate.tsx
@@ -7,14 +7,22 @@ import { WalletKitProvider } from './WalletKitProvider'
  * Gates the WalletConnect-for-dApps feature behind the NATIVE_WALLETCONNECT chain-config
  * flag. When the active chain does not advertise the feature — or no Safe is active yet,
  * so useHasFeature is undefined — WalletKitProvider is never mounted: no listeners, no
- * request sheet, no singleton init. Children always render either way.
+ * request sheet, no singleton init.
+ *
+ * `children` (the navigation tree) is always rendered in the same position, and the
+ * provider is mounted as a sibling rather than a wrapper. This is deliberate: flipping
+ * `isEnabled` (e.g. when the first Safe is imported and an active chain appears) must NOT
+ * change the element type wrapping `children`, or React would unmount and remount the
+ * whole navigation stack — discarding in-flight navigation and bouncing the user back to
+ * the landing screen.
  */
 export const WalletKitGate: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const isEnabled = useHasFeature(FEATURES.NATIVE_WALLETCONNECT) ?? false
 
-  if (!isEnabled) {
-    return <>{children}</>
-  }
-
-  return <WalletKitProvider>{children}</WalletKitProvider>
+  return (
+    <>
+      {children}
+      {isEnabled ? <WalletKitProvider /> : null}
+    </>
+  )
 }

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/WalletKitProvider.tsx
@@ -11,7 +11,7 @@ import { setSessions, removeSession, pushPending, isDeferredTxMethod } from '../
 import { RequestSheetHost } from '../components/RequestSheetHost'
 import { logWalletKitError } from '../utils/errors'
 
-export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export const WalletKitProvider: React.FC = () => {
   const dispatch = useAppDispatch()
   const [walletKit, setWalletKit] = useState<IWalletKit | null>(null)
 
@@ -126,10 +126,5 @@ export const WalletKitProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   useSessionProposalHandler(walletKit)
   useActiveSafeBinding(walletKit)
 
-  return (
-    <>
-      {children}
-      <RequestSheetHost walletKit={walletKit} />
-    </>
-  )
+  return <RequestSheetHost walletKit={walletKit} />
 }

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/__tests__/WalletKitGate.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/__tests__/WalletKitGate.test.tsx
@@ -49,4 +49,41 @@ describe('WalletKitGate', () => {
     expect(getByText('child')).toBeTruthy()
     expect(queryByText('provider-mounted')).toBeNull()
   })
+
+  // Regression for the onboarding bounce: importing the first Safe flips the flag
+  // false -> true. Children (the navigation tree) must survive that flip without
+  // remounting, or in-flight navigation is discarded and the user lands back on
+  // the landing screen. A mount effect fires once per mount, so the spy count
+  // staying at 1 proves the subtree was not torn down and rebuilt.
+  it('does not remount children when the feature flag flips on', () => {
+    const onMount = jest.fn()
+    const Child = () => {
+      React.useEffect(() => {
+        onMount()
+      }, [])
+      return <Text>child</Text>
+    }
+
+    mockUseHasFeature.mockReturnValue(false)
+    const { rerender, getByText, queryByText } = render(
+      <WalletKitGate>
+        <Child />
+      </WalletKitGate>,
+    )
+    expect(onMount).toHaveBeenCalledTimes(1)
+    expect(queryByText('provider-mounted')).toBeNull()
+
+    mockUseHasFeature.mockReturnValue(true)
+    rerender(
+      <WalletKitGate>
+        <Child />
+      </WalletKitGate>,
+    )
+
+    expect(getByText('provider-mounted')).toBeTruthy()
+    // Child is still on screen (the gate renders it directly, not inside the provider)
+    // and its mount effect never fired a second time: same instance, no remount.
+    expect(getByText('child')).toBeTruthy()
+    expect(onMount).toHaveBeenCalledTimes(1)
+  })
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/__tests__/WalletKitGate.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/__tests__/WalletKitGate.test.tsx
@@ -10,12 +10,7 @@ jest.mock('@/src/hooks/useHasFeature', () => ({ useHasFeature: () => mockUseHasF
 jest.mock('../WalletKitProvider', () => {
   const { Text: RNText } = jest.requireActual('react-native')
   return {
-    WalletKitProvider: ({ children }: { children: React.ReactNode }) => (
-      <>
-        <RNText>provider-mounted</RNText>
-        {children}
-      </>
-    ),
+    WalletKitProvider: () => <RNText>provider-mounted</RNText>,
   }
 })
 

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/__tests__/WalletKitProvider.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/__tests__/WalletKitProvider.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Text } from 'react-native'
 import { waitFor } from '@testing-library/react-native'
 import { renderWithStore, createTestStore } from '@/src/tests/test-utils'
 import { WalletKitProvider } from '../WalletKitProvider'
@@ -42,12 +41,7 @@ const renderProvider = () => {
   const store = createTestStore({
     [walletKitSliceName]: { sessions: {}, pending: [], outstandingRequests: {} },
   } as never)
-  const utils = renderWithStore(
-    <WalletKitProvider>
-      <Text>child</Text>
-    </WalletKitProvider>,
-    store,
-  )
+  const utils = renderWithStore(<WalletKitProvider />, store)
   return { store, ...utils }
 }
 
@@ -59,9 +53,8 @@ describe('WalletKitProvider', () => {
     mockGetInitialURL.mockResolvedValue(null)
   })
 
-  it('renders children', () => {
-    const { getByText } = renderProvider()
-    expect(getByText('child')).toBeTruthy()
+  it('mounts without crashing', () => {
+    expect(() => renderProvider()).not.toThrow()
   })
 
   it('seeds the slice from getActiveSessions on mount', async () => {


### PR DESCRIPTION
## What it solves

Importing the first Safe during onboarding redirected back to the landing screen instead of the imported Safe's home view.

## How this PR fixes it

`WalletKitGate` wraps the whole navigation tree and switched its child element type between a `Fragment` and `WalletKitProvider` based on the `NATIVE_WALLETCONNECT` flag. That flag derives from the active Safe's chain, so finishing the import (`setActiveSafe` → flag flips `false`→`true`) changed the element type wrapping the stack. React can't reconcile a type change, so it remounted the navigation stack and discarded the post-import `reset` → bounce to landing.

Fix: render `children` in a stable slot and mount `WalletKitProvider` as a sibling instead of a wrapper. The flag now mounts/unmounts only the WalletKit machinery, never the navigation tree. `WalletKitProvider` no longer renders `children` — it's a side-effect host rendering `RequestSheetHost`.

## How to test it

1. Fresh-install the app (no Safes) and go through onboarding.
2. Import a read-only Safe on a `NATIVE_WALLETCONNECT` chain, then tap Continue on the signers step.
3. Expected: you land on the Safe home `(tabs)` view, not the landing screen.

## Affected flows

- Import-first-Safe onboarding → lands on Safe home `(tabs)`.
- dApp WalletConnect on an enabled chain — unchanged, now hosted as a sibling.

## Blast radius

- `WalletKitGate` — wraps the app navigation tree in `_layout.tsx`; only consumer of `WalletKitProvider`.
- `WalletKitProvider` — contract change: no longer accepts/renders `children`.
- Flag/config: `NATIVE_WALLETCONNECT` (`useHasFeature` → `selectActiveChain`).
- No shared-package or web impact.

## Risks / not checked

- Not verified end-to-end on a device/simulator.
- Left the `CommonActions.reset` in `AddSignersForm.container.tsx` as-is (not the cause); `router.replace('/(tabs)')` is a possible follow-up.

## Visual summary

```mermaid
flowchart TB
  subgraph Before["Before — flag flip changes element type → remount"]
    G1[WalletKitGate] -->|flag false| F1["&lt;&gt; children &lt;/&gt;"]
    G1 -.->|flag true| P1[WalletKitProvider] --> C1[NavigationStack]
    C1 -. "type change remounts stack → reset discarded" .-> X[Bounced to landing]
  end
  subgraph After["After — children stable, provider is a sibling"]
    G2[WalletKitGate] --> C2[NavigationStack ✅ stable]
    G2 --> S2{flag true?}
    S2 -->|yes| P2[WalletKitProvider] --> RSH[RequestSheetHost]
    S2 -->|no| N2[null]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
