### PR TITLE
feat: sort the account selector dropdown by balance (WA-2738)

### DIFF
--- a/apps/web/src/components/common/SafeListSortToggle/index.test.tsx
+++ b/apps/web/src/components/common/SafeListSortToggle/index.test.tsx
@@ -1,14 +1,12 @@
 import { render, screen } from '@/tests/test-utils'
-import { ORDER_BY_RESET_VERSION, OrderByOption } from '@/store/orderByPreferenceSlice'
+import { ORDER_BY_RESET_VERSION, OrderByOption, ALL_SORT_OPTIONS } from '@/store/orderByPreferenceSlice'
 import SafeListSortToggle from '.'
 
-// The popup/menu open state is verified in the browser: base-ui menus don't open in jsdom
-// (the repo mocks dropdown-menu elsewhere), so here we cover that the trigger mounts and
-// reflects the persisted order preference.
+// The popup/menu open state is verified in the browser: base-ui menus don't open in jsdom,
+// so here we cover that the trigger mounts and reflects the persisted preference.
 describe('SafeListSortToggle', () => {
   it('renders the trigger reflecting the default sort option (Name)', () => {
     render(<SafeListSortToggle />)
-
     const trigger = screen.getByTestId('safe-list-sort-toggle')
     expect(trigger).toBeInTheDocument()
     expect(trigger).toHaveTextContent('Name')
@@ -16,12 +14,30 @@ describe('SafeListSortToggle', () => {
 
   it('labels the last-visited sort as "Last visited"', () => {
     render(<SafeListSortToggle />, {
-      // resetVersion must match or the store's hydration reducer reverts to the default order.
       initialReduxState: {
         orderByPreference: { orderBy: OrderByOption.LAST_VISITED, resetVersion: ORDER_BY_RESET_VERSION },
       },
     })
-
     expect(screen.getByTestId('safe-list-sort-toggle')).toHaveTextContent('Last visited')
+  })
+
+  it('shows "Balance" on the trigger when given the extended options', () => {
+    render(<SafeListSortToggle options={ALL_SORT_OPTIONS} />, {
+      initialReduxState: {
+        orderByPreference: { orderBy: OrderByOption.BALANCE, resetVersion: ORDER_BY_RESET_VERSION },
+      },
+    })
+    expect(screen.getByTestId('safe-list-sort-toggle')).toHaveTextContent('Balance')
+  })
+
+  it('falls back to Name when the persisted order is Balance but the basic options are used (modal)', () => {
+    render(<SafeListSortToggle />, {
+      initialReduxState: {
+        orderByPreference: { orderBy: OrderByOption.BALANCE, resetVersion: ORDER_BY_RESET_VERSION },
+      },
+    })
+    const trigger = screen.getByTestId('safe-list-sort-toggle')
+    expect(trigger).toHaveTextContent('Name')
+    expect(trigger).not.toHaveTextContent('Balance')
   })
 })

--- a/apps/web/src/components/common/SafeListSortToggle/index.test.tsx
+++ b/apps/web/src/components/common/SafeListSortToggle/index.test.tsx
@@ -1,6 +1,11 @@
 import { render, screen } from '@/tests/test-utils'
-import { ORDER_BY_RESET_VERSION, OrderByOption, ALL_SORT_OPTIONS } from '@/store/orderByPreferenceSlice'
-import SafeListSortToggle from '.'
+import {
+  ORDER_BY_RESET_VERSION,
+  OrderByOption,
+  ALL_SORT_OPTIONS,
+  setOrderByPreference,
+} from '@/store/orderByPreferenceSlice'
+import SafeListSortToggle, { sortChangeAction } from '.'
 
 // The popup/menu open state is verified in the browser: base-ui menus don't open in jsdom,
 // so here we cover that the trigger mounts and reflects the persisted preference.
@@ -39,5 +44,17 @@ describe('SafeListSortToggle', () => {
     const trigger = screen.getByTestId('safe-list-sort-toggle')
     expect(trigger).toHaveTextContent('Name')
     expect(trigger).not.toHaveTextContent('Balance')
+  })
+})
+
+describe('sortChangeAction', () => {
+  it('returns a setOrderByPreference action for a newly chosen option', () => {
+    expect(sortChangeAction(OrderByOption.BALANCE, OrderByOption.NAME)).toEqual(
+      setOrderByPreference({ orderBy: OrderByOption.BALANCE }),
+    )
+  })
+
+  it('returns null when re-selecting the shown option (no clobber)', () => {
+    expect(sortChangeAction(OrderByOption.NAME, OrderByOption.NAME)).toBeNull()
   })
 })

--- a/apps/web/src/components/common/SafeListSortToggle/index.tsx
+++ b/apps/web/src/components/common/SafeListSortToggle/index.tsx
@@ -13,6 +13,10 @@ import { useAppDispatch, useAppSelector } from '@/store'
 import type { OrderByOption, SortOption } from '@/store/orderByPreferenceSlice'
 import { BASIC_SORT_OPTIONS, selectOrderByPreference, setOrderByPreference } from '@/store/orderByPreferenceSlice'
 
+// base-ui fires onValueChange even on re-select; return null then to avoid clobbering a balance order set elsewhere.
+export const sortChangeAction = (next: string, activeValue: OrderByOption) =>
+  next === activeValue ? null : setOrderByPreference({ orderBy: next as OrderByOption })
+
 interface SafeListSortToggleProps {
   /** Sort options to offer. Defaults to the basic set; pass ALL_SORT_OPTIONS where balances are eager-loaded. */
   options?: SortOption[]
@@ -53,9 +57,9 @@ const SafeListSortToggle = ({ options = BASIC_SORT_OPTIONS }: SafeListSortToggle
           <DropdownMenuLabel>Sort by</DropdownMenuLabel>
           <DropdownMenuRadioGroup
             value={active.value}
-            // base-ui fires onValueChange even on re-selecting the shown item; guard against it.
             onValueChange={(next) => {
-              if (next !== active.value) dispatch(setOrderByPreference({ orderBy: next as OrderByOption }))
+              const action = sortChangeAction(next, active.value)
+              if (action) dispatch(action)
             }}
           >
             {options.map((option) => (

--- a/apps/web/src/components/common/SafeListSortToggle/index.tsx
+++ b/apps/web/src/components/common/SafeListSortToggle/index.tsx
@@ -10,20 +10,23 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { useAppDispatch, useAppSelector } from '@/store'
-import { OrderByOption, selectOrderByPreference, setOrderByPreference } from '@/store/orderByPreferenceSlice'
+import type { OrderByOption, SortOption } from '@/store/orderByPreferenceSlice'
+import { BASIC_SORT_OPTIONS, selectOrderByPreference, setOrderByPreference } from '@/store/orderByPreferenceSlice'
 
-const labels: Record<OrderByOption, string> = {
-  [OrderByOption.NAME]: 'Name',
-  [OrderByOption.LAST_VISITED]: 'Last visited',
+interface SafeListSortToggleProps {
+  /** Sort options to offer. Defaults to the basic set; pass ALL_SORT_OPTIONS where balances are eager-loaded. */
+  options?: SortOption[]
 }
 
 /**
  * Sort control for the Safe lists (account selector dropdown + All accounts modal).
  * Reads/writes the shared, persisted orderByPreference so every Safe list stays in sync.
  */
-const SafeListSortToggle = () => {
+const SafeListSortToggle = ({ options = BASIC_SORT_OPTIONS }: SafeListSortToggleProps) => {
   const dispatch = useAppDispatch()
   const { orderBy } = useAppSelector(selectOrderByPreference)
+  // Fall back to the first option when the persisted order isn't offered here (e.g. balance in the modal).
+  const active = options.find((option) => option.value === orderBy) ?? options[0]
 
   return (
     <DropdownMenu>
@@ -32,7 +35,7 @@ const SafeListSortToggle = () => {
           <Button
             variant="outline"
             // Match the adjacent search InputGroup exactly: h-9, rounded-md, border-gray-100, shadow-none.
-            // Fixed width so the trigger doesn't grow/shrink between "Name" and "Last visited".
+            // Fixed width so the trigger doesn't grow/shrink between options.
             size="default"
             className="h-9 w-[160px] shrink-0 justify-between gap-1.5 rounded-md border-gray-100 shadow-none text-muted-foreground"
             data-testid="safe-list-sort-toggle"
@@ -41,7 +44,7 @@ const SafeListSortToggle = () => {
       >
         <span className="flex items-center gap-1.5 whitespace-nowrap">
           <ArrowDownUp className="size-4 shrink-0" />
-          {labels[orderBy]}
+          {active.label}
         </span>
         <ChevronDown className="size-4 shrink-0 opacity-60" />
       </DropdownMenuTrigger>
@@ -49,13 +52,19 @@ const SafeListSortToggle = () => {
         <DropdownMenuGroup>
           <DropdownMenuLabel>Sort by</DropdownMenuLabel>
           <DropdownMenuRadioGroup
-            value={orderBy}
-            onValueChange={(value) => dispatch(setOrderByPreference({ orderBy: value as OrderByOption }))}
+            value={active.value}
+            // The menu fires onValueChange even for the already-selected item; guard against the active
+            // value so re-clicking the shown option (e.g. the coerced fallback) doesn't overwrite a
+            // preference set on another surface.
+            onValueChange={(next) => {
+              if (next !== active.value) dispatch(setOrderByPreference({ orderBy: next as OrderByOption }))
+            }}
           >
-            <DropdownMenuRadioItem value={OrderByOption.NAME}>{labels[OrderByOption.NAME]}</DropdownMenuRadioItem>
-            <DropdownMenuRadioItem value={OrderByOption.LAST_VISITED}>
-              {labels[OrderByOption.LAST_VISITED]}
-            </DropdownMenuRadioItem>
+            {options.map((option) => (
+              <DropdownMenuRadioItem key={option.value} value={option.value}>
+                {option.label}
+              </DropdownMenuRadioItem>
+            ))}
           </DropdownMenuRadioGroup>
         </DropdownMenuGroup>
       </DropdownMenuContent>

--- a/apps/web/src/components/common/SafeListSortToggle/index.tsx
+++ b/apps/web/src/components/common/SafeListSortToggle/index.tsx
@@ -53,9 +53,7 @@ const SafeListSortToggle = ({ options = BASIC_SORT_OPTIONS }: SafeListSortToggle
           <DropdownMenuLabel>Sort by</DropdownMenuLabel>
           <DropdownMenuRadioGroup
             value={active.value}
-            // The menu fires onValueChange even for the already-selected item; guard against the active
-            // value so re-clicking the shown option (e.g. the coerced fallback) doesn't overwrite a
-            // preference set on another surface.
+            // base-ui fires onValueChange even on re-selecting the shown item; guard against it.
             onValueChange={(next) => {
               if (next !== active.value) dispatch(setOrderByPreference({ orderBy: next as OrderByOption }))
             }}

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.tsx
@@ -22,6 +22,7 @@ import SafeItemCard from './SafeItemCard'
 import MultiSafeItemCard from './MultiSafeItemCard'
 import { useAccountsModalItems } from './useAccountsModalItems'
 import SafeListSortToggle from '@/components/common/SafeListSortToggle'
+import { BASIC_SORT_OPTIONS } from '@/store/orderByPreferenceSlice'
 import type { AllSafeItems } from '@/hooks/safes'
 
 interface AccountsModalProps {
@@ -152,7 +153,7 @@ const AccountsModal = ({
               data-testid="accounts-search-input"
             />
           </InputGroup>
-          <SafeListSortToggle />
+          <SafeListSortToggle options={BASIC_SORT_OPTIONS} />
         </div>
 
         <div

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSpaceSafeSelectorItems.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSpaceSafeSelectorItems.test.ts
@@ -73,6 +73,7 @@ import useChains from '@/hooks/useChains'
 import { useGetMultipleSafeOverviewsQuery } from '@/store/api/gateway'
 import { useAppSelector } from '@/store'
 import { selectUndeployedSafes } from '@/features/counterfactual/store'
+import { selectOrderByPreference, OrderByOption } from '@/store/orderByPreferenceSlice'
 import useWallet from '@/hooks/wallets/useWallet'
 import { useRouter } from 'next/router'
 
@@ -666,6 +667,38 @@ describe('useSpaceSafeSelectorItems', () => {
 
     const { result } = renderHook(() => useSpaceSafeSelectorItems())
     expect(result.current.items[0].chains[0].isUndeployed).toBe(false)
+  })
+
+  // ── balance sort ──
+
+  it('orders items by balance (desc) with the current safe first when the order is balance', () => {
+    const current = {
+      chainId: '1',
+      address: '0xSafe1',
+      isReadOnly: false,
+      isPinned: false,
+      lastVisited: 0,
+      name: 'Current',
+    }
+    const safeA = { chainId: '1', address: '0xA', isReadOnly: false, isPinned: false, lastVisited: 0, name: 'A' }
+    const safeB = { chainId: '1', address: '0xB', isReadOnly: false, isPinned: false, lastVisited: 0, name: 'B' }
+
+    setupDefaults({
+      allSafes: [current, safeA, safeB],
+      safeAddress: '0xSafe1',
+      overviews: [
+        { address: { value: '0xSafe1' }, chainId: '1', fiatTotal: '10', threshold: 1, owners: [{ value: '0xO' }] },
+        { address: { value: '0xA' }, chainId: '1', fiatTotal: '100', threshold: 1, owners: [{ value: '0xO' }] },
+        { address: { value: '0xB' }, chainId: '1', fiatTotal: '900', threshold: 1, owners: [{ value: '0xO' }] },
+      ],
+    })
+    ;(useAppSelector as jest.Mock).mockImplementation((selector: unknown) =>
+      selector === selectOrderByPreference ? { orderBy: OrderByOption.BALANCE } : 'usd',
+    )
+
+    const { result } = renderHook(() => useSpaceSafeSelectorItems())
+    // current ('0xSafe1', $10) pinned first; rest by balance desc: B ($900), A ($100)
+    expect(result.current.items.map((i) => i.address)).toEqual(['0xSafe1', '0xB', '0xA'])
   })
 
   // ── undeployed status mapped per-chain on multi-chain safes ──

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/orderItemsByBalance.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/orderItemsByBalance.test.ts
@@ -1,0 +1,44 @@
+import { orderItemsByBalance } from './orderItemsByBalance'
+import type { SafeItemData } from '@/features/spaces'
+
+const makeItem = (id: string, balance: string): SafeItemData => ({
+  id,
+  name: id,
+  address: id,
+  threshold: 1,
+  owners: 1,
+  chains: [],
+  balance,
+})
+
+describe('orderItemsByBalance', () => {
+  it('sorts by balance descending', () => {
+    const items = [makeItem('a', '100'), makeItem('b', '500'), makeItem('c', '300')]
+    expect(orderItemsByBalance(items, 'none').map((i) => i.id)).toEqual(['b', 'c', 'a'])
+  })
+
+  it('keeps the current item first regardless of its balance', () => {
+    const items = [makeItem('a', '100'), makeItem('cur', '0'), makeItem('b', '500')]
+    expect(orderItemsByBalance(items, 'cur').map((i) => i.id)).toEqual(['cur', 'b', 'a'])
+  })
+
+  it('sorts missing or zero balances last', () => {
+    const items = [makeItem('a', ''), makeItem('b', '500'), makeItem('c', '0')]
+    expect(orderItemsByBalance(items, 'none').map((i) => i.id)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('preserves input order for equal balances (stable)', () => {
+    const items = [makeItem('a', '100'), makeItem('b', '100'), makeItem('c', '100')]
+    expect(orderItemsByBalance(items, 'none').map((i) => i.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('keeps input order when every balance is still loading ("0")', () => {
+    const items = [makeItem('a', '0'), makeItem('b', '0'), makeItem('c', '0')]
+    expect(orderItemsByBalance(items, 'none').map((i) => i.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('returns only the sorted rest when the current item is not present', () => {
+    const items = [makeItem('a', '100'), makeItem('b', '500')]
+    expect(orderItemsByBalance(items, 'missing').map((i) => i.id)).toEqual(['b', 'a'])
+  })
+})

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/orderItemsByBalance.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/orderItemsByBalance.test.ts
@@ -22,7 +22,7 @@ describe('orderItemsByBalance', () => {
     expect(orderItemsByBalance(items, 'cur').map((i) => i.id)).toEqual(['cur', 'b', 'a'])
   })
 
-  it('sorts missing or zero balances last', () => {
+  it('sorts zero and missing balances after positive ones', () => {
     const items = [makeItem('a', ''), makeItem('b', '500'), makeItem('c', '0')]
     expect(orderItemsByBalance(items, 'none').map((i) => i.id)).toEqual(['b', 'a', 'c'])
   })

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/orderItemsByBalance.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/orderItemsByBalance.ts
@@ -1,0 +1,14 @@
+import type { SafeItemData } from '@/features/spaces'
+
+/**
+ * Orders dropdown items by fiat balance, highest first, with the current Safe
+ * pinned to the front (mirrors the Name / Last visited behaviour). Uses the same
+ * `balance` shown on the row (single-chain = that chain; multi-chain = current
+ * chain). Zero, missing, or still-loading balances ('0' / '') sort last; ties keep input order.
+ */
+export const orderItemsByBalance = (items: SafeItemData[], currentItemId: string): SafeItemData[] => {
+  const current = items.find((item) => item.id === currentItemId)
+  const rest = items.filter((item) => item.id !== currentItemId)
+  const sorted = rest.slice().sort((a, b) => (Number(b.balance) || 0) - (Number(a.balance) || 0))
+  return current ? [current, ...sorted] : sorted
+}

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/orderItemsByBalance.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/orderItemsByBalance.ts
@@ -1,10 +1,8 @@
 import type { SafeItemData } from '@/features/spaces'
 
 /**
- * Orders dropdown items by fiat balance, highest first, with the current Safe
- * pinned to the front (mirrors the Name / Last visited behaviour). Uses the same
- * `balance` shown on the row (single-chain = that chain; multi-chain = current
- * chain). Zero, missing, or still-loading balances ('0' / '') sort last; ties keep input order.
+ * Orders items by fiat balance (desc), current Safe pinned first, using each row's shown `balance`
+ * (multi-chain = current chain). Zero/missing balances sort last; ties keep input order.
  */
 export const orderItemsByBalance = (items: SafeItemData[], currentItemId: string): SafeItemData[] => {
   const current = items.find((item) => item.id === currentItemId)

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSafeBarSafes.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSafeBarSafes.ts
@@ -3,7 +3,7 @@ import { useIsQualifiedSafe, useSpaceSafes } from '@/features/spaces'
 import { useAllSafes, useAllSafesGrouped, getComparator, type AllSafeItems } from '@/hooks/safes'
 import type { SafeItem, MultiChainSafeItem } from '@/hooks/safes'
 import { useAppSelector } from '@/store'
-import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
+import { OrderByOption, selectOrderByPreference } from '@/store/orderByPreferenceSlice'
 import useChainId from '@/hooks/useChainId'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { useIsSpaceRoute } from '@/hooks/useIsSpaceRoute'
@@ -19,12 +19,11 @@ import { sameAddress } from '@safe-global/utils/utils/addresses'
 const orderDropdownSafes = (
   items: AllSafeItems,
   safeAddress: string,
-  comparator: ReturnType<typeof getComparator>,
+  comparator: ReturnType<typeof getComparator> | undefined,
   current: SafeItem | MultiChainSafeItem | undefined,
 ): AllSafeItems => {
-  const rest = (safeAddress ? items.filter((s) => !sameAddress(s.address, safeAddress)) : items)
-    .slice()
-    .sort(comparator)
+  const filtered = safeAddress ? items.filter((s) => !sameAddress(s.address, safeAddress)) : items
+  const rest = comparator ? filtered.slice().sort(comparator) : filtered
   return safeAddress && current ? [current, ...rest] : rest
 }
 
@@ -51,7 +50,8 @@ export function useSafeBarSafes() {
   const allSafeItems = useAllSafes()
 
   const { orderBy } = useAppSelector(selectOrderByPreference)
-  const comparator = useMemo(() => getComparator(orderBy), [orderBy])
+  // Balance is sorted downstream on enriched items (useSpaceSafeSelectorItems); skip the throwaway sort here.
+  const comparator = useMemo(() => (orderBy === OrderByOption.BALANCE ? undefined : getComparator(orderBy)), [orderBy])
 
   const pinnedItems = useMemo(() => allSafeItems?.filter((s) => s.isPinned) ?? [], [allSafeItems])
 

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceSafeSelectorItems.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceSafeSelectorItems.ts
@@ -180,8 +180,7 @@ export function useSpaceSafeSelectorItems() {
       return buildSingleChainItem(item, isCurrentSafe, overviews, overviewsLoading, safe, chainConfigs, undeployedSafes)
     })
 
-    // Balance sorts on the enriched items here; the upstream Name/Last visited sort from
-    // useSafeBarSafes is intentionally superseded in this case.
+    // Balance re-sorts the enriched items here, superseding the upstream name/last-visited sort.
     return sortByBalance ? orderItemsByBalance(baseItems, selectedItemId) : baseItems
   }, [
     allSafes,

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceSafeSelectorItems.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceSafeSelectorItems.ts
@@ -180,7 +180,6 @@ export function useSpaceSafeSelectorItems() {
       return buildSingleChainItem(item, isCurrentSafe, overviews, overviewsLoading, safe, chainConfigs, undeployedSafes)
     })
 
-    // Balance re-sorts the enriched items here, superseding the upstream name/last-visited sort.
     return sortByBalance ? orderItemsByBalance(baseItems, selectedItemId) : baseItems
   }, [
     allSafes,

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceSafeSelectorItems.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceSafeSelectorItems.ts
@@ -10,6 +10,8 @@ import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
 import { useGetMultipleSafeOverviewsQuery } from '@/store/api/gateway'
 import { useAppSelector } from '@/store'
 import { selectCurrency } from '@/store/settingsSlice'
+import { OrderByOption, selectOrderByPreference } from '@/store/orderByPreferenceSlice'
+import { orderItemsByBalance } from './orderItemsByBalance'
 import { selectUndeployedSafes } from '@/features/counterfactual/store'
 import { PendingSafeStatus } from '@/features/counterfactual/types'
 import type { UndeployedSafesState } from '@/features/counterfactual/types'
@@ -142,6 +144,8 @@ export function useSpaceSafeSelectorItems() {
   const router = useRouter()
   const currency = useAppSelector(selectCurrency)
   const undeployedSafes = useAppSelector(selectUndeployedSafes)
+  const { orderBy } = useAppSelector(selectOrderByPreference)
+  const sortByBalance = orderBy === OrderByOption.BALANCE
   const { address: walletAddress } = useWallet() || {}
   const spaceId = useCurrentSpaceId()
 
@@ -154,8 +158,10 @@ export function useSpaceSafeSelectorItems() {
     refetch: refetchOverviews,
   } = useGetMultipleSafeOverviewsQuery(flatSafes.length > 0 ? { safes: flatSafes, currency, walletAddress } : skipToken)
 
+  const selectedItemId = effectiveSafeAddress ? `${currentChainId}:${effectiveSafeAddress}` : ''
+
   const items: SafeItemData[] = useMemo(() => {
-    return allSafes.map((item) => {
+    const baseItems = allSafes.map((item) => {
       const isCurrentSafe = sameAddress(item.address, effectiveSafeAddress)
 
       if (isMultiChainSafeItem(item)) {
@@ -173,9 +179,22 @@ export function useSpaceSafeSelectorItems() {
 
       return buildSingleChainItem(item, isCurrentSafe, overviews, overviewsLoading, safe, chainConfigs, undeployedSafes)
     })
-  }, [allSafes, effectiveSafeAddress, currentChainId, safe, overviews, overviewsLoading, chainConfigs, undeployedSafes])
 
-  const selectedItemId = effectiveSafeAddress ? `${currentChainId}:${effectiveSafeAddress}` : ''
+    // Balance sorts on the enriched items here; the upstream Name/Last visited sort from
+    // useSafeBarSafes is intentionally superseded in this case.
+    return sortByBalance ? orderItemsByBalance(baseItems, selectedItemId) : baseItems
+  }, [
+    allSafes,
+    effectiveSafeAddress,
+    currentChainId,
+    safe,
+    overviews,
+    overviewsLoading,
+    chainConfigs,
+    undeployedSafes,
+    sortByBalance,
+    selectedItemId,
+  ])
 
   const handleItemSelect = useCallback(
     (itemId: string) => {

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -140,7 +140,12 @@ function SelectLabel({ className, ...props }: SelectPrimitive.GroupLabel.Props) 
   )
 }
 
-function SelectItem({ className, children, ...props }: SelectPrimitive.Item.Props) {
+function SelectItem({
+  className,
+  children,
+  hideIndicator,
+  ...props
+}: SelectPrimitive.Item.Props & { hideIndicator?: boolean }) {
   return (
     <SelectPrimitive.Item
       data-slot="select-item"
@@ -153,11 +158,13 @@ function SelectItem({ className, children, ...props }: SelectPrimitive.Item.Prop
       <SelectPrimitive.ItemText className="flex flex-1 gap-2 shrink-0 whitespace-nowrap">
         {children}
       </SelectPrimitive.ItemText>
-      <SelectPrimitive.ItemIndicator
-        render={<span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />}
-      >
-        <CheckIcon className="pointer-events-none" />
-      </SelectPrimitive.ItemIndicator>
+      {!hideIndicator && (
+        <SelectPrimitive.ItemIndicator
+          render={<span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />}
+        >
+          <CheckIcon className="pointer-events-none" />
+        </SelectPrimitive.ItemIndicator>
+      )}
     </SelectPrimitive.Item>
   )
 }

--- a/apps/web/src/features/myAccounts/components/OrderByButton/index.test.tsx
+++ b/apps/web/src/features/myAccounts/components/OrderByButton/index.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@/tests/test-utils'
+import { fireEvent } from '@testing-library/react'
+import OrderByButton from '.'
+import { OrderByOption } from '@/store/orderByPreferenceSlice'
+
+jest.mock('@/services/analytics', () => ({
+  ...jest.requireActual('@/services/analytics'),
+  trackEvent: jest.fn(),
+}))
+
+describe('OrderByButton', () => {
+  it('shows the current order in the trigger', () => {
+    render(<OrderByButton orderBy={OrderByOption.LAST_VISITED} onOrderByChange={jest.fn()} />)
+    expect(screen.getByTestId('sortby-button')).toHaveTextContent('Last visited')
+  })
+
+  it('shows Name when the order is Balance (this control cannot sort by balance)', () => {
+    render(<OrderByButton orderBy={OrderByOption.BALANCE} onOrderByChange={jest.fn()} />)
+    const trigger = screen.getByTestId('sortby-button')
+    expect(trigger).toHaveTextContent('Name')
+    expect(trigger).not.toHaveTextContent('Balance')
+  })
+
+  it('does not re-dispatch when the displayed (coerced) option is clicked', async () => {
+    const onOrderByChange = jest.fn()
+    render(<OrderByButton orderBy={OrderByOption.BALANCE} onOrderByChange={onOrderByChange} />)
+    fireEvent.click(screen.getByTestId('sortby-button'))
+    // Name is shown selected because Balance is coerced to Name here; clicking it must not clobber Balance.
+    fireEvent.click(await screen.findByTestId('name-option'))
+    expect(onOrderByChange).not.toHaveBeenCalled()
+  })
+
+  it('dispatches when a different order is chosen', async () => {
+    const onOrderByChange = jest.fn()
+    render(<OrderByButton orderBy={OrderByOption.BALANCE} onOrderByChange={onOrderByChange} />)
+    fireEvent.click(screen.getByTestId('sortby-button'))
+    fireEvent.click(await screen.findByTestId('last-visited-option'))
+    expect(onOrderByChange).toHaveBeenCalledWith(OrderByOption.LAST_VISITED)
+  })
+})

--- a/apps/web/src/features/myAccounts/components/OrderByButton/index.tsx
+++ b/apps/web/src/features/myAccounts/components/OrderByButton/index.tsx
@@ -3,7 +3,7 @@ import { Box, Button, ListItemText, MenuItem, SvgIcon, Typography } from '@mui/m
 import ContextMenu from '@/components/common/ContextMenu'
 import TransactionsIcon from '@/public/images/transactions/transactions.svg'
 import CheckIcon from '@/public/images/common/check.svg'
-import { OrderByOption } from '@/store/orderByPreferenceSlice'
+import { OrderByOption, BASIC_SORT_OPTIONS } from '@/store/orderByPreferenceSlice'
 import { OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
 
 type OrderByButtonProps = {
@@ -11,13 +11,12 @@ type OrderByButtonProps = {
   onOrderByChange: (orderBy: OrderByOption) => void
 }
 
-const orderByLabels = {
-  [OrderByOption.LAST_VISITED]: 'Last visited',
-  [OrderByOption.NAME]: 'Name',
-}
+const labelOf = (value: OrderByOption) => BASIC_SORT_OPTIONS.find((option) => option.value === value)?.label ?? ''
 
-const OrderByButton = ({ orderBy: orderBy, onOrderByChange: onOrderByChange }: OrderByButtonProps) => {
+const OrderByButton = ({ orderBy, onOrderByChange }: OrderByButtonProps) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | undefined>()
+  // This control only offers the basic options; a persisted balance order falls back to the first one.
+  const active = BASIC_SORT_OPTIONS.find((option) => option.value === orderBy) ?? BASIC_SORT_OPTIONS[0]
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget)
@@ -27,9 +26,12 @@ const OrderByButton = ({ orderBy: orderBy, onOrderByChange: onOrderByChange }: O
     setAnchorEl(undefined)
   }
 
-  const handleOrderByChange = (newOrderBy: OrderByOption) => {
-    trackEvent({ ...OVERVIEW_EVENTS.SORT_SAFES, label: orderByLabels[newOrderBy] })
-    onOrderByChange(newOrderBy)
+  const handleOrderByChange = (newOrderBy: OrderByOption.NAME | OrderByOption.LAST_VISITED) => {
+    // Skip when the shown option is re-selected, so an order set on another surface isn't overwritten.
+    if (newOrderBy !== active.value) {
+      trackEvent({ ...OVERVIEW_EVENTS.SORT_SAFES, label: labelOf(newOrderBy) })
+      onOrderByChange(newOrderBy)
+    }
     handleClose()
   }
 
@@ -43,7 +45,7 @@ const OrderByButton = ({ orderBy: orderBy, onOrderByChange: onOrderByChange }: O
         size="small"
       >
         <Typography variant="body2" noWrap>
-          Sort by: {orderByLabels[orderBy]}
+          Sort by: {active.label}
         </Typography>
       </Button>
 
@@ -61,22 +63,23 @@ const OrderByButton = ({ orderBy: orderBy, onOrderByChange: onOrderByChange }: O
         <MenuItem disabled>
           <ListItemText>Sort by</ListItemText>
         </MenuItem>
+        {/* Items kept explicit to preserve the existing data-testids (last-visited-option / name-option). */}
         <MenuItem
           data-testid="last-visited-option"
           sx={{ borderRadius: 0 }}
           onClick={() => handleOrderByChange(OrderByOption.LAST_VISITED)}
-          selected={orderBy === OrderByOption.LAST_VISITED}
+          selected={active.value === OrderByOption.LAST_VISITED}
         >
-          <ListItemText sx={{ mr: 2 }}>{orderByLabels[OrderByOption.LAST_VISITED]}</ListItemText>
-          {orderBy === OrderByOption.LAST_VISITED && <CheckIcon sx={{ ml: 1 }} />}
+          <ListItemText sx={{ mr: 2 }}>{labelOf(OrderByOption.LAST_VISITED)}</ListItemText>
+          {active.value === OrderByOption.LAST_VISITED && <CheckIcon sx={{ ml: 1 }} />}
         </MenuItem>
         <MenuItem
           data-testid="name-option"
           onClick={() => handleOrderByChange(OrderByOption.NAME)}
-          selected={orderBy === OrderByOption.NAME}
+          selected={active.value === OrderByOption.NAME}
         >
-          <ListItemText>{orderByLabels[OrderByOption.NAME]}</ListItemText>
-          {orderBy === OrderByOption.NAME && <CheckIcon sx={{ ml: 1 }} />}
+          <ListItemText>{labelOf(OrderByOption.NAME)}</ListItemText>
+          {active.value === OrderByOption.NAME && <CheckIcon sx={{ ml: 1 }} />}
         </MenuItem>
       </ContextMenu>
     </Box>

--- a/apps/web/src/features/myAccounts/components/OrderByButton/index.tsx
+++ b/apps/web/src/features/myAccounts/components/OrderByButton/index.tsx
@@ -15,7 +15,6 @@ const labelOf = (value: OrderByOption) => BASIC_SORT_OPTIONS.find((option) => op
 
 const OrderByButton = ({ orderBy, onOrderByChange }: OrderByButtonProps) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | undefined>()
-  // This control only offers the basic options; a persisted balance order falls back to the first one.
   const active = BASIC_SORT_OPTIONS.find((option) => option.value === orderBy) ?? BASIC_SORT_OPTIONS[0]
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/MultiChainSafeItemRow.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/MultiChainSafeItemRow.tsx
@@ -69,8 +69,8 @@ const MultiChainSafeItemRow = ({ item }: MultiChainSafeItemRowProps) => {
               <SelectItem
                 key={`${chain.chainId}:${item.address}`}
                 value={`${chain.chainId}:${item.address}`}
-                // [&>span.absolute]:hidden suppresses the built-in checkmark span (see SelectItem in ui/select.tsx) — this row uses its own right-aligned StatusBadge / queued count / balance instead, and the checkmark would overlap them.
-                className="flex items-center gap-3 rounded-md px-3 py-2 cursor-pointer data-[state=checked]:bg-muted hover:bg-muted/30 [&>span.absolute]:hidden"
+                hideIndicator // this row's own badges / balance sit where the checkmark would
+                className="flex items-center gap-3 rounded-md px-3 py-2 cursor-pointer data-[state=checked]:bg-muted hover:bg-muted/30"
               >
                 <ChainLogo chainId={chain.chainId} />
                 <div className="flex min-w-0 flex-1 flex-col gap-0.5">

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -126,8 +126,8 @@ const SafeDropdownContainer = ({
         <SelectItem
           key={item.id}
           value={item.id}
-          // Hide the built-in checkmark — it overlaps the balance (active safe shown via bg-muted).
-          className="h-auto py-4 px-4 rounded-lg my-1 data-[state=checked]:bg-muted hover:bg-muted/30 cursor-pointer [&>span.absolute]:hidden"
+          hideIndicator // the checkmark overlaps the balance; active safe is shown via bg-muted
+          className="h-auto py-4 px-4 rounded-lg my-1 data-[state=checked]:bg-muted hover:bg-muted/30 cursor-pointer"
         >
           <SafeItem {...item} />
         </SelectItem>

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -126,9 +126,7 @@ const SafeDropdownContainer = ({
         <SelectItem
           key={item.id}
           value={item.id}
-          // [&>span.absolute]:hidden suppresses the built-in checkmark (see SelectItem in ui/select.tsx) —
-          // the current safe is already indicated by data-[state=checked]:bg-muted, and the checkmark would
-          // overlap the balance (matches MultiChainSafeItemRow's sub-items).
+          // Hide the built-in checkmark — it overlaps the balance (active safe shown via bg-muted).
           className="h-auto py-4 px-4 rounded-lg my-1 data-[state=checked]:bg-muted hover:bg-muted/30 cursor-pointer [&>span.absolute]:hidden"
         >
           <SafeItem {...item} />

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -10,6 +10,7 @@ import useWallet from '@/hooks/wallets/useWallet'
 import SafeItem from './SafeItem'
 import MultiChainSafeItemRow from './MultiChainSafeItemRow'
 import SafeListSortToggle from '@/components/common/SafeListSortToggle'
+import { ALL_SORT_OPTIONS } from '@/store/orderByPreferenceSlice'
 import type { SafeItemData } from '../types'
 
 const matchesSearch = (item: SafeItemData, displayName: string, query: string): boolean => {
@@ -125,7 +126,10 @@ const SafeDropdownContainer = ({
         <SelectItem
           key={item.id}
           value={item.id}
-          className="h-auto py-4 px-4 rounded-lg my-1 data-[state=checked]:bg-muted hover:bg-muted/30 cursor-pointer"
+          // [&>span.absolute]:hidden suppresses the built-in checkmark (see SelectItem in ui/select.tsx) —
+          // the current safe is already indicated by data-[state=checked]:bg-muted, and the checkmark would
+          // overlap the balance (matches MultiChainSafeItemRow's sub-items).
+          className="h-auto py-4 px-4 rounded-lg my-1 data-[state=checked]:bg-muted hover:bg-muted/30 cursor-pointer [&>span.absolute]:hidden"
         >
           <SafeItem {...item} />
         </SelectItem>
@@ -170,7 +174,7 @@ const SafeDropdownContainer = ({
                     data-testid="safe-dropdown-search-input"
                   />
                 </InputGroup>
-                <SafeListSortToggle />
+                <SafeListSortToggle options={ALL_SORT_OPTIONS} />
               </div>
             )}
           </div>

--- a/apps/web/src/hooks/safes/comparators.test.ts
+++ b/apps/web/src/hooks/safes/comparators.test.ts
@@ -1,0 +1,48 @@
+import { OrderByOption } from '@/store/orderByPreferenceSlice'
+import { nameComparator, lastVisitedComparator, getComparator } from './comparators'
+import type { SafeItem } from './useAllSafes'
+
+const makeSafe = (overrides: Partial<SafeItem>): SafeItem => ({
+  chainId: '1',
+  address: '0x1',
+  isReadOnly: false,
+  isPinned: false,
+  lastVisited: 0,
+  name: undefined,
+  ...overrides,
+})
+
+describe('comparators', () => {
+  describe('nameComparator', () => {
+    it('sorts names A→Z', () => {
+      const result = [makeSafe({ name: 'Beta' }), makeSafe({ name: 'Alpha' })].sort(nameComparator)
+      expect(result.map((s) => s.name)).toEqual(['Alpha', 'Beta'])
+    })
+
+    it('puts unnamed safes last', () => {
+      const result = [makeSafe({ name: undefined }), makeSafe({ name: 'Alpha' })].sort(nameComparator)
+      expect(result.map((s) => s.name)).toEqual(['Alpha', undefined])
+    })
+  })
+
+  describe('lastVisitedComparator', () => {
+    it('sorts most-recent first', () => {
+      const result = [makeSafe({ lastVisited: 1 }), makeSafe({ lastVisited: 5 })].sort(lastVisitedComparator)
+      expect(result.map((s) => s.lastVisited)).toEqual([5, 1])
+    })
+  })
+
+  describe('getComparator', () => {
+    it('returns the name comparator for NAME', () => {
+      expect(getComparator(OrderByOption.NAME)).toBe(nameComparator)
+    })
+
+    it('returns the last-visited comparator for LAST_VISITED', () => {
+      expect(getComparator(OrderByOption.LAST_VISITED)).toBe(lastVisitedComparator)
+    })
+
+    it('falls back to the name comparator for BALANCE (not a SafeItem field)', () => {
+      expect(getComparator(OrderByOption.BALANCE)).toBe(nameComparator)
+    })
+  })
+})

--- a/apps/web/src/hooks/safes/comparators.ts
+++ b/apps/web/src/hooks/safes/comparators.ts
@@ -2,7 +2,9 @@ import { OrderByOption } from '@/store/orderByPreferenceSlice'
 import type { SafeItem } from './useAllSafes'
 import type { MultiChainSafeItem } from './useAllSafesGrouped'
 
-export const nameComparator = (a: SafeItem | MultiChainSafeItem, b: SafeItem | MultiChainSafeItem) => {
+type Comparator = (a: SafeItem | MultiChainSafeItem, b: SafeItem | MultiChainSafeItem) => number
+
+export const nameComparator: Comparator = (a, b) => {
   // Put undefined names last
   if (!a.name && !b.name) return 0
   if (!a.name) return 1
@@ -10,10 +12,14 @@ export const nameComparator = (a: SafeItem | MultiChainSafeItem, b: SafeItem | M
   return a.name.localeCompare(b.name)
 }
 
-export const lastVisitedComparator = (a: SafeItem | MultiChainSafeItem, b: SafeItem | MultiChainSafeItem) => {
-  return b.lastVisited - a.lastVisited
+export const lastVisitedComparator: Comparator = (a, b) => b.lastVisited - a.lastVisited
+
+// Comparators for keys that live on SafeItem. Other orders — e.g. balance, which comes from
+// SafeOverview and is sorted on enriched data only in the dropdown — aren't listed and fall back
+// to name, so lazy-loaded lists stay sensibly ordered when the shared preference is one of them.
+const COMPARATORS: Partial<Record<OrderByOption, Comparator>> = {
+  [OrderByOption.NAME]: nameComparator,
+  [OrderByOption.LAST_VISITED]: lastVisitedComparator,
 }
 
-export const getComparator = (orderBy: OrderByOption) => {
-  return orderBy === OrderByOption.NAME ? nameComparator : lastVisitedComparator
-}
+export const getComparator = (orderBy: OrderByOption): Comparator => COMPARATORS[orderBy] ?? nameComparator

--- a/apps/web/src/hooks/safes/comparators.ts
+++ b/apps/web/src/hooks/safes/comparators.ts
@@ -14,9 +14,7 @@ export const nameComparator: Comparator = (a, b) => {
 
 export const lastVisitedComparator: Comparator = (a, b) => b.lastVisited - a.lastVisited
 
-// Comparators for keys that live on SafeItem. Other orders — e.g. balance, which comes from
-// SafeOverview and is sorted on enriched data only in the dropdown — aren't listed and fall back
-// to name, so lazy-loaded lists stay sensibly ordered when the shared preference is one of them.
+// Balance isn't on SafeItem (it's sorted on enriched data in the dropdown); unlisted orders fall back to name.
 const COMPARATORS: Partial<Record<OrderByOption, Comparator>> = {
   [OrderByOption.NAME]: nameComparator,
   [OrderByOption.LAST_VISITED]: lastVisitedComparator,

--- a/apps/web/src/store/orderByPreferenceSlice.test.ts
+++ b/apps/web/src/store/orderByPreferenceSlice.test.ts
@@ -20,6 +20,11 @@ describe('orderByPreferenceSlice', () => {
     expect(state.orderBy).toBe(OrderByOption.LAST_VISITED)
   })
 
+  it('supports the balance order', () => {
+    const state = reducer(undefined, setOrderByPreference({ orderBy: OrderByOption.BALANCE }))
+    expect(state.orderBy).toBe(OrderByOption.BALANCE)
+  })
+
   it('selector falls back to the Name default when the slice is absent', () => {
     expect(selectOrderByPreference({} as RootState).orderBy).toBe(OrderByOption.NAME)
   })

--- a/apps/web/src/store/orderByPreferenceSlice.ts
+++ b/apps/web/src/store/orderByPreferenceSlice.ts
@@ -5,7 +5,27 @@ import type { RootState } from '@/store'
 export enum OrderByOption {
   NAME = 'name',
   LAST_VISITED = 'lastVisited',
+  BALANCE = 'balance',
 }
+
+export type SortOption = {
+  value: OrderByOption
+  label: string
+}
+
+// Sort options available on any Safe list — the keys are intrinsic to SafeItem.
+export const BASIC_SORT_OPTIONS: SortOption[] = [
+  { value: OrderByOption.NAME, label: 'Name' },
+  { value: OrderByOption.LAST_VISITED, label: 'Last visited' },
+]
+
+// Overview-derived sorts (balance, …) — only offered where every row's overview is eager-loaded.
+// To add one: add a row here, then sort it in useSpaceSafeSelectorItems (on the enriched items).
+// Don't add it to comparators.ts — that only handles keys present on SafeItem before enrichment.
+export const EXTENDED_SORT_OPTIONS: SortOption[] = [{ value: OrderByOption.BALANCE, label: 'Balance' }]
+
+// The full set, for surfaces that can show everything (the account selector dropdown).
+export const ALL_SORT_OPTIONS: SortOption[] = [...BASIC_SORT_OPTIONS, ...EXTENDED_SORT_OPTIONS]
 
 // Bump to force every user back to the default order once (see _hydrationReducer).
 // WA-2567 set the default to A→Z; this resets users still on the previous default.

--- a/apps/web/src/store/orderByPreferenceSlice.ts
+++ b/apps/web/src/store/orderByPreferenceSlice.ts
@@ -13,18 +13,14 @@ export type SortOption = {
   label: string
 }
 
-// Sort options available on any Safe list — the keys are intrinsic to SafeItem.
 export const BASIC_SORT_OPTIONS: SortOption[] = [
   { value: OrderByOption.NAME, label: 'Name' },
   { value: OrderByOption.LAST_VISITED, label: 'Last visited' },
 ]
 
-// Overview-derived sorts (balance, …) — only offered where every row's overview is eager-loaded.
-// To add one: add a row here, then sort it in useSpaceSafeSelectorItems (on the enriched items).
-// Don't add it to comparators.ts — that only handles keys present on SafeItem before enrichment.
+// Balance needs eager-loaded overviews, so it's only offered where those exist (the dropdown).
 export const EXTENDED_SORT_OPTIONS: SortOption[] = [{ value: OrderByOption.BALANCE, label: 'Balance' }]
 
-// The full set, for surfaces that can show everything (the account selector dropdown).
 export const ALL_SORT_OPTIONS: SortOption[] = [...BASIC_SORT_OPTIONS, ...EXTENDED_SORT_OPTIONS]
 
 // Bump to force every user back to the default order once (see _hydrationReducer).


### PR DESCRIPTION
## What it solves

Resolves: [WA-2738](https://linear.app/safe-global/issue/WA-2738/sorting-by-balance-in-safe-dropdownlist)

> Note: an earlier attempt deferred balance sorting as "too slow" (WA-2567). That objection applies to the lists that fetch balances **lazily per row on scroll**; the account dropdown is the one place that already batch-loads every row's balance up front, so it can sort by balance with no new fetching.

## How this PR fixes it

Adds a third sort option, **"Balance"** (highest → lowest), to the account selector dropdown:

- `OrderByOption.BALANCE` is added to the shared sort enum. The sort options are declared once as data — `BASIC_SORT_OPTIONS` (Name, Last visited), `EXTENDED_SORT_OPTIONS` (Balance), and `ALL_SORT_OPTIONS` (= basic + extended).
- `SafeListSortToggle` renders whatever option set it's given. The **dropdown** passes `ALL_SORT_OPTIONS`; the **All-accounts modal** passes `BASIC_SORT_OPTIONS`. A persisted order the surface can't offer (e.g. balance in the modal) is coerced to the first option, so no surface ever shows a label it can't honour.
- The real balance sort runs only in the dropdown (`useSpaceSafeSelectorItems`, where overviews are eager-loaded), via the pure helper `orderItemsByBalance`: the current Safe is pinned first, the rest sorted by fiat value descending (stable). Multi-chain Safes sort by the value shown on their row (the current chain).
- `getComparator` (used by ~9 lazy lists) is backed by a `Partial<Record<OrderByOption, Comparator>>` listing only the SafeItem-intrinsic keys, falling back to name. So when the shared preference is `balance`, every lazy list keeps a sensible name order — no breakage, no "lying" labels.
- The dropdown rows now suppress base-ui's built-in selected-item checkmark (the active Safe is already indicated by the row's muted background, and the checkmark overlapped the balance — matching the multi-chain sub-rows).

## How to test it

1. Connect a wallet that owns / has pinned several Safes with **different balances**.
2. Open the account selector dropdown (top bar) → the "Sort by" control now offers **Name**, **Last visited**, **Balance**.
3. Pick **Balance** → the list reorders highest-balance-first, with the current Safe pinned at the top; the trigger reads "Balance".
4. Reload → the dropdown is still on **Balance** (persisted).
5. Pick **Name** → reverts to A→Z.
6. Open **All Accounts / Explore other Safes** → its "Sort by" control still offers only **Name** / **Last visited** and behaves as before.
7. The active Safe's row no longer shows a checkmark overlapping its balance; it stays highlighted via the muted background.

## Affected flows

- **Account selector dropdown — sorting** (the intentional change): new "Balance" option; current Safe pinned first; rows no longer show the overlapping selected-checkmark.
- **All-accounts modal sorting** (unchanged behaviour, verified): still Name / Last visited only.
- **Sidebar / login `OrderByButton` sorting** (unchanged behaviour, verified): still Name / Last visited; a persisted `balance` shows & sorts as Name.
- **Sidebar / spaces account lists** (unchanged behaviour, verified): a persisted `balance` falls back to name sort via `getComparator`.

## Blast radius

- **`store/orderByPreferenceSlice.ts`** — shared, persisted preference. Adds `BALANCE` to the enum + the `BASIC/EXTENDED/ALL` option arrays. Read by ~9 list consumers.
- **`hooks/safes/comparators.ts` (`getComparator`)** — now `Partial<Record>` + name fallback; behaviour for the pre-existing `NAME`/`LAST_VISITED` values is unchanged; `BALANCE` falls back to name. Consumers: dropdown, All-accounts modal, sidebar lists, spaces accounts page, onboarding, multi-account hook, add-accounts.
- **`SafeListSortToggle`** — shared by dropdown + modal; now option-list driven via the `options` prop.
- **`useSpaceSafeSelectorItems` + `orderItemsByBalance`** — dropdown-only balance ordering.
- **`OrderByButton`** — login/sidebar control; reuses the option labels and coerces balance→name.
- **`SafeDropdownContainer`** — passes `ALL_SORT_OPTIONS`; hides the built-in checkmark on single-chain rows.
- No RTK Query / endpoint / API-contract changes. **No change to balance fetching.** Persistence: `orderBy` is a single field, so a persisted `balance` survives normally; the one-time `ORDER_BY_RESET_VERSION` hydration reset is unaffected. **Mobile:** none — all touched files are web-only (`apps/web`).

## Risks / not checked

- **Manual browser walkthrough not yet run in this branch** — recommend exercising the "How to test it" steps before merge (especially the visual checkmark change, which can't be unit-tested: base-ui's Select menu doesn't render in jsdom).
- Multi-chain Safes sort by the **current-chain** value shown on the row, not a cross-chain total — deliberate product decision.
- The toggle/OrderByButton no-clobber guard (clicking the already-shown option doesn't overwrite a balance preference set elsewhere) is verified by the OrderByButton menu-click tests; the dropdown toggle's menu interaction is browser-tier (base-ui doesn't open in jsdom).
- Did not test on mobile (N/A — web-only change).

## Visual summary

```mermaid
flowchart TD
  U[User picks an option in SafeListSortToggle] --> S[setOrderByPreference orderBy]
  S --> Q{orderBy === BALANCE?}

  Q -->|Yes — dropdown only, balances eager-loaded| D[useSpaceSafeSelectorItems → orderItemsByBalance on enriched SafeItemData]
  D --> R1[Dropdown: current Safe first, rest by fiat desc]

  Q -->|Name / Last visited| C[getComparator on SafeItem]
  C --> R2[All lists sorted by name / last visited]

  Q -->|balance on lazy lists modal / sidebar| F[getComparator falls back to nameComparator + label coerced to Name]
  F --> R3[Lazy lists: name order, honest label]
```


## Checklist

- [ ] I've tested the branch on mobile 📱 — N/A (web-only change)
- [x] I've documented how it affects the analytics (if at all) 📊 — reuses the existing `OVERVIEW_EVENTS.SORT_SAFES` event; no new analytics
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — slice, comparators, `orderItemsByBalance`, toggle, hook, OrderByButton
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
