### PR TITLE
feat(web): enable UTF-8 for names (AB, Members, Spaces)

### DIFF
--- a/apps/web/cypress/e2e/pages/address_book.page.js
+++ b/apps/web/cypress/e2e/pages/address_book.page.js
@@ -34,7 +34,7 @@ const exportBtn = 'Export'
 const whatsNewBtnStr = "What's new"
 const beamrCookiesStr = 'accept the "Beamer" cookies'
 const headerImportBtnStr = 'Import'
-const mandatoryNameStr = 'Name *'
+const requiredNameStr = 'Required'
 const nameSortBtn = 'Name'
 const addressortBtn = 'Address'
 const addToAddressBookStr = 'Add to address book'
@@ -241,5 +241,5 @@ export function verifyBeameriFrameExists() {
 export function verifyEmptyOwnerNameNotAllowed() {
   cy.get(main.nameInput).clear()
   main.verifyElementsStatus([saveBtn], constants.enabledStates.disabled)
-  cy.get(divInput).contains(mandatoryNameStr)
+  cy.get(divInput).contains(requiredNameStr)
 }

--- a/apps/web/cypress/e2e/pages/load_safe.pages.js
+++ b/apps/web/cypress/e2e/pages/load_safe.pages.js
@@ -6,7 +6,7 @@ import { addressBookRecipient } from '../pages/address_book.page'
 const addExistingAccountBtnStr = 'Add existing one'
 const contactStr = 'Choose address, network and a name'
 export const invalidAddressFormatErrorMsg = 'Invalid address format'
-const invalidAddressNameLengthErrorMsg = 'Maximum 50 symbols'
+const invalidAddressNameLengthErrorMsg = constants.addressBookErrrMsg.exceedChars
 
 const safeDataForm = '[data-testid=load-safe-form]'
 const removeOwnerBtn = '[data-testid="remove-owner-btn"]'

--- a/apps/web/cypress/e2e/pages/spaces.page.js
+++ b/apps/web/cypress/e2e/pages/spaces.page.js
@@ -1,6 +1,7 @@
 import * as constants from '../../support/constants.js'
 import * as main from './main.page.js'
 import * as navigation from './navigation.page.js'
+import * as wallet from '../../support/utils/wallet.js'
 
 // ===========================================
 // Selectors
@@ -185,6 +186,18 @@ const spaceDashboardWidgetSelectorByTitle = {
 
 export function clickOnSignInBtn() {
   cy.get(continueWithWalletBtn).click()
+}
+
+// Authenticate past the require-login gate, then visit a login-gated page.
+// The global beforeEach in support/e2e.js clears cookies/storage before every
+// test, so the gated UI must be unlocked per test, not once in `before`.
+export function signInAndVisit(url, signer) {
+  blockBeamer()
+  cy.visit(constants.spacesUrl)
+  wallet.connectSigner(signer)
+  clickOnSignInBtn()
+  waitForSpacesWelcomeReady()
+  cy.visit(url)
 }
 
 export function blockBeamer() {

--- a/apps/web/cypress/e2e/regression/address_book.cy.js
+++ b/apps/web/cypress/e2e/regression/address_book.cy.js
@@ -6,7 +6,7 @@ import * as main from '../../e2e/pages/main.page'
 import * as ls from '../../support/localstorage_data.js'
 import * as accountsModal from '../pages/accounts_modal.pages.js'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
-import * as wallet from '../../support/utils/wallet.js'
+import * as space from '../pages/spaces.page.js'
 
 let staticSafes = []
 const walletCredentials = JSON.parse(Cypress.env('CYPRESS_WALLET_CREDENTIALS'))
@@ -22,7 +22,7 @@ describe('Address book tests', () => {
   })
 
   beforeEach(() => {
-    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4)
+    space.signInAndVisit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4, signer)
   })
 
   it('Verify owners name can be edited', () => {
@@ -122,7 +122,6 @@ describe('Address book tests', () => {
         addressBook.clickOnImportFileBtn()
         addressBook.importCSVFile(addressBook.addedSafesCSVFile)
         addressBook.clickOnImportBtn()
-        wallet.connectSigner(signer)
         accountsModal.openAccountsModal()
         accountsModal.verifyAccountsListContains(importedSafe)
       })

--- a/apps/web/cypress/e2e/regression/address_book_2.cy.js
+++ b/apps/web/cypress/e2e/regression/address_book_2.cy.js
@@ -5,9 +5,12 @@ import * as ls from '../../support/localstorage_data.js'
 import * as createtx from '../../e2e/pages/create_tx.pages'
 import * as data from '../../fixtures/txhistory_data_data.json'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
+import * as space from '../pages/spaces.page.js'
 
 let staticSafes = []
 
+const walletCredentials = JSON.parse(Cypress.env('CYPRESS_WALLET_CREDENTIALS'))
+const signer = walletCredentials.OWNER_4_PRIVATE_KEY
 const typeReceive = data.type.receive
 
 const owner1 = 'Automation owner'
@@ -20,7 +23,7 @@ describe('Address book tests - 2', () => {
   })
 
   beforeEach(() => {
-    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4)
+    space.signInAndVisit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4, signer)
   })
 
   it('Verify Name and Address columns sorting works', () => {

--- a/apps/web/cypress/e2e/regression/address_book_3.cy.js
+++ b/apps/web/cypress/e2e/regression/address_book_3.cy.js
@@ -4,6 +4,7 @@ import * as main from '../pages/main.page.js'
 import * as ls from '../../support/localstorage_data.js'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 import * as wallet from '../../support/utils/wallet.js'
+import * as space from '../pages/spaces.page.js'
 
 let staticSafes = []
 
@@ -22,7 +23,7 @@ describe('Address book tests - 3', () => {
   })
 
   beforeEach(() => {
-    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4)
+    space.signInAndVisit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4, signer)
   })
 
   it('Verify entry can be added', () => {

--- a/apps/web/cypress/e2e/smoke/tokens.cy.js
+++ b/apps/web/cypress/e2e/smoke/tokens.cy.js
@@ -3,8 +3,11 @@ import * as main from '../pages/main.page'
 import * as assets from '../pages/assets.pages'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 import * as ls from '../../support/localstorage_data.js'
+import * as space from '../pages/spaces.page.js'
 
 let staticSafes = []
+const walletCredentials = JSON.parse(Cypress.env('CYPRESS_WALLET_CREDENTIALS'))
+const signer = walletCredentials.OWNER_4_PRIVATE_KEY
 
 describe('[SMOKE] Tokens tests', () => {
   before(async () => {
@@ -15,11 +18,12 @@ describe('[SMOKE] Tokens tests', () => {
       constants.localStorageKeys.SAFE_v2__tokenlist_onboarding,
       ls.cookies.acceptedTokenListOnboarding,
     )
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_2)
+    space.signInAndVisit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_2, signer)
   })
 
   // Added to prod
   it('Verify that when owner is disconnected, Send button is disabled', () => {
+    space.disconnectFromSpaceLevel()
     assets.toggleShowAllTokens(true)
     assets.toggleHideDust(false)
     assets.showSendBtn(0)

--- a/apps/web/cypress/support/constants.js
+++ b/apps/web/cypress/support/constants.js
@@ -249,7 +249,7 @@ export const tokenNames = {
 export const addressBookErrrMsg = {
   invalidFormat: 'Invalid address format',
   invalidChecksum: 'Invalid address checksum',
-  exceedChars: 'Maximum 50 symbols',
+  exceedChars: 'Names must be at most 50 characters long',
   ownSafeManage: 'The Safe account cannot own itself',
   ownSafe: 'Cannot use Safe account itself as signer',
   alreadyAdded: 'Address already added',

--- a/apps/web/src/components/address-book/EntryDialog/index.tsx
+++ b/apps/web/src/components/address-book/EntryDialog/index.tsx
@@ -5,7 +5,7 @@ import { FormProvider, useForm } from 'react-hook-form'
 import AddressInput from '@/components/common/AddressInput'
 import ModalDialog from '@/components/common/ModalDialog'
 import NameInput from '@/components/common/NameInput'
-import { ADDRESS_BOOK_NAME_MAX_LENGTH, NAME_MIN_LENGTH } from '@safe-global/utils/validation/names'
+import { ADDRESS_BOOK_NAME_MAX_LENGTH, NAME_MIN_LENGTH, sanitizeName } from '@safe-global/utils/validation/names'
 import useChainId from '@/hooks/useChainId'
 import { useAppDispatch } from '@/store'
 import { upsertAddressBookEntries } from '@/store/addressBookSlice'
@@ -47,7 +47,13 @@ function EntryDialog({
   const { handleSubmit, formState } = methods
 
   const submitCallback = handleSubmit((data: AddressEntry) => {
-    dispatch(upsertAddressBookEntries({ ...data, chainIds: chainIds ?? [actualChainId] }))
+    dispatch(
+      upsertAddressBookEntries({
+        address: data.address,
+        name: sanitizeName(data.name),
+        chainIds: chainIds ?? [actualChainId],
+      }),
+    )
     handleClose()
   })
 

--- a/apps/web/src/components/address-book/EntryDialog/index.tsx
+++ b/apps/web/src/components/address-book/EntryDialog/index.tsx
@@ -5,6 +5,7 @@ import { FormProvider, useForm } from 'react-hook-form'
 import AddressInput from '@/components/common/AddressInput'
 import ModalDialog from '@/components/common/ModalDialog'
 import NameInput from '@/components/common/NameInput'
+import { ADDRESS_BOOK_NAME_MAX_LENGTH, NAME_MIN_LENGTH } from '@safe-global/utils/validation/names'
 import useChainId from '@/hooks/useChainId'
 import { useAppDispatch } from '@/store'
 import { upsertAddressBookEntries } from '@/store/addressBookSlice'
@@ -69,7 +70,15 @@ function EntryDialog({
         <form onSubmit={onSubmit}>
           <DialogContent>
             <Box mb={2}>
-              <NameInput data-testid="name-input" label="Name" autoFocus name="name" required />
+              <NameInput
+                data-testid="name-input"
+                label="Name"
+                autoFocus
+                name="name"
+                required
+                minLength={NAME_MIN_LENGTH}
+                maxLength={ADDRESS_BOOK_NAME_MAX_LENGTH}
+              />
             </Box>
 
             <Box>

--- a/apps/web/src/components/address-book/ExportDialog/index.test.tsx
+++ b/apps/web/src/components/address-book/ExportDialog/index.test.tsx
@@ -23,6 +23,18 @@ describe('ExportDialog', () => {
         { address: '0x2', name: 'Alice Cooper', chainId: '100' },
       ])
     })
+
+    it('neutralizes CSV formula-injection in cell values', () => {
+      const addressBooks = {
+        '4': {
+          '=cmd|/c calc': '=HYPERLINK("http://evil")',
+        },
+      }
+
+      expect(_getCsvData(addressBooks)).toStrictEqual([
+        { address: "'=cmd|/c calc", name: '\'=HYPERLINK("http://evil")', chainId: '4' },
+      ])
+    })
   })
 
   it('should render the export dialog', () => {

--- a/apps/web/src/components/address-book/ExportDialog/index.tsx
+++ b/apps/web/src/components/address-book/ExportDialog/index.tsx
@@ -13,6 +13,7 @@ import { trackEvent, ADDRESS_BOOK_EVENTS } from '@/services/analytics'
 import ExternalLink from '@/components/common/ExternalLink'
 import madProps from '@/utils/mad-props'
 import { HelpCenterArticle } from '@safe-global/utils/config/constants'
+import { escapeCsvFormula } from '@safe-global/utils/utils/csv'
 
 const COL_1 = 'address'
 const COL_2 = 'name'
@@ -24,9 +25,9 @@ export const _getCsvData = (addressBooks: AddressBookState): CsvData => {
   const csvData = Object.entries(addressBooks).reduce<CsvData>((acc, [chainId, entries]) => {
     Object.entries(entries).forEach(([address, name]) => {
       acc.push({
-        [COL_1]: address,
-        [COL_2]: name,
-        [COL_3]: chainId,
+        [COL_1]: escapeCsvFormula(address),
+        [COL_2]: escapeCsvFormula(name),
+        [COL_3]: escapeCsvFormula(chainId),
       })
     })
 

--- a/apps/web/src/components/address-book/ImportDialog/__tests__/validation.test.ts
+++ b/apps/web/src/components/address-book/ImportDialog/__tests__/validation.test.ts
@@ -79,13 +79,34 @@ describe('Address book import validation', () => {
       expect(hasValidAbNames(entries)).toBe(true)
     })
 
-    it('should return false if any entry has invalid names', () => {
+    it('should return false if any entry has an empty name', () => {
       const entries = [
         ['0xAb5e3288640396C3988af5a820510682f3C58adF', '', 'chainId'],
         ['0x1F2504De05f5167650bEA', 'name2', 'chainId2'],
       ]
 
       expect(hasValidAbNames(entries)).toBe(false)
+    })
+
+    it('should return false if any name is shorter than the minimum', () => {
+      const entries = [['0xAb5e3288640396C3988af5a820510682f3C58adF', 'Jo', 'chainId']]
+
+      expect(hasValidAbNames(entries)).toBe(false)
+    })
+
+    it('should return false if any name contains disallowed characters', () => {
+      const entries = [['0xAb5e3288640396C3988af5a820510682f3C58adF', 'Bad<script>', 'chainId']]
+
+      expect(hasValidAbNames(entries)).toBe(false)
+    })
+
+    it('should return true for accented and punctuation names', () => {
+      const entries = [
+        ['0xAb5e3288640396C3988af5a820510682f3C58adF', 'José', 'chainId'],
+        ['0x1F2504De05f5167650bE5B28c472601Be434b60A', 'Smith & Co.', 'chainId'],
+      ]
+
+      expect(hasValidAbNames(entries)).toBe(true)
     })
   })
 
@@ -159,17 +180,17 @@ describe('Address book import validation', () => {
       expect(abOnUploadValidator(result)).toBe('Address book contains an invalid address on row 2')
     })
 
-    it('should return an error if some entries have empty names', () => {
+    it('should return an error with the row and reason for an invalid name', () => {
       const result = {
         data: [
           ['address', 'name', 'chainId'],
-          ['0xAb5e3288640396C3988af5a820510682f3C58adF', '', '1'],
+          ['0xAb5e3288640396C3988af5a820510682f3C58adF', 'Bad<script>', '1'],
         ],
         errors: [],
         meta: {} as ParseMeta,
       } as ParseResult<string[]>
 
-      expect(abOnUploadValidator(result)).toBe('Address book contains an invalid name on row 2')
+      expect(abOnUploadValidator(result)).toMatch(/^Address book contains an invalid name on row 2: /)
     })
   })
 })

--- a/apps/web/src/components/address-book/ImportDialog/__tests__/validation.test.ts
+++ b/apps/web/src/components/address-book/ImportDialog/__tests__/validation.test.ts
@@ -108,6 +108,12 @@ describe('Address book import validation', () => {
 
       expect(hasValidAbNames(entries)).toBe(true)
     })
+
+    it('should return false if a row has no name column', () => {
+      const entries = [['0xAb5e3288640396C3988af5a820510682f3C58adF']]
+
+      expect(hasValidAbNames(entries)).toBe(false)
+    })
   })
 
   describe('abOnUploadValidator', () => {

--- a/apps/web/src/components/address-book/ImportDialog/__tests__/validation.test.ts
+++ b/apps/web/src/components/address-book/ImportDialog/__tests__/validation.test.ts
@@ -88,16 +88,16 @@ describe('Address book import validation', () => {
       expect(hasValidAbNames(entries)).toBe(false)
     })
 
-    it('should return false if any name is shorter than the minimum', () => {
+    it('should return true for short names (local address book has no length restriction)', () => {
       const entries = [['0xAb5e3288640396C3988af5a820510682f3C58adF', 'Jo', 'chainId']]
 
-      expect(hasValidAbNames(entries)).toBe(false)
+      expect(hasValidAbNames(entries)).toBe(true)
     })
 
-    it('should return false if any name contains disallowed characters', () => {
+    it('should return true for names with special characters (local address book has no character restrictions)', () => {
       const entries = [['0xAb5e3288640396C3988af5a820510682f3C58adF', 'Bad<script>', 'chainId']]
 
-      expect(hasValidAbNames(entries)).toBe(false)
+      expect(hasValidAbNames(entries)).toBe(true)
     })
 
     it('should return true for accented and punctuation names', () => {
@@ -186,7 +186,7 @@ describe('Address book import validation', () => {
       expect(abOnUploadValidator(result)).toBe('Address book contains an invalid address on row 2')
     })
 
-    it('should return an error with the row and reason for an invalid name', () => {
+    it('should return undefined for names with special characters (local address book has no character restrictions)', () => {
       const result = {
         data: [
           ['address', 'name', 'chainId'],
@@ -196,7 +196,7 @@ describe('Address book import validation', () => {
         meta: {} as ParseMeta,
       } as ParseResult<string[]>
 
-      expect(abOnUploadValidator(result)).toMatch(/^Address book contains an invalid name on row 2: /)
+      expect(abOnUploadValidator(result)).toBeUndefined()
     })
   })
 })

--- a/apps/web/src/components/address-book/ImportDialog/index.tsx
+++ b/apps/web/src/components/address-book/ImportDialog/index.tsx
@@ -1,6 +1,7 @@
 import DialogContent from '@mui/material/DialogContent'
 import DialogActions from '@mui/material/DialogActions'
 import Button from '@mui/material/Button'
+import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { useCSVReader, formatFileSize } from 'react-papaparse'
 import type { ParseResult } from 'papaparse'
@@ -129,11 +130,13 @@ const ImportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
               ? {
                   name: acceptedFile.name,
                   additionalInfo: formatFileSize(acceptedFile.size),
-                  summary: [
-                    <Typography data-testid="summary-message" key="abSummary">
-                      {`Found ${entryCount} entries on ${chainCount} ${chainCount > 1 ? 'chains' : 'chain'}`}
-                    </Typography>,
-                  ],
+                  summary: error
+                    ? []
+                    : [
+                        <Typography data-testid="summary-message" key="abSummary">
+                          {`Found ${entryCount} entries on ${chainCount} ${chainCount > 1 ? 'chains' : 'chain'}`}
+                        </Typography>,
+                      ],
                 }
               : undefined
 
@@ -151,7 +154,11 @@ const ImportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
 
         <div className={css.horizontalDivider} />
 
-        {error && <ErrorMessage>{error}</ErrorMessage>}
+        {error && (
+          <Box my={2}>
+            <ErrorMessage>{error}</ErrorMessage>
+          </Box>
+        )}
 
         <Typography>
           Only CSV files exported from a {BRAND_NAME} can be imported.

--- a/apps/web/src/components/address-book/ImportDialog/index.tsx
+++ b/apps/web/src/components/address-book/ImportDialog/index.tsx
@@ -8,6 +8,7 @@ import { type ReactElement, useState, type MouseEvent, useMemo } from 'react'
 
 import ModalDialog from '@/components/common/ModalDialog'
 import { upsertAddressBookEntries } from '@/store/addressBookSlice'
+import { sanitizeName } from '@safe-global/utils/validation/names'
 import { useAppDispatch } from '@/store'
 
 import css from './styles.module.css'
@@ -61,7 +62,7 @@ const ImportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
 
     for (const entry of entries) {
       const [address, name, chainId] = entry
-      dispatch(upsertAddressBookEntries({ address, name, chainIds: [chainId.trim()] }))
+      dispatch(upsertAddressBookEntries({ address, name: sanitizeName(name), chainIds: [chainId.trim()] }))
     }
 
     trackEvent({ ...ADDRESS_BOOK_EVENTS.IMPORT, label: entries.length })

--- a/apps/web/src/components/address-book/ImportDialog/validation.ts
+++ b/apps/web/src/components/address-book/ImportDialog/validation.ts
@@ -3,6 +3,7 @@ import type { ParseResult } from 'papaparse'
 import { validateAddress } from '@safe-global/utils/utils/validation'
 import {
   ADDRESS_BOOK_NAME_MAX_LENGTH,
+  EMPTY_NAME_MESSAGE,
   NAME_MIN_LENGTH,
   sanitizeName,
   validateName,
@@ -23,7 +24,7 @@ export const hasValidAbEntryAddresses = (entries: string[][]) => {
 }
 
 export const getAbNameError = (name: string | undefined): string | undefined => {
-  if (!name) return 'name is empty'
+  if (!name) return EMPTY_NAME_MESSAGE
   return validateName(sanitizeName(name), {
     minLength: NAME_MIN_LENGTH,
     maxLength: ADDRESS_BOOK_NAME_MAX_LENGTH,
@@ -31,7 +32,7 @@ export const getAbNameError = (name: string | undefined): string | undefined => 
 }
 
 export const hasValidAbNames = (entries: string[][]) => {
-  return entries.every((entry) => entry.length >= 2 && !getAbNameError(entry[1]))
+  return entries.every((entry) => !getAbNameError(entry[1]))
 }
 
 export const abOnUploadValidator = ({ data, errors }: ParseResult<string[]>): string | undefined => {
@@ -66,9 +67,9 @@ export const abOnUploadValidator = ({ data, errors }: ParseResult<string[]>): st
   }
 
   // An entry has invalid name
-  if (!hasValidAbNames(entries)) {
-    const i = entries.findIndex((entry) => (entry.length >= 2 ? getAbNameError(entry[1]) : true))
-    const reason = entries[i]?.length >= 2 ? getAbNameError(entries[i][1]) : 'name is missing'
-    return `Address book contains an invalid name on row ${i + 2}: ${reason}`
+  const invalidNameIndex = entries.findIndex((entry) => getAbNameError(entry[1]))
+  if (invalidNameIndex !== -1) {
+    const reason = getAbNameError(entries[invalidNameIndex][1])
+    return `Address book contains an invalid name on row ${invalidNameIndex + 2}: ${reason}`
   }
 }

--- a/apps/web/src/components/address-book/ImportDialog/validation.ts
+++ b/apps/web/src/components/address-book/ImportDialog/validation.ts
@@ -1,6 +1,12 @@
 import type { ParseResult } from 'papaparse'
 
 import { validateAddress } from '@safe-global/utils/utils/validation'
+import {
+  ADDRESS_BOOK_NAME_MAX_LENGTH,
+  NAME_MIN_LENGTH,
+  sanitizeName,
+  validateName,
+} from '@safe-global/utils/validation/names'
 
 export const abCsvReaderValidator = ({ size }: File): string[] | undefined => {
   if (size > 1_000_000) {
@@ -16,8 +22,16 @@ export const hasValidAbEntryAddresses = (entries: string[][]) => {
   return entries.every((entry) => entry.length >= 1 && !validateAddress(entry[0]))
 }
 
+export const getAbNameError = (name: string | undefined): string | undefined => {
+  if (!name) return 'name is empty'
+  return validateName(sanitizeName(name), {
+    minLength: NAME_MIN_LENGTH,
+    maxLength: ADDRESS_BOOK_NAME_MAX_LENGTH,
+  })
+}
+
 export const hasValidAbNames = (entries: string[][]) => {
-  return entries.every((entry) => entry.length >= 2 && !!entry[1])
+  return entries.every((entry) => entry.length >= 2 && !getAbNameError(entry[1]))
 }
 
 export const abOnUploadValidator = ({ data, errors }: ParseResult<string[]>): string | undefined => {
@@ -53,7 +67,8 @@ export const abOnUploadValidator = ({ data, errors }: ParseResult<string[]>): st
 
   // An entry has invalid name
   if (!hasValidAbNames(entries)) {
-    const i = entries.findIndex((entry) => (entry.length >= 2 ? !entry[1] : true))
-    return `Address book contains an invalid name on row ${i + 2}`
+    const i = entries.findIndex((entry) => (entry.length >= 2 ? getAbNameError(entry[1]) : true))
+    const reason = entries[i]?.length >= 2 ? getAbNameError(entries[i][1]) : 'name is missing'
+    return `Address book contains an invalid name on row ${i + 2}: ${reason}`
   }
 }

--- a/apps/web/src/components/address-book/ImportDialog/validation.ts
+++ b/apps/web/src/components/address-book/ImportDialog/validation.ts
@@ -1,13 +1,7 @@
 import type { ParseResult } from 'papaparse'
 
 import { validateAddress } from '@safe-global/utils/utils/validation'
-import {
-  ADDRESS_BOOK_NAME_MAX_LENGTH,
-  EMPTY_NAME_MESSAGE,
-  NAME_MIN_LENGTH,
-  sanitizeName,
-  validateName,
-} from '@safe-global/utils/validation/names'
+import { EMPTY_NAME_MESSAGE } from '@safe-global/utils/validation/names'
 
 export const abCsvReaderValidator = ({ size }: File): string[] | undefined => {
   if (size > 1_000_000) {
@@ -25,10 +19,7 @@ export const hasValidAbEntryAddresses = (entries: string[][]) => {
 
 export const getAbNameError = (name: string | undefined): string | undefined => {
   if (!name) return EMPTY_NAME_MESSAGE
-  return validateName(sanitizeName(name), {
-    minLength: NAME_MIN_LENGTH,
-    maxLength: ADDRESS_BOOK_NAME_MAX_LENGTH,
-  })
+  return undefined
 }
 
 export const hasValidAbNames = (entries: string[][]) => {

--- a/apps/web/src/components/common/FileUpload/FileUpload.test.tsx
+++ b/apps/web/src/components/common/FileUpload/FileUpload.test.tsx
@@ -1,0 +1,59 @@
+import { render, fireEvent } from '@/tests/test-utils'
+import FileUpload, { FileTypes, type FileInfo } from './index'
+
+const getRootProps = <T,>(props?: T): T => (props ?? {}) as T
+const onRemove = jest.fn()
+
+const renderUpload = (fileInfo?: FileInfo) =>
+  render(<FileUpload fileType={FileTypes.CSV} getRootProps={getRootProps} onRemove={onRemove} fileInfo={fileInfo} />)
+
+describe('FileUpload', () => {
+  beforeEach(() => onRemove.mockClear())
+
+  it('renders the dropzone prompt when no file is selected', () => {
+    const { getByTestId, getByText } = renderUpload()
+
+    expect(getByTestId('file-upload-section')).toBeInTheDocument()
+    expect(getByText(/Drag and drop a CSV file/)).toBeInTheDocument()
+  })
+
+  it('calls onRemove when the remove button is clicked', () => {
+    const { getByRole } = renderUpload({ name: 'address-book.csv', summary: [] })
+
+    fireEvent.click(getByRole('button'))
+    expect(onRemove).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the connector line and summary when there are summary rows', () => {
+    const { getByTestId, getByText } = renderUpload({
+      name: 'address-book.csv',
+      additionalInfo: '1 KB',
+      summary: [<span key="s">Found 3 entries on 1 chain</span>],
+    })
+
+    expect(getByText('Found 3 entries on 1 chain')).toBeInTheDocument()
+    expect(getByTestId('file-upload-connector')).toBeInTheDocument()
+  })
+
+  it('hides the connector line and summary when entries are invalid (empty summary, no error)', () => {
+    const { queryByTestId, queryByText } = renderUpload({
+      name: 'address-book.csv',
+      additionalInfo: '1 KB',
+      summary: [],
+    })
+
+    expect(queryByText(/Found .* entries/)).not.toBeInTheDocument()
+    expect(queryByTestId('file-upload-connector')).not.toBeInTheDocument()
+  })
+
+  it('shows the connector line when there is an error but no summary rows', () => {
+    const { getByTestId, getByText } = renderUpload({
+      name: 'address-book.csv',
+      summary: [],
+      error: 'Invalid file',
+    })
+
+    expect(getByText('Invalid file')).toBeInTheDocument()
+    expect(getByTestId('file-upload-connector')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/common/FileUpload/index.tsx
+++ b/apps/web/src/components/common/FileUpload/index.tsx
@@ -60,16 +60,18 @@ const UploadSummary = ({ fileInfo, onRemove }: { fileInfo: FileInfo; onRemove: (
           </IconButton>
         </Grid>
       </Grid>
-      <Grid
-        item
-        xs={12}
-        sx={{
-          display: 'flex',
-          justifyContent: 'flex-start',
-        }}
-      >
-        <div className={css.verticalLine} />
-      </Grid>
+      {(fileInfo.summary.length > 0 || fileInfo.error) && (
+        <Grid
+          item
+          xs={12}
+          sx={{
+            display: 'flex',
+            justifyContent: 'flex-start',
+          }}
+        >
+          <div data-testid="file-upload-connector" className={css.verticalLine} />
+        </Grid>
+      )}
       <>
         {fileInfo.summary.map((summaryItem, idx) => (
           <Grid

--- a/apps/web/src/components/common/NameInput/NameInput.test.tsx
+++ b/apps/web/src/components/common/NameInput/NameInput.test.tsx
@@ -1,0 +1,81 @@
+import { NAME_MIN_LENGTH, DISALLOWED_CHARACTER_MESSAGE } from '@safe-global/utils/validation/names'
+import { useForm, FormProvider } from 'react-hook-form'
+import { fireEvent, render, screen, waitFor } from '@/tests/test-utils'
+import NameInput from '.'
+
+const TestForm = ({ children }: { children: React.ReactNode }) => {
+  const methods = useForm({ mode: 'onChange', defaultValues: { name: '' } })
+  return <FormProvider {...methods}>{children}</FormProvider>
+}
+
+const renderNameInput = (props: Partial<React.ComponentProps<typeof NameInput>> = {}) =>
+  render(
+    <TestForm>
+      <NameInput name="name" label="Name" {...props} />
+    </TestForm>,
+  )
+
+const typeName = (value: string) => {
+  const input = screen.getByLabelText('Name', { exact: false })
+  fireEvent.change(input, { target: { value } })
+  return input
+}
+
+describe('NameInput', () => {
+  it('accepts a valid name', async () => {
+    renderNameInput({ minLength: NAME_MIN_LENGTH })
+    typeName('Alice')
+
+    await waitFor(() => {
+      expect(screen.queryByText(DISALLOWED_CHARACTER_MESSAGE)).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows the disallowed-character message for invalid input', async () => {
+    renderNameInput({ minLength: NAME_MIN_LENGTH })
+    typeName('Alice<script>')
+
+    expect((await screen.findAllByText(DISALLOWED_CHARACTER_MESSAGE)).length).toBeGreaterThan(0)
+  })
+
+  it('enforces the minimum length when minLength is set', async () => {
+    renderNameInput({ minLength: NAME_MIN_LENGTH })
+    typeName('Jo')
+
+    expect((await screen.findAllByText('Names must be at least 3 character(s) long')).length).toBeGreaterThan(0)
+  })
+
+  it('does not enforce a minimum length by default', async () => {
+    renderNameInput()
+    typeName('Jo')
+
+    await waitFor(() => {
+      expect(screen.queryByText(/at least/)).not.toBeInTheDocument()
+    })
+  })
+
+  it('enforces the maximum length', async () => {
+    renderNameInput({ maxLength: 5 })
+    typeName('abcdef')
+
+    expect((await screen.findAllByText('Names must be at most 5 characters long')).length).toBeGreaterThan(0)
+  })
+
+  it('sanitizes the value on blur', async () => {
+    renderNameInput()
+    const input = typeName('  O’Brien  ') as HTMLInputElement
+    fireEvent.blur(input)
+
+    await waitFor(() => {
+      expect(input.value).toBe("O'Brien")
+    })
+  })
+
+  it('shows Required when empty and required', async () => {
+    renderNameInput({ required: true })
+    const input = typeName('abc')
+    fireEvent.change(input, { target: { value: '' } })
+
+    expect((await screen.findAllByText('Required')).length).toBeGreaterThan(0)
+  })
+})

--- a/apps/web/src/components/common/NameInput/NameInput.test.tsx
+++ b/apps/web/src/components/common/NameInput/NameInput.test.tsx
@@ -1,4 +1,8 @@
-import { NAME_MIN_LENGTH, DISALLOWED_CHARACTER_MESSAGE } from '@safe-global/utils/validation/names'
+import {
+  DISALLOWED_CHARACTER_MESSAGE,
+  DISALLOWED_CHARACTER_SHORT_MESSAGE,
+  NAME_MIN_LENGTH,
+} from '@safe-global/utils/validation/names'
 import { useForm, FormProvider } from 'react-hook-form'
 import { fireEvent, render, screen, waitFor } from '@/tests/test-utils'
 import NameInput from '.'
@@ -16,7 +20,7 @@ const renderNameInput = (props: Partial<React.ComponentProps<typeof NameInput>> 
   )
 
 const typeName = (value: string) => {
-  const input = screen.getByLabelText('Name', { exact: false })
+  const input = screen.getByRole('textbox')
   fireEvent.change(input, { target: { value } })
   return input
 }
@@ -31,18 +35,30 @@ describe('NameInput', () => {
     })
   })
 
-  it('shows the disallowed-character message for invalid input', async () => {
+  it('shows invalid characters in the label with full details in a tooltip', async () => {
     renderNameInput({ minLength: NAME_MIN_LENGTH })
     typeName('Alice<script>')
 
-    expect((await screen.findAllByText(DISALLOWED_CHARACTER_MESSAGE)).length).toBeGreaterThan(0)
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: DISALLOWED_CHARACTER_SHORT_MESSAGE })).toHaveAttribute(
+        'aria-invalid',
+        'true',
+      )
+    })
+    expect(screen.getByTitle(DISALLOWED_CHARACTER_MESSAGE)).toBeInTheDocument()
+    expect(screen.queryByRole('textbox', { name: 'Name' })).not.toBeInTheDocument()
   })
 
   it('enforces the minimum length when minLength is set', async () => {
     renderNameInput({ minLength: NAME_MIN_LENGTH })
     typeName('Jo')
 
-    expect((await screen.findAllByText('Names must be at least 3 character(s) long')).length).toBeGreaterThan(0)
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: 'Names must be at least 3 character(s) long' })).toHaveAttribute(
+        'aria-invalid',
+        'true',
+      )
+    })
   })
 
   it('does not enforce a minimum length by default', async () => {
@@ -58,7 +74,12 @@ describe('NameInput', () => {
     renderNameInput({ maxLength: 5 })
     typeName('abcdef')
 
-    expect((await screen.findAllByText('Names must be at most 5 characters long')).length).toBeGreaterThan(0)
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: 'Names must be at most 5 characters long' })).toHaveAttribute(
+        'aria-invalid',
+        'true',
+      )
+    })
   })
 
   it('sanitizes the value on blur', async () => {
@@ -76,6 +97,8 @@ describe('NameInput', () => {
     const input = typeName('abc')
     fireEvent.change(input, { target: { value: '' } })
 
-    expect((await screen.findAllByText('Required')).length).toBeGreaterThan(0)
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: 'Required' })).toHaveAttribute('aria-invalid', 'true')
+    })
   })
 })

--- a/apps/web/src/components/common/NameInput/__snapshots__/NameInput.stories.test.tsx.snap
+++ b/apps/web/src/components/common/NameInput/__snapshots__/NameInput.stories.test.tsx.snap
@@ -9,12 +9,14 @@ exports[`./NameInput.stories Default 1`] = `
   >
     <div
       class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root input mui-style-cmpglg-MuiFormControl-root-MuiTextField-root"
+      data-mui-internal-clone-element="true"
+      title=""
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined mui-style-ll8nw6-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="_r_1_"
-        id="_r_1_-label"
+        for="_r_2_"
+        id="_r_2_-label"
       >
         Owner name
       </label>
@@ -24,7 +26,7 @@ exports[`./NameInput.stories Default 1`] = `
         <input
           aria-invalid="false"
           class="MuiInputBase-input MuiOutlinedInput-input mui-style-1eoo0u4-MuiInputBase-input-MuiOutlinedInput-input"
-          id="_r_1_"
+          id="_r_2_"
           name="ownerName"
           type="text"
         />
@@ -55,12 +57,14 @@ exports[`./NameInput.stories Disabled 1`] = `
   >
     <div
       class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root input mui-style-cmpglg-MuiFormControl-root-MuiTextField-root"
+      data-mui-internal-clone-element="true"
+      title=""
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined mui-style-ll8nw6-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="_r_3_"
-        id="_r_3_-label"
+        for="_r_5_"
+        id="_r_5_-label"
       >
         Owner name
       </label>
@@ -71,7 +75,7 @@ exports[`./NameInput.stories Disabled 1`] = `
           aria-invalid="false"
           class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled mui-style-1eoo0u4-MuiInputBase-input-MuiOutlinedInput-input"
           disabled=""
-          id="_r_3_"
+          id="_r_5_"
           name="ownerName"
           type="text"
         />
@@ -102,12 +106,14 @@ exports[`./NameInput.stories Required 1`] = `
   >
     <div
       class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root input mui-style-cmpglg-MuiFormControl-root-MuiTextField-root"
+      data-mui-internal-clone-element="true"
+      title=""
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined mui-style-ll8nw6-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="_r_5_"
-        id="_r_5_-label"
+        for="_r_8_"
+        id="_r_8_-label"
       >
         Owner name
         <span
@@ -124,7 +130,7 @@ exports[`./NameInput.stories Required 1`] = `
         <input
           aria-invalid="false"
           class="MuiInputBase-input MuiOutlinedInput-input mui-style-1eoo0u4-MuiInputBase-input-MuiOutlinedInput-input"
-          id="_r_5_"
+          id="_r_8_"
           name="ownerName"
           required=""
           type="text"
@@ -158,12 +164,14 @@ exports[`./NameInput.stories WithPlaceholder 1`] = `
   >
     <div
       class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root input mui-style-cmpglg-MuiFormControl-root-MuiTextField-root"
+      data-mui-internal-clone-element="true"
+      title=""
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined mui-style-ll8nw6-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="_r_7_"
-        id="_r_7_-label"
+        for="_r_b_"
+        id="_r_b_-label"
       >
         Owner name
       </label>
@@ -173,7 +181,7 @@ exports[`./NameInput.stories WithPlaceholder 1`] = `
         <input
           aria-invalid="false"
           class="MuiInputBase-input MuiOutlinedInput-input mui-style-1eoo0u4-MuiInputBase-input-MuiOutlinedInput-input"
-          id="_r_7_"
+          id="_r_b_"
           name="ownerName"
           placeholder="Enter owner name"
           type="text"

--- a/apps/web/src/components/common/NameInput/index.tsx
+++ b/apps/web/src/components/common/NameInput/index.tsx
@@ -1,6 +1,11 @@
 import type { TextFieldProps } from '@mui/material'
-import { TextField } from '@mui/material'
-import { ADDRESS_BOOK_NAME_MAX_LENGTH, sanitizeName, validateName } from '@safe-global/utils/validation/names'
+import { TextField, Tooltip } from '@mui/material'
+import {
+  ADDRESS_BOOK_NAME_MAX_LENGTH,
+  getNameValidationDisplay,
+  sanitizeName,
+  validateName,
+} from '@safe-global/utils/validation/names'
 import get from 'lodash/get'
 import { Controller, type FieldError, useFormContext } from 'react-hook-form'
 import inputCss from '@/styles/inputs.module.css'
@@ -10,6 +15,9 @@ const NameInput = ({
   required = false,
   minLength = 0,
   maxLength = ADDRESS_BOOK_NAME_MAX_LENGTH,
+  helperText,
+  label,
+  FormHelperTextProps,
   ...props
 }: Omit<TextFieldProps, 'error' | 'variant' | 'ref' | 'fullWidth'> & {
   name: string
@@ -20,6 +28,9 @@ const NameInput = ({
   const { formState, control } = useFormContext() || {}
   // the name can be a path: e.g. "owner.3.name"
   const fieldError = get(formState.errors, name) as FieldError | undefined
+  const validationDisplay = fieldError?.message ? getNameValidationDisplay(fieldError.message) : undefined
+  const resolvedLabel = validationDisplay?.label ?? label
+  const resolvedHelperText = fieldError ? undefined : helperText
 
   return (
     <Controller
@@ -33,24 +44,38 @@ const NameInput = ({
         },
       }}
       // eslint-disable-next-line
-      render={({ field: { ref, onBlur, onChange, ...field } }) => (
-        <TextField
-          {...field}
-          {...props}
-          variant="outlined"
-          label={<>{fieldError?.message || props.label}</>}
-          error={Boolean(fieldError)}
-          fullWidth
-          onChange={(e) => onChange(e)}
-          onBlur={(e) => {
-            onBlur()
-            onChange(sanitizeName(e.target.value))
-          }}
-          required={required}
-          className={inputCss.input}
-          onKeyDown={(e) => e.stopPropagation()}
-        />
-      )}
+      render={({ field: { ref, onBlur, onChange, ...field } }) => {
+        const textField = (
+          <TextField
+            {...field}
+            {...props}
+            variant="outlined"
+            label={resolvedLabel}
+            helperText={resolvedHelperText}
+            FormHelperTextProps={FormHelperTextProps}
+            error={Boolean(fieldError)}
+            fullWidth
+            onChange={(e) => onChange(e)}
+            onBlur={(e) => {
+              onBlur()
+              onChange(sanitizeName(e.target.value))
+            }}
+            required={required}
+            className={inputCss.input}
+            onKeyDown={(e) => e.stopPropagation()}
+          />
+        )
+
+        if (!validationDisplay?.tooltip) {
+          return textField
+        }
+
+        return (
+          <Tooltip title={validationDisplay.tooltip} arrow describeChild>
+            <span style={{ display: 'block', width: '100%' }}>{textField}</span>
+          </Tooltip>
+        )
+      }}
     />
   )
 }

--- a/apps/web/src/components/common/NameInput/index.tsx
+++ b/apps/web/src/components/common/NameInput/index.tsx
@@ -7,6 +7,7 @@ import {
   validateName,
 } from '@safe-global/utils/validation/names'
 import get from 'lodash/get'
+import { useState } from 'react'
 import { Controller, type FieldError, useFormContext } from 'react-hook-form'
 import inputCss from '@/styles/inputs.module.css'
 
@@ -26,11 +27,13 @@ const NameInput = ({
   maxLength?: number
 }) => {
   const { formState, control } = useFormContext() || {}
+  const [isFocused, setIsFocused] = useState(false)
   // the name can be a path: e.g. "owner.3.name"
   const fieldError = get(formState.errors, name) as FieldError | undefined
   const validationDisplay = fieldError?.message ? getNameValidationDisplay(fieldError.message) : undefined
   const resolvedLabel = validationDisplay?.label ?? label
   const resolvedHelperText = fieldError ? undefined : helperText
+  const tooltip = validationDisplay?.tooltip
 
   return (
     <Controller
@@ -44,11 +47,12 @@ const NameInput = ({
         },
       }}
       // eslint-disable-next-line
-      render={({ field: { ref, onBlur, onChange, ...field } }) => {
-        const textField = (
+      render={({ field: { ref, onBlur, onChange, ...field } }) => (
+        <Tooltip title={tooltip ?? ''} open={Boolean(tooltip) && isFocused} arrow describeChild>
           <TextField
             {...field}
             {...props}
+            inputRef={ref}
             variant="outlined"
             label={resolvedLabel}
             helperText={resolvedHelperText}
@@ -56,7 +60,9 @@ const NameInput = ({
             error={Boolean(fieldError)}
             fullWidth
             onChange={(e) => onChange(e)}
+            onFocus={() => setIsFocused(true)}
             onBlur={(e) => {
+              setIsFocused(false)
               onBlur()
               onChange(sanitizeName(e.target.value))
             }}
@@ -64,18 +70,8 @@ const NameInput = ({
             className={inputCss.input}
             onKeyDown={(e) => e.stopPropagation()}
           />
-        )
-
-        if (!validationDisplay?.tooltip) {
-          return textField
-        }
-
-        return (
-          <Tooltip title={validationDisplay.tooltip} arrow describeChild>
-            <span style={{ display: 'block', width: '100%' }}>{textField}</span>
-          </Tooltip>
-        )
-      }}
+        </Tooltip>
+      )}
     />
   )
 }

--- a/apps/web/src/components/common/NameInput/index.tsx
+++ b/apps/web/src/components/common/NameInput/index.tsx
@@ -1,5 +1,6 @@
 import type { TextFieldProps } from '@mui/material'
 import { TextField } from '@mui/material'
+import { ADDRESS_BOOK_NAME_MAX_LENGTH, sanitizeName, validateName } from '@safe-global/utils/validation/names'
 import get from 'lodash/get'
 import { Controller, type FieldError, useFormContext } from 'react-hook-form'
 import inputCss from '@/styles/inputs.module.css'
@@ -7,10 +8,14 @@ import inputCss from '@/styles/inputs.module.css'
 const NameInput = ({
   name,
   required = false,
+  minLength = 0,
+  maxLength = ADDRESS_BOOK_NAME_MAX_LENGTH,
   ...props
 }: Omit<TextFieldProps, 'error' | 'variant' | 'ref' | 'fullWidth'> & {
   name: string
   required?: boolean
+  minLength?: number
+  maxLength?: number
 }) => {
   const { formState, control } = useFormContext() || {}
   // the name can be a path: e.g. "owner.3.name"
@@ -21,11 +26,10 @@ const NameInput = ({
       name={name}
       control={control}
       rules={{
-        maxLength: 50,
-        required,
         validate: (value) => {
-          if (value?.trim() === '' && required) return 'Required'
-          return true
+          const sanitized = sanitizeName(value ?? '')
+          if (sanitized === '') return required ? 'Required' : true
+          return validateName(sanitized, { minLength, maxLength }) ?? true
         },
       }}
       // eslint-disable-next-line
@@ -34,13 +38,13 @@ const NameInput = ({
           {...field}
           {...props}
           variant="outlined"
-          label={<>{fieldError?.type === 'maxLength' ? 'Maximum 50 symbols' : fieldError?.message || props.label}</>}
+          label={<>{fieldError?.message || props.label}</>}
           error={Boolean(fieldError)}
           fullWidth
           onChange={(e) => onChange(e)}
           onBlur={(e) => {
             onBlur()
-            onChange(e.target.value.trim())
+            onChange(sanitizeName(e.target.value))
           }}
           required={required}
           className={inputCss.input}

--- a/apps/web/src/components/common/NameInput/index.tsx
+++ b/apps/web/src/components/common/NameInput/index.tsx
@@ -46,7 +46,6 @@ const NameInput = ({
           return validateName(sanitized, { minLength, maxLength }) ?? true
         },
       }}
-      // eslint-disable-next-line
       render={({ field: { ref, onBlur, onChange, ...field } }) => (
         <Tooltip title={tooltip ?? ''} open={Boolean(tooltip) && isFocused} arrow describeChild>
           <TextField

--- a/apps/web/src/components/settings/owner/EditOwnerDialog/index.tsx
+++ b/apps/web/src/components/settings/owner/EditOwnerDialog/index.tsx
@@ -1,7 +1,7 @@
 import EthHashInfo from '@/components/common/EthHashInfo'
 import ModalDialog from '@/components/common/ModalDialog'
 import NameInput from '@/components/common/NameInput'
-import { ADDRESS_BOOK_NAME_MAX_LENGTH, NAME_MIN_LENGTH } from '@safe-global/utils/validation/names'
+import { ADDRESS_BOOK_NAME_MAX_LENGTH, NAME_MIN_LENGTH, sanitizeName } from '@safe-global/utils/validation/names'
 import Track from '@/components/common/Track'
 import { SETTINGS_EVENTS } from '@/services/analytics/events/settings'
 import { useAppDispatch } from '@/store'
@@ -23,12 +23,13 @@ export const EditOwnerDialog = ({ chainId, address, name }: { chainId: string; a
   const handleClose = () => setOpen(false)
 
   const onSubmit = (data: EditOwnerValues) => {
-    if (data.name !== name) {
+    const sanitizedName = sanitizeName(data.name)
+    if (sanitizedName !== name) {
       dispatch(
         upsertAddressBookEntries({
           chainIds: [chainId],
           address,
-          name: data.name,
+          name: sanitizedName,
         }),
       )
       handleClose()

--- a/apps/web/src/components/settings/owner/EditOwnerDialog/index.tsx
+++ b/apps/web/src/components/settings/owner/EditOwnerDialog/index.tsx
@@ -1,6 +1,7 @@
 import EthHashInfo from '@/components/common/EthHashInfo'
 import ModalDialog from '@/components/common/ModalDialog'
 import NameInput from '@/components/common/NameInput'
+import { ADDRESS_BOOK_NAME_MAX_LENGTH, NAME_MIN_LENGTH } from '@safe-global/utils/validation/names'
 import Track from '@/components/common/Track'
 import { SETTINGS_EVENTS } from '@/services/analytics/events/settings'
 import { useAppDispatch } from '@/store'
@@ -64,7 +65,13 @@ export const EditOwnerDialog = ({ chainId, address, name }: { chainId: string; a
           <form onSubmit={handleSubmit(onSubmit)}>
             <DialogContent>
               <Box py={2}>
-                <NameInput label="Signer name" name="name" required />
+                <NameInput
+                  label="Signer name"
+                  name="name"
+                  required
+                  minLength={NAME_MIN_LENGTH}
+                  maxLength={ADDRESS_BOOK_NAME_MAX_LENGTH}
+                />
               </Box>
 
               <Box py={2}>

--- a/apps/web/src/features/myAccounts/components/AccountItem/AccountItemChainBadge.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItem/AccountItemChainBadge.tsx
@@ -23,12 +23,9 @@ function AccountItemChainBadge({ chainId, safes, className, imageSize = 24 }: Ac
             <NetworkLogosList networks={safes} showHasMore />
           </TooltipTrigger>
           <TooltipContent>
-            <div data-testid="multichain-tooltip">
-              <p className="text-sm">Multichain account on:</p>
+            <div data-testid="multichain-tooltip" className="flex flex-col gap-1">
               {safes.map((safeItem) => (
-                <div key={safeItem.chainId} className="py-1">
-                  <ChainIndicator imageSize={imageSize} chainId={safeItem.chainId} />
-                </div>
+                <ChainIndicator key={safeItem.chainId} imageSize={imageSize} chainId={safeItem.chainId} />
               ))}
             </div>
           </TooltipContent>

--- a/apps/web/src/features/myAccounts/components/NonPinnedWarning/AddTrustedSafeDialog.tsx
+++ b/apps/web/src/features/myAccounts/components/NonPinnedWarning/AddTrustedSafeDialog.tsx
@@ -5,6 +5,7 @@ import ModalDialog from '@/components/common/ModalDialog'
 import WarningAmberIcon from '@mui/icons-material/WarningAmber'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import NameInput from '@/components/common/NameInput'
+import { ADDRESS_BOOK_NAME_MAX_LENGTH, NAME_MIN_LENGTH } from '@safe-global/utils/validation/names'
 import SimilarAddressAlert from './SimilarAddressAlert'
 import type { SimilarAddressInfo } from '../../hooks/useNonPinnedSafeWarning.types'
 
@@ -99,6 +100,8 @@ const AddTrustedSafeDialog = ({
                 label="Safe name"
                 placeholder="Enter a name for this Safe"
                 autoFocus
+                minLength={NAME_MIN_LENGTH}
+                maxLength={ADDRESS_BOOK_NAME_MAX_LENGTH}
               />
             </Box>
           </DialogContent>

--- a/apps/web/src/features/spaces/components/AddMemberModal/MemberInfoForm.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/MemberInfoForm.tsx
@@ -1,4 +1,5 @@
 import NameInput from '@/components/common/NameInput'
+import { MEMBER_NAME_MAX_LENGTH, NAME_MIN_LENGTH } from '@safe-global/utils/validation/names'
 import { Controller, useFormContext } from 'react-hook-form'
 import { MenuItem, Select, Stack } from '@mui/material'
 import { RoleMenuItem } from './index'
@@ -10,7 +11,15 @@ const MemberInfoForm = ({ isEdit = false }: { isEdit?: boolean }) => {
 
   return (
     <Stack direction="row" spacing={2} alignItems="center">
-      <NameInput data-testid="member-name-input" name="name" label="Name" required disabled={isEdit} />
+      <NameInput
+        data-testid="member-name-input"
+        name="name"
+        label="Name"
+        required
+        disabled={isEdit}
+        minLength={NAME_MIN_LENGTH}
+        maxLength={MEMBER_NAME_MAX_LENGTH}
+      />
 
       <Controller
         control={control}

--- a/apps/web/src/features/spaces/components/AddMemberModal/utils.ts
+++ b/apps/web/src/features/spaces/components/AddMemberModal/utils.ts
@@ -1,5 +1,6 @@
 import { isAddress } from 'ethers'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
+import { sanitizeName } from '@safe-global/utils/validation/names'
 import type { MemberRole } from '../../hooks/useSpaceMembers'
 import type { EmailInviteUserDto, WalletInviteUserDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 
@@ -25,13 +26,14 @@ export const normalizeInviteeIdentifier = (value: string): string => value.trim(
 
 export const buildInviteUserPayload = (data: MemberField): InvitePayload => {
   const inviteeIdentifier = normalizeInviteeIdentifier(data.inviteeIdentifier)
+  const name = sanitizeName(data.name)
 
   if (isEmailAddress(inviteeIdentifier)) {
     return {
       type: 'email',
       email: inviteeIdentifier.toLowerCase(),
       role: data.role,
-      name: data.name,
+      name,
     }
   }
 
@@ -39,7 +41,7 @@ export const buildInviteUserPayload = (data: MemberField): InvitePayload => {
     type: 'wallet',
     address: inviteeIdentifier,
     role: data.role,
-    name: data.name,
+    name,
   }
 }
 

--- a/apps/web/src/features/spaces/components/CreateSpaceOnboarding/hooks/useSpaceSubmit.ts
+++ b/apps/web/src/features/spaces/components/CreateSpaceOnboarding/hooks/useSpaceSubmit.ts
@@ -7,6 +7,7 @@ import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { AppRoutes } from '@/config/routes'
 import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
+import { sanitizeName } from '@safe-global/utils/validation/names'
 import { useSafeQueryParam } from '@/hooks/useSafeAddressFromUrl'
 import { sanitizeNextUrl } from '@/utils/nextUrl'
 import type { UseFormHandleSubmit } from 'react-hook-form'
@@ -65,10 +66,12 @@ const useSpaceSubmit = (
     try {
       setIsSubmitting(true)
 
+      const name = sanitizeName(data.name)
+
       if (isEditMode && spaceId) {
-        await editSpace(data.name)
+        await editSpace(name)
       } else {
-        await createSpace(data.name)
+        await createSpace(name)
       }
     } catch (error) {
       const errorMessage =

--- a/apps/web/src/features/spaces/components/CreateSpaceOnboarding/index.tsx
+++ b/apps/web/src/features/spaces/components/CreateSpaceOnboarding/index.tsx
@@ -21,6 +21,7 @@ import useExistingSpace from './hooks/useExistingSpace'
 import useSpaceSubmit from './hooks/useSpaceSubmit'
 import useOnboardingExit from './hooks/useOnboardingExit'
 import { SPACE_NAME_MAX_LENGTH } from '@/features/spaces/constants'
+import { NAME_MIN_LENGTH, sanitizeName, validateName } from '@safe-global/utils/validation/names'
 
 const ONBOARDING_STEP = 1
 const FORM_ID = 'create-space-form'
@@ -50,12 +51,11 @@ const CreateSpaceOnboarding = (): ReactElement => {
   const [hasUserEdited, setHasUserEdited] = useState(false)
   const nameReg = register('name', {
     required: true,
-    maxLength: {
-      value: SPACE_NAME_MAX_LENGTH,
-      message: `Workspace name must be ${SPACE_NAME_MAX_LENGTH} characters or less`,
+    validate: (value) => {
+      const sanitized = sanitizeName(value ?? '')
+      if (sanitized === '') return 'Required'
+      return validateName(sanitized, { minLength: NAME_MIN_LENGTH, maxLength: SPACE_NAME_MAX_LENGTH }) ?? true
     },
-    pattern: { value: /^[a-zA-Z0-9 ]+$/, message: 'Workspace name must not contain special characters' },
-    validate: (value) => value?.trim() !== '',
   })
 
   // spaceId gate avoids leaking lastUsedSpace's safes into a fresh "create" landing.
@@ -103,7 +103,7 @@ const CreateSpaceOnboarding = (): ReactElement => {
             error={errors.name?.message}
             onBlur={(e) => {
               nameReg.onBlur(e)
-              setValue('name', e.target.value.trim(), { shouldValidate: true })
+              setValue('name', sanitizeName(e.target.value), { shouldValidate: true })
             }}
           />
           {isSpaceLoading && (

--- a/apps/web/src/features/spaces/components/InviteBanner/AcceptInviteDialog.tsx
+++ b/apps/web/src/features/spaces/components/InviteBanner/AcceptInviteDialog.tsx
@@ -8,6 +8,8 @@ import { Alert, Box, Button, CircularProgress, DialogActions, DialogContent, Typ
 import { FormProvider, useForm } from 'react-hook-form'
 import ModalDialog from '@/components/common/ModalDialog'
 import NameInput from '@/components/common/NameInput'
+import { MEMBER_NAME_MAX_LENGTH, NAME_MIN_LENGTH, sanitizeName } from '@safe-global/utils/validation/names'
+import { applyBackendNameError } from '@/utils/rtkQuery'
 import { AppRoutes } from '@/config/routes'
 import { useAppDispatch, useAppSelector } from '@/store'
 import { isAuthenticated } from '@/store/authSlice'
@@ -18,7 +20,7 @@ import { showNotification } from '@/store/notificationsSlice'
 import ExternalLink from '@/components/common/ExternalLink'
 
 function AcceptInviteDialog({ space, onClose }: { space: GetSpaceResponse; onClose: () => void }): ReactElement {
-  const [error, setError] = useState<string>()
+  const [localError, setLocalError] = useState<string>()
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const dispatch = useAppDispatch()
@@ -29,17 +31,23 @@ function AcceptInviteDialog({ space, onClose }: { space: GetSpaceResponse; onClo
   const memberName = space.members.find((member) => member.user.id === currentUser?.id)?.name
 
   const methods = useForm<{ name: string }>({ mode: 'onChange', defaultValues: { name: memberName } })
-  const { handleSubmit, formState } = methods
+  const { handleSubmit, formState, setError } = methods
 
   const onSubmit = handleSubmit(async (data) => {
-    setError(undefined)
+    setLocalError(undefined)
 
     try {
       setIsSubmitting(true)
-      const response = await acceptInvite({ spaceId: space.uuid, acceptInviteDto: { name: data.name } })
+      const response = await acceptInvite({
+        spaceId: space.uuid,
+        acceptInviteDto: { name: sanitizeName(data.name) },
+      })
 
       if (response.error) {
-        throw response.error
+        if (!applyBackendNameError(response.error, setError, 'name')) {
+          setLocalError('Failed accepting the invite. Please try again.')
+        }
+        return
       }
 
       trackEvent(
@@ -60,8 +68,8 @@ function AcceptInviteDialog({ space, onClose }: { space: GetSpaceResponse; onClo
           groupKey: 'accept-invite-success',
         }),
       )
-    } catch (e) {
-      setError('Failed accepting the invite. Please try again.')
+    } catch {
+      setLocalError('Failed accepting the invite. Please try again.')
     } finally {
       setIsSubmitting(false)
     }
@@ -73,15 +81,23 @@ function AcceptInviteDialog({ space, onClose }: { space: GetSpaceResponse; onClo
         <form onSubmit={onSubmit}>
           <DialogContent sx={{ py: 2 }}>
             <Box mb={2}>
-              <NameInput data-testid="invite-name-input" label="Name" autoFocus name="name" required />
+              <NameInput
+                data-testid="invite-name-input"
+                label="Name"
+                autoFocus
+                name="name"
+                required
+                minLength={NAME_MIN_LENGTH}
+                maxLength={MEMBER_NAME_MAX_LENGTH}
+              />
             </Box>
             <Typography variant="body2" color="text.secondary">
               How is my data processed? Read our <ExternalLink href={AppRoutes.privacy}>privacy policy</ExternalLink>
             </Typography>
 
-            {error && (
+            {localError && (
               <Alert severity="error" sx={{ mt: 2 }}>
-                {error}
+                {localError}
               </Alert>
             )}
           </DialogContent>

--- a/apps/web/src/features/spaces/components/InviteBanner/AcceptInviteDialog.tsx
+++ b/apps/web/src/features/spaces/components/InviteBanner/AcceptInviteDialog.tsx
@@ -30,7 +30,7 @@ function AcceptInviteDialog({ space, onClose }: { space: GetSpaceResponse; onClo
   const [acceptInvite] = useMembersAcceptInviteV1Mutation()
   const memberName = space.members.find((member) => member.user.id === currentUser?.id)?.name
 
-  const methods = useForm<{ name: string }>({ mode: 'onChange', defaultValues: { name: memberName } })
+  const methods = useForm<{ name: string }>({ mode: 'onChange', defaultValues: { name: memberName ?? '' } })
   const { handleSubmit, formState, setError } = methods
 
   const onSubmit = handleSubmit(async (data) => {

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
@@ -61,8 +61,8 @@ describe('toInviteName', () => {
     expect(toInviteName('john+safe@example.com')).toBe('johnsafe')
   })
 
-  it('strips leading non-alphanumeric characters', () => {
-    expect(toInviteName('_test@example.com')).toBe('test')
+  it('keeps allowed leading punctuation that the backend accepts', () => {
+    expect(toInviteName('_test@example.com')).toBe('_test')
   })
 
   it('falls back to a default when nothing valid remains', () => {

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
@@ -6,6 +6,7 @@ import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { MemberRole } from '../../../hooks/useSpaceMembers'
 import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
+import { ALLOWED_NAME_REGEX, NAME_MIN_LENGTH, sanitizeName } from '@safe-global/utils/validation/names'
 import { buildInviteUserPayload, isEmailAddress } from '../../AddMemberModal/utils'
 
 interface MemberInvite {
@@ -18,27 +19,16 @@ export interface InviteMembersFormValues {
   members: MemberInvite[]
 }
 
-// Mirrors the backend's name.schema NAME_MIN_LENGTH: names shorter than this are rejected.
-const NAME_MIN_LENGTH = 3
-
-/**
- * The onboarding flow has no dedicated name field, so a display name is derived from the
- * identifier. Wallet/ENS invites keep using the address as the name (as before); email
- * invites use the email's local part, sanitized to the alphanumeric-ish characters the
- * backend's name validation accepts (the raw email's "@" would be rejected). A local part
- * shorter than the backend minimum (e.g. "r@cc0x.dev") falls back to a default name so the
- * invite isn't rejected for a too-short name.
- */
+// Derives a display name from the identifier: wallet/ENS keep the address; emails use the
+// sanitized local part (the "@" is stripped), falling back to 'Member' when too short.
 export const toInviteName = (identifier: string): string => {
   if (!isEmailAddress(identifier)) return identifier
 
   const localPart = identifier.slice(0, identifier.indexOf('@'))
-  const sanitized = localPart
-    .replace(/[^a-zA-Z0-9 ._-]/g, '')
-    .replace(/^[^a-zA-Z0-9]+/, '')
-    .trim()
+  const allowedChars = [...sanitizeName(localPart)].filter((char) => ALLOWED_NAME_REGEX.test(char)).join('')
+  const sanitized = sanitizeName(allowedChars)
 
-  return sanitized.length >= NAME_MIN_LENGTH ? sanitized : 'Member'
+  return [...sanitized].length >= NAME_MIN_LENGTH ? sanitized : 'Member'
 }
 
 const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddContactDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddContactDialog.tsx
@@ -7,7 +7,7 @@ import ModalDialog from '@/components/common/ModalDialog'
 import { useState, type ReactNode } from 'react'
 import AddressInput from '@/components/common/AddressInput'
 import NameInput from '@/components/common/NameInput'
-import { ADDRESS_BOOK_NAME_MAX_LENGTH, NAME_MIN_LENGTH } from '@safe-global/utils/validation/names'
+import { ADDRESS_BOOK_NAME_MAX_LENGTH, NAME_MIN_LENGTH, sanitizeName } from '@safe-global/utils/validation/names'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import NetworkMultiSelectorInput from '@/components/common/NetworkSelector/NetworkMultiSelectorInput'
 import useChains from '@/hooks/useChains'
@@ -94,7 +94,7 @@ const AddContactDialog = ({
     setError(undefined)
 
     const item: AddContactItem = {
-      name: data.name,
+      name: sanitizeName(data.name),
       address: data.address,
       chainIds: data.networks.map((network) => network.chainId),
     }

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddContactDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddContactDialog.tsx
@@ -7,6 +7,7 @@ import ModalDialog from '@/components/common/ModalDialog'
 import { useState, type ReactNode } from 'react'
 import AddressInput from '@/components/common/AddressInput'
 import NameInput from '@/components/common/NameInput'
+import { ADDRESS_BOOK_NAME_MAX_LENGTH, NAME_MIN_LENGTH } from '@safe-global/utils/validation/names'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import NetworkMultiSelectorInput from '@/components/common/NetworkSelector/NetworkMultiSelectorInput'
 import useChains from '@/hooks/useChains'
@@ -144,7 +145,13 @@ const AddContactDialog = ({
               <div className="flex flex-col gap-6">
                 {intro && <p className="text-muted-foreground text-sm">{intro}</p>}
 
-                <NameInput name="name" label="Name" required />
+                <NameInput
+                  name="name"
+                  label="Name"
+                  required
+                  minLength={NAME_MIN_LENGTH}
+                  maxLength={ADDRESS_BOOK_NAME_MAX_LENGTH}
+                />
                 <AddressInput name="address" label="Address or ENS" required showPrefix={false} chain={ensChain} />
 
                 <div>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddToWorkspaceButton.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddToWorkspaceButton.tsx
@@ -72,7 +72,7 @@ const AddToWorkspaceButton = ({ address, name, chainIds }: AddToWorkspaceButtonP
   if (hasInvalidChars) {
     return (
       <Tooltip>
-        <TooltipTrigger render={<span />}>{button}</TooltipTrigger>
+        <TooltipTrigger render={<div />}>{button}</TooltipTrigger>
         <TooltipContent>
           This contact contains invalid characters. Edit the contact before adding it to a workspace.
         </TooltipContent>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddToWorkspaceButton.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddToWorkspaceButton.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useAddressBooksUpsertAddressBookItemsV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useCurrentSpaceId } from '@/features/spaces'
 import { showNotification } from '@/store/notificationsSlice'
 import { useAppDispatch } from '@/store'
 import { Spinner } from '@/components/ui/spinner'
 import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
+import { ALLOWED_NAME_REGEX } from '@safe-global/utils/validation/names'
 
 type AddToWorkspaceButtonProps = {
   address: string
@@ -59,11 +61,26 @@ const AddToWorkspaceButton = ({ address, name, chainIds }: AddToWorkspaceButtonP
     }
   }
 
-  return (
-    <Button variant="outline" size="sm" onClick={handleAdd} disabled={isSubmitting || added}>
+  const hasInvalidChars = !ALLOWED_NAME_REGEX.test(name)
+
+  const button = (
+    <Button variant="outline" size="sm" onClick={handleAdd} disabled={isSubmitting || added || hasInvalidChars}>
       {isSubmitting ? <Spinner className="size-3.5" /> : added ? 'Added' : 'Add to workspace'}
     </Button>
   )
+
+  if (hasInvalidChars) {
+    return (
+      <Tooltip>
+        <TooltipTrigger render={<span />}>{button}</TooltipTrigger>
+        <TooltipContent>
+          This contact contains invalid characters. Edit the contact before adding it to a workspace.
+        </TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  return button
 }
 
 export default AddToWorkspaceButton

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/EditContactDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/EditContactDialog.tsx
@@ -4,7 +4,7 @@ import ModalDialog from '@/components/common/ModalDialog'
 import { useState, useMemo } from 'react'
 import AddressInputReadOnly from '@/components/common/AddressInputReadOnly'
 import NameInput from '@/components/common/NameInput'
-import { ADDRESS_BOOK_NAME_MAX_LENGTH, NAME_MIN_LENGTH } from '@safe-global/utils/validation/names'
+import { ADDRESS_BOOK_NAME_MAX_LENGTH, NAME_MIN_LENGTH, sanitizeName } from '@safe-global/utils/validation/names'
 import { applyBackendNameError } from '@/utils/rtkQuery'
 import NetworkMultiSelectorInput from '@/components/common/NetworkSelector/NetworkMultiSelectorInput'
 import { trackEvent } from '@/services/analytics'
@@ -80,7 +80,7 @@ const EditContactDialog = ({ entry, onClose }: EditContactDialogProps) => {
     setLocalError(undefined)
 
     const addressBookItem = {
-      name: data.name,
+      name: sanitizeName(data.name),
       address: data.address,
       chainIds: data.networks.map((network) => network.chainId),
     }

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/EditContactDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/EditContactDialog.tsx
@@ -4,6 +4,8 @@ import ModalDialog from '@/components/common/ModalDialog'
 import { useState, useMemo } from 'react'
 import AddressInputReadOnly from '@/components/common/AddressInputReadOnly'
 import NameInput from '@/components/common/NameInput'
+import { ADDRESS_BOOK_NAME_MAX_LENGTH, NAME_MIN_LENGTH } from '@safe-global/utils/validation/names'
+import { applyBackendNameError } from '@/utils/rtkQuery'
 import NetworkMultiSelectorInput from '@/components/common/NetworkSelector/NetworkMultiSelectorInput'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
@@ -23,7 +25,7 @@ type EditContactDialogProps = {
 }
 
 const EditContactDialog = ({ entry, onClose }: EditContactDialogProps) => {
-  const [error, setError] = useState<string>()
+  const [localError, setLocalError] = useState<string>()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const { configs } = useChains()
   const dispatch = useAppDispatch()
@@ -47,7 +49,7 @@ const EditContactDialog = ({ entry, onClose }: EditContactDialogProps) => {
     defaultValues,
   })
 
-  const { handleSubmit, formState, control, reset, watch } = methods
+  const { handleSubmit, formState, control, reset, watch, setError } = methods
 
   const { errors } = formState
 
@@ -70,12 +72,12 @@ const EditContactDialog = ({ entry, onClose }: EditContactDialogProps) => {
 
   const handleClose = () => {
     reset(defaultValues)
-    setError('')
+    setLocalError('')
     onClose()
   }
 
   const onSubmit = handleSubmit(async (data) => {
-    setError(undefined)
+    setLocalError(undefined)
 
     const addressBookItem = {
       name: data.name,
@@ -93,7 +95,9 @@ const EditContactDialog = ({ entry, onClose }: EditContactDialogProps) => {
       })
 
       if (result.error) {
-        setError('Something went wrong. Please try again.')
+        if (!applyBackendNameError(result.error, setError, 'name')) {
+          setLocalError('Something went wrong. Please try again.')
+        }
         return
       }
 
@@ -106,8 +110,8 @@ const EditContactDialog = ({ entry, onClose }: EditContactDialogProps) => {
       )
 
       handleClose()
-    } catch (error) {
-      setError('Something went wrong. Please try again.')
+    } catch {
+      setLocalError('Something went wrong. Please try again.')
     } finally {
       setIsSubmitting(false)
     }
@@ -124,7 +128,13 @@ const EditContactDialog = ({ entry, onClose }: EditContactDialogProps) => {
                 <AddressInputReadOnly address={entry.address} chainId={entry.chainIds[0]} />
               </Box>
 
-              <NameInput name="name" label="Name" required />
+              <NameInput
+                name="name"
+                label="Name"
+                required
+                minLength={NAME_MIN_LENGTH}
+                maxLength={ADDRESS_BOOK_NAME_MAX_LENGTH}
+              />
 
               <Box>
                 <Typography variant="h5" fontWeight={700} display="inline-flex" alignItems="center" gap={1} mt={2}>
@@ -150,9 +160,9 @@ const EditContactDialog = ({ entry, onClose }: EditContactDialogProps) => {
               </Box>
             </Stack>
 
-            {error && (
+            {localError && (
               <Alert severity="error" sx={{ mt: 2 }}>
-                {error}
+                {localError}
               </Alert>
             )}
           </DialogContent>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ContactsList.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ContactsList.tsx
@@ -6,6 +6,7 @@ import { Controller, useFormContext, useWatch } from 'react-hook-form'
 import type { ImportContactsFormValues } from './ImportAddressBookDialog'
 import { getSelectedAddresses, getContactId } from '../utils'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
+import { ALLOWED_NAME_REGEX } from '@safe-global/utils/validation/names'
 import { useGetSpaceAddressBook } from '@/features/spaces'
 import { cn } from '@/utils/cn'
 
@@ -28,6 +29,7 @@ const ContactsList = ({ contactItems }: { contactItems: ContactItem[] }) => {
         const alreadyAdded = spaceContacts.some((spaceContact) =>
           sameAddress(spaceContact.address, contactItem.address),
         )
+        const hasInvalidChars = !ALLOWED_NAME_REGEX.test(contactItem.name)
 
         return (
           <Controller
@@ -37,7 +39,7 @@ const ContactsList = ({ contactItems }: { contactItems: ContactItem[] }) => {
             render={({ field }) => {
               const isSelected = Boolean(field.value)
               const isSameAddressSelected = selectedAddresses.has(contactItem.address) && !isSelected
-              const disabled = alreadyAdded || isSameAddressSelected
+              const disabled = alreadyAdded || isSameAddressSelected || hasInvalidChars
 
               const setSelected = (next: boolean) => field.onChange(next ? contactItem.name : false)
 
@@ -92,9 +94,11 @@ const ContactsList = ({ contactItems }: { contactItems: ContactItem[] }) => {
                         {row}
                       </TooltipTrigger>
                       <TooltipContent>
-                        {alreadyAdded
-                          ? 'You already added a contact with this address.'
-                          : 'You already selected a contact with this address.'}
+                        {hasInvalidChars
+                          ? 'This contact contains invalid characters. Edit the contact before adding it to a workspace.'
+                          : alreadyAdded
+                            ? 'You already added a contact with this address.'
+                            : 'You already selected a contact with this address.'}
                       </TooltipContent>
                     </Tooltip>
                   ) : (

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/Import/__tests__/ImportAddressBookDialog.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/Import/__tests__/ImportAddressBookDialog.test.tsx
@@ -159,6 +159,22 @@ describe('ImportAddressBookDialog', () => {
     expect(screen.getByRole('button', { name: /Import contacts \(1\)/i })).not.toBeDisabled()
   })
 
+  it('disables a row with invalid chars and shows a tooltip', async () => {
+    mockedUseAllAddressBooks.mockReturnValue({
+      '1': { '0x123': 'José 🦄' },
+    })
+
+    render(<ImportAddressBookDialog handleClose={jest.fn()} />)
+
+    const row = screen.getByText('José 🦄').closest('[role="button"]')!
+    expect(row).toHaveAttribute('aria-disabled', 'true')
+
+    await userEvent.hover(row)
+    await waitFor(() =>
+      expect(screen.getByText(/Edit the contact before adding it to a workspace/i)).toBeInTheDocument(),
+    )
+  })
+
   it('filters the contact list based on the search input', async () => {
     jest.useFakeTimers()
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime.bind(jest) })

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -101,7 +101,9 @@ function SpaceAddressBookTable({
                     {entry.isLocal && <HardDrive className="text-muted-foreground size-4 flex-shrink-0" />}
                     <span className="min-w-0 truncate">{entry.name}</span>
                   </TooltipTrigger>
-                  <TooltipContent>{entry.name}</TooltipContent>
+                  <TooltipContent align="start" alignOffset={6}>
+                    {entry.name}
+                  </TooltipContent>
                 </Tooltip>
               </TableCell>
 

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -78,8 +78,8 @@ function SpaceAddressBookTable({
         <TableHeader>
           <TableRow>
             <TableHead className="w-[20%]">Name</TableHead>
-            <TableHead className="w-[30%]">Address</TableHead>
-            <TableHead className="w-[15%]">Chains</TableHead>
+            <TableHead className={isSmallScreen ? 'w-[30%]' : 'w-[37%]'}>Address</TableHead>
+            <TableHead className={isSmallScreen ? 'w-[15%]' : 'w-[8%]'}>Chains</TableHead>
             {hasMiddleColumn && <TableHead className="w-[20%]">{showAddedBy ? 'Added by' : 'Last updated'}</TableHead>}
             <TableHead className={hasMiddleColumn ? 'w-[15%]' : 'w-[35%]'} />
           </TableRow>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/AddToWorkspaceButton.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/AddToWorkspaceButton.test.tsx
@@ -23,7 +23,7 @@ describe('AddToWorkspaceButton', () => {
     jest.clearAllMocks()
   })
 
-  it('adds the contact to the workspace address book', async () => {
+  it('adds the contact to the workspace address book and transitions to Added state on success', async () => {
     mockUpsert.mockResolvedValue({ data: {} })
     render(<AddToWorkspaceButton address={address} name="Alice" chainIds={['1', '137']} />, {
       initialReduxState: { addressBook: { '1': { [address]: 'Alice' }, '137': { [address]: 'Alice' } } },
@@ -38,7 +38,7 @@ describe('AddToWorkspaceButton', () => {
       })
     })
 
-    await waitFor(() => expect(screen.getByText('Added')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Added' })).toBeDisabled())
   })
 
   it('keeps the contact in the local address book after adding to the workspace', async () => {
@@ -98,5 +98,25 @@ describe('AddToWorkspaceButton', () => {
       const notifications = getStoreInstance().getState().notifications
       expect(notifications.some((n) => /Something went wrong \(500\)\. Please try again/.test(n.message))).toBe(true)
     })
+  })
+
+  it('disables the button and shows a tooltip when the name contains invalid characters', async () => {
+    render(<AddToWorkspaceButton address={address} name="José 🦄" chainIds={['1']} />)
+
+    const button = screen.getByRole('button', { name: 'Add to workspace' })
+    expect(button).toBeDisabled()
+
+    await userEvent.hover(button.closest('span')!)
+    await waitFor(() =>
+      expect(screen.getByText(/Edit the contact before adding it to a workspace/i)).toBeInTheDocument(),
+    )
+
+    expect(mockUpsert).not.toHaveBeenCalled()
+  })
+
+  it('does not disable the button for a valid name', () => {
+    render(<AddToWorkspaceButton address={address} name="Alice" chainIds={['1']} />)
+
+    expect(screen.getByRole('button', { name: 'Add to workspace' })).toBeEnabled()
   })
 })

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/AddToWorkspaceButton.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/AddToWorkspaceButton.test.tsx
@@ -106,7 +106,7 @@ describe('AddToWorkspaceButton', () => {
     const button = screen.getByRole('button', { name: 'Add to workspace' })
     expect(button).toBeDisabled()
 
-    await userEvent.hover(button.closest('span')!)
+    await userEvent.hover(button.closest('div')!)
     await waitFor(() =>
       expect(screen.getByText(/Edit the contact before adding it to a workspace/i)).toBeInTheDocument(),
     )

--- a/apps/web/src/features/spaces/components/SpaceSettings/UpdateSpaceForm.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/UpdateSpaceForm.tsx
@@ -5,6 +5,7 @@ import { Button, TextField } from '@mui/material'
 import { type GetSpaceResponse } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useIsAdmin } from '@/features/spaces'
 import { SPACE_NAME_MAX_LENGTH } from '@/features/spaces/constants'
+import { NAME_MIN_LENGTH, sanitizeName, validateName } from '@safe-global/utils/validation/names'
 
 const UpdateSpaceForm = ({ space }: { space: GetSpaceResponse | undefined }) => {
   const { handleUpdate, error } = useUpdateSpace(space)
@@ -31,13 +32,23 @@ const UpdateSpaceForm = ({ space }: { space: GetSpaceResponse | undefined }) => 
         <Controller
           name="name"
           control={control}
-          render={({ field }) => (
+          rules={{
+            validate: (value) => {
+              const sanitized = sanitizeName(value ?? '')
+              if (sanitized === '') return 'Required'
+              return validateName(sanitized, { minLength: NAME_MIN_LENGTH, maxLength: SPACE_NAME_MAX_LENGTH }) ?? true
+            },
+          }}
+          render={({ field, fieldState }) => (
             <TextField
               {...field}
               label="Workspace name"
               fullWidth
               value={field.value || ''}
+              error={Boolean(fieldState.error)}
+              helperText={fieldState.error?.message}
               slotProps={{ inputLabel: { shrink: true }, htmlInput: { maxLength: SPACE_NAME_MAX_LENGTH } }}
+              onBlur={() => field.onChange(sanitizeName(field.value ?? ''))}
               onKeyDown={(e) => e.stopPropagation()}
             />
           )}

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
@@ -30,7 +30,10 @@ const IdentitySection = ({ space }: { space: GetSpaceResponse | undefined }) => 
   }, [space?.name])
 
   const sanitizedName = sanitizeName(name)
-  const validationError = name.length > 0 ? validateName(sanitizedName, { minLength: NAME_MIN_LENGTH }) : undefined
+  const validationError =
+    name.length > 0
+      ? validateName(sanitizedName, { minLength: NAME_MIN_LENGTH, maxLength: SPACE_NAME_MAX_LENGTH })
+      : undefined
   const isDirty = !!space && sanitizedName !== space.name && sanitizedName.length > 0
   const canSave = isDirty && isAdmin && !validationError && !isSaving && !isAwaitingCacheSync.current
   const canCancel = !!space && name !== space.name && isAdmin && !isSaving && !isAwaitingCacheSync.current

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
@@ -8,8 +8,9 @@ import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Typography } from '@/components/ui/typography'
 import InitialsAvatar from '@/components/common/InitialsAvatar'
-
-const MAX_NAME_LENGTH = 60
+import { SPACE_NAME_MAX_LENGTH } from '@/features/spaces/constants'
+import { NAME_MIN_LENGTH, sanitizeName, validateName } from '@safe-global/utils/validation/names'
+import { getBackendNameError } from '@/utils/rtkQuery'
 
 const IdentitySection = ({ space }: { space: GetSpaceResponse | undefined }) => {
   const dispatch = useAppDispatch()
@@ -28,9 +29,10 @@ const IdentitySection = ({ space }: { space: GetSpaceResponse | undefined }) => 
     setName(space?.name ?? '')
   }, [space?.name])
 
-  const trimmedName = name.trim()
-  const isDirty = !!space && trimmedName !== space.name && trimmedName.length > 0
-  const canSave = isDirty && isAdmin && !isSaving && !isAwaitingCacheSync.current
+  const sanitizedName = sanitizeName(name)
+  const validationError = name.length > 0 ? validateName(sanitizedName, { minLength: NAME_MIN_LENGTH }) : undefined
+  const isDirty = !!space && sanitizedName !== space.name && sanitizedName.length > 0
+  const canSave = isDirty && isAdmin && !validationError && !isSaving && !isAwaitingCacheSync.current
   const canCancel = !!space && name !== space.name && isAdmin && !isSaving && !isAwaitingCacheSync.current
 
   const handleCancel = () => {
@@ -43,8 +45,8 @@ const IdentitySection = ({ space }: { space: GetSpaceResponse | undefined }) => 
     setError(undefined)
     try {
       isAwaitingCacheSync.current = true
-      await updateSpace({ id: space.uuid, updateSpaceDto: { name: trimmedName } }).unwrap()
-      setName(trimmedName)
+      await updateSpace({ id: space.uuid, updateSpaceDto: { name: sanitizedName } }).unwrap()
+      setName(sanitizedName)
       isAwaitingCacheSync.current = false
       dispatch(
         showNotification({
@@ -56,7 +58,7 @@ const IdentitySection = ({ space }: { space: GetSpaceResponse | undefined }) => 
     } catch (e) {
       console.error(e)
       isAwaitingCacheSync.current = false
-      setError("Couldn't update workspace. Please try again.")
+      setError(getBackendNameError(e) ?? "Couldn't update workspace. Please try again.")
     }
   }
 
@@ -76,8 +78,9 @@ const IdentitySection = ({ space }: { space: GetSpaceResponse | undefined }) => 
             id="space-name"
             data-testid="space-name-input"
             value={name}
-            maxLength={MAX_NAME_LENGTH}
+            maxLength={SPACE_NAME_MAX_LENGTH}
             onChange={(e) => setName(e.target.value)}
+            onBlur={() => setName(sanitizeName(name))}
             onKeyDown={(e) => {
               if (e.key === 'Enter' && canSave) {
                 e.preventDefault()
@@ -85,7 +88,7 @@ const IdentitySection = ({ space }: { space: GetSpaceResponse | undefined }) => 
               }
             }}
             disabled={!isAdmin}
-            error={error}
+            error={error ?? validationError}
             className="max-w-md"
           />
           {canCancel && (

--- a/apps/web/src/features/spaces/components/SpaceSettings/useUpdateSpace.ts
+++ b/apps/web/src/features/spaces/components/SpaceSettings/useUpdateSpace.ts
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import { useAppDispatch } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
 import { type GetSpaceResponse, useSpacesUpdateV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { getBackendNameError } from '@/utils/rtkQuery'
+import { sanitizeName } from '@safe-global/utils/validation/names'
 
 export type UpdateSpaceFormData = {
   name: string
@@ -20,7 +22,7 @@ export const useUpdateSpace = (space: GetSpaceResponse | undefined) => {
     }
 
     try {
-      await updateSpace({ id: space.uuid, updateSpaceDto: { name: data.name } }).unwrap()
+      await updateSpace({ id: space.uuid, updateSpaceDto: { name: sanitizeName(data.name) } }).unwrap()
 
       dispatch(
         showNotification({
@@ -31,7 +33,7 @@ export const useUpdateSpace = (space: GetSpaceResponse | undefined) => {
       )
     } catch (e) {
       console.error(e)
-      setError('Error updating the workspace. Please try again.')
+      setError(getBackendNameError(e) ?? 'Error updating the workspace. Please try again.')
     }
   }
 

--- a/apps/web/src/features/spaces/constants.ts
+++ b/apps/web/src/features/spaces/constants.ts
@@ -11,8 +11,8 @@ export const SAFE_ACCOUNTS_LIMIT = !Number.isNaN(safeAccountsLimitRaw) ? safeAcc
 
 export const SPACES_LIMIT = 10
 
-/** Maximum length of a workspace name. Enforced on both create and rename. */
-export const SPACE_NAME_MAX_LENGTH = 30
+/** Maximum length of a workspace name. Enforced on both create and rename. Mirrors CGW's default NameSchema. */
+export { SPACE_NAME_MAX_LENGTH } from '@safe-global/utils/validation/names'
 
 /** Friendly notice shown when a workspace is already at the Safe accounts cap. */
 export const safeAccountsLimitReachedText = (limit: number = SAFE_ACCOUNTS_LIMIT) =>

--- a/apps/web/src/utils/rtkQuery.ts
+++ b/apps/web/src/utils/rtkQuery.ts
@@ -1,7 +1,9 @@
 import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import type { SerializedError } from '@reduxjs/toolkit'
+import type { UseFormSetError, FieldValues, FieldPath } from 'react-hook-form'
 
 const HTTP_TOO_MANY_REQUESTS = 429
+const HTTP_UNPROCESSABLE_ENTITY = 422
 
 // User-facing copy for transport-level failures, so raw JS error strings (e.g.
 // "TypeError: Failed to fetch", "SyntaxError: ... is not valid JSON" from a plain-text
@@ -56,3 +58,28 @@ export const getRtkQueryErrorMessage = (error: FetchBaseQueryError | SerializedE
   // SerializedError
   return error.message || RTK_QUERY_ERROR_MESSAGES.generic
 }
+
+const isUnprocessableEntity = (error: unknown): error is FetchBaseQueryError =>
+  typeof error === 'object' &&
+  error !== null &&
+  'status' in error &&
+  (error as FetchBaseQueryError).status === HTTP_UNPROCESSABLE_ENTITY
+
+/**
+ * Maps a backend 422 onto a form field so its message shows inline. Returns true when set
+ * (caller falls back to a toast otherwise). The field is caller-supplied because the 422
+ * `path` is `[]` for bare-string schemas.
+ */
+export const applyBackendNameError = <T extends FieldValues>(
+  error: unknown,
+  setError: UseFormSetError<T>,
+  field: FieldPath<T>,
+): boolean => {
+  if (!isUnprocessableEntity(error)) return false
+  setError(field, { type: 'server', message: getRtkQueryErrorMessage(error) })
+  return true
+}
+
+// Non-RHF variant: returns the 422 message for local error state, or undefined otherwise.
+export const getBackendNameError = (error: unknown): string | undefined =>
+  isUnprocessableEntity(error) ? getRtkQueryErrorMessage(error) : undefined

--- a/packages/utils/src/utils/csv.test.ts
+++ b/packages/utils/src/utils/csv.test.ts
@@ -1,0 +1,34 @@
+import { escapeCsvFormula } from './csv'
+
+describe('escapeCsvFormula', () => {
+  it.each([
+    ['equals', '=1+1', "'=1+1"],
+    ['plus', '+1', "'+1"],
+    ['minus', '-1', "'-1"],
+    ['at', '@SUM(A1)', "'@SUM(A1)"],
+    ['leading space', ' =1+1', "' =1+1"],
+    ['tab', '\t=1+1', "'\t=1+1"],
+    ['carriage return', '\r=1+1', "'\r=1+1"],
+    ['newline', '\n=1+1', "'\n=1+1"],
+    ['full-width equals', '＝1', "'＝1"],
+    ['full-width plus', '＋1', "'＋1"],
+    ['full-width minus', '－1', "'－1"],
+    ['full-width at', '＠1', "'＠1"],
+  ])('prefixes a quote for a leading %s trigger', (_label, input, expected) => {
+    expect(escapeCsvFormula(input)).toBe(expected)
+  })
+
+  it.each([
+    ['plain text', 'Alice'],
+    ['address', '0xAb5e3288640396C3988af5a820510682f3C58adF'],
+    ['number', '1'],
+    ['trigger not in first position', 'a=b'],
+  ])('leaves a safe %s untouched', (_label, input) => {
+    expect(escapeCsvFormula(input)).toBe(input)
+  })
+
+  it('returns an empty string for null or undefined', () => {
+    expect(escapeCsvFormula(null)).toBe('')
+    expect(escapeCsvFormula(undefined)).toBe('')
+  })
+})

--- a/packages/utils/src/utils/csv.ts
+++ b/packages/utils/src/utils/csv.ts
@@ -1,0 +1,14 @@
+// Mirror of safe-client-gateway/src/modules/csv-export/csv-utils/escape-csv-formula.ts.
+// Triggers: ASCII = + - @, leading whitespace, and full-width ＝＋－＠ (folded by spreadsheets).
+const FORMULA_TRIGGERS = ['=', '+', '-', '@', ' ', '\t', '\r', '\n', '＝', '＋', '－', '＠']
+
+export const escapeCsvFormula = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return ''
+  }
+  const str = String(value)
+  if (str.length > 0 && FORMULA_TRIGGERS.includes(str[0])) {
+    return `'${str}`
+  }
+  return str
+}

--- a/packages/utils/src/validation/index.ts
+++ b/packages/utils/src/validation/index.ts
@@ -1,0 +1,1 @@
+export * from './names'

--- a/packages/utils/src/validation/names.test.ts
+++ b/packages/utils/src/validation/names.test.ts
@@ -1,0 +1,109 @@
+import { DISALLOWED_CHARACTER_MESSAGE, EMPTY_NAME_MESSAGE, NAME_MAX_LENGTH, sanitizeName, validateName } from './names'
+
+const ZERO_WIDTH_SPACE = '​'
+const BIDI_OVERRIDE = '‮'
+const ZWJ = '‍'
+const ZWNJ = '‌'
+
+describe('sanitizeName', () => {
+  it('normalizes decomposed input to NFC', () => {
+    const decomposed = 'Jos' + 'é'
+    expect(sanitizeName(decomposed)).toBe('José')
+  })
+
+  it.each([
+    ['curly right apostrophe', 'O’Brien', "O'Brien"],
+    ['curly left quote', '‘Mac’', "'Mac'"],
+    ['prime', '5′ tall', "5' tall"],
+    ['en dash', 'Jean–Luc', 'Jean-Luc'],
+    ['em dash', 'Jean—Luc', 'Jean-Luc'],
+  ])('folds smart punctuation: %s', (_label, input, expected) => {
+    expect(sanitizeName(input)).toBe(expected)
+  })
+
+  it('strips a bidi override and keeps the visible remainder', () => {
+    expect(sanitizeName(`ab${BIDI_OVERRIDE}cd`)).toBe('abcd')
+  })
+
+  it('strips zero-width characters', () => {
+    expect(sanitizeName(`a${ZERO_WIDTH_SPACE}b${ZWJ}c${ZWNJ}d`)).toBe('abcd')
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(sanitizeName('  Alice  ')).toBe('Alice')
+  })
+})
+
+describe('validateName', () => {
+  it.each(['José', '山田太郎', 'Müller', 'Анна', 'محمد علي'])('accepts UTF-8 letters: %s', (name) => {
+    expect(validateName(sanitizeName(name))).toBeUndefined()
+  })
+
+  it.each([
+    'Contact #1',
+    'maria@web.com',
+    'Smith & Co.',
+    "O'Brien",
+    'Acme, Inc.',
+    'Doe (work)',
+    'a-valid_Account.name',
+  ])('accepts allowed punctuation: %s', (name) => {
+    expect(validateName(sanitizeName(name))).toBeUndefined()
+  })
+
+  it.each([
+    ['equals', 'ab=cd'],
+    ['plus', 'ab+cd'],
+    ['asterisk', 'ab*cd'],
+    ['slash', 'ab/cd'],
+    ['backslash', 'ab\\cd'],
+    ['less-than', 'ab<cd'],
+    ['greater-than', 'ab>cd'],
+    ['double quote', 'ab"cd'],
+    ['percent', 'ab%cd'],
+    ['dollar', 'ab$cd'],
+    ['colon', 'ab:cd'],
+    ['semicolon', 'ab;cd'],
+    ['pipe', 'ab|cd'],
+    ['curly brace', 'ab{cd'],
+    ['square bracket', 'ab[cd'],
+    ['emoji', 'abc\u{1F44D}'],
+    ['symbol', 'abc★'],
+  ])('rejects disallowed character: %s', (_label, name) => {
+    expect(validateName(sanitizeName(name))).toBe(DISALLOWED_CHARACTER_MESSAGE)
+  })
+
+  it('reports empty-name for input that is empty after sanitizing', () => {
+    expect(validateName(sanitizeName(`${ZERO_WIDTH_SPACE}${BIDI_OVERRIDE}`))).toBe(EMPTY_NAME_MESSAGE)
+  })
+
+  it('reports empty-name (not min-length) for whitespace-only input', () => {
+    expect(validateName(sanitizeName('   '))).toBe(EMPTY_NAME_MESSAGE)
+  })
+
+  it('rejects an emoji even when it satisfies length bounds', () => {
+    expect(validateName('\u{1F44D}', { minLength: 1, maxLength: 1 })).toBe(DISALLOWED_CHARACTER_MESSAGE)
+  })
+
+  it('rejects a name shorter than the minimum', () => {
+    expect(validateName('Jo')).toBe('Names must be at least 3 character(s) long')
+  })
+
+  it('rejects a name longer than the maximum', () => {
+    expect(validateName('a'.repeat(NAME_MAX_LENGTH + 1))).toBe('Names must be at most 30 characters long')
+  })
+
+  it('counts max length by code point', () => {
+    expect(validateName('山'.repeat(NAME_MAX_LENGTH))).toBeUndefined()
+    expect(validateName('山'.repeat(NAME_MAX_LENGTH + 1))).toBe('Names must be at most 30 characters long')
+  })
+
+  it('respects a per-context max length override', () => {
+    expect(validateName('a'.repeat(50), { maxLength: 50 })).toBeUndefined()
+    expect(validateName('a'.repeat(51), { maxLength: 50 })).toBe('Names must be at most 50 characters long')
+  })
+
+  it('allows empty input when minLength is 0', () => {
+    expect(validateName('', { minLength: 0 })).toBeUndefined()
+  })
+})

--- a/packages/utils/src/validation/names.test.ts
+++ b/packages/utils/src/validation/names.test.ts
@@ -1,4 +1,12 @@
-import { DISALLOWED_CHARACTER_MESSAGE, EMPTY_NAME_MESSAGE, NAME_MAX_LENGTH, sanitizeName, validateName } from './names'
+import {
+  DISALLOWED_CHARACTER_MESSAGE,
+  DISALLOWED_CHARACTER_SHORT_MESSAGE,
+  EMPTY_NAME_MESSAGE,
+  NAME_MAX_LENGTH,
+  getNameValidationDisplay,
+  sanitizeName,
+  validateName,
+} from './names'
 
 const ZERO_WIDTH_SPACE = '​'
 const BIDI_OVERRIDE = '‮'
@@ -31,6 +39,20 @@ describe('sanitizeName', () => {
 
   it('trims surrounding whitespace', () => {
     expect(sanitizeName('  Alice  ')).toBe('Alice')
+  })
+})
+
+describe('getNameValidationDisplay', () => {
+  it('returns a short label and full tooltip for disallowed characters', () => {
+    expect(getNameValidationDisplay(DISALLOWED_CHARACTER_MESSAGE)).toEqual({
+      label: DISALLOWED_CHARACTER_SHORT_MESSAGE,
+      tooltip: DISALLOWED_CHARACTER_MESSAGE,
+    })
+  })
+
+  it('returns the message as the label when no short form exists', () => {
+    const message = 'Names must be at least 3 character(s) long'
+    expect(getNameValidationDisplay(message)).toEqual({ label: message })
   })
 })
 

--- a/packages/utils/src/validation/names.ts
+++ b/packages/utils/src/validation/names.ts
@@ -1,0 +1,49 @@
+// Mirror of safe-client-gateway/src/domain/common/schemas/name.schema.ts. Keep in lockstep.
+// names.test.ts (ported from name.schema.spec.ts) is the drift guard.
+
+export const NAME_MIN_LENGTH = 3
+export const NAME_MAX_LENGTH = 30
+export const ADDRESS_BOOK_NAME_MAX_LENGTH = 50
+export const MEMBER_NAME_MAX_LENGTH = 255
+// CGW has no dedicated constants for these; both use the default NameSchema (max 30).
+export const MEMBER_ALIAS_MAX_LENGTH = NAME_MAX_LENGTH
+export const SPACE_NAME_MAX_LENGTH = NAME_MAX_LENGTH
+
+const INVISIBLE_CHARACTERS = /[\p{Cc}\p{Cf}]/gu
+
+// Folded to ASCII: smart quotes/prime -> ', en/em dash/minus -> -
+const SMART_PUNCTUATION: ReadonlyArray<[RegExp, string]> = [
+  [/[‘’‚‛′]/gu, "'"],
+  [/[–—−]/gu, '-'],
+]
+
+const ALLOWED_PUNCTUATION = " ._\\-#@&',()"
+
+export const ALLOWED_NAME_REGEX = new RegExp(`^[\\p{L}\\p{M}\\p{N}${ALLOWED_PUNCTUATION}]*$`, 'u')
+
+export const DISALLOWED_CHARACTER_MESSAGE =
+  "Names can only contain letters, numbers, spaces and the characters . _ - # @ & ' , ( )"
+
+export const EMPTY_NAME_MESSAGE = 'Names cannot be empty'
+
+export const sanitizeName = (value: string): string => {
+  let result = value.normalize('NFC').replace(INVISIBLE_CHARACTERS, '')
+  for (const [pattern, replacement] of SMART_PUNCTUATION) {
+    result = result.replace(pattern, replacement)
+  }
+  return result.trim()
+}
+
+// Assumes value is already sanitized. Check order mirrors CGW.
+export const validateName = (value: string, opts?: { minLength?: number; maxLength?: number }): string | undefined => {
+  const min = opts?.minLength ?? NAME_MIN_LENGTH
+  const max = opts?.maxLength ?? NAME_MAX_LENGTH
+  const length = [...value].length // code points
+
+  if (length === 0 && min > 0) return EMPTY_NAME_MESSAGE
+  if (!ALLOWED_NAME_REGEX.test(value)) return DISALLOWED_CHARACTER_MESSAGE
+  if (length > 0 && length < min) return `Names must be at least ${min} character(s) long`
+  if (length > max) return `Names must be at most ${max} characters long`
+
+  return undefined
+}

--- a/packages/utils/src/validation/names.ts
+++ b/packages/utils/src/validation/names.ts
@@ -24,6 +24,20 @@ export const ALLOWED_NAME_REGEX = new RegExp(`^[\\p{L}\\p{M}\\p{N}${ALLOWED_PUNC
 export const DISALLOWED_CHARACTER_MESSAGE =
   "Names can only contain letters, numbers, spaces and the characters . _ - # @ & ' , ( )"
 
+export const DISALLOWED_CHARACTER_SHORT_MESSAGE = 'Invalid characters'
+
+export interface NameValidationDisplay {
+  label: string
+  tooltip?: string
+}
+
+export const getNameValidationDisplay = (message: string): NameValidationDisplay => {
+  if (message === DISALLOWED_CHARACTER_MESSAGE) {
+    return { label: DISALLOWED_CHARACTER_SHORT_MESSAGE, tooltip: message }
+  }
+  return { label: message }
+}
+
 export const EMPTY_NAME_MESSAGE = 'Names cannot be empty'
 
 export const sanitizeName = (value: string): string => {

--- a/packages/utils/src/validation/names.ts
+++ b/packages/utils/src/validation/names.ts
@@ -22,7 +22,7 @@ const ALLOWED_PUNCTUATION = " ._\\-#@&',()"
 export const ALLOWED_NAME_REGEX = new RegExp(`^[\\p{L}\\p{M}\\p{N}${ALLOWED_PUNCTUATION}]*$`, 'u')
 
 export const DISALLOWED_CHARACTER_MESSAGE =
-  "Names can only contain letters, numbers, spaces and the characters . _ - # @ & ' , ( )"
+  "Names can only contain letters, numbers, spaces and the characters _ - # @ & ' , ( ) ."
 
 export const DISALLOWED_CHARACTER_SHORT_MESSAGE = 'Invalid characters'
 


### PR DESCRIPTION
## What it solves

Resolves: [WA-2668](https://linear.app/safe-global/issue/WA-2707/adjust-frontend-to-cgw-changes),
Resolves: [WA-2646](https://linear.app/safe-global/issue/WA-2646/error-message-indicates-that-member-names-may-contain-underscores-but) as secondary
Resolves: [WA-2715](https://linear.app/safe-global/issue/WA-2715/address-book-and-accounts-ui-feedback) (related minor UI changes)
Related PR: [CGW 3178](https://github.com/safe-global/safe-client-gateway/pull/3178)

Resolves inconsistent and incomplete name validation across the web app. Names entered for address book contacts, Safe owners, workspaces, and workspace members were not validated consistently with the backend (safe-client-gateway), so users could submit names with disallowed/invisible characters, mismatched length rules, or get them rejected only at the server with raw error strings. CSV export was also not guarded against formula injection.

## How this PR fixes it

- Adds a shared, framework-agnostic name validation module in `@safe-global/utils` (`validation/names.ts`) that mirrors the CGW `name.schema.ts` — allowed character set, length bounds (default 3–30, address book 50, member 255), Unicode-aware code-point counting, NFC normalization, invisible-character stripping, and smart-punctuation folding. A ported test suite acts as the drift guard against the backend schema.
- Adds `escapeCsvFormula` in `@safe-global/utils` (`utils/csv.ts`), mirroring the CGW formula-escape util, to neutralize CSV/formula injection (`= + - @`, leading whitespace, full-width variants) on export.
- Wires the shared validation into `NameInput` (sanitize on blur, validate via RHF, focus-preserving tooltip for the "Invalid characters" case), the address book Entry/Export/Import dialogs, the Edit Owner dialog, and the workspace create/settings/member/invite/address-book forms.
- **CSV import for local address book now allows names with any non-empty value** — the strict character validation that previously blocked valid names with special characters has been relaxed; only empty names are rejected. Names with special characters (e.g. from external CSVs) are imported as-is.
- CSV import (workspace address book) still validates each row's name with the shared rules and reports the offending row and reason.
- Adds `getRtkQueryErrorMessage` / `applyBackendNameError` / `getBackendNameError` helpers so backend 422 validation errors surface inline on the right field, and transport-level errors (network/timeout/rate-limit/non-JSON body) show friendly copy instead of raw JS error strings.
- The "Add to workspace" button on local address book contacts now shows a human-readable error message instead of a raw error string when the server rejects the request, and is **disabled with an explanatory tooltip when the contact's name contains invalid characters** — preventing a server rejection before the user even tries.
- Fixes workspace identity section missing `maxLength` validation, preventing users from entering overly long workspace names without feedback.
- Fixes UI details: input keeps focus on invalid character entry, and the import preview hides entry count and connector line when the CSV is invalid.

### Additional small fixes
- E2E tests (smoke + regression) that were failing due to AB + Spaces changes

## How to test it

1. **Address book**: Add/edit a contact. Try names with emoji-only/invisible chars, disallowed symbols (`= < > {}`), and very long names — invalid input shows an inline "Invalid characters" label with a tooltip; valid input is sanitized (smart quotes → `'`, dashes normalized, trimmed) on blur.
2. **CSV import (local address book)**: Import a CSV containing names with special characters (e.g. `O'Brien`, `Müller`, names with commas) — these should import successfully. Only rows with completely empty names should be rejected.
3. **CSV import (workspace address book)**: Import a CSV with an invalid name on a row — the error names the row and reason; the entry count and connector line are hidden for an invalid file.
4. **CSV export**: Export an address book containing a name starting with `=`, `+`, `-`, `@`, or whitespace — the exported cell is prefixed with `'` so spreadsheets don't evaluate it as a formula.
5. **Owners / Workspaces**: Repeat name entry on the Edit Owner dialog, workspace creation, workspace settings, member info, invite, and workspace address book forms — all apply the same rules. Workspace identity name field should enforce `maxLength`.
6. **Backend errors**: Trigger a server-side 422 (e.g. a name the backend rejects) — the message appears inline on the field, not as a toast with a raw string. The "Add to workspace" button should also show a readable error message on failure.
7. **Add to workspace button**: Open a local address book contact whose name contains invalid characters — the "Add to workspace" button should be disabled and show a tooltip explaining why.

## Affected flows

- Address book: create / edit contact, CSV import (local), CSV export
- Safe settings: edit owner name
- Workspaces: create workspace onboarding, workspace settings (identity), add member, invite member (accept invite), workspace address book add/edit contact, add local contact to workspace

## Blast radius

- **Shared package `@safe-global/utils`**: new `validation/names.ts` (exported via `validation/index.ts`) and `utils/csv.ts`. New code, no changes to existing exports — but lives in a package consumed by both web and mobile.
- **`NameInput` (`apps/web/src/components/common/NameInput`)**: validation behavior, sanitize-on-blur, and label/tooltip rendering changed. Consumers: address book Entry dialog, Edit Owner dialog, workspace member/settings/identity/invite/address-book forms.
- **`FileUpload` (`apps/web/src/components/common/FileUpload`)**: invalid-state rendering (entry count / connector line) changed; used by the address book Import dialog.
- **`apps/web/src/utils/rtkQuery.ts`**: new error-message helpers; adopted by workspace mutation forms (create, update, add member, invite) and the "Add to workspace" button.
- **`ImportDialog/validation.ts`**: local AB CSV import name validation relaxed — only empty names now fail. Previously any name failing the strict character set was rejected.
- **`SpaceSettings/IdentitySection`**: `maxLength` now enforced on workspace name input.
- **`AddToWorkspaceButton`**: disabled state + tooltip added when contact name contains invalid characters; unit tests added.
- **CGW contract coupling**: `names.ts` and `csv.ts` are deliberate mirrors of backend schemas; their test suites guard against drift. If the backend schema changes, these must be updated in lockstep.

## Risks / not checked

- Did not exhaustively verify every Unicode edge case beyond the ported CGW test suite (e.g. exotic combining-mark sequences).
- Did not manually exercise every transport-error branch (timeout / rate-limit / non-JSON body) end-to-end against a live backend.
- Drift between these mirrors and the actual CGW schema is only caught if the backend schema itself changes and someone re-checks; there is no automated cross-repo check.
- Did not test the relaxed local CSV import against a broad range of real-world CSV exports from other wallet tools.

## Visual summary



https://github.com/user-attachments/assets/aa09711f-26b4-4933-ad03-2dfd9a7b90b9




```mermaid
flowchart TB
  subgraph Shared["@safe-global/utils (new)"]
    N["validation/names.ts<br/>sanitizeName · validateName"]
    C["utils/csv.ts<br/>escapeCsvFormula"]
  end

  subgraph Web["apps/web"]
    NI["NameInput"] --> N
    IMP_WS["Workspace AB CSV import"] --> N
    IMP_LOCAL["Local AB CSV import<br/>(relaxed: non-empty only)"]
    EXP["Address book CSV export"] --> C
    OWN["Edit Owner dialog"] --> NI
    AB["Address book Entry dialog"] --> NI
    WS["Workspace forms<br/>(create · settings · member · invite · address book)"] --> NI
    WS --> RTK["rtkQuery.ts<br/>applyBackendNameError · getRtkQueryErrorMessage"]
    ADD_BTN["AddToWorkspaceButton<br/>(disabled + tooltip on invalid name)"] --> RTK
    ADD_BTN --> N
  end

  CGW["safe-client-gateway schemas<br/>(name.schema · escape-csv-formula)"] -. mirrored & drift-guarded by tests .-> Shared
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
