### PR TITLE
fix: use configured RPC for ENS resolution in web3-onboard

### DIFF
--- a/.yarn/patches/@web3-onboard-core-npm-2.24.1-56d6bba493.patch
+++ b/.yarn/patches/@web3-onboard-core-npm-2.24.1-56d6bba493.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/index-6ae5acf7.js b/dist/index-6ae5acf7.js
+index 2a629f8f1fa428c0d475551b706be3fdcf7594d3..8e619c583cd47ee692a72acfebeb888d3667db7b 100644
+--- a/dist/index-6ae5acf7.js
++++ b/dist/index-6ae5acf7.js
+@@ -2762,7 +2762,7 @@ async function getProvider(chain) {
+         const { createPublicClient, http } = await import('viem');
+         const publicProvider = createPublicClient({
+             chain: viemChain,
+-            transport: http()
++            transport: http(chain.rpcUrl || chain.publicRpcUrl)
+         });
+         viemProviders[chain.rpcUrl] = publicProvider;
+     }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -90,7 +90,7 @@
     "@walletconnect/core": "^2.21.10",
     "@walletconnect/utils": "^2.21.10",
     "@web3-onboard/coinbase": "^2.4.2",
-    "@web3-onboard/core": "^2.24.1",
+    "@web3-onboard/core": "patch:@web3-onboard/core@npm%3A2.24.1#~/.yarn/patches/@web3-onboard-core-npm-2.24.1-56d6bba493.patch",
     "@web3-onboard/hw-common": "^2.3.3",
     "@web3-onboard/injected-wallets": "^2.11.3",
     "@web3-onboard/walletconnect": "2.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14122,7 +14122,7 @@ __metadata:
     "@walletconnect/core": "npm:^2.21.10"
     "@walletconnect/utils": "npm:^2.21.10"
     "@web3-onboard/coinbase": "npm:^2.4.2"
-    "@web3-onboard/core": "npm:^2.24.1"
+    "@web3-onboard/core": "patch:@web3-onboard/core@npm%3A2.24.1#~/.yarn/patches/@web3-onboard-core-npm-2.24.1-56d6bba493.patch"
     "@web3-onboard/hw-common": "npm:^2.3.3"
     "@web3-onboard/injected-wallets": "npm:^2.11.3"
     "@web3-onboard/walletconnect": "npm:2.6.2"
@@ -21269,7 +21269,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@web3-onboard/core@npm:^2.24.1":
+"@web3-onboard/core@npm:2.24.1":
   version: 2.24.1
   resolution: "@web3-onboard/core@npm:2.24.1"
   dependencies:
@@ -21286,6 +21286,26 @@ __metadata:
     svelte-i18n: "npm:^4.0.1"
     viem: "npm:2.12.0"
   checksum: 10/ce3808b2884574049b82a223cebfd8da0d31010a36fa139ce1c97db4b068224c6d1f3999792fd575191d4c3e12a89d4e18b9ac1f43a17573c35c72861f78b0b6
+  languageName: node
+  linkType: hard
+
+"@web3-onboard/core@patch:@web3-onboard/core@npm%3A2.24.1#~/.yarn/patches/@web3-onboard-core-npm-2.24.1-56d6bba493.patch":
+  version: 2.24.1
+  resolution: "@web3-onboard/core@patch:@web3-onboard/core@npm%3A2.24.1#~/.yarn/patches/@web3-onboard-core-npm-2.24.1-56d6bba493.patch::version=2.24.1&hash=44ef30"
+  dependencies:
+    "@web3-onboard/common": "npm:^2.4.1"
+    bnc-sdk: "npm:^4.6.7"
+    bowser: "npm:^2.11.0"
+    eventemitter3: "npm:^4.0.7"
+    joi: "npm:17.9.1"
+    lodash.merge: "npm:^4.6.2"
+    lodash.partition: "npm:^4.6.0"
+    nanoid: "npm:^4.0.0"
+    rxjs: "npm:^7.5.5"
+    svelte: "npm:^3.49.0"
+    svelte-i18n: "npm:^4.0.1"
+    viem: "npm:2.12.0"
+  checksum: 10/1c14c1d17e9240c8c07b007910e0b5418d7f455b923329d48047f56d5d6c9fac5cb36b218c366368163551e310312ef2984b57d9a118a2510281dc5647d97600
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What it solves

Resolves: #6989

On Sepolia, wallet connect throws `ContractFunctionExecutionError` on the ENS reverse lookup. The viem chain bundled inside `@web3-onboard/core` hard-codes `https://rpc.sepolia.org`, which is dead.

## How this PR fixes it

Yarn patch on `@web3-onboard/core` to pass the configured RPC into the viem transport:

```diff
- transport: http()
+ transport: http(chain.rpcUrl || chain.publicRpcUrl)
```

`chain.rpcUrl` is whatever the app passed into `init({ chains })`. Couldn't see a clean override seam — `getProvider` builds the transport inline. Will follow up upstream.

## How to test it

1. Connect a wallet on Sepolia.
2. Watch the console / network tab.

Before: `ContractFunctionExecutionError` from `rpc.sepolia.org`. After: ENS resolves against the configured Sepolia RPC.

## Affected flows

- Wallet connect on Sepolia (ENS reverse lookup)

## Blast radius

- One-line patch in `@web3-onboard/core@2.24.1` `getProvider`
- `apps/web/package.json` + `yarn.lock` for the patch ref
- Web only — package isn't a mobile dep

## Risks / not checked

- If a chain has neither `rpcUrl` nor `publicRpcUrl`, falls back to viem default — same as today
- Patch is pinned to 2.24.1; next bump will need a re-roll
- Didn't manually re-test mainnet ENS

## Visual summary

```mermaid
flowchart LR
  A[wallet connect] --> B["getProvider(chain)"]
  B --> C["http()  →  viem default RPC (rpc.sepolia.org, dead)"]
  B --> D["http(chain.rpcUrl)  →  configured Sepolia RPC"]
  C --> E[ContractFunctionExecutionError]
  D --> F[ENS resolves]
```

## Checklist

- [x] I've tested the branch on mobile 📱 — n/a, web-only dep
- [x] I've documented how it affects the analytics (if at all) 📊 — none
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — n/a, patch on third-party bundled output
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

I have read and hereby sign the [Contributor License Agreement](https://safe.global/cla).