### PR TITLE
fix(store): filter unsupported chains out of read paths for addedSafes

### DIFF
--- a/apps/web/src/components/settings/PushNotifications/GlobalPushNotifications.tsx
+++ b/apps/web/src/components/settings/PushNotifications/GlobalPushNotifications.tsx
@@ -24,6 +24,7 @@ import { type Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
+import { pickSupportedChainEntries } from '@/utils/chainEntries'
 import useChains from '@/hooks/useChains'
 import { useAppSelector } from '@/store'
 import { useNotificationPreferences } from './hooks/useNotificationPreferences'
@@ -83,15 +84,7 @@ export const _transformCurrentSubscribedSafes = (
 
 // Remove Safes that are not on a supported chain
 export const _sanitizeNotifiableSafes = (chains: Array<Chain>, notifiableSafes: NotifiableSafes): NotifiableSafes => {
-  return Object.entries(notifiableSafes).reduce<NotifiableSafes>((acc, [chainId, safeAddresses]) => {
-    const chain = chains.find((chain) => chain.chainId === chainId)
-
-    if (chain) {
-      acc[chainId] = safeAddresses
-    }
-
-    return acc
-  }, {})
+  return pickSupportedChainEntries(notifiableSafes, chains)
 }
 
 // Merges added Safes, currently notified Safes, and owned safes into a single data structure without duplicates

--- a/apps/web/src/features/spaces/components/SpacesList/LocalSafesAlert.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/LocalSafesAlert.tsx
@@ -1,10 +1,12 @@
 import { WalletMinimal } from 'lucide-react'
 import { useAppSelector } from '@/store'
-import { selectAllAddedSafes } from '@/store/addedSafesSlice'
+import { selectAllAddedSafesOnSupportedChains } from '@/store/addedSafesSlice'
+import useChains from '@/hooks/useChains'
 
 const LocalSafesAlert = () => {
-  const allAdded = useAppSelector(selectAllAddedSafes)
-  const count = Object.values(allAdded ?? {}).reduce((sum, safes) => sum + Object.keys(safes).length, 0)
+  const { configs } = useChains()
+  const allAdded = useAppSelector((state) => selectAllAddedSafesOnSupportedChains(state, configs))
+  const count = Object.values(allAdded).reduce((sum, safes) => sum + Object.keys(safes).length, 0)
 
   if (count === 0) return null
 

--- a/apps/web/src/features/spaces/components/SpacesList/__tests__/LocalSafesAlert.test.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/__tests__/LocalSafesAlert.test.tsx
@@ -2,18 +2,25 @@ import { render, screen } from '@testing-library/react'
 import LocalSafesAlert from '../LocalSafesAlert'
 
 const mockUseAppSelector = jest.fn()
+const mockUseChains = jest.fn()
 
 jest.mock('@/store', () => ({
   useAppSelector: (selector: unknown) => mockUseAppSelector(selector),
 }))
 
 jest.mock('@/store/addedSafesSlice', () => ({
-  selectAllAddedSafes: jest.fn(() => 'selectAllAddedSafes'),
+  selectAllAddedSafesOnSupportedChains: jest.fn(() => 'selectAllAddedSafesOnSupportedChains'),
+}))
+
+jest.mock('@/hooks/useChains', () => ({
+  __esModule: true,
+  default: () => mockUseChains(),
 }))
 
 describe('LocalSafesAlert', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockUseChains.mockReturnValue({ configs: [{ chainId: '1' }, { chainId: '100' }, { chainId: '137' }] })
   })
 
   it('renders nothing when no local Safes are present', () => {
@@ -23,7 +30,7 @@ describe('LocalSafesAlert', () => {
   })
 
   it('renders nothing when the addedSafes slice is undefined (cold start)', () => {
-    mockUseAppSelector.mockReturnValue(undefined)
+    mockUseAppSelector.mockReturnValue({})
     const { container } = render(<LocalSafesAlert />)
     expect(container).toBeEmptyDOMElement()
   })

--- a/apps/web/src/store/__tests__/addedSafesSlice.test.ts
+++ b/apps/web/src/store/__tests__/addedSafesSlice.test.ts
@@ -1,5 +1,6 @@
 import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
-import { addOrUpdateSafe, removeSafe, addedSafesSlice } from '../addedSafesSlice'
+import { addOrUpdateSafe, removeSafe, addedSafesSlice, selectAllAddedSafesOnSupportedChains } from '../addedSafesSlice'
+import type { RootState } from '..'
 
 describe('addedSafesSlice', () => {
   describe('addOrUpdateSafe', () => {
@@ -44,6 +45,30 @@ describe('addedSafesSlice', () => {
         removeSafe({ chainId: '1', address: '0x0' }),
       )
       expect(state).toEqual({ '4': { ['0x0']: {} as SafeState } })
+    })
+  })
+
+  describe('selectAllAddedSafesOnSupportedChains', () => {
+    const buildState = (added: Record<string, Record<string, unknown>>) =>
+      ({ [addedSafesSlice.name]: added }) as unknown as RootState
+
+    it('drops Safes on chains that are no longer supported', () => {
+      const state = buildState({
+        '1': { '0xAAA': {} },
+        '137': { '0xBBB': {} },
+        '999': { '0xCCC': {} },
+      })
+
+      expect(selectAllAddedSafesOnSupportedChains(state, [{ chainId: '1' }, { chainId: '137' }])).toEqual({
+        '1': { '0xAAA': {} },
+        '137': { '0xBBB': {} },
+      })
+    })
+
+    it('returns an empty map when no chain is supported', () => {
+      const state = buildState({ '1': { '0xAAA': {} } })
+
+      expect(selectAllAddedSafesOnSupportedChains(state, [])).toEqual({})
     })
   })
 })

--- a/apps/web/src/store/addedSafesSlice.ts
+++ b/apps/web/src/store/addedSafesSlice.ts
@@ -1,6 +1,8 @@
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import type { SafeState, AddressInfo } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import type { RootState } from '.'
+import { pickSupportedChainEntries } from '@/utils/chainEntries'
 
 export type AddedSafesOnChain = {
   [safeAddress: string]: {
@@ -77,4 +79,13 @@ export const selectAddedSafes = createSelector(
   (allAddedSafes, chainId): AddedSafesOnChain | undefined => {
     return allAddedSafes?.[chainId]
   },
+)
+
+/**
+ * Returns the added Safes map with entries on unsupported chains dropped.
+ * Read-time filter — does not mutate the persisted state. See #2585.
+ */
+export const selectAllAddedSafesOnSupportedChains = createSelector(
+  [selectAllAddedSafes, (_: RootState, chains: ReadonlyArray<Pick<Chain, 'chainId'>>) => chains],
+  (allAddedSafes, chains): AddedSafesState => pickSupportedChainEntries(allAddedSafes, chains),
 )

--- a/apps/web/src/utils/__tests__/chainEntries.test.ts
+++ b/apps/web/src/utils/__tests__/chainEntries.test.ts
@@ -1,0 +1,31 @@
+import { pickSupportedChainEntries } from '../chainEntries'
+
+describe('pickSupportedChainEntries', () => {
+  const chains = [{ chainId: '1' }, { chainId: '100' }]
+
+  it('keeps only entries whose chainId appears in the supported chains list', () => {
+    const entries = {
+      '1': { foo: 'mainnet' },
+      '100': { foo: 'gnosis' },
+      '137': { foo: 'polygon' },
+    }
+    expect(pickSupportedChainEntries(entries, chains)).toEqual({
+      '1': { foo: 'mainnet' },
+      '100': { foo: 'gnosis' },
+    })
+  })
+
+  it('returns an empty object when the input map is undefined', () => {
+    expect(pickSupportedChainEntries(undefined, chains)).toEqual({})
+  })
+
+  it('drops everything when the supported chains list is empty', () => {
+    expect(pickSupportedChainEntries({ '1': 'x' }, [])).toEqual({})
+  })
+
+  it('does not mutate the input map', () => {
+    const entries = { '1': 'mainnet', '137': 'polygon' }
+    pickSupportedChainEntries(entries, chains)
+    expect(entries).toEqual({ '1': 'mainnet', '137': 'polygon' })
+  })
+})

--- a/apps/web/src/utils/chainEntries.ts
+++ b/apps/web/src/utils/chainEntries.ts
@@ -1,0 +1,18 @@
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+
+/**
+ * Drop entries on chains that are no longer in the supported chains list.
+ * Read-time filter for persisted, chainId-keyed slices — does not mutate the source object
+ * or localStorage. See #2585.
+ */
+export const pickSupportedChainEntries = <T>(
+  byChainId: Record<string, T> | undefined,
+  chains: ReadonlyArray<Pick<Chain, 'chainId'>>,
+): Record<string, T> => {
+  if (!byChainId) return {}
+  const supported = new Set(chains.map((c) => c.chainId))
+  return Object.keys(byChainId).reduce<Record<string, T>>((acc, chainId) => {
+    if (supported.has(chainId)) acc[chainId] = byChainId[chainId]
+    return acc
+  }, {})
+}


### PR DESCRIPTION
## What it solves

Resolves: #2585

Persisted chainId-keyed slices (`addedSafes`, address book, undeployed Safes, pinned Safe apps, …) hold entries for chains the gateway no longer lists. Consumers that iterate the raw maps surface stale state — this was the original trigger behind the linked incident in #2584.

Maintainer guidance on the issue was to filter at READ time rather than mutate localStorage. There was already a private `_sanitizeNotifiableSafes` doing exactly this for push-notification registration. This PR lifts that into a shared util and starts wiring it through the rest of the read paths.

## How this PR fixes it

- `apps/web/src/utils/chainEntries.ts` — new generic `pickSupportedChainEntries(byChainId, chains)` util (kept out of `utils/chains.ts` to avoid pulling the store-init graph back into the slice file).
- `addedSafesSlice` — new memoised `selectAllAddedSafesOnSupportedChains(state, chains)` selector.
- `LocalSafesAlert` (Spaces sign-in entry point) routed through the sanitised selector so the on-this-browser count stops including Safes on chains the gateway dropped.
- `_sanitizeNotifiableSafes` collapsed to delegate to the shared util — no behavioural change, just removes the duplicate.

First slice; the same `pickSupportedChainEntries` + per-slice memoised selector pattern can be extended to `addressBook`, `undeployedSafes`, `pinnedSafeApps`, `visitedSafes`, etc. in follow-ups. Doing them all in one PR would touch ~150 call sites and make review hard.

## How to test it

1. Add a Safe on a chain the gateway no longer returns (or temporarily filter the chain out of the `useChains` mock).
2. Open the Spaces sign-in screen.
3. Before: `LocalSafesAlert` counts the stale-chain Safe. After: it's excluded; the count matches the actual usable list.

Unit tests cover the util's filter / no-mutation / empty-chains semantics, the new sanitised selector, and the updated alert behaviour.

## Affected flows

- Spaces sign-in → `LocalSafesAlert` count

## Blast radius

- New util file + new selector; existing public selectors untouched
- `_sanitizeNotifiableSafes` keeps its signature, only its body now reuses the util
- `LocalSafesAlert` is the only consumer migrated to the sanitised selector
- No analytics / route / persisted state / RTK Query changes
- Mobile unaffected (web-only files)

## Risks / not checked

- Other consumers (`useAllSafes`, `AddAccounts`, `useOnboardingSafes`, `DataWidget`, …) still read raw `selectAllAddedSafes` — incremental follow-ups
- Sanitised selector is parametrised by the supported chains array; consumers must pass `useChains().configs` (or equivalent) for the filter to engage
- Did not test on mobile (Spaces is web-only)

## Visual summary

```mermaid
flowchart LR
  A["addedSafes slice (persisted, chainId-keyed)"] --> B["selectAllAddedSafes"]
  B --> C["direct consumers — stale-chain entries leak through"]
  A --> D["selectAllAddedSafesOnSupportedChains(state, chains)"]
  D --> E["pickSupportedChainEntries util"]
  E --> F["LocalSafesAlert count — stale-chain Safes dropped"]
```

## Checklist

- [x] I've tested the branch on mobile 📱 — n/a, web-only files
- [x] I've documented how it affects the analytics (if at all) 📊 — none
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — util, sanitised selector, alert
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

I have read and hereby sign the [Contributor License Agreement](https://safe.global/cla).
