### PR TITLE
fix(spaces): recognise nested Safe owners on the send-tokens button

### DIFF
--- a/apps/web/src/features/spaces/components/SafeAccounts/SendTransactionButton.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/SendTransactionButton.tsx
@@ -1,5 +1,5 @@
 import type { AddressInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
-import { useContext } from 'react'
+import { useContext, useMemo } from 'react'
 import { IconButton, Tooltip } from '@mui/material'
 import { useRouter } from 'next/router'
 import ArrowOutwardIcon from '@/public/images/transactions/outgoing.svg'
@@ -9,7 +9,9 @@ import { TokenTransferFlow } from '@/components/tx-flow/flows'
 import { getEip3770ShortName } from '@safe-global/utils/utils/chains'
 import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import useWallet from '@/hooks/wallets/useWallet'
+import useOwnedSafes from '@/hooks/useOwnedSafes'
 import { isOwner } from '@/utils/transaction-guards'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { trackEvent } from '@/services/analytics'
 import { gtmSetSafeAddress } from '@/services/analytics/gtm'
@@ -17,7 +19,14 @@ import { gtmSetSafeAddress } from '@/services/analytics/gtm'
 const SendTransactionButton = ({ safe }: { safe: SafeOverview }) => {
   const router = useRouter()
   const wallet = useWallet()
-  const canSend = isOwner(safe.owners as AddressInfo[], wallet?.address)
+  const owners = safe.owners as AddressInfo[]
+  const ownedSafes = useOwnedSafes(safe.chainId)
+  const isDirectOwner = isOwner(owners, wallet?.address)
+  const isNestedOwner = useMemo(() => {
+    const ownedOnChain = ownedSafes[safe.chainId] ?? []
+    return owners.some(({ value }) => ownedOnChain.some((addr) => sameAddress(addr, value)))
+  }, [ownedSafes, owners, safe.chainId])
+  const canSend = isDirectOwner || isNestedOwner
 
   const { setTxFlow } = useContext(TxModalContext)
 

--- a/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SendTransactionButton.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SendTransactionButton.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@/tests/test-utils'
+import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import SendTransactionButton from '../SendTransactionButton'
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ replace: jest.fn(), pathname: '/', query: {} }),
+}))
+
+jest.mock('@/hooks/wallets/useWallet', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+
+jest.mock('@/hooks/useOwnedSafes', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+
+import useWallet from '@/hooks/wallets/useWallet'
+import useOwnedSafes from '@/hooks/useOwnedSafes'
+
+const mockedUseWallet = useWallet as jest.MockedFunction<typeof useWallet>
+const mockedUseOwnedSafes = useOwnedSafes as jest.MockedFunction<typeof useOwnedSafes>
+
+const EOA = '0x1111111111111111111111111111111111111111'
+const PARENT_SAFE = '0x2222222222222222222222222222222222222222'
+const NESTED_SAFE = '0x3333333333333333333333333333333333333333'
+
+const buildOverview = (owners: string[]): SafeOverview =>
+  ({
+    chainId: '1',
+    address: { value: NESTED_SAFE },
+    owners: owners.map((value) => ({ value })),
+  }) as unknown as SafeOverview
+
+describe('SendTransactionButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedUseOwnedSafes.mockReturnValue({})
+  })
+
+  it('enables the button when the connected wallet is a direct owner', () => {
+    mockedUseWallet.mockReturnValue({ address: EOA } as ReturnType<typeof useWallet>)
+    render(<SendTransactionButton safe={buildOverview([EOA])} />)
+
+    expect(screen.getByRole('button')).not.toBeDisabled()
+  })
+
+  it('enables the button when the connected wallet owns a parent Safe that is an owner', () => {
+    mockedUseWallet.mockReturnValue({ address: EOA } as ReturnType<typeof useWallet>)
+    mockedUseOwnedSafes.mockReturnValue({ '1': [PARENT_SAFE] })
+
+    render(<SendTransactionButton safe={buildOverview([PARENT_SAFE])} />)
+
+    expect(screen.getByRole('button')).not.toBeDisabled()
+  })
+
+  it('disables the button when the wallet is neither a direct nor a nested owner', () => {
+    mockedUseWallet.mockReturnValue({ address: EOA } as ReturnType<typeof useWallet>)
+    mockedUseOwnedSafes.mockReturnValue({ '1': [] })
+
+    render(<SendTransactionButton safe={buildOverview([PARENT_SAFE])} />)
+
+    expect(screen.getByRole('button')).toBeDisabled()
+  })
+
+  it('disables the button when no wallet is connected', () => {
+    mockedUseWallet.mockReturnValue(null)
+
+    render(<SendTransactionButton safe={buildOverview([PARENT_SAFE])} />)
+
+    expect(screen.getByRole('button')).toBeDisabled()
+  })
+})


### PR DESCRIPTION
## What it solves

Resolves: #7679

In the Spaces SafeAccounts list, the per-row Send tokens button only checks direct ownership (`isOwner(safe.owners, wallet?.address)`). A wallet whose only path to a Safe is through a parent Safe gets the button disabled with "You are not a signer of this Safe Account".

The sibling new-transaction entry points (`NewTxButton`, Spaces `SidebarActionButton`) already wrap their buttons in `CheckWallet`, which falls back to `useIsNestedSafeOwner`. Only this button skipped the nested-owner branch.

## How this PR fixes it

Can't drop `CheckWallet` in directly — it reads the currently active Safe from `useSafeInfo()`, but this button receives an arbitrary row Safe as a prop. Mirror the nested-owner check inline: pull `useOwnedSafes(safe.chainId)` and treat the wallet as a signer when any owned Safe appears in the row's owners.

Same one-level-deep semantics as `useNestedSafeOwners`, consistent with `specs/001-nested-safe-proposer/spec.md`.

## How to test it

1. Connect a wallet that is a direct signer of Safe A.
2. Make Safe A an owner of Safe B (no direct EOA → Safe B relationship).
3. Put both in the same Space. View the SafeAccounts list.

Before: Send-tokens on Safe B's row is greyed out. After: enabled; clicking opens the Token Transfer flow with Safe B set active.

## Affected flows

- Spaces → SafeAccounts list → per-row Send tokens enablement and tooltip

## Blast radius

- `SendTransactionButton.tsx` only (Spaces feature, web-only)
- No change to `CheckWallet`, `useIsSafeOwner`, `useIsNestedSafeOwner`, `useOwnedSafes`, or the RTK Query endpoint
- Mobile unaffected (Spaces is a web feature)

## Risks / not checked

- Button stays disabled until `useOwnedSafes` lands data for the row's chain (loading window only)
- Multi-parent case (wallet owns several parents of same row Safe) — first match wins, same as `useNestedSafeOwners`
- Didn't test on mobile (feature not present)

## Visual summary

```mermaid
flowchart LR
  A[Wallet: EOA] --> B[Parent Safe A]
  B --> C[Nested Safe B in Spaces list]
  C -. before .-> D["isOwner(B.owners, EOA) → false<br/>Send disabled"]
  C -. after .-> E["isOwner OR ownedSafes ∩ B.owners<br/>Send enabled"]
```

## Checklist

- [x] I've tested the branch on mobile 📱 — n/a, Spaces is web-only
- [x] I've documented how it affects the analytics (if at all) 📊 — none
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — 4 cases in `SendTransactionButton.test.tsx`
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

I have read and hereby sign the [Contributor License Agreement](https://safe.global/cla).
