### PR TITLE
fix(web): keep local contact when admin adds it to workspace address book

### DIFF
--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddToWorkspaceButton.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddToWorkspaceButton.tsx
@@ -3,7 +3,6 @@ import { Button } from '@/components/ui/button'
 import { useAddressBooksUpsertAddressBookItemsV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useCurrentSpaceId } from '@/features/spaces'
 import { showNotification } from '@/store/notificationsSlice'
-import { removeAddressBookEntry } from '@/store/addressBookSlice'
 import { useAppDispatch } from '@/store'
 import { Spinner } from '@/components/ui/spinner'
 
@@ -36,11 +35,6 @@ const AddToWorkspaceButton = ({ address, name, chainIds }: AddToWorkspaceButtonP
           showNotification({ message: 'Failed to add contact', variant: 'error', groupKey: 'add-to-workspace-error' }),
         )
         return
-      }
-
-      // Remove from local address book
-      for (const chainId of chainIds) {
-        dispatch(removeAddressBookEntry({ chainId, address }))
       }
 
       setAdded(true)

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/AddToWorkspaceButton.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/AddToWorkspaceButton.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor } from '@/tests/test-utils'
+import userEvent from '@testing-library/user-event'
+import AddToWorkspaceButton from '../AddToWorkspaceButton'
+import { getStoreInstance } from '@/store'
+import { checksumAddress } from '@safe-global/utils/utils/addresses'
+import { faker } from '@faker-js/faker'
+
+const MOCK_SPACE_UUID = '11111111-1111-1111-1111-111111111111'
+const mockUpsert = jest.fn()
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
+  useAddressBooksUpsertAddressBookItemsV1Mutation: () => [mockUpsert],
+}))
+
+jest.mock('@/features/spaces', () => ({
+  useCurrentSpaceId: () => MOCK_SPACE_UUID,
+}))
+
+describe('AddToWorkspaceButton', () => {
+  const address = checksumAddress(faker.finance.ethereumAddress())
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('adds the contact to the workspace address book', async () => {
+    mockUpsert.mockResolvedValue({ data: {} })
+    render(<AddToWorkspaceButton address={address} name="Alice" chainIds={['1', '137']} />, {
+      initialReduxState: { addressBook: { '1': { [address]: 'Alice' }, '137': { [address]: 'Alice' } } },
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add to workspace' }))
+
+    await waitFor(() => {
+      expect(mockUpsert).toHaveBeenCalledWith({
+        spaceId: MOCK_SPACE_UUID,
+        upsertAddressBookItemsDto: { items: [{ name: 'Alice', address, chainIds: ['1', '137'] }] },
+      })
+    })
+
+    await waitFor(() => expect(screen.getByText('Added')).toBeInTheDocument())
+  })
+
+  it('keeps the contact in the local address book after adding to the workspace', async () => {
+    mockUpsert.mockResolvedValue({ data: {} })
+    render(<AddToWorkspaceButton address={address} name="Alice" chainIds={['1', '137']} />, {
+      initialReduxState: { addressBook: { '1': { [address]: 'Alice' }, '137': { [address]: 'Alice' } } },
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add to workspace' }))
+
+    await waitFor(() => expect(mockUpsert).toHaveBeenCalled())
+
+    const addressBook = getStoreInstance().getState().addressBook
+    expect(addressBook['1'][address]).toBe('Alice')
+    expect(addressBook['137'][address]).toBe('Alice')
+  })
+
+  it('does not remove the local entry when the workspace add fails', async () => {
+    mockUpsert.mockResolvedValue({ error: { status: 500, data: {} } })
+    render(<AddToWorkspaceButton address={address} name="Alice" chainIds={['1']} />, {
+      initialReduxState: { addressBook: { '1': { [address]: 'Alice' } } },
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add to workspace' }))
+
+    await waitFor(() => expect(mockUpsert).toHaveBeenCalled())
+
+    expect(getStoreInstance().getState().addressBook['1'][address]).toBe('Alice')
+    expect(screen.queryByText('Added')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What it solves

When an admin added a contact from their local "My contacts" to the workspace address book, the contact was immediately deleted from their local address book. Members proposing a contact (and admins approving those proposals) never lose the local entry, so admins behaved inconsistently. This makes the admin direct-add behave like every other path: the contact is shared to the workspace but kept locally.

Resolves: https://linear.app/safe-global/issue/WA-2718/prevent-local-address-deletion-when-adding-to-workspace

## How this PR fixes it

Removed the `removeAddressBookEntry` dispatch loop from the admin direct-add handler so the local entry is preserved.

The "Add to workspace" button does not disappear from the row — once the workspace list refetches (the upsert mutation invalidates the `spaces` tag), the existing duplicate-detection in `SpaceAddressBook` marks the still-present local contact as a duplicate and the row shows an "Already shared" badge instead. This is the same end-state the member-approval flow already produces, so the two paths now converge.

## How to test it

1. As an admin of a Space, open the address book and go to the "My contacts" tab.
2. Click "Add to workspace" on a local contact.
3. Confirm the contact appears in "Workspace contacts".
4. Confirm the contact still exists in "My contacts" and its row now shows an "Already shared" badge (instead of being removed).

## Screenshots

https://github.com/user-attachments/assets/948fff75-9a09-4b35-a836-cec0cea70df8

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).