### PR TITLE
feat(mobile): WC read-only RPC proxy and EIP-5792 wallet-control methods

### DIFF
--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/getCallsStatus.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/getCallsStatus.test.ts
@@ -1,0 +1,76 @@
+import { buildGetCallsResult, type CallsStatusTx, type RawTxReceipt } from '../getCallsStatus'
+
+const receipt: RawTxReceipt = {
+  logs: [{ address: '0xabc' }],
+  blockHash: '0xbbb',
+  blockNumber: '0x10',
+  gasUsed: '0x5208',
+  transactionHash: '0xrcptHash',
+}
+
+describe('buildGetCallsResult', () => {
+  describe('status mapping', () => {
+    it.each([
+      ['SUCCESS', 200],
+      ['CANCELLED', 400],
+      ['FAILED', 500],
+      ['AWAITING_CONFIRMATIONS', 100],
+      ['AWAITING_EXECUTION', 100],
+      [undefined, 100],
+    ])('maps txStatus %s to %i', (txStatus, expected) => {
+      const result = buildGetCallsResult('0xhash', '1', { txStatus: txStatus as string }, null)
+      expect(result.status).toBe(expected)
+    })
+  })
+
+  it('returns a receipt-less envelope when no receipt is provided', () => {
+    const result = buildGetCallsResult('0xhash', '137', { txStatus: 'AWAITING_EXECUTION', txHash: null }, null)
+    expect(result).toEqual({ version: '2.0.0', id: '0xhash', chainId: '0x89', status: 100, atomic: true })
+    expect(result.receipts).toBeUndefined()
+  })
+
+  it('hex-encodes the chain id in the envelope', () => {
+    expect(buildGetCallsResult('0xhash', '11155111', {}, null).chainId).toBe('0xaa36a7')
+  })
+
+  it('builds one receipt with normalized hex fields for a confirmed single call', () => {
+    const tx: CallsStatusTx = { txStatus: 'SUCCESS', txHash: '0xtxHash' }
+    const result = buildGetCallsResult('0xhash', '1', tx, receipt)
+    expect(result.receipts).toHaveLength(1)
+    expect(result.receipts?.[0]).toEqual({
+      logs: receipt.logs,
+      status: '0x1',
+      blockHash: '0xbbb',
+      blockNumber: '0x10',
+      gasUsed: '0x5208',
+      transactionHash: '0xtxHash',
+    })
+  })
+
+  it('marks the on-chain receipt status 0x0 for a non-success tx', () => {
+    const result = buildGetCallsResult('0xhash', '1', { txStatus: 'FAILED', txHash: '0xtxHash' }, receipt)
+    expect(result.receipts?.[0].status).toBe('0x0')
+  })
+
+  it('replicates the receipt once per bundled call from valueDecoded', () => {
+    const tx: CallsStatusTx = {
+      txStatus: 'SUCCESS',
+      txHash: '0xtxHash',
+      txData: { dataDecoded: { parameters: [{ valueDecoded: [{}, {}, {}] }] } },
+    }
+    const result = buildGetCallsResult('0xhash', '1', tx, receipt)
+    expect(result.receipts).toHaveLength(3)
+  })
+
+  it('falls back to the receipt transactionHash when the tx hash is absent', () => {
+    const result = buildGetCallsResult('0xhash', '1', { txStatus: 'SUCCESS' }, receipt)
+    expect(result.receipts?.[0].transactionHash).toBe('0xrcptHash')
+  })
+
+  it('normalizes zero-padded receipt hex (e.g. 0x010) to canonical form', () => {
+    const padded: RawTxReceipt = { ...receipt, blockNumber: '0x010', gasUsed: '0x0a' }
+    const result = buildGetCallsResult('0xhash', '1', { txStatus: 'SUCCESS', txHash: '0xtxHash' }, padded)
+    expect(result.receipts?.[0].blockNumber).toBe('0x10')
+    expect(result.receipts?.[0].gasUsed).toBe('0xa')
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
@@ -90,9 +90,9 @@ describe('routeSessionRequest', () => {
 
   it('errors on eth_chainId / net_version while the chain config is unresolved', async () => {
     const chainIdRes = await routeSessionRequest(makeCtx(makeRequest('eth_chainId'), { activeChain: null }))
-    expect((chainIdRes as { error: { code: number } }).error.code).toBe(-32603)
+    expect((chainIdRes as { error: { code: number } }).error.code).toBe(-32002)
     const netVersionRes = await routeSessionRequest(makeCtx(makeRequest('net_version'), { activeChain: null }))
-    expect((netVersionRes as { error: { code: number } }).error.code).toBe(-32603)
+    expect((netVersionRes as { error: { code: number } }).error.code).toBe(-32002)
   })
 
   it('defers eth_sendTransaction for the sheet', async () => {
@@ -109,7 +109,7 @@ describe('routeSessionRequest', () => {
     const res = await routeSessionRequest(
       makeCtx(makeRequest('eth_sendTransaction', sendTxParams), { activeSafeAddress: null }),
     )
-    expect((res as { error: { code: number } }).error.code).toBe(-32603)
+    expect((res as { error: { code: number } }).error.code).toBe(-32002)
     expect(isDeferredResponse(res)).toBe(false)
   })
 
@@ -124,7 +124,7 @@ describe('routeSessionRequest', () => {
     const res = await routeSessionRequest(
       makeCtx(makeRequest('eth_sendTransaction', sendTxParams), { activeChain: null }),
     )
-    expect((res as { error: { code: number } }).error.code).toBe(-32603)
+    expect((res as { error: { code: number } }).error.code).toBe(-32002)
   })
 
   it('rejects tx requests on the wrong active chain with UNSUPPORTED_CHAINS', async () => {
@@ -341,16 +341,17 @@ describe('routeSessionRequest — read-only + wallet-control branches', () => {
       expect((res as { result: string }).result).toBe('0x10')
     })
 
-    it('responds -32603 when no active chain is resolved', async () => {
+    it('responds -32002 when no active chain is resolved', async () => {
       const res = await routeSessionRequest(makeCtx(makeRequest('eth_call', [{}]), { activeChain: null }))
-      expect((res as { error: { code: number } }).error.code).toBe(-32603)
+      expect((res as { error: { code: number } }).error.code).toBe(-32002)
       expect(mockProxyReadOnlyCall).not.toHaveBeenCalled()
     })
 
-    it('maps a proxy failure to -32603', async () => {
+    it('maps a proxy failure to -32000 with the reason preserved', async () => {
       mockProxyReadOnlyCall.mockRejectedValue(new Error('RPC down'))
       const res = await routeSessionRequest(makeCtx(makeRequest('eth_getBalance', [SAFE_ADDRESS, 'latest'])))
-      expect((res as { error: { code: number } }).error.code).toBe(-32603)
+      expect((res as { error: { code: number; message: string } }).error.code).toBe(-32000)
+      expect((res as { error: { message: string } }).error.message).toBe('RPC down')
     })
   })
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
@@ -289,6 +289,25 @@ describe('routeSessionRequest — read-only + wallet-control branches', () => {
       expect((res as { result: Record<string, unknown> }).result).toEqual({})
     })
 
+    it('warns (cold start) when no deployed chains are known, but not on a genuine miss', async () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+      // deployedChainIds non-empty but the requested chain isn't among them → legitimate {}, no warn.
+      await routeSessionRequest(
+        makeCtx(makeRequest('wallet_getCapabilities', [SAFE_ADDRESS, ['0x89']]), { deployedChainIds: ['1'] }),
+      )
+      expect(warn).not.toHaveBeenCalled()
+
+      // No deployed chains at all → Safe data hasn't synced yet → warn.
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_getCapabilities', [SAFE_ADDRESS, ['0x1']]), { deployedChainIds: [] }),
+      )
+      expect((res as { result: Record<string, unknown> }).result).toEqual({})
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('no deployed chains known yet'))
+
+      warn.mockRestore()
+    })
+
     it('skips a non-numeric deployed chain id instead of throwing (BigInt safety)', async () => {
       const res = await routeSessionRequest(
         makeCtx(makeRequest('wallet_getCapabilities', [SAFE_ADDRESS, ['0x1']]), {

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
@@ -9,6 +9,14 @@ import {
   NO_SIGNER_ERROR_CODE,
   type RouteContext,
 } from '../methodRouter'
+import { proxyReadOnlyCall } from '../readRpcProxy'
+
+// Keep the real allow-list guard (isReadOnlyMethod) but stub the network call.
+jest.mock('../readRpcProxy', () => ({
+  ...jest.requireActual('../readRpcProxy'),
+  proxyReadOnlyCall: jest.fn(),
+}))
+const mockProxyReadOnlyCall = proxyReadOnlyCall as jest.Mock
 
 // Contains hex letters so casing-sensitivity tests actually exercise a different string.
 const SAFE_ADDRESS = '0xAbCd111111111111111111111111111111111111'
@@ -31,6 +39,10 @@ const makeCtx = (request: WalletKitTypes.SessionRequest, overrides: Partial<Rout
     activeChain: chain,
     activeSafeAddress: SAFE_ADDRESS,
     hasSigner: true,
+    deployedChainIds: ['1', '137'],
+    switchActiveChainByCaip2: jest.fn().mockResolvedValue({ ok: true }),
+    getCallsStatus: jest.fn(),
+    navigateToCallsStatus: jest.fn(),
     ...overrides,
   }) as unknown as RouteContext
 
@@ -190,6 +202,142 @@ describe('routeSessionRequest', () => {
   it('returns UNSUPPORTED_METHODS for unknown methods', async () => {
     const res = await routeSessionRequest(makeCtx(makeRequest('eth_unknownMethod')))
     expect((res as { error: { message: string } }).error.message).toBe(getSdkError('UNSUPPORTED_METHODS').message)
+  })
+})
+
+describe('routeSessionRequest — read-only + wallet-control branches', () => {
+  beforeEach(() => {
+    mockProxyReadOnlyCall.mockReset()
+  })
+
+  describe('wallet_switchEthereumChain', () => {
+    it('switches to a deployed chain and responds null', async () => {
+      const switchActiveChainByCaip2 = jest.fn().mockResolvedValue({ ok: true })
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_switchEthereumChain', [{ chainId: '0x89' }]), { switchActiveChainByCaip2 }),
+      )
+      expect(switchActiveChainByCaip2).toHaveBeenCalledWith('eip155:137')
+      expect((res as { result: null }).result).toBeNull()
+    })
+
+    it('responds 4901 for a non-deployed chain', async () => {
+      const switchActiveChainByCaip2 = jest.fn().mockResolvedValue({ ok: false, reason: 'NOT_DEPLOYED' })
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_switchEthereumChain', [{ chainId: '0x89' }]), { switchActiveChainByCaip2 }),
+      )
+      expect((res as { error: { code: number } }).error.code).toBe(4901)
+    })
+
+    it('responds -32602 when the target chainId is missing', async () => {
+      const res = await routeSessionRequest(makeCtx(makeRequest('wallet_switchEthereumChain', [{}])))
+      expect((res as { error: { code: number } }).error.code).toBe(-32602)
+    })
+  })
+
+  describe('wallet_getCapabilities', () => {
+    it('reports atomic capability for explicitly requested chains', async () => {
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_getCapabilities', [SAFE_ADDRESS, ['0x1', '0x89']])),
+      )
+      const result = (res as { result: Record<string, unknown> }).result
+      expect(Object.keys(result)).toEqual(['0x1', '0x89'])
+    })
+
+    it('falls back to the envelope session chain when no chains are requested', async () => {
+      const res = await routeSessionRequest(makeCtx(makeRequest('wallet_getCapabilities', [SAFE_ADDRESS])))
+      const result = (res as { result: Record<string, unknown> }).result
+      expect(Object.keys(result)).toEqual(['0x1'])
+    })
+
+    it('tolerates malformed (non-string) chainIds and falls back to the envelope chain', async () => {
+      // A malformed dApp request must not throw out of the router (which would leave the dApp
+      // without any response); non-string entries are dropped.
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_getCapabilities', [SAFE_ADDRESS, [1, 137] as unknown as string[]])),
+      )
+      const result = (res as { result: Record<string, unknown> }).result
+      expect(Object.keys(result)).toEqual(['0x1'])
+    })
+
+    it('omits requested chains the Safe is not deployed on', async () => {
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_getCapabilities', [SAFE_ADDRESS, ['0x1', '0x89']]), {
+          deployedChainIds: ['1'],
+        }),
+      )
+      const result = (res as { result: Record<string, unknown> }).result
+      expect(Object.keys(result)).toEqual(['0x1'])
+    })
+
+    it('returns {} when no requested chain is deployed', async () => {
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_getCapabilities', [SAFE_ADDRESS, ['0x89']]), { deployedChainIds: ['1'] }),
+      )
+      expect((res as { result: Record<string, unknown> }).result).toEqual({})
+    })
+
+    it('skips a non-numeric deployed chain id instead of throwing (BigInt safety)', async () => {
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_getCapabilities', [SAFE_ADDRESS, ['0x1']]), {
+          deployedChainIds: ['1', 'not-a-chain'],
+        }),
+      )
+      const result = (res as { result: Record<string, unknown> }).result
+      expect(Object.keys(result)).toEqual(['0x1'])
+    })
+  })
+
+  describe('wallet_getCallsStatus', () => {
+    it('returns the status envelope from getCallsStatus', async () => {
+      const envelope = { version: '2.0.0', id: '0xhash', chainId: '0x1', status: 200, atomic: true }
+      const getCallsStatus = jest.fn().mockResolvedValue(envelope)
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_getCallsStatus', ['0xhash']), { getCallsStatus }),
+      )
+      expect(getCallsStatus).toHaveBeenCalledWith('eip155:1', '0xhash')
+      expect((res as { result: unknown }).result).toEqual(envelope)
+    })
+
+    it('maps a thrown lookup to -32603', async () => {
+      const getCallsStatus = jest.fn().mockRejectedValue(new Error('Transaction not found'))
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_getCallsStatus', ['0xunknown']), { getCallsStatus }),
+      )
+      // jsonrpc-utils normalizes the message for the reserved -32603 code, so assert the code.
+      expect((res as { error: { code: number } }).error.code).toBe(-32603)
+    })
+  })
+
+  describe('wallet_showCallsStatus', () => {
+    it('navigates and responds null', async () => {
+      const navigateToCallsStatus = jest.fn()
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_showCallsStatus', ['0xhash']), { navigateToCallsStatus }),
+      )
+      expect(navigateToCallsStatus).toHaveBeenCalledWith('eip155:1', '0xhash')
+      expect((res as { result: null }).result).toBeNull()
+    })
+  })
+
+  describe('read-only RPC passthrough', () => {
+    it('proxies an allow-listed method to the active chain', async () => {
+      mockProxyReadOnlyCall.mockResolvedValue('0x10')
+      const res = await routeSessionRequest(makeCtx(makeRequest('eth_blockNumber', [])))
+      expect(mockProxyReadOnlyCall).toHaveBeenCalledWith(chain, 'eth_blockNumber', [])
+      expect((res as { result: string }).result).toBe('0x10')
+    })
+
+    it('responds -32603 when no active chain is resolved', async () => {
+      const res = await routeSessionRequest(makeCtx(makeRequest('eth_call', [{}]), { activeChain: null }))
+      expect((res as { error: { code: number } }).error.code).toBe(-32603)
+      expect(mockProxyReadOnlyCall).not.toHaveBeenCalled()
+    })
+
+    it('maps a proxy failure to -32603', async () => {
+      mockProxyReadOnlyCall.mockRejectedValue(new Error('RPC down'))
+      const res = await routeSessionRequest(makeCtx(makeRequest('eth_getBalance', [SAFE_ADDRESS, 'latest'])))
+      expect((res as { error: { code: number } }).error.code).toBe(-32603)
+    })
   })
 })
 

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/methodRouter.test.ts
@@ -53,12 +53,15 @@ describe('routeSessionRequest', () => {
   it('rejects cross-namespace requests', async () => {
     const res = await routeSessionRequest(makeCtx(makeRequest('eth_sendTransaction', sendTxParams, 'cosmos:1')))
     expect(res).toHaveProperty('error')
+    // The SDK code survives (not stripped to -32000).
+    expect((res as { error: { code: number } }).error.code).toBe(getSdkError('UNAUTHORIZED_METHOD').code)
     expect(isDeferredResponse(res)).toBe(false)
   })
 
   it('rejects message-signing methods without UI', async () => {
     const res = await routeSessionRequest(makeCtx(makeRequest('personal_sign', ['0xmsg', SAFE_ADDRESS])))
     expect((res as { error: { message: string } }).error.message).toBe(getSdkError('UNSUPPORTED_METHODS').message)
+    expect((res as { error: { code: number } }).error.code).toBe(getSdkError('UNSUPPORTED_METHODS').code)
   })
 
   it('answers eth_accounts with the checksummed active Safe address', async () => {
@@ -202,6 +205,7 @@ describe('routeSessionRequest', () => {
   it('returns UNSUPPORTED_METHODS for unknown methods', async () => {
     const res = await routeSessionRequest(makeCtx(makeRequest('eth_unknownMethod')))
     expect((res as { error: { message: string } }).error.message).toBe(getSdkError('UNSUPPORTED_METHODS').message)
+    expect((res as { error: { code: number } }).error.code).toBe(getSdkError('UNSUPPORTED_METHODS').code)
   })
 })
 
@@ -231,6 +235,15 @@ describe('routeSessionRequest — read-only + wallet-control branches', () => {
     it('responds -32602 when the target chainId is missing', async () => {
       const res = await routeSessionRequest(makeCtx(makeRequest('wallet_switchEthereumChain', [{}])))
       expect((res as { error: { code: number } }).error.code).toBe(-32602)
+    })
+
+    it('responds -32602 (not a NOT_DEPLOYED reject) for a malformed hex chainId', async () => {
+      const switchActiveChainByCaip2 = jest.fn().mockResolvedValue({ ok: true })
+      const res = await routeSessionRequest(
+        makeCtx(makeRequest('wallet_switchEthereumChain', [{ chainId: '0xZZ' }]), { switchActiveChainByCaip2 }),
+      )
+      expect((res as { error: { code: number } }).error.code).toBe(-32602)
+      expect(switchActiveChainByCaip2).not.toHaveBeenCalled()
     })
   })
 
@@ -298,13 +311,14 @@ describe('routeSessionRequest — read-only + wallet-control branches', () => {
       expect((res as { result: unknown }).result).toEqual(envelope)
     })
 
-    it('maps a thrown lookup to -32603', async () => {
+    it('maps a thrown lookup to -32000 with the reason preserved', async () => {
       const getCallsStatus = jest.fn().mockRejectedValue(new Error('Transaction not found'))
       const res = await routeSessionRequest(
         makeCtx(makeRequest('wallet_getCallsStatus', ['0xunknown']), { getCallsStatus }),
       )
-      // jsonrpc-utils normalizes the message for the reserved -32603 code, so assert the code.
-      expect((res as { error: { code: number } }).error.code).toBe(-32603)
+      // -32000 (not the reserved -32603) so jsonrpc-utils keeps our message on the wire.
+      expect((res as { error: { code: number; message: string } }).error.code).toBe(-32000)
+      expect((res as { error: { message: string } }).error.message).toBe('Transaction not found')
     })
   })
 

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/readRpcProxy.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/readRpcProxy.test.ts
@@ -1,0 +1,79 @@
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import { createWeb3ReadOnly } from '@/src/services/web3'
+import { isReadOnlyMethod, proxyReadOnlyCall } from '../readRpcProxy'
+
+jest.mock('@/src/services/web3', () => ({
+  createWeb3ReadOnly: jest.fn(),
+  // The proxy keys its cache by the resolved url, so the mock derives it from rpcUri.value.
+  getRpcServiceUrl: jest.fn((rpcUri?: { value?: string }) => rpcUri?.value ?? ''),
+}))
+const mockCreateWeb3ReadOnly = createWeb3ReadOnly as jest.Mock
+
+const makeChain = (chainId: string, url = `https://rpc.test/${chainId}`): Chain =>
+  ({ chainId, rpcUri: { authentication: 'NO_AUTHENTICATION', value: url } }) as unknown as Chain
+
+describe('isReadOnlyMethod', () => {
+  it('accepts allow-listed read-only methods', () => {
+    expect(isReadOnlyMethod('eth_call')).toBe(true)
+    expect(isReadOnlyMethod('eth_getBalance')).toBe(true)
+    expect(isReadOnlyMethod('eth_blockNumber')).toBe(true)
+  })
+
+  it('rejects non-allow-listed methods', () => {
+    expect(isReadOnlyMethod('eth_sendTransaction')).toBe(false)
+    expect(isReadOnlyMethod('personal_sign')).toBe(false)
+    expect(isReadOnlyMethod('eth_unknown')).toBe(false)
+  })
+})
+
+describe('proxyReadOnlyCall', () => {
+  beforeEach(() => {
+    mockCreateWeb3ReadOnly.mockReset()
+  })
+
+  it('forwards an allow-listed call to provider.send', async () => {
+    const send = jest.fn().mockResolvedValue('0x10')
+    mockCreateWeb3ReadOnly.mockReturnValue({ send })
+    const result = await proxyReadOnlyCall(makeChain('100'), 'eth_blockNumber', [])
+    expect(send).toHaveBeenCalledWith('eth_blockNumber', [])
+    expect(result).toBe('0x10')
+  })
+
+  it('defaults missing params to an empty array', async () => {
+    const send = jest.fn().mockResolvedValue(null)
+    mockCreateWeb3ReadOnly.mockReturnValue({ send })
+    await proxyReadOnlyCall(makeChain('101'), 'eth_gasPrice', undefined as unknown as unknown[])
+    expect(send).toHaveBeenCalledWith('eth_gasPrice', [])
+  })
+
+  it('throws for a method outside the allow-list without building a provider', async () => {
+    await expect(proxyReadOnlyCall(makeChain('102'), 'eth_sendTransaction', [])).rejects.toThrow(
+      'is not in the read-only allow-list',
+    )
+    expect(mockCreateWeb3ReadOnly).not.toHaveBeenCalled()
+  })
+
+  it('throws when no RPC URL is configured for the chain', async () => {
+    await expect(proxyReadOnlyCall(makeChain('103', ''), 'eth_call', [{}])).rejects.toThrow(
+      'No RPC URL configured for chainId=103',
+    )
+    expect(mockCreateWeb3ReadOnly).not.toHaveBeenCalled()
+  })
+
+  it('caches one provider per chain+url across calls', async () => {
+    const send = jest.fn().mockResolvedValue('0x1')
+    mockCreateWeb3ReadOnly.mockReturnValue({ send })
+    const chain = makeChain('104')
+    await proxyReadOnlyCall(chain, 'eth_blockNumber', [])
+    await proxyReadOnlyCall(chain, 'eth_gasPrice', [])
+    expect(mockCreateWeb3ReadOnly).toHaveBeenCalledTimes(1)
+  })
+
+  it('rebuilds the provider when the same chain reports a new RPC url', async () => {
+    const send = jest.fn().mockResolvedValue('0x1')
+    mockCreateWeb3ReadOnly.mockReturnValue({ send })
+    await proxyReadOnlyCall(makeChain('105', 'https://rpc.old/105'), 'eth_blockNumber', [])
+    await proxyReadOnlyCall(makeChain('105', 'https://rpc.new/105'), 'eth_blockNumber', [])
+    expect(mockCreateWeb3ReadOnly).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/readRpcProxy.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/__tests__/readRpcProxy.test.ts
@@ -1,6 +1,6 @@
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { createWeb3ReadOnly } from '@/src/services/web3'
-import { isReadOnlyMethod, proxyReadOnlyCall } from '../readRpcProxy'
+import { isReadOnlyMethod, proxyReadOnlyCall, __clearProviderCache } from '../readRpcProxy'
 
 jest.mock('@/src/services/web3', () => ({
   createWeb3ReadOnly: jest.fn(),
@@ -29,6 +29,7 @@ describe('isReadOnlyMethod', () => {
 describe('proxyReadOnlyCall', () => {
   beforeEach(() => {
     mockCreateWeb3ReadOnly.mockReset()
+    __clearProviderCache()
   })
 
   it('forwards an allow-listed call to provider.send', async () => {
@@ -75,5 +76,15 @@ describe('proxyReadOnlyCall', () => {
     await proxyReadOnlyCall(makeChain('105', 'https://rpc.old/105'), 'eth_blockNumber', [])
     await proxyReadOnlyCall(makeChain('105', 'https://rpc.new/105'), 'eth_blockNumber', [])
     expect(mockCreateWeb3ReadOnly).toHaveBeenCalledTimes(2)
+  })
+
+  it('evicts the stale entry on a url swap (does not accumulate per chain)', async () => {
+    const send = jest.fn().mockResolvedValue('0x1')
+    mockCreateWeb3ReadOnly.mockReturnValue({ send })
+    await proxyReadOnlyCall(makeChain('106', 'https://rpc.old/106'), 'eth_blockNumber', [])
+    await proxyReadOnlyCall(makeChain('106', 'https://rpc.new/106'), 'eth_blockNumber', [])
+    // Reverting to the old url rebuilds — the old entry was evicted, not retained alongside the new.
+    await proxyReadOnlyCall(makeChain('106', 'https://rpc.old/106'), 'eth_blockNumber', [])
+    expect(mockCreateWeb3ReadOnly).toHaveBeenCalledTimes(3)
   })
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/constants.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/constants.ts
@@ -1,8 +1,7 @@
 import { EIP155 } from '@safe-global/utils/features/walletconnect/constants'
 
-// Methods advertised in the session namespace. Intentionally excludes READ_ONLY_RPC_ALLOW_LIST:
-// reads are proxied opportunistically, and a strict dApp that gates on the namespace can fall
-// back to its own RPC for them (mirrors web's safe-wallet-provider).
+// Intentionally excludes the read-only methods: those are proxied opportunistically, and a strict
+// dApp that gates on the namespace can fall back to its own RPC (mirrors web's safe-wallet-provider).
 export const WALLET_SUPPORTED_METHODS = [
   'eth_accounts',
   'eth_chainId',
@@ -17,8 +16,8 @@ export const WALLET_SUPPORTED_METHODS = [
 
 export type SupportedMethod = (typeof WALLET_SUPPORTED_METHODS)[number]
 
-// Read-only methods proxied to the chain RPC. Params aren't range-validated (e.g. eth_getLogs
-// block range) — the configured RPC enforces its own limits, so this is an accepted limitation.
+// Proxied to the chain RPC. Params aren't range-validated (e.g. eth_getLogs block range); the
+// configured RPC enforces its own limits — an accepted limitation.
 export const READ_ONLY_RPC_ALLOW_LIST = [
   'eth_blockNumber',
   'eth_call',

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/constants.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/constants.ts
@@ -1,6 +1,8 @@
 import { EIP155 } from '@safe-global/utils/features/walletconnect/constants'
 
-// EIP-1193 / WC namespace methods this wallet supports.
+// Methods advertised in the session namespace. Intentionally excludes READ_ONLY_RPC_ALLOW_LIST:
+// reads are proxied opportunistically, and a strict dApp that gates on the namespace can fall
+// back to its own RPC for them (mirrors web's safe-wallet-provider).
 export const WALLET_SUPPORTED_METHODS = [
   'eth_accounts',
   'eth_chainId',

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/constants.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/constants.ts
@@ -17,7 +17,8 @@ export const WALLET_SUPPORTED_METHODS = [
 
 export type SupportedMethod = (typeof WALLET_SUPPORTED_METHODS)[number]
 
-// Read-only methods proxied to the chain RPC (ethers JsonRpcProvider).
+// Read-only methods proxied to the chain RPC. Params aren't range-validated (e.g. eth_getLogs
+// block range) — the configured RPC enforces its own limits, so this is an accepted limitation.
 export const READ_ONLY_RPC_ALLOW_LIST = [
   'eth_blockNumber',
   'eth_call',

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/getCallsStatus.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/getCallsStatus.ts
@@ -28,25 +28,15 @@ export type RawTxReceipt = {
   transactionHash: `0x${string}`
 }
 
-// Minimal shape of the CGW transaction details this builder reads (assignable from the
-// generated TransactionDetails, whose nested fields are nullable).
 export type CallsStatusTx = {
   txStatus?: string
   txHash?: string | null
   txData?: { dataDecoded?: { parameters?: { valueDecoded?: unknown }[] | null } | null } | null
 }
 
-// BundleTxStatuses (verbatim from web):
-//   AWAITING_CONFIRMATIONS / AWAITING_EXECUTION → 100 PENDING
-//   SUCCESS → 200 CONFIRMED | CANCELLED → 400 OFFCHAIN_FAILURE | FAILED → 500 REVERTED
 const mapTxStatus = (txStatus?: string): number =>
   txStatus === 'SUCCESS' ? 200 : txStatus === 'CANCELLED' ? 400 : txStatus === 'FAILED' ? 500 : 100
 
-/**
- * Build the EIP-5792 GetCallsResult envelope from a CGW transaction and an optional on-chain
- * receipt. Pure: the caller fetches `tx` (and `receipt` when there's a tx hash to look up).
- * When `receipt` is null the envelope is still valid (a pending / off-chain-failed bundle).
- */
 export const buildGetCallsResult = (
   id: string,
   numericChainId: string,
@@ -75,7 +65,6 @@ export const buildGetCallsResult = (
       logs: receipt.logs,
       status: onChainStatusHex,
       blockHash: receipt.blockHash,
-      // BigInt-based: handles block numbers / gas above 2^53 and normalizes padding.
       blockNumber: toHex(receipt.blockNumber) as `0x${string}`,
       gasUsed: toHex(receipt.gasUsed) as `0x${string}`,
       transactionHash: (tx.txHash ?? receipt.transactionHash) as `0x${string}`,

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/getCallsStatus.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/getCallsStatus.ts
@@ -1,4 +1,4 @@
-import { chainIdToHex } from '@safe-global/utils/features/walletconnect/utils'
+import { toHex } from '@safe-global/utils/features/walletconnect/utils'
 
 // EIP-5792 GetCallsResult envelope (mirrors apps/web/.../safe-wallet-provider/index.ts).
 // status codes: 100 PENDING | 200 CONFIRMED | 400 OFFCHAIN_FAILURE | 500 REVERTED.
@@ -56,7 +56,7 @@ export const buildGetCallsResult = (
   const envelope = {
     version: '2.0.0' as const,
     id,
-    chainId: chainIdToHex(numericChainId) as `0x${string}`,
+    chainId: toHex(numericChainId) as `0x${string}`,
     status: mapTxStatus(tx.txStatus),
     atomic: true as const,
   }
@@ -75,9 +75,9 @@ export const buildGetCallsResult = (
       logs: receipt.logs,
       status: onChainStatusHex,
       blockHash: receipt.blockHash,
-      // chainIdToHex (BigInt-based) handles block numbers / gas above 2^53 and normalizes padding.
-      blockNumber: chainIdToHex(receipt.blockNumber) as `0x${string}`,
-      gasUsed: chainIdToHex(receipt.gasUsed) as `0x${string}`,
+      // BigInt-based: handles block numbers / gas above 2^53 and normalizes padding.
+      blockNumber: toHex(receipt.blockNumber) as `0x${string}`,
+      gasUsed: toHex(receipt.gasUsed) as `0x${string}`,
       transactionHash: (tx.txHash ?? receipt.transactionHash) as `0x${string}`,
     })),
   }

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/getCallsStatus.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/getCallsStatus.ts
@@ -1,0 +1,84 @@
+import { chainIdToHex } from '@safe-global/utils/features/walletconnect/utils'
+
+// EIP-5792 GetCallsResult envelope (mirrors apps/web/.../safe-wallet-provider/index.ts).
+// status codes: 100 PENDING | 200 CONFIRMED | 400 OFFCHAIN_FAILURE | 500 REVERTED.
+export type GetCallsResult = {
+  version: '2.0.0'
+  id: string
+  chainId: `0x${string}`
+  status: number
+  atomic: true
+  receipts?: {
+    logs: unknown[]
+    status: `0x${string}`
+    blockHash: `0x${string}`
+    blockNumber: `0x${string}`
+    gasUsed: `0x${string}`
+    transactionHash: `0x${string}`
+  }[]
+}
+
+// Raw eth_getTransactionReceipt JSON-RPC result — hex-string fields, as returned by
+// provider.send(). Distinct from ethers' parsed TransactionReceipt class.
+export type RawTxReceipt = {
+  logs: unknown[]
+  blockHash: `0x${string}`
+  blockNumber: `0x${string}`
+  gasUsed: `0x${string}`
+  transactionHash: `0x${string}`
+}
+
+// Minimal shape of the CGW transaction details this builder reads (assignable from the
+// generated TransactionDetails, whose nested fields are nullable).
+export type CallsStatusTx = {
+  txStatus?: string
+  txHash?: string | null
+  txData?: { dataDecoded?: { parameters?: { valueDecoded?: unknown }[] | null } | null } | null
+}
+
+// BundleTxStatuses (verbatim from web):
+//   AWAITING_CONFIRMATIONS / AWAITING_EXECUTION → 100 PENDING
+//   SUCCESS → 200 CONFIRMED | CANCELLED → 400 OFFCHAIN_FAILURE | FAILED → 500 REVERTED
+const mapTxStatus = (txStatus?: string): number =>
+  txStatus === 'SUCCESS' ? 200 : txStatus === 'CANCELLED' ? 400 : txStatus === 'FAILED' ? 500 : 100
+
+/**
+ * Build the EIP-5792 GetCallsResult envelope from a CGW transaction and an optional on-chain
+ * receipt. Pure: the caller fetches `tx` (and `receipt` when there's a tx hash to look up).
+ * When `receipt` is null the envelope is still valid (a pending / off-chain-failed bundle).
+ */
+export const buildGetCallsResult = (
+  id: string,
+  numericChainId: string,
+  tx: CallsStatusTx,
+  receipt: RawTxReceipt | null,
+): GetCallsResult => {
+  const envelope = {
+    version: '2.0.0' as const,
+    id,
+    chainId: chainIdToHex(numericChainId) as `0x${string}`,
+    status: mapTxStatus(tx.txStatus),
+    atomic: true as const,
+  }
+  if (!receipt) {
+    return envelope
+  }
+
+  // Web replicates the same receipt for each underlying call in the bundle.
+  const valueDecoded = tx.txData?.dataDecoded?.parameters?.[0]?.valueDecoded
+  const callsCount = Array.isArray(valueDecoded) && valueDecoded.length > 0 ? valueDecoded.length : 1
+  const onChainStatusHex = (tx.txStatus === 'SUCCESS' ? '0x1' : '0x0') as `0x${string}`
+
+  return {
+    ...envelope,
+    receipts: Array.from({ length: callsCount }, () => ({
+      logs: receipt.logs,
+      status: onChainStatusHex,
+      blockHash: receipt.blockHash,
+      // chainIdToHex (BigInt-based) handles block numbers / gas above 2^53 and normalizes padding.
+      blockNumber: chainIdToHex(receipt.blockNumber) as `0x${string}`,
+      gasUsed: chainIdToHex(receipt.gasUsed) as `0x${string}`,
+      transactionHash: (tx.txHash ?? receipt.transactionHash) as `0x${string}`,
+    })),
+  }
+}

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -4,9 +4,12 @@ import { getAddress } from 'ethers'
 import type { WalletKitTypes } from '@reown/walletkit'
 import type { AppDispatch, RootState } from '@/src/store'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
-import { chainIdToHex } from '@safe-global/utils/features/walletconnect/utils'
+import { chainIdToHex, getEip155ChainId, stripEip155Prefix } from '@safe-global/utils/features/walletconnect/utils'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
+import { buildAtomicCapabilities } from '@safe-global/utils/features/walletconnect/eip5792'
 import { REJECTED_SIGNING_METHODS, SUPPORTED_NAMESPACE } from './constants'
+import { isReadOnlyMethod, proxyReadOnlyCall } from './readRpcProxy'
+import type { GetCallsResult } from './getCallsStatus'
 
 export type RoutedResponse = ReturnType<typeof formatJsonRpcResult> | ReturnType<typeof formatJsonRpcError>
 
@@ -21,6 +24,12 @@ export type RouteContext = {
   activeChain: Chain | null
   activeSafeAddress: string | null
   hasSigner: boolean
+  // Decimal (not hex) chain ids the active Safe is deployed on.
+  deployedChainIds: string[]
+  switchActiveChainByCaip2: (caip2: string) => Promise<{ ok: true } | { ok: false; reason: 'NOT_DEPLOYED' }>
+  // The id is a safeTxHash; throws when it's unknown.
+  getCallsStatus: (chainId: string, id: string) => Promise<GetCallsResult>
+  navigateToCallsStatus: (chainId: string, id: string) => void
 }
 
 const NS = SUPPORTED_NAMESPACE + ':'
@@ -40,6 +49,16 @@ const invalidParamsError = (id: number) => formatJsonRpcError(id, { code: -32602
 
 // The active chain config hasn't resolved (yet) — the dApp can retry.
 const noActiveChainError = (id: number) => formatJsonRpcError(id, { code: -32603, message: 'No active chain' })
+
+// chainIdToHex throws on a non-integer id; wallet_getCapabilities feeds it dApp-supplied chain
+// ids, so drop malformed ones rather than failing the whole request.
+const toChainHexOrNull = (chainId: string): string | null => {
+  try {
+    return chainIdToHex(chainId)
+  } catch {
+    return null
+  }
+}
 
 // Per-call shape (web's mapping rules), shared by eth_sendTransaction and wallet_sendCalls:
 //   - missing / all-fields-empty → invalid
@@ -74,8 +93,6 @@ export const isValidTxRequestParams = (
   return !!bundle?.calls?.length && Array.isArray(bundle.calls) && bundle.calls.every(isValidDappCall)
 }
 
-// Scope: the tx-request flow only. The 5792 capabilities / status surface and read-only
-// passthrough land later as extra branches here.
 export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResponse> => {
   const { request, activeChain, activeSafeAddress, hasSigner } = ctx
   const { id, params } = request
@@ -104,6 +121,73 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
       return noActiveChainError(id)
     }
     return formatJsonRpcResult(id, method === 'eth_chainId' ? chainIdToHex(activeChain.chainId) : activeChain.chainId)
+  }
+
+  // Chain switch — the target chain lives in rpc.params[0].chainId as a hex string (EIP-3326).
+  // `chainId` on the WC envelope is the *current* session chain, so don't read it here.
+  if (method === 'wallet_switchEthereumChain') {
+    const [target] = rpcParams as [{ chainId?: string } | undefined]
+    if (!target?.chainId) {
+      return formatJsonRpcError(id, { code: -32602, message: 'Missing target chainId' })
+    }
+    const targetDecimal = String(parseInt(target.chainId, 16))
+    const result = await ctx.switchActiveChainByCaip2(getEip155ChainId(targetDecimal))
+    if (!result.ok) {
+      return formatJsonRpcError(id, { code: 4901, message: 'Safe is not deployed on this chain' })
+    }
+    return formatJsonRpcResult(id, null)
+  }
+
+  // EIP-5792 wallet_getCapabilities(address, chainIds?). Response is keyed by hex chain id (not
+  // CAIP-2) for the chains the dApp asked about (falling back to the envelope chain). Only
+  // advertise batching for chains the Safe is deployed on, else a later wallet_sendCalls rejects.
+  if (method === 'wallet_getCapabilities') {
+    const [, requestedChainIds] = rpcParams as [string, unknown]
+    // Drop non-string entries (a dApp can send numbers); an uncaught throw would drop the reply.
+    const normalizedRequested = Array.isArray(requestedChainIds)
+      ? requestedChainIds.filter((c): c is string => typeof c === 'string').map((c) => c.toLowerCase())
+      : []
+    const envelopeChainHex = toChainHexOrNull(stripEip155Prefix(chainId))
+    const candidateChains =
+      normalizedRequested.length > 0 ? normalizedRequested : envelopeChainHex ? [envelopeChainHex] : []
+    const deployedChainsHex = new Set(ctx.deployedChainIds.map(toChainHexOrNull).filter((c): c is string => c !== null))
+    const chainsToReport = candidateChains.filter((c) => deployedChainsHex.has(c))
+    if (chainsToReport.length === 0) {
+      return formatJsonRpcResult(id, {})
+    }
+    return formatJsonRpcResult(id, buildAtomicCapabilities(chainsToReport))
+  }
+
+  if (method === 'wallet_getCallsStatus') {
+    const [callsId] = rpcParams as [string]
+    try {
+      const result = await ctx.getCallsStatus(chainId, callsId)
+      return formatJsonRpcResult(id, result)
+    } catch (e) {
+      // An unknown id is an error, not {status:100} — viem/wagmi treat "missing" and "pending"
+      // as distinct. jsonrpc-utils replaces the message for the reserved -32603 code, so this
+      // string is only a developer hint.
+      return formatJsonRpcError(id, { code: -32603, message: e instanceof Error ? e.message : 'Transaction not found' })
+    }
+  }
+  if (method === 'wallet_showCallsStatus') {
+    const [callsId] = rpcParams as [string]
+    ctx.navigateToCallsStatus(chainId, callsId)
+    return formatJsonRpcResult(id, null)
+  }
+
+  // Read-only RPC passthrough. A multichain session asking for a non-active (but approved) chain
+  // still hits the active chain — this is intentional.
+  if (isReadOnlyMethod(method)) {
+    if (!activeChain) {
+      return noActiveChainError(id)
+    }
+    try {
+      const result = await proxyReadOnlyCall(activeChain, method, rpcParams)
+      return formatJsonRpcResult(id, result)
+    } catch (e) {
+      return formatJsonRpcError(id, { code: -32603, message: e instanceof Error ? e.message : 'RPC proxy failed' })
+    }
   }
 
   // Transaction methods — deferred to the sheet (the response is sent after review).

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -143,9 +143,8 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
     return formatJsonRpcResult(id, null)
   }
 
-  // EIP-5792 wallet_getCapabilities(address, chainIds?). Response is keyed by hex chain id (not
-  // CAIP-2) for the chains the dApp asked about (falling back to the envelope chain). Only
-  // advertise batching for chains the Safe is deployed on, else a later wallet_sendCalls rejects.
+  // EIP-5792 wallet_getCapabilities, keyed by hex chain id (not CAIP-2). Only advertise batching
+  // for chains the Safe is deployed on, else a later wallet_sendCalls rejects.
   if (method === 'wallet_getCapabilities') {
     const [, requestedChainIds] = rpcParams as [string, unknown]
     // Drop non-string entries (a dApp can send numbers); an uncaught throw would drop the reply.
@@ -174,8 +173,7 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
       return formatJsonRpcResult(id, result)
     } catch (e) {
       // An unknown id is an error, not {status:100} — viem/wagmi treat "missing" and "pending" as
-      // distinct. Use -32000 (web parity), not the reserved -32603 whose message jsonrpc-utils
-      // rewrites, so the dApp keeps the actual reason.
+      // distinct. -32000 is non-reserved (see noActiveChainError).
       return formatJsonRpcError(id, { code: -32000, message: e instanceof Error ? e.message : 'Transaction not found' })
     }
   }
@@ -195,7 +193,7 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
       const result = await proxyReadOnlyCall(activeChain, method, rpcParams)
       return formatJsonRpcResult(id, result)
     } catch (e) {
-      // -32000 (non-reserved) so the upstream RPC reason survives jsonrpc-utils' reserved-code rewrite.
+      // Non-reserved code so the upstream RPC reason survives (see noActiveChainError).
       return formatJsonRpcError(id, { code: -32000, message: e instanceof Error ? e.message : 'RPC proxy failed' })
     }
   }

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -9,6 +9,7 @@ import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { buildAtomicCapabilities } from '@safe-global/utils/features/walletconnect/eip5792'
 import { REJECTED_SIGNING_METHODS, SUPPORTED_NAMESPACE } from './constants'
 import { isReadOnlyMethod, proxyReadOnlyCall } from './readRpcProxy'
+import { logWalletKitWarn } from '../utils/errors'
 import type { GetCallsResult } from './getCallsStatus'
 
 export type RoutedResponse = ReturnType<typeof formatJsonRpcResult> | ReturnType<typeof formatJsonRpcError>
@@ -157,6 +158,10 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
     const deployedChainsHex = new Set(ctx.deployedChainIds.map(toChainHexOrNull).filter((c): c is string => c !== null))
     const chainsToReport = candidateChains.filter((c) => deployedChainsHex.has(c))
     if (chainsToReport.length === 0) {
+      // No deployed chains at all means Safe data hasn't synced yet (cold start), not a genuine miss.
+      if (ctx.deployedChainIds.length === 0) {
+        logWalletKitWarn('wallet_getCapabilities: no deployed chains known yet (Safe data not synced?)')
+      }
       return formatJsonRpcResult(id, {})
     }
     return formatJsonRpcResult(id, buildAtomicCapabilities(chainsToReport))

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -47,8 +47,8 @@ const unsupportedError = (id: number) => formatJsonRpcError(id, getSdkError('UNS
 
 const invalidParamsError = (id: number) => formatJsonRpcError(id, { code: -32602, message: 'Invalid call parameters.' })
 
-// The active chain config hasn't resolved (yet) — the dApp can retry.
-const noActiveChainError = (id: number) => formatJsonRpcError(id, { code: -32603, message: 'No active chain' })
+// -32002 (non-reserved), not -32603: jsonrpc-utils rewrites reserved codes' messages, dropping our hint.
+const noActiveChainError = (id: number) => formatJsonRpcError(id, { code: -32002, message: 'No active chain' })
 
 // toHex throws on a non-integer id; wallet_getCapabilities feeds it dApp-supplied chain
 // ids, so drop malformed ones rather than failing the whole request.
@@ -190,14 +190,15 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
       const result = await proxyReadOnlyCall(activeChain, method, rpcParams)
       return formatJsonRpcResult(id, result)
     } catch (e) {
-      return formatJsonRpcError(id, { code: -32603, message: e instanceof Error ? e.message : 'RPC proxy failed' })
+      // -32000 (non-reserved) so the upstream RPC reason survives jsonrpc-utils' reserved-code rewrite.
+      return formatJsonRpcError(id, { code: -32000, message: e instanceof Error ? e.message : 'RPC proxy failed' })
     }
   }
 
   // Transaction methods — deferred to the sheet (the response is sent after review).
   if (method === 'eth_sendTransaction' || method === 'wallet_sendCalls') {
     if (!activeSafeAddress) {
-      return formatJsonRpcError(id, { code: -32603, message: 'No active Safe' })
+      return formatJsonRpcError(id, { code: -32002, message: 'No active Safe' })
     }
     if (!hasSigner) {
       return formatJsonRpcError(id, { code: NO_SIGNER_ERROR_CODE, message: 'No signer attached to this Safe' })

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/methodRouter.ts
@@ -4,7 +4,7 @@ import { getAddress } from 'ethers'
 import type { WalletKitTypes } from '@reown/walletkit'
 import type { AppDispatch, RootState } from '@/src/store'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
-import { chainIdToHex, getEip155ChainId, stripEip155Prefix } from '@safe-global/utils/features/walletconnect/utils'
+import { toHex, getEip155ChainId, stripEip155Prefix } from '@safe-global/utils/features/walletconnect/utils'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { buildAtomicCapabilities } from '@safe-global/utils/features/walletconnect/eip5792'
 import { REJECTED_SIGNING_METHODS, SUPPORTED_NAMESPACE } from './constants'
@@ -41,20 +41,20 @@ export const NO_SIGNER_ERROR_CODE = 4100
 // Sentinel (checked via isDeferredResponse): the request needs UI, so don't respond yet.
 const DEFERRED_RESULT = '__DEFERRED__'
 
-const crossNamespaceError = (id: number) => formatJsonRpcError(id, getSdkError('UNAUTHORIZED_METHOD').message)
+const crossNamespaceError = (id: number) => formatJsonRpcError(id, getSdkError('UNAUTHORIZED_METHOD'))
 
-const unsupportedError = (id: number) => formatJsonRpcError(id, getSdkError('UNSUPPORTED_METHODS').message)
+const unsupportedError = (id: number) => formatJsonRpcError(id, getSdkError('UNSUPPORTED_METHODS'))
 
 const invalidParamsError = (id: number) => formatJsonRpcError(id, { code: -32602, message: 'Invalid call parameters.' })
 
 // The active chain config hasn't resolved (yet) — the dApp can retry.
 const noActiveChainError = (id: number) => formatJsonRpcError(id, { code: -32603, message: 'No active chain' })
 
-// chainIdToHex throws on a non-integer id; wallet_getCapabilities feeds it dApp-supplied chain
+// toHex throws on a non-integer id; wallet_getCapabilities feeds it dApp-supplied chain
 // ids, so drop malformed ones rather than failing the whole request.
 const toChainHexOrNull = (chainId: string): string | null => {
   try {
-    return chainIdToHex(chainId)
+    return toHex(chainId)
   } catch {
     return null
   }
@@ -120,7 +120,7 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
     if (!activeChain) {
       return noActiveChainError(id)
     }
-    return formatJsonRpcResult(id, method === 'eth_chainId' ? chainIdToHex(activeChain.chainId) : activeChain.chainId)
+    return formatJsonRpcResult(id, method === 'eth_chainId' ? toHex(activeChain.chainId) : activeChain.chainId)
   }
 
   // Chain switch — the target chain lives in rpc.params[0].chainId as a hex string (EIP-3326).
@@ -130,8 +130,12 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
     if (!target?.chainId) {
       return formatJsonRpcError(id, { code: -32602, message: 'Missing target chainId' })
     }
-    const targetDecimal = String(parseInt(target.chainId, 16))
-    const result = await ctx.switchActiveChainByCaip2(getEip155ChainId(targetDecimal))
+    const parsed = parseInt(target.chainId, 16)
+    // A malformed hex chainId must read as invalid params, not a NOT_DEPLOYED ('NaN' chain) reject.
+    if (Number.isNaN(parsed)) {
+      return formatJsonRpcError(id, { code: -32602, message: 'Invalid target chainId' })
+    }
+    const result = await ctx.switchActiveChainByCaip2(getEip155ChainId(String(parsed)))
     if (!result.ok) {
       return formatJsonRpcError(id, { code: 4901, message: 'Safe is not deployed on this chain' })
     }
@@ -164,10 +168,10 @@ export const routeSessionRequest = async (ctx: RouteContext): Promise<RoutedResp
       const result = await ctx.getCallsStatus(chainId, callsId)
       return formatJsonRpcResult(id, result)
     } catch (e) {
-      // An unknown id is an error, not {status:100} — viem/wagmi treat "missing" and "pending"
-      // as distinct. jsonrpc-utils replaces the message for the reserved -32603 code, so this
-      // string is only a developer hint.
-      return formatJsonRpcError(id, { code: -32603, message: e instanceof Error ? e.message : 'Transaction not found' })
+      // An unknown id is an error, not {status:100} — viem/wagmi treat "missing" and "pending" as
+      // distinct. Use -32000 (web parity), not the reserved -32603 whose message jsonrpc-utils
+      // rewrites, so the dApp keeps the actual reason.
+      return formatJsonRpcError(id, { code: -32000, message: e instanceof Error ? e.message : 'Transaction not found' })
     }
   }
   if (method === 'wallet_showCallsStatus') {

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/namespaces.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/namespaces.ts
@@ -1,7 +1,7 @@
 import { buildApprovedNamespaces } from '@walletconnect/utils'
 import type { SessionTypes, ProposalTypes } from '@walletconnect/types'
 import { getAddress } from 'ethers'
-import { getEip155ChainId, chainIdToHex } from '@safe-global/utils/features/walletconnect/utils'
+import { getEip155ChainId, toHex } from '@safe-global/utils/features/walletconnect/utils'
 import {
   ATOMIC_CAPABILITY,
   buildAtomicCapabilities,
@@ -64,7 +64,7 @@ export const buildSafeSessionProperties = ({
 }): ProposalTypes.SessionProperties => {
   const checksummed = getAddress(safeAddress)
   const capabilities: Record<string, Record<string, AtomicCapability>> = {
-    [checksummed]: buildAtomicCapabilities(supportedChains.map((c) => chainIdToHex(c.chainId))),
+    [checksummed]: buildAtomicCapabilities(supportedChains.map((c) => toHex(c.chainId))),
   }
   return {
     atomic: JSON.stringify(ATOMIC_CAPABILITY.atomic),

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/readRpcProxy.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/readRpcProxy.ts
@@ -20,8 +20,19 @@ const getProviderForChain = (chain: Chain): JsonRpcProvider => {
   if (!provider) {
     throw new Error(`No RPC URL configured for chainId=${chain.chainId}`)
   }
+  // Evict any stale provider for this chain (a changed RPC url) so the cache keeps one per chain.
+  for (const key of providerCache.keys()) {
+    if (key.startsWith(`${chain.chainId}|`)) {
+      providerCache.delete(key)
+    }
+  }
   providerCache.set(cacheKey, provider)
   return provider
+}
+
+// Test-only: reset the module-level cache so tests don't couple through provider identity.
+export const __clearProviderCache = (): void => {
+  providerCache.clear()
 }
 
 export const isReadOnlyMethod = (method: string): boolean =>

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/readRpcProxy.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/readRpcProxy.ts
@@ -30,7 +30,7 @@ const getProviderForChain = (chain: Chain): JsonRpcProvider => {
   return provider
 }
 
-// Test-only: reset the module-level cache so tests don't couple through provider identity.
+// Test-only: reset the module-level cache.
 export const __clearProviderCache = (): void => {
   providerCache.clear()
 }

--- a/apps/mobile/src/features/WalletConnect/Wallet/services/readRpcProxy.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/services/readRpcProxy.ts
@@ -1,0 +1,36 @@
+import type { JsonRpcProvider } from 'ethers'
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import { createWeb3ReadOnly, getRpcServiceUrl } from '@/src/services/web3'
+import { READ_ONLY_RPC_ALLOW_LIST } from './constants'
+
+const providerCache = new Map<string, JsonRpcProvider>()
+
+const getProviderForChain = (chain: Chain): JsonRpcProvider => {
+  const url = getRpcServiceUrl(chain.rpcUri)
+  if (!url) {
+    throw new Error(`No RPC URL configured for chainId=${chain.chainId}`)
+  }
+  // Key by url as well as chainId so a changed RPC endpoint isn't served by a stale provider.
+  const cacheKey = `${chain.chainId}|${url}`
+  const cached = providerCache.get(cacheKey)
+  if (cached) {
+    return cached
+  }
+  const provider = createWeb3ReadOnly(chain)
+  if (!provider) {
+    throw new Error(`No RPC URL configured for chainId=${chain.chainId}`)
+  }
+  providerCache.set(cacheKey, provider)
+  return provider
+}
+
+export const isReadOnlyMethod = (method: string): boolean =>
+  (READ_ONLY_RPC_ALLOW_LIST as readonly string[]).includes(method)
+
+export const proxyReadOnlyCall = async (chain: Chain, method: string, params: unknown[]): Promise<unknown> => {
+  if (!isReadOnlyMethod(method)) {
+    throw new Error(`Method ${method} is not in the read-only allow-list`)
+  }
+  const provider = getProviderForChain(chain)
+  return provider.send(method, params ?? [])
+}

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/__tests__/sessionRequestActions.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/__tests__/sessionRequestActions.test.ts
@@ -1,0 +1,138 @@
+import type { AppDispatch, RootState } from '@/src/store'
+import { switchActiveChain } from '@/src/store/activeSafeSlice'
+import { selectChainById } from '@/src/store/chains'
+import { proxyReadOnlyCall } from '../../services/readRpcProxy'
+import { makeSwitchActiveChainByCaip2, makeGetCallsStatus, navigateToCallsStatus } from '../sessionRequestActions'
+
+jest.mock('../../services/readRpcProxy', () => ({ proxyReadOnlyCall: jest.fn() }))
+jest.mock('@/src/store/chains', () => ({ selectChainById: jest.fn() }))
+
+const mockRouterPush = jest.fn()
+jest.mock('expo-router', () => ({ router: { push: (...args: unknown[]) => mockRouterPush(...args) } }))
+
+const mockProxy = proxyReadOnlyCall as jest.Mock
+const mockSelectChainById = selectChainById as jest.Mock
+
+const SAFE = '0x1111111111111111111111111111111111111111'
+
+const stateWith = (overrides: Partial<RootState> = {}): RootState =>
+  ({
+    activeSafe: { address: SAFE, chainId: '1' },
+    safes: { [SAFE]: { '1': {} } },
+    ...overrides,
+  }) as unknown as RootState
+
+const getStateReturning = (state: RootState) => () => state
+
+beforeEach(() => jest.clearAllMocks())
+
+describe('makeSwitchActiveChainByCaip2', () => {
+  it('rejects (NOT_DEPLOYED) without dispatching when the chain config is unknown', async () => {
+    mockSelectChainById.mockReturnValue(undefined)
+    const dispatch = jest.fn() as unknown as AppDispatch
+
+    const result = await makeSwitchActiveChainByCaip2(getStateReturning(stateWith()), dispatch)('eip155:137')
+
+    expect(result).toEqual({ ok: false, reason: 'NOT_DEPLOYED' })
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('rejects (NOT_DEPLOYED) without dispatching when the Safe is not deployed on the target chain', async () => {
+    mockSelectChainById.mockReturnValue({ chainId: '137' })
+    const dispatch = jest.fn() as unknown as AppDispatch
+    const result = await makeSwitchActiveChainByCaip2(getStateReturning(stateWith()), dispatch)('eip155:137')
+
+    expect(result).toEqual({ ok: false, reason: 'NOT_DEPLOYED' })
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('switches the active chain and resolves ok when the Safe is deployed there', async () => {
+    mockSelectChainById.mockReturnValue({ chainId: '137' })
+    const dispatch = jest.fn() as unknown as AppDispatch
+    const state = stateWith({ safes: { [SAFE]: { '1': {}, '137': {} } } as never })
+
+    const result = await makeSwitchActiveChainByCaip2(getStateReturning(state), dispatch)('eip155:137')
+
+    expect(result).toEqual({ ok: true })
+    expect(dispatch).toHaveBeenCalledWith(switchActiveChain({ chainId: '137' }))
+  })
+})
+
+describe('makeGetCallsStatus', () => {
+  const dispatchResolving = (tx: unknown) =>
+    jest.fn().mockReturnValue({ unwrap: () => Promise.resolve(tx) }) as unknown as AppDispatch
+
+  const receipt = {
+    logs: [],
+    blockHash: '0xb',
+    blockNumber: '0x10',
+    gasUsed: '0x5',
+    transactionHash: '0xtx',
+  }
+
+  it('throws "Transaction not found" when the CGW lookup rejects', async () => {
+    const dispatch = jest
+      .fn()
+      .mockReturnValue({ unwrap: () => Promise.reject(new Error('404')) }) as unknown as AppDispatch
+
+    await expect(makeGetCallsStatus(getStateReturning(stateWith()), dispatch)('eip155:1', '0xhash')).rejects.toThrow(
+      'Transaction not found',
+    )
+    expect(mockProxy).not.toHaveBeenCalled()
+  })
+
+  it('returns a receipt-less envelope for a pending tx (no txHash)', async () => {
+    const dispatch = dispatchResolving({ txStatus: 'AWAITING_EXECUTION', txHash: null })
+
+    const result = await makeGetCallsStatus(getStateReturning(stateWith()), dispatch)('eip155:1', '0xhash')
+
+    expect(result.status).toBe(100)
+    expect(result.receipts).toBeUndefined()
+    expect(mockProxy).not.toHaveBeenCalled()
+  })
+
+  it('fetches and attaches the receipt when a tx hash and chain config are present', async () => {
+    mockSelectChainById.mockReturnValue({ chainId: '1' })
+    mockProxy.mockResolvedValue(receipt)
+    const dispatch = dispatchResolving({ txStatus: 'SUCCESS', txHash: '0xtx' })
+
+    const result = await makeGetCallsStatus(getStateReturning(stateWith()), dispatch)('eip155:1', '0xhash')
+
+    expect(mockProxy).toHaveBeenCalledWith({ chainId: '1' }, 'eth_getTransactionReceipt', ['0xtx'])
+    expect(result.status).toBe(200)
+    expect(result.receipts).toHaveLength(1)
+    expect(result.receipts?.[0]).toMatchObject({ status: '0x1', transactionHash: '0xtx' })
+  })
+
+  it('falls back to a receipt-less envelope when the receipt fetch throws (non-fatal)', async () => {
+    mockSelectChainById.mockReturnValue({ chainId: '1' })
+    mockProxy.mockRejectedValue(new Error('RPC down'))
+    const dispatch = dispatchResolving({ txStatus: 'SUCCESS', txHash: '0xtx' })
+
+    const result = await makeGetCallsStatus(getStateReturning(stateWith()), dispatch)('eip155:1', '0xhash')
+
+    expect(result.status).toBe(200)
+    expect(result.receipts).toBeUndefined()
+  })
+
+  it('skips the receipt fetch when no chain config is available for the lookup', async () => {
+    mockSelectChainById.mockReturnValue(undefined)
+    const dispatch = dispatchResolving({ txStatus: 'SUCCESS', txHash: '0xtx' })
+
+    const result = await makeGetCallsStatus(getStateReturning(stateWith()), dispatch)('eip155:1', '0xhash')
+
+    expect(mockProxy).not.toHaveBeenCalled()
+    expect(result.receipts).toBeUndefined()
+  })
+})
+
+describe('navigateToCallsStatus', () => {
+  it('pushes the pending-transactions route with the chain id and tx id', () => {
+    navigateToCallsStatus('eip155:1', '0xhash')
+
+    expect(mockRouterPush).toHaveBeenCalledWith({
+      pathname: '/pending-transactions',
+      params: { chainId: 'eip155:1', txId: '0xhash' },
+    })
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/__tests__/walletKitListeners.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/__tests__/walletKitListeners.test.ts
@@ -91,7 +91,11 @@ const dispatchPropose = (store: Store) =>
     }) as never,
   )
 
-const rejectedResponse = expect.objectContaining({ error: expect.anything() })
+// Assert the WC USER_REJECTED code (5000) survives — passing only the .message would collapse it
+// to -32000, which dApps can't read as a rejection.
+const rejectedResponse = expect.objectContaining({
+  error: expect.objectContaining({ code: getSdkError('USER_REJECTED').code }),
+})
 
 // Flush pending microtasks + timers so a no-op effect has had its chance to run before we
 // assert that nothing happened (jest.useFakeTimers() is global in this project).

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/sessionRequestActions.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/sessionRequestActions.ts
@@ -1,0 +1,68 @@
+import { router } from 'expo-router'
+import { cgwApi } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { stripEip155Prefix } from '@safe-global/utils/features/walletconnect/utils'
+import type { AppDispatch, RootState } from '@/src/store'
+import { selectActiveSafe, switchActiveChain } from '@/src/store/activeSafeSlice'
+import { selectChainById } from '@/src/store/chains'
+import { proxyReadOnlyCall } from '../services/readRpcProxy'
+import { buildGetCallsResult, type GetCallsResult, type RawTxReceipt } from '../services/getCallsStatus'
+import { logWalletKitError } from '../utils/errors'
+
+type GetState = () => RootState
+
+// Side-effecting methodRouter callbacks, factored out of walletKitListeners so they're unit-testable.
+
+// switchActiveChain re-syncs the WC sessions via the safe-switch listener, so no explicit updateSession.
+export const makeSwitchActiveChainByCaip2 =
+  (getState: GetState, dispatch: AppDispatch) =>
+  async (caip2: string): Promise<{ ok: true } | { ok: false; reason: 'NOT_DEPLOYED' }> => {
+    const chainId = stripEip155Prefix(caip2)
+    const current = getState()
+    if (!selectChainById(current, chainId)) {
+      return { ok: false, reason: 'NOT_DEPLOYED' }
+    }
+    const safeAddress = selectActiveSafe(current)?.address
+    const safeChains = safeAddress ? Object.keys(current.safes[safeAddress] ?? {}) : []
+    if (!safeChains.includes(chainId)) {
+      return { ok: false, reason: 'NOT_DEPLOYED' }
+    }
+    dispatch(switchActiveChain({ chainId }))
+    return { ok: true }
+  }
+
+export const makeGetCallsStatus =
+  (getState: GetState, dispatch: AppDispatch) =>
+  async (chainId: string, id: string): Promise<GetCallsResult> => {
+    const numericChainId = stripEip155Prefix(chainId)
+
+    let tx
+    try {
+      tx = await dispatch(
+        cgwApi.endpoints.transactionsGetTransactionByIdV1.initiate({ chainId: numericChainId, id }),
+      ).unwrap()
+    } catch {
+      throw new Error('Transaction not found')
+    }
+
+    // A null receipt is valid (pending bundle); only fetch when there's a hash and a chain to reach.
+    let receipt: RawTxReceipt | null = null
+    if (tx.txHash) {
+      const chain = selectChainById(getState(), numericChainId)
+      if (chain) {
+        try {
+          receipt = (await proxyReadOnlyCall(chain, 'eth_getTransactionReceipt', [tx.txHash])) as RawTxReceipt | null
+        } catch (e) {
+          logWalletKitError('getCallsStatus receipt fetch failed', e)
+          receipt = null
+        }
+      } else {
+        logWalletKitError('getCallsStatus: no chain config for receipt lookup', new Error(`chainId=${numericChainId}`))
+      }
+    }
+
+    return buildGetCallsResult(id, numericChainId, tx, receipt)
+  }
+
+export const navigateToCallsStatus = (chainId: string, id: string): void => {
+  router.push({ pathname: '/pending-transactions', params: { chainId, txId: id } })
+}

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/sessionRequestActions.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/sessionRequestActions.ts
@@ -10,8 +10,6 @@ import { logWalletKitError } from '../utils/errors'
 
 type GetState = () => RootState
 
-// Side-effecting methodRouter callbacks, factored out of walletKitListeners so they're unit-testable.
-
 // switchActiveChain re-syncs the WC sessions via the safe-switch listener, so no explicit updateSession.
 export const makeSwitchActiveChainByCaip2 =
   (getState: GetState, dispatch: AppDispatch) =>
@@ -44,7 +42,6 @@ export const makeGetCallsStatus =
       throw new Error('Transaction not found')
     }
 
-    // A null receipt is valid (pending bundle); only fetch when there's a hash and a chain to reach.
     let receipt: RawTxReceipt | null = null
     if (tx.txHash) {
       const chain = selectChainById(getState(), numericChainId)

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitListeners.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitListeners.ts
@@ -9,13 +9,11 @@ import { selectActiveSafe, setActiveSafe, switchActiveChain, clearActiveSafe } f
 import { selectActiveSigner } from '@/src/store/activeSignerSlice'
 import { selectChainById } from '@/src/store/chains'
 import { showToast } from '@/src/store/toastSlice'
-import { router } from 'expo-router'
 import { getWalletKit } from '../walletKit'
 import { logWalletKitError } from '../utils/errors'
 import { routeSessionRequest, isDeferredResponse, NO_SIGNER_ERROR_CODE } from '../services/methodRouter'
-import { proxyReadOnlyCall } from '../services/readRpcProxy'
-import { buildGetCallsResult, type RawTxReceipt } from '../services/getCallsStatus'
 import { REJECTED_SIGNING_METHODS } from '../services/constants'
+import { makeSwitchActiveChainByCaip2, makeGetCallsStatus, navigateToCallsStatus } from './sessionRequestActions'
 import {
   clearOutstandingRequest,
   markOutstandingProposing,
@@ -169,71 +167,8 @@ export const walletKitListeners = (startListening: AppStartListening) => {
       const hasSigner = activeSafe ? !!selectActiveSigner(state, activeSafe.address) : false
       const deployedChainIds = activeSafe ? Object.keys(state.safes[activeSafe.address] ?? {}) : []
 
-      // switchActiveChain triggers the setActiveSafe/switchActiveChain listener above, which
-      // re-syncs the WC sessions — so no explicit walletKit.updateSession is needed here. The two
-      // NOT_DEPLOYED gates are distinct: no chain config loaded, and Safe not deployed there.
-      const switchActiveChainByCaip2 = async (caip2: string) => {
-        const chainId = stripEip155Prefix(caip2)
-        const current = api.getState() as RootState
-        if (!selectChainById(current, chainId)) {
-          return { ok: false as const, reason: 'NOT_DEPLOYED' as const }
-        }
-        const safeAddress = selectActiveSafe(current)?.address
-        const safeChains = safeAddress ? Object.keys(current.safes[safeAddress] ?? {}) : []
-        if (!safeChains.includes(chainId)) {
-          return { ok: false as const, reason: 'NOT_DEPLOYED' as const }
-        }
-        api.dispatch(switchActiveChain({ chainId }))
-        return { ok: true as const }
-      }
-
-      // `chainId` is the WC envelope's session chain — correct because wallet_sendCalls is bound
-      // to the active chain at send time. Mirrors apps/web/.../safe-wallet-provider/index.ts.
-      const getCallsStatus = async (chainId: string, id: string) => {
-        const numericChainId = stripEip155Prefix(chainId)
-
-        let tx
-        try {
-          tx = await api
-            .dispatch(cgwApi.endpoints.transactionsGetTransactionByIdV1.initiate({ chainId: numericChainId, id }))
-            .unwrap()
-        } catch {
-          throw new Error('Transaction not found')
-        }
-
-        // buildGetCallsResult tolerates a null receipt (pending bundle), so only fetch one when
-        // there's a hash to look up and a chain config to reach.
-        let receipt: RawTxReceipt | null = null
-        if (tx.txHash) {
-          const chain = selectChainById(api.getState() as RootState, numericChainId)
-          if (chain) {
-            try {
-              receipt = (await proxyReadOnlyCall(chain, 'eth_getTransactionReceipt', [
-                tx.txHash,
-              ])) as RawTxReceipt | null
-            } catch (e) {
-              // Non-fatal: fall back to the receipt-less envelope, but leave a breadcrumb.
-              logWalletKitError('getCallsStatus receipt fetch failed', e)
-              receipt = null
-            }
-          } else {
-            // A mined tx on a chain we have no config for is anomalous — log rather than silently
-            // dropping to the receipt-less envelope.
-            logWalletKitError(
-              'getCallsStatus: no chain config for receipt lookup',
-              new Error(`chainId=${numericChainId}`),
-            )
-          }
-        }
-
-        return buildGetCallsResult(id, numericChainId, tx, receipt)
-      }
-
-      // The screen ignores the params for now, so this lands on the queue, not the specific tx.
-      // chainId is the CAIP-2 envelope value — strip the prefix before any numeric use.
-      const navigateToCallsStatus = (chainId: string, id: string) => {
-        router.push({ pathname: '/pending-transactions', params: { chainId, txId: id } })
-      }
+      const switchActiveChainByCaip2 = makeSwitchActiveChainByCaip2(api.getState as () => RootState, api.dispatch)
+      const getCallsStatus = makeGetCallsStatus(api.getState as () => RootState, api.dispatch)
 
       const response = await routeSessionRequest({
         request,

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitListeners.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitListeners.ts
@@ -49,7 +49,7 @@ const respondRejected = async (topic: string, id: number) => {
     const walletKit = await getWalletKit()
     await walletKit.respondSessionRequest({
       topic,
-      response: formatJsonRpcError(id, getSdkError('USER_REJECTED').message),
+      response: formatJsonRpcError(id, getSdkError('USER_REJECTED')),
     })
   } catch (e) {
     logWalletKitError('respondSessionRequest USER_REJECTED failed', e)

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitListeners.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitListeners.ts
@@ -9,9 +9,12 @@ import { selectActiveSafe, setActiveSafe, switchActiveChain, clearActiveSafe } f
 import { selectActiveSigner } from '@/src/store/activeSignerSlice'
 import { selectChainById } from '@/src/store/chains'
 import { showToast } from '@/src/store/toastSlice'
+import { router } from 'expo-router'
 import { getWalletKit } from '../walletKit'
 import { logWalletKitError } from '../utils/errors'
 import { routeSessionRequest, isDeferredResponse, NO_SIGNER_ERROR_CODE } from '../services/methodRouter'
+import { proxyReadOnlyCall } from '../services/readRpcProxy'
+import { buildGetCallsResult, type RawTxReceipt } from '../services/getCallsStatus'
 import { REJECTED_SIGNING_METHODS } from '../services/constants'
 import {
   clearOutstandingRequest,
@@ -164,6 +167,73 @@ export const walletKitListeners = (startListening: AppStartListening) => {
       const activeSafe = selectActiveSafe(state)
       const activeChain = activeSafe ? (selectChainById(state, activeSafe.chainId) ?? null) : null
       const hasSigner = activeSafe ? !!selectActiveSigner(state, activeSafe.address) : false
+      const deployedChainIds = activeSafe ? Object.keys(state.safes[activeSafe.address] ?? {}) : []
+
+      // switchActiveChain triggers the setActiveSafe/switchActiveChain listener above, which
+      // re-syncs the WC sessions — so no explicit walletKit.updateSession is needed here. The two
+      // NOT_DEPLOYED gates are distinct: no chain config loaded, and Safe not deployed there.
+      const switchActiveChainByCaip2 = async (caip2: string) => {
+        const chainId = stripEip155Prefix(caip2)
+        const current = api.getState() as RootState
+        if (!selectChainById(current, chainId)) {
+          return { ok: false as const, reason: 'NOT_DEPLOYED' as const }
+        }
+        const safeAddress = selectActiveSafe(current)?.address
+        const safeChains = safeAddress ? Object.keys(current.safes[safeAddress] ?? {}) : []
+        if (!safeChains.includes(chainId)) {
+          return { ok: false as const, reason: 'NOT_DEPLOYED' as const }
+        }
+        api.dispatch(switchActiveChain({ chainId }))
+        return { ok: true as const }
+      }
+
+      // `chainId` is the WC envelope's session chain — correct because wallet_sendCalls is bound
+      // to the active chain at send time. Mirrors apps/web/.../safe-wallet-provider/index.ts.
+      const getCallsStatus = async (chainId: string, id: string) => {
+        const numericChainId = stripEip155Prefix(chainId)
+
+        let tx
+        try {
+          tx = await api
+            .dispatch(cgwApi.endpoints.transactionsGetTransactionByIdV1.initiate({ chainId: numericChainId, id }))
+            .unwrap()
+        } catch {
+          throw new Error('Transaction not found')
+        }
+
+        // buildGetCallsResult tolerates a null receipt (pending bundle), so only fetch one when
+        // there's a hash to look up and a chain config to reach.
+        let receipt: RawTxReceipt | null = null
+        if (tx.txHash) {
+          const chain = selectChainById(api.getState() as RootState, numericChainId)
+          if (chain) {
+            try {
+              receipt = (await proxyReadOnlyCall(chain, 'eth_getTransactionReceipt', [
+                tx.txHash,
+              ])) as RawTxReceipt | null
+            } catch (e) {
+              // Non-fatal: fall back to the receipt-less envelope, but leave a breadcrumb.
+              logWalletKitError('getCallsStatus receipt fetch failed', e)
+              receipt = null
+            }
+          } else {
+            // A mined tx on a chain we have no config for is anomalous — log rather than silently
+            // dropping to the receipt-less envelope.
+            logWalletKitError(
+              'getCallsStatus: no chain config for receipt lookup',
+              new Error(`chainId=${numericChainId}`),
+            )
+          }
+        }
+
+        return buildGetCallsResult(id, numericChainId, tx, receipt)
+      }
+
+      // The screen ignores the params for now, so this lands on the queue, not the specific tx.
+      // chainId is the CAIP-2 envelope value — strip the prefix before any numeric use.
+      const navigateToCallsStatus = (chainId: string, id: string) => {
+        router.push({ pathname: '/pending-transactions', params: { chainId, txId: id } })
+      }
 
       const response = await routeSessionRequest({
         request,
@@ -172,6 +242,10 @@ export const walletKitListeners = (startListening: AppStartListening) => {
         activeChain,
         activeSafeAddress: activeSafe?.address ?? null,
         hasSigner,
+        deployedChainIds,
+        switchActiveChainByCaip2,
+        getCallsStatus,
+        navigateToCallsStatus,
       })
 
       if (isDeferredResponse(response)) {

--- a/apps/mobile/src/features/WalletConnect/Wallet/utils/errors.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/utils/errors.ts
@@ -45,3 +45,7 @@ export const logWalletKitError = (context: string, e: unknown): void => {
   }
   console.error(label, e)
 }
+
+export const logWalletKitWarn = (context: string): void => {
+  console.warn(`[walletKit] ${context}`)
+}

--- a/packages/utils/src/features/walletconnect/__tests__/utils.test.ts
+++ b/packages/utils/src/features/walletconnect/__tests__/utils.test.ts
@@ -6,4 +6,14 @@ describe('chainIdToHex', () => {
     expect(chainIdToHex('137')).toBe('0x89')
     expect(chainIdToHex(11155111)).toBe('0xaa36a7')
   })
+
+  it('normalizes a 0x-hex input to a canonical quantity', () => {
+    expect(chainIdToHex('0x010')).toBe('0x10')
+    expect(chainIdToHex('0x0')).toBe('0x0')
+  })
+
+  it('preserves precision above 2^53 (BigInt, not Number)', () => {
+    // 0x20000000000001 = 2^53 + 1 — Number would round this down to 2^53.
+    expect(chainIdToHex('0x20000000000001')).toBe('0x20000000000001')
+  })
 })

--- a/packages/utils/src/features/walletconnect/__tests__/utils.test.ts
+++ b/packages/utils/src/features/walletconnect/__tests__/utils.test.ts
@@ -1,19 +1,19 @@
-import { chainIdToHex } from '../utils'
+import { toHex } from '../utils'
 
-describe('chainIdToHex', () => {
+describe('toHex', () => {
   it('converts numeric chain ids to hex', () => {
-    expect(chainIdToHex('1')).toBe('0x1')
-    expect(chainIdToHex('137')).toBe('0x89')
-    expect(chainIdToHex(11155111)).toBe('0xaa36a7')
+    expect(toHex('1')).toBe('0x1')
+    expect(toHex('137')).toBe('0x89')
+    expect(toHex(11155111)).toBe('0xaa36a7')
   })
 
   it('normalizes a 0x-hex input to a canonical quantity', () => {
-    expect(chainIdToHex('0x010')).toBe('0x10')
-    expect(chainIdToHex('0x0')).toBe('0x0')
+    expect(toHex('0x010')).toBe('0x10')
+    expect(toHex('0x0')).toBe('0x0')
   })
 
   it('preserves precision above 2^53 (BigInt, not Number)', () => {
     // 0x20000000000001 = 2^53 + 1 — Number would round this down to 2^53.
-    expect(chainIdToHex('0x20000000000001')).toBe('0x20000000000001')
+    expect(toHex('0x20000000000001')).toBe('0x20000000000001')
   })
 })

--- a/packages/utils/src/features/walletconnect/utils.ts
+++ b/packages/utils/src/features/walletconnect/utils.ts
@@ -11,8 +11,8 @@ export const getEip155ChainId = (chainId: string): `${typeof EIP155}:${string}` 
 
 // Integer (decimal or 0x-hex string, or number) -> canonical hex quantity, e.g. '137' -> '0x89'.
 // Uses BigInt so values above 2^53 (e.g. block numbers / gas) don't lose precision.
-export const chainIdToHex = (chainId: string | number): string => {
-  return '0x' + BigInt(chainId).toString(16)
+export const toHex = (value: string | number): string => {
+  return '0x' + BigInt(value).toString(16)
 }
 
 // CAIP-2 / CAIP-10 -> trailing segment, e.g. 'eip155:1' -> '1', 'eip155:1:0xabc' -> '0xabc'.

--- a/packages/utils/src/features/walletconnect/utils.ts
+++ b/packages/utils/src/features/walletconnect/utils.ts
@@ -9,9 +9,10 @@ export const getEip155ChainId = (chainId: string): `${typeof EIP155}:${string}` 
   return `${EIP155}:${chainId}`
 }
 
-// Numeric chain id -> hex, e.g. '137' -> '0x89'
+// Integer (decimal or 0x-hex string, or number) -> canonical hex quantity, e.g. '137' -> '0x89'.
+// Uses BigInt so values above 2^53 (e.g. block numbers / gas) don't lose precision.
 export const chainIdToHex = (chainId: string | number): string => {
-  return '0x' + Number(chainId).toString(16)
+  return '0x' + BigInt(chainId).toString(16)
 }
 
 // CAIP-2 / CAIP-10 -> trailing segment, e.g. 'eip155:1' -> '1', 'eip155:1:0xabc' -> '0xabc'.


### PR DESCRIPTION
> Rebased onto fresh dev,
> read-only proxy and 5792 routes return,
> rejections speak 5000 now.

> [!IMPORTANT]
> **Supersedes #8121** (now outdated). Its base branch was squash-merged into `dev` as #8092, so this PR drops the duplicated commits and re-applies the remaining WA-2322 work on the post-#8092 store-listener architecture. #8121 is left open for now — review/merge this one instead.

## What it solves

Resolves: [WA-2322](https://linear.app/safe-global/issue/WA-2322/read-only-rpc-proxy-wallet-control-methods)

dApps (e.g. CowSwap) now get real answers from the mobile WC wallet instead of `UNSUPPORTED_METHODS`:

- **Read-only RPC passthrough** for allow-listed methods, proxied to the active chain.
- **EIP-5792** `wallet_getCapabilities` (scoped to the Safe's deployed chains), `wallet_getCallsStatus`, `wallet_showCallsStatus`, `wallet_switchEthereumChain`.
- **`chainIdToHex`** BigInt fix (no precision loss above 2^53).
- **Rejection fix:** rejected requests now reply with WC code `5000`, not a stripped `-32000`.

## How this PR fixes it

- New services `readRpcProxy.ts` and `getCallsStatus.ts`; the new branches + `RouteContext` fields live in `methodRouter.ts`, with handlers reading from the store in `walletKitListeners` (post-#8092 model).
- `respondRejected` passed `getSdkError('USER_REJECTED').message` (a string), so `formatJsonRpcError` dropped the code to `-32000`; viem (CowSwap) couldn't read it as a rejection and showed *"JSON is not a valid request object."* Passing the full SDK error keeps `5000` → `UserRejectedRequestError`.

## How to test it

1. Connect CowSwap to a Safe via WC on a deployed chain, signer imported.
2. Read-only calls and `wallet_getCapabilities` resolve (no `UNSUPPORTED_METHODS`).
3. Reject a tx → dApp shows a clean "user rejected" (no *"JSON is not a valid request object."*).
4. `wallet_switchEthereumChain` switches to a deployed chain; non-deployed → `4901`.

## Affected flows

- dApp WC session making read-only / EIP-5792 requests (now handled).
- Rejecting a dApp tx/signing request (now WC `5000`).

## Blast radius

- `methodRouter.ts` / `walletKitListeners.ts` — only each other consume these.
- New `readRpcProxy.ts`, `getCallsStatus.ts` — self-contained.
- `packages/utils` `chainIdToHex` — shared util; in-repo consumers are mobile WC files; change is precision-only.
- No RTK endpoint, flag, route, or persisted-state changes.

## Risks / not checked

- Same `.message`-stripping pattern still in `crossNamespaceError` / `unsupportedError` (emit `-32000`) — follow-up.
- Didn't audit web consumers of `chainIdToHex`, nor the Ledger / WC-signer path.
- Covered by unit tests + a live CowSwap repro, not a full per-dApp E2E sweep.

## Visual summary

```mermaid
flowchart TD
  A[dApp session_request] --> R{routeSessionRequest}
  R -->|cross-namespace / signing| X[reject: SDK code preserved]
  R -->|eth_accounts / eth_chainId| L[answer locally]
  R -->|wallet_switchEthereumChain| SW[switch if Safe deployed, else 4901]
  R -->|wallet_getCapabilities| C[atomic caps, deployed chains only]
  R -->|wallet_getCallsStatus / showCallsStatus| S[local status / navigate]
  R -->|read-only eth_* allow-list| P[proxy to active chain RPC]
  R -->|eth_sendTransaction / wallet_sendCalls| D[defer to review sheet]
  X -.->|fix| F[code 5000, was -32000]
```

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
