### PR TITLE
Fix: Show understandable error msg for invalid contacts addition

### DIFF
--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddContactDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddContactDialog.tsx
@@ -14,6 +14,9 @@ import { DEFAULT_MAINNET_CHAIN_ID } from '@/config/constants'
 import { useCurrentSpaceId } from '@/features/spaces'
 import { showNotification } from '@/store/notificationsSlice'
 import { useAppDispatch } from '@/store'
+import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
+import type { SerializedError } from '@reduxjs/toolkit'
 
 export type ContactField = {
   name: string
@@ -102,7 +105,9 @@ const AddContactDialog = ({
       const result = await submit(item, spaceId ?? '')
 
       if (result.error) {
-        setError('Something went wrong. Please try again.')
+        const message = getRtkQueryErrorMessage(result.error as FetchBaseQueryError | SerializedError)
+        setError(message)
+        dispatch(showNotification({ message, variant: 'error', groupKey: `${successGroupKey}-error` }))
         return
       }
 
@@ -117,8 +122,10 @@ const AddContactDialog = ({
       )
 
       handleClose()
-    } catch {
-      setError('Something went wrong. Please try again.')
+    } catch (error) {
+      const message = getRtkQueryErrorMessage(error as FetchBaseQueryError | SerializedError)
+      setError(message)
+      dispatch(showNotification({ message, variant: 'error', groupKey: `${successGroupKey}-error` }))
     } finally {
       setIsSubmitting(false)
     }

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddToWorkspaceButton.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddToWorkspaceButton.tsx
@@ -5,6 +5,7 @@ import { useCurrentSpaceId } from '@/features/spaces'
 import { showNotification } from '@/store/notificationsSlice'
 import { useAppDispatch } from '@/store'
 import { Spinner } from '@/components/ui/spinner'
+import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
 
 type AddToWorkspaceButtonProps = {
   address: string
@@ -32,7 +33,11 @@ const AddToWorkspaceButton = ({ address, name, chainIds }: AddToWorkspaceButtonP
 
       if (result.error) {
         dispatch(
-          showNotification({ message: 'Failed to add contact', variant: 'error', groupKey: 'add-to-workspace-error' }),
+          showNotification({
+            message: getRtkQueryErrorMessage(result.error),
+            variant: 'error',
+            groupKey: 'add-to-workspace-error',
+          }),
         )
         return
       }

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ImportAddressBookDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ImportAddressBookDialog.tsx
@@ -20,6 +20,9 @@ import { useCurrentSpaceId, useGetSpaceAddressBook } from '@/features/spaces'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { showNotification } from '@/store/notificationsSlice'
 import { useAppDispatch } from '@/store'
+import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
+import type { SerializedError } from '@reduxjs/toolkit'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 
@@ -91,14 +94,9 @@ const ImportAddressBookDialog = ({ handleClose }: { handleClose: () => void }) =
       })
 
       if (result.error) {
-        setError('Something went wrong. Please try again.')
-        dispatch(
-          showNotification({
-            message: 'Failed to import contacts. Please try again.',
-            variant: 'error',
-            groupKey: 'import-contacts-error',
-          }),
-        )
+        const message = getRtkQueryErrorMessage(result.error as FetchBaseQueryError | SerializedError)
+        setError(message)
+        dispatch(showNotification({ message, variant: 'error', groupKey: 'import-contacts-error' }))
         return
       }
 
@@ -114,14 +112,9 @@ const ImportAddressBookDialog = ({ handleClose }: { handleClose: () => void }) =
 
       setIsSuccess(true)
     } catch (e) {
-      setError('Something went wrong. Please try again.')
-      dispatch(
-        showNotification({
-          message: 'Failed to import contacts. Please try again.',
-          variant: 'error',
-          groupKey: 'import-contacts-error',
-        }),
-      )
+      const message = getRtkQueryErrorMessage(e as FetchBaseQueryError | SerializedError)
+      setError(message)
+      dispatch(showNotification({ message, variant: 'error', groupKey: 'import-contacts-error' }))
     } finally {
       setIsSubmitting(false)
     }
@@ -155,24 +148,22 @@ const ImportAddressBookDialog = ({ handleClose }: { handleClose: () => void }) =
 
             <ContactsList contactItems={searchQuery ? filteredEntries : allContactItems} />
 
-            {error && (
-              <Alert variant="destructive" className="mt-2 mx-4">
-                {error}
-              </Alert>
-            )}
+            <DialogFooter className="flex-col items-stretch gap-2 p-4 border-t">
+              {error && <Alert variant="destructive">{error}</Alert>}
 
-            <DialogFooter className="flex-row justify-end gap-2 p-4 border-t">
-              <Button variant="ghost" data-testid="cancel-btn" onClick={handleClose}>
-                Cancel
-              </Button>
-              <Tooltip>
-                <TooltipTrigger render={<div className="inline-flex" />}>
-                  <Button type="submit" disabled={selectedCount === 0 || isSubmitting || isSuccess}>
-                    {isSubmitting ? <Spinner className="size-4" /> : `Import contacts (${selectedCount})`}
-                  </Button>
-                </TooltipTrigger>
-                {hasNoImportableContacts && <TooltipContent>You have no new contacts to import.</TooltipContent>}
-              </Tooltip>
+              <div className="flex flex-row justify-end gap-2">
+                <Button variant="ghost" data-testid="cancel-btn" onClick={handleClose}>
+                  Cancel
+                </Button>
+                <Tooltip>
+                  <TooltipTrigger render={<div className="inline-flex" />}>
+                    <Button type="submit" disabled={selectedCount === 0 || isSubmitting || isSuccess}>
+                      {isSubmitting ? <Spinner className="size-4" /> : `Import contacts (${selectedCount})`}
+                    </Button>
+                  </TooltipTrigger>
+                  {hasNoImportableContacts && <TooltipContent>You have no new contacts to import.</TooltipContent>}
+                </Tooltip>
+              </div>
             </DialogFooter>
           </form>
         </FormProvider>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/Import/__tests__/ImportAddressBookDialog.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/Import/__tests__/ImportAddressBookDialog.test.tsx
@@ -139,8 +139,10 @@ describe('ImportAddressBookDialog', () => {
     jest.useRealTimers()
   })
 
-  it('shows an inline error when the mutation returns an error', async () => {
-    upsertionSpyFn.mockResolvedValue({ error: { status: 500 } })
+  it('bubbles the backend error message inline when the mutation returns an error', async () => {
+    upsertionSpyFn.mockResolvedValue({
+      error: { status: 422, data: { message: 'name must contain only valid characters' } },
+    })
 
     mockedUseAllAddressBooks.mockReturnValue({
       '1': { '0x123': 'Alice' },
@@ -152,7 +154,7 @@ describe('ImportAddressBookDialog', () => {
     await userEvent.click(screen.getByText(/Import contacts \(1\)/i))
 
     await waitFor(() => {
-      expect(screen.getByText(/Something went wrong\. Please try again\./i)).toBeInTheDocument()
+      expect(screen.getByText(/name must contain only valid characters/i)).toBeInTheDocument()
     })
     expect(screen.getByRole('button', { name: /Import contacts \(1\)/i })).not.toBeDisabled()
   })

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/AddContactDialog.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/AddContactDialog.test.tsx
@@ -162,7 +162,7 @@ describe('AddContactDialog', () => {
     expect(order).toEqual(['start', 'submit'])
   })
 
-  it('on result.error shows an alert, keeps the dialog open, and does not fire onSuccess or notify', async () => {
+  it('on result.error shows an alert, dispatches an error toast, keeps the dialog open, and does not fire onSuccess', async () => {
     const onSuccess = jest.fn()
     const submit = jest.fn().mockResolvedValue({ error: { status: 500 } })
     render(<AddContactDialog {...baseProps} submit={submit} onSuccess={onSuccess} />)
@@ -174,16 +174,44 @@ describe('AddContactDialog', () => {
     fireEvent.click(submitButton)
 
     await waitFor(() => {
-      expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument()
+      expect(screen.getByText(/Something went wrong \(500\)/)).toBeInTheDocument()
     })
     expect(onSuccess).not.toHaveBeenCalled()
-    expect(mockDispatch).not.toHaveBeenCalled()
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'notifications/show',
+      payload: expect.objectContaining({ variant: 'error' }),
+    })
     expect(screen.getByRole('dialog')).toBeInTheDocument()
   })
 
-  it('on thrown error shows an alert and keeps the dialog open', async () => {
+  it('bubbles the backend message into both the alert and the error toast', async () => {
+    const submit = jest.fn().mockResolvedValue({
+      error: { status: 422, data: { message: 'name must contain only valid characters' } },
+    })
+    render(<AddContactDialog {...baseProps} submit={submit} />)
+    openDialog()
+    fillRequiredFields()
+
+    const submitButton = screen.getByRole('button', { name: 'Add contact' })
+    await waitFor(() => expect(submitButton).not.toBeDisabled())
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('name must contain only valid characters')).toBeInTheDocument()
+    })
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'notifications/show',
+      payload: expect.objectContaining({
+        message: 'name must contain only valid characters',
+        variant: 'error',
+      }),
+    })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('on a thrown error bubbles the message into the alert and the error toast, keeping the dialog open', async () => {
     const onSuccess = jest.fn()
-    const submit = jest.fn().mockRejectedValue(new Error('boom'))
+    const submit = jest.fn().mockRejectedValue({ status: 422, data: { message: 'invalid characters in name' } })
     render(<AddContactDialog {...baseProps} submit={submit} onSuccess={onSuccess} />)
     openDialog()
     fillRequiredFields()
@@ -193,7 +221,11 @@ describe('AddContactDialog', () => {
     fireEvent.click(submitButton)
 
     await waitFor(() => {
-      expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument()
+      expect(screen.getByText('invalid characters in name')).toBeInTheDocument()
+    })
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'notifications/show',
+      payload: expect.objectContaining({ message: 'invalid characters in name', variant: 'error' }),
     })
     expect(onSuccess).not.toHaveBeenCalled()
     expect(screen.getByRole('dialog')).toBeInTheDocument()

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/AddToWorkspaceButton.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/AddToWorkspaceButton.test.tsx
@@ -69,4 +69,34 @@ describe('AddToWorkspaceButton', () => {
     expect(getStoreInstance().getState().addressBook['1'][address]).toBe('Alice')
     expect(screen.queryByText('Added')).not.toBeInTheDocument()
   })
+
+  it('surfaces the backend error message in the toast', async () => {
+    mockUpsert.mockResolvedValue({
+      error: { status: 422, data: { message: 'Name contains invalid characters' } },
+    })
+    render(<AddToWorkspaceButton address={address} name="Alice" chainIds={['1']} />, {
+      initialReduxState: { addressBook: { '1': { [address]: 'Alice' } } },
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add to workspace' }))
+
+    await waitFor(() => {
+      const notifications = getStoreInstance().getState().notifications
+      expect(notifications.some((n) => n.message === 'Name contains invalid characters')).toBe(true)
+    })
+  })
+
+  it('falls back to a friendly message when the backend provides none', async () => {
+    mockUpsert.mockResolvedValue({ error: { status: 500, data: {} } })
+    render(<AddToWorkspaceButton address={address} name="Alice" chainIds={['1']} />, {
+      initialReduxState: { addressBook: { '1': { [address]: 'Alice' } } },
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add to workspace' }))
+
+    await waitFor(() => {
+      const notifications = getStoreInstance().getState().notifications
+      expect(notifications.some((n) => /Something went wrong \(500\)\. Please try again/.test(n.message))).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
## What it solves

Resolves:  [WA-2623](https://linear.app/safe-global/issue/WA-2651/address-book-edit-contact-or-import-contact-show-generic-error-instead)

Resolves: contact import / add dialogs showed a generic "Something went wrong. Please try again." for every failure, hiding the real reason (e.g. invalid characters in a name). Users couldn't tell what to fix.

## How this PR fixes it

- Replace hardcoded generic error strings with the actual server message via `getRtkQueryErrorMessage(...)` in:
  - `AddContactDialog` (add contact)
  - `AddToWorkspaceButton` (add to workspace)
  - `ImportAddressBookDialog` (import contacts)
- `AddContactDialog` now also surfaces the error as a notification (previously inline-only).
- `ImportAddressBookDialog` footer moved to a column layout so the inline `Alert` sits above the actions instead of overlapping the list.

## How to test it

1. Open a workspace address book.
2. Add / import a contact with invalid characters in the name (or otherwise trigger a server-side rejection).
3. Verify the dialog shows the specific backend error message (inline alert + error notification) instead of the generic "Something went wrong".
4. Confirm a successful add/import still works and closes the dialog as before.

## Affected flows

- Add contact to workspace address book
- Add address to workspace ("Add to workspace" button)
- Import contacts into workspace address book

## Blast radius

- Components touched: `AddContactDialog`, `AddToWorkspaceButton`, `ImportAddressBookDialog` (all under `features/spaces/SpaceAddressBook`) — no shared hooks/selectors/slices changed.
- New dependency on existing util `getRtkQueryErrorMessage` (`@/utils/rtkQuery`) — read-only consumer, util itself unchanged.
- Error/notification copy now comes from the backend response; no API contract or persistence changes.

## Risks / not checked

- Did not verify behavior for non-`FetchBaseQueryError`/`SerializedError` shapes beyond what `getRtkQueryErrorMessage` already handles.
- Did not test on mobile (these dialogs are web-only).
- Backend error messages are surfaced verbatim — assumed they are user-appropriate.

## Visual summary

**Before:**
<img width="770" height="401" alt="image" src="https://github.com/user-attachments/assets/8d545453-2880-4b78-ac55-70cca0f2a79f" />

**After:**
<img width="1264" height="763" alt="image" src="https://github.com/user-attachments/assets/7906b687-9969-4648-bbdf-30d0e27e5ccd" />


```mermaid
flowchart LR
  A[Submit add/import] --> B{result.error?}
  B -->|Before| C["Generic: 'Something went wrong'"]
  B -->|After| D["getRtkQueryErrorMessage(error)"]
  D --> E[Inline Alert]
  D --> F[Error notification]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
