### PR TITLE
feat(gtf): hide execution fee tooltip

### DIFF
--- a/apps/web/src/features/gtf/components/FeesPreview/index.tsx
+++ b/apps/web/src/features/gtf/components/FeesPreview/index.tsx
@@ -14,7 +14,7 @@ import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import type { GtfPaymentMode } from '@/features/gtf/types'
 import type { FeesPreviewData, TotalOutgoing } from '../../hooks/useFeesPreview'
 import { FeeBreakdownRow } from '../shared/FeeBreakdownRow'
-import { EXECUTION_FEE_TOOLTIP, GAS_FEE_TOOLTIP } from '../shared/tooltips'
+import { GAS_FEE_TOOLTIP } from '../shared/tooltips'
 import css from './styles.module.css'
 
 const SIGNER_FEE_TOOLTIP = 'Fees will be paid from the connected signer wallet when executing this transaction.'
@@ -372,7 +372,7 @@ const FeesPreview = (props: FeesPreviewData): ReactElement => {
           </>
         )}
 
-        <FeeBreakdownRow {...executionFee} loading={props.loading} tooltip={EXECUTION_FEE_TOOLTIP} />
+        <FeeBreakdownRow {...executionFee} loading={props.loading} />
         <FeeBreakdownRow {...gasFee} loading={props.loading} error={props.error} tooltip={GAS_FEE_TOOLTIP} />
       </div>
 

--- a/apps/web/src/features/gtf/components/HistoryFeesAccordion/index.tsx
+++ b/apps/web/src/features/gtf/components/HistoryFeesAccordion/index.tsx
@@ -12,7 +12,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import type { HistoryFeesData } from '../../hooks/useHistoryFeesBreakdown'
 import { FeeBreakdownRow } from '../shared/FeeBreakdownRow'
-import { EXECUTION_FEE_TOOLTIP, GAS_FEE_TOOLTIP } from '../shared/tooltips'
+import { GAS_FEE_TOOLTIP } from '../shared/tooltips'
 import css from './styles.module.css'
 import accordionCss from '@/styles/accordion.module.css'
 
@@ -84,7 +84,7 @@ const HistoryFeesAccordion = ({
 
       <AccordionDetails sx={{ p: 0 }}>
         <div className={css.breakdownContainer}>
-          <FeeBreakdownRow {...data.executionFee} tooltip={EXECUTION_FEE_TOOLTIP} strikeAs="del" />
+          <FeeBreakdownRow {...data.executionFee} strikeAs="del" />
           <FeeBreakdownRow {...data.gasFee} tooltip={GAS_FEE_TOOLTIP} strikeAs="del" />
         </div>
       </AccordionDetails>


### PR DESCRIPTION
Hide the execution fee info tooltip in the live fees preview and the history fees accordion while the fee model is still being introduced. The tooltip copy is retained in shared/tooltips.ts for later phases.

## What it solves

Resolves: https://linear.app/safe-global/issue/PLA-1692/delete-tooltip-execution-fee

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
