### PR TITLE
fix(web): surface backend error messages in workspace dialogs

### DIFF
--- a/apps/web/src/features/spaces/components/InviteBanner/AcceptInviteDialog.tsx
+++ b/apps/web/src/features/spaces/components/InviteBanner/AcceptInviteDialog.tsx
@@ -17,6 +17,12 @@ import { trackEvent } from '@/services/analytics'
 import { showNotification } from '@/store/notificationsSlice'
 import ExternalLink from '@/components/common/ExternalLink'
 
+const getAcceptInviteErrorMessage = (error: unknown): string => {
+  const err = error as { data?: { message?: string } }
+  if (typeof err?.data?.message === 'string') return err.data.message
+  return 'Failed accepting the invite. Please try again.'
+}
+
 function AcceptInviteDialog({ space, onClose }: { space: GetSpaceResponse; onClose: () => void }): ReactElement {
   const [error, setError] = useState<string>()
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -61,7 +67,7 @@ function AcceptInviteDialog({ space, onClose }: { space: GetSpaceResponse; onClo
         }),
       )
     } catch (e) {
-      setError('Failed accepting the invite. Please try again.')
+      setError(getAcceptInviteErrorMessage(e))
     } finally {
       setIsSubmitting(false)
     }

--- a/apps/web/src/features/spaces/components/InviteBanner/AcceptInviteDialog.tsx
+++ b/apps/web/src/features/spaces/components/InviteBanner/AcceptInviteDialog.tsx
@@ -16,12 +16,9 @@ import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { trackEvent } from '@/services/analytics'
 import { showNotification } from '@/store/notificationsSlice'
 import ExternalLink from '@/components/common/ExternalLink'
-
-const getAcceptInviteErrorMessage = (error: unknown): string => {
-  const err = error as { data?: { message?: string } }
-  if (typeof err?.data?.message === 'string') return err.data.message
-  return 'Failed accepting the invite. Please try again.'
-}
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
+import type { SerializedError } from '@reduxjs/toolkit'
+import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
 
 function AcceptInviteDialog({ space, onClose }: { space: GetSpaceResponse; onClose: () => void }): ReactElement {
   const [error, setError] = useState<string>()
@@ -67,7 +64,7 @@ function AcceptInviteDialog({ space, onClose }: { space: GetSpaceResponse; onClo
         }),
       )
     } catch (e) {
-      setError(getAcceptInviteErrorMessage(e))
+      setError(getRtkQueryErrorMessage(e as FetchBaseQueryError | SerializedError))
     } finally {
       setIsSubmitting(false)
     }

--- a/apps/web/src/features/spaces/components/InviteBanner/AcceptInviteDialog.tsx
+++ b/apps/web/src/features/spaces/components/InviteBanner/AcceptInviteDialog.tsx
@@ -42,32 +42,34 @@ function AcceptInviteDialog({ space, onClose }: { space: GetSpaceResponse; onClo
       const response = await acceptInvite({ spaceId: space.uuid, acceptInviteDto: { name: data.name } })
 
       if (response.error) {
-        throw response.error
+        setError(getRtkQueryErrorMessage(response.error as FetchBaseQueryError | SerializedError))
+        return
       }
-
-      trackEvent(
-        { ...SPACE_EVENTS.WORKSPACE_MEMBER_INVITE_ACCEPTED, label: space.uuid },
-        { workspace_id: space.uuid, user_id: currentUser?.id },
-      )
-
-      if (router.pathname === AppRoutes.welcome.spaces) {
-        router.push({ pathname: AppRoutes.spaces.index, query: { spaceId: space.uuid } })
-      }
-
-      onClose()
-
-      dispatch(
-        showNotification({
-          message: `Accepted invite to ${space.name}`,
-          variant: 'success',
-          groupKey: 'accept-invite-success',
-        }),
-      )
     } catch (e) {
       setError(getRtkQueryErrorMessage(e as FetchBaseQueryError | SerializedError))
+      return
     } finally {
       setIsSubmitting(false)
     }
+
+    trackEvent(
+      { ...SPACE_EVENTS.WORKSPACE_MEMBER_INVITE_ACCEPTED, label: space.uuid },
+      { workspace_id: space.uuid, user_id: currentUser?.id },
+    )
+
+    if (router.pathname === AppRoutes.welcome.spaces) {
+      router.push({ pathname: AppRoutes.spaces.index, query: { spaceId: space.uuid } })
+    }
+
+    onClose()
+
+    dispatch(
+      showNotification({
+        message: `Accepted invite to ${space.name}`,
+        variant: 'success',
+        groupKey: 'accept-invite-success',
+      }),
+    )
   })
 
   return (

--- a/apps/web/src/features/spaces/components/InviteBanner/__tests__/AcceptInviteDialog.test.tsx
+++ b/apps/web/src/features/spaces/components/InviteBanner/__tests__/AcceptInviteDialog.test.tsx
@@ -103,7 +103,9 @@ describe('AcceptInviteDialog tracking', () => {
   })
 
   it('bubbles the backend error message when accepting the invite fails', async () => {
-    mockAcceptInvite.mockResolvedValue({ error: { data: { message: 'Name contains invalid characters' } } })
+    mockAcceptInvite.mockResolvedValue({
+      error: { status: 422, data: { message: 'Name contains invalid characters' } },
+    })
 
     render(<AcceptInviteDialog space={mockSpace} onClose={jest.fn()} />)
 
@@ -117,7 +119,7 @@ describe('AcceptInviteDialog tracking', () => {
   })
 
   it('falls back to a generic error when the backend provides no message', async () => {
-    mockAcceptInvite.mockResolvedValue({ error: {} })
+    mockAcceptInvite.mockResolvedValue({ error: { status: 500, data: {} } })
 
     render(<AcceptInviteDialog space={mockSpace} onClose={jest.fn()} />)
 
@@ -127,6 +129,6 @@ describe('AcceptInviteDialog tracking', () => {
     await waitFor(() => expect(submitButton).not.toBeDisabled())
     fireEvent.click(submitButton)
 
-    expect(await screen.findByText('Failed accepting the invite. Please try again.')).toBeInTheDocument()
+    expect(await screen.findByText(/Something went wrong \(500\)/)).toBeInTheDocument()
   })
 })

--- a/apps/web/src/features/spaces/components/InviteBanner/__tests__/AcceptInviteDialog.test.tsx
+++ b/apps/web/src/features/spaces/components/InviteBanner/__tests__/AcceptInviteDialog.test.tsx
@@ -101,4 +101,32 @@ describe('AcceptInviteDialog tracking', () => {
       )
     })
   })
+
+  it('bubbles the backend error message when accepting the invite fails', async () => {
+    mockAcceptInvite.mockResolvedValue({ error: { data: { message: 'Name contains invalid characters' } } })
+
+    render(<AcceptInviteDialog space={mockSpace} onClose={jest.fn()} />)
+
+    fireEvent.change(screen.getByTestId('name-input'), { target: { value: 'Test User' } })
+
+    const submitButton = screen.getByTestId('confirm-accept-invite-button')
+    await waitFor(() => expect(submitButton).not.toBeDisabled())
+    fireEvent.click(submitButton)
+
+    expect(await screen.findByText('Name contains invalid characters')).toBeInTheDocument()
+  })
+
+  it('falls back to a generic error when the backend provides no message', async () => {
+    mockAcceptInvite.mockResolvedValue({ error: {} })
+
+    render(<AcceptInviteDialog space={mockSpace} onClose={jest.fn()} />)
+
+    fireEvent.change(screen.getByTestId('name-input'), { target: { value: 'Test User' } })
+
+    const submitButton = screen.getByTestId('confirm-accept-invite-button')
+    await waitFor(() => expect(submitButton).not.toBeDisabled())
+    fireEvent.click(submitButton)
+
+    expect(await screen.findByText('Failed accepting the invite. Please try again.')).toBeInTheDocument()
+  })
 })

--- a/apps/web/src/features/spaces/components/MembersList/EditMemberDialog.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/EditMemberDialog.tsx
@@ -53,31 +53,33 @@ const EditMemberDialog = ({ member, handleClose }: { member: MemberDto; handleCl
       })
 
       if (error) {
-        throw error
+        setError(getRtkQueryErrorMessage(error as FetchBaseQueryError | SerializedError))
+        return
       }
-
-      trackEvent(
-        { ...SPACE_EVENTS.WORKSPACE_MEMBER_ROLE_CHANGED, label: spaceId },
-        {
-          workspace_id: spaceId,
-          target_user_id: member.user.id,
-          from_role: member.role.toLowerCase(),
-          to_role: data.role.toLowerCase(),
-        },
-      )
-
-      dispatch(
-        showNotification({
-          message: `Updated role of ${data.name} to ${data.role}`,
-          variant: 'success',
-          groupKey: 'update-member-success',
-        }),
-      )
-
-      handleClose()
     } catch (e) {
       setError(getRtkQueryErrorMessage(e as FetchBaseQueryError | SerializedError))
+      return
     }
+
+    trackEvent(
+      { ...SPACE_EVENTS.WORKSPACE_MEMBER_ROLE_CHANGED, label: spaceId },
+      {
+        workspace_id: spaceId,
+        target_user_id: member.user.id,
+        from_role: member.role.toLowerCase(),
+        to_role: data.role.toLowerCase(),
+      },
+    )
+
+    dispatch(
+      showNotification({
+        message: `Updated role of ${data.name} to ${data.role}`,
+        variant: 'success',
+        groupKey: 'update-member-success',
+      }),
+    )
+
+    handleClose()
   })
 
   return (

--- a/apps/web/src/features/spaces/components/MembersList/EditMemberDialog.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/EditMemberDialog.tsx
@@ -10,6 +10,9 @@ import { useAppDispatch } from '@/store'
 import MemberInfoForm from '../AddMemberModal/MemberInfoForm'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
+import type { SerializedError } from '@reduxjs/toolkit'
+import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
 
 type MemberField = {
   name: string
@@ -73,7 +76,7 @@ const EditMemberDialog = ({ member, handleClose }: { member: MemberDto; handleCl
 
       handleClose()
     } catch (e) {
-      setError('An unexpected error occurred while editing the member.')
+      setError(getRtkQueryErrorMessage(e as FetchBaseQueryError | SerializedError))
     }
   })
 

--- a/apps/web/src/features/spaces/components/MembersList/__tests__/EditMemberDialog.test.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/__tests__/EditMemberDialog.test.tsx
@@ -1,0 +1,96 @@
+import type * as ReactHookForm from 'react-hook-form'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import EditMemberDialog from '../EditMemberDialog'
+import type { MemberDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+
+const mockDispatch = jest.fn()
+const mockEditMember = jest.fn()
+
+jest.mock('@/store', () => ({
+  useAppDispatch: () => mockDispatch,
+}))
+
+jest.mock('@/store/notificationsSlice', () => ({
+  showNotification: (payload: unknown) => ({ type: 'notifications/show', payload }),
+}))
+
+jest.mock('@/features/spaces', () => ({
+  useCurrentSpaceId: () => '42',
+}))
+
+jest.mock('@/services/analytics', () => ({
+  trackEvent: jest.fn(),
+}))
+
+jest.mock('@/services/analytics/events/spaces', () => ({
+  SPACE_EVENTS: { WORKSPACE_MEMBER_ROLE_CHANGED: { action: 'Member role changed', category: 'spaces' } },
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
+  useMembersUpdateRoleV1Mutation: () => [mockEditMember],
+}))
+
+jest.mock('@/components/common/ModalDialog', () => ({
+  __esModule: true,
+  default: ({ children, open }: { children: React.ReactNode; open: boolean }) => (open ? <div>{children}</div> : null),
+}))
+
+jest.mock('@/components/tx/ErrorMessage', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div role="alert">{children}</div>,
+}))
+
+jest.mock('../../AddMemberModal/MemberInfoForm', () => ({
+  __esModule: true,
+  default: function MemberInfoForm() {
+    const { register } = (jest.requireActual('react-hook-form') as typeof ReactHookForm).useFormContext()
+    return (
+      <select aria-label="Role" {...register('role')}>
+        <option value="ADMIN">Admin</option>
+        <option value="MEMBER">Member</option>
+      </select>
+    )
+  },
+}))
+
+const member: MemberDto = {
+  id: 1,
+  name: 'Alice',
+  role: 'MEMBER',
+  status: 'ACTIVE',
+  invitedBy: null,
+  createdAt: '',
+  updatedAt: '',
+  user: { id: 1, status: 'ACTIVE', email: null },
+}
+
+const changeRoleAndSubmit = async () => {
+  fireEvent.change(screen.getByLabelText('Role'), { target: { value: 'ADMIN' } })
+  const submitButton = screen.getByRole('button', { name: 'Update' })
+  await waitFor(() => expect(submitButton).not.toBeDisabled())
+  fireEvent.click(submitButton)
+}
+
+describe('EditMemberDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('bubbles the backend error message when editing the member fails', async () => {
+    mockEditMember.mockResolvedValue({ error: { status: 422, data: { message: 'Role change not allowed' } } })
+
+    render(<EditMemberDialog member={member} handleClose={jest.fn()} />)
+    await changeRoleAndSubmit()
+
+    expect(await screen.findByText('Role change not allowed')).toBeInTheDocument()
+  })
+
+  it('falls back to a generic error when the backend provides no message', async () => {
+    mockEditMember.mockResolvedValue({ error: { status: 500, data: {} } })
+
+    render(<EditMemberDialog member={member} handleClose={jest.fn()} />)
+    await changeRoleAndSubmit()
+
+    expect(await screen.findByText(/Something went wrong \(500\)/)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/EditContactDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/EditContactDialog.tsx
@@ -16,6 +16,9 @@ import {
 import { showNotification } from '@/store/notificationsSlice'
 import { useCurrentSpaceId } from '@/features/spaces'
 import { useAppDispatch } from '@/store'
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
+import type { SerializedError } from '@reduxjs/toolkit'
+import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
 
 type EditContactDialogProps = {
   entry: SpaceAddressBookItemDto
@@ -93,7 +96,7 @@ const EditContactDialog = ({ entry, onClose }: EditContactDialogProps) => {
       })
 
       if (result.error) {
-        setError('Something went wrong. Please try again.')
+        setError(getRtkQueryErrorMessage(result.error as FetchBaseQueryError | SerializedError))
         return
       }
 
@@ -107,7 +110,7 @@ const EditContactDialog = ({ entry, onClose }: EditContactDialogProps) => {
 
       handleClose()
     } catch (error) {
-      setError('Something went wrong. Please try again.')
+      setError(getRtkQueryErrorMessage(error as FetchBaseQueryError | SerializedError))
     } finally {
       setIsSubmitting(false)
     }

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/EditContactDialog.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/EditContactDialog.test.tsx
@@ -1,0 +1,113 @@
+import type * as ReactHookForm from 'react-hook-form'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import EditContactDialog from '../EditContactDialog'
+import type { SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+
+const mockDispatch = jest.fn()
+const mockUpsertAddressBook = jest.fn()
+
+jest.mock('@/store', () => ({
+  useAppDispatch: () => mockDispatch,
+}))
+
+jest.mock('@/store/notificationsSlice', () => ({
+  showNotification: (payload: unknown) => ({ type: 'notifications/show', payload }),
+}))
+
+jest.mock('@/features/spaces', () => ({
+  useCurrentSpaceId: () => '42',
+}))
+
+jest.mock('@/services/analytics', () => ({
+  trackEvent: jest.fn(),
+}))
+
+jest.mock('@/services/analytics/events/spaces', () => ({
+  SPACE_EVENTS: { EDIT_ADDRESS_SUBMIT: { action: 'Edit address submit', category: 'spaces' } },
+}))
+
+jest.mock('@/hooks/useChains', () => ({
+  __esModule: true,
+  default: () => ({ configs: [{ chainId: '1', chainName: 'Ethereum' }] }),
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
+  useAddressBooksUpsertAddressBookItemsV1Mutation: () => [mockUpsertAddressBook],
+}))
+
+jest.mock('@/components/common/ModalDialog', () => ({
+  __esModule: true,
+  default: ({ children, open }: { children: React.ReactNode; open: boolean }) => (open ? <div>{children}</div> : null),
+}))
+
+jest.mock('@/components/common/AddressInputReadOnly', () => ({
+  __esModule: true,
+  default: () => <div data-testid="address-readonly" />,
+}))
+
+jest.mock('@/components/common/NameInput', () => ({
+  __esModule: true,
+  default: ({ name, label }: { name: string; label: string }) => {
+    const { register } = (jest.requireActual('react-hook-form') as typeof ReactHookForm).useFormContext()
+    return <input aria-label={label} {...register(name, { required: true })} />
+  },
+}))
+
+jest.mock('@/components/common/NetworkSelector/NetworkMultiSelectorInput', () => ({
+  __esModule: true,
+  default: () => <div data-testid="network-selector" />,
+}))
+
+const entry: SpaceAddressBookItemDto = {
+  name: 'Alice',
+  address: '0xabc',
+  chainIds: ['1'],
+  createdBy: '0xabc',
+  createdByUserId: 1,
+  lastUpdatedBy: '0xabc',
+  lastUpdatedByUserId: 1,
+  createdAt: '',
+  updatedAt: '',
+}
+
+const submitForm = async () => {
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Alice Updated' } })
+  const submitButton = screen.getByRole('button', { name: 'Save' })
+  await waitFor(() => expect(submitButton).not.toBeDisabled())
+  fireEvent.click(submitButton)
+}
+
+describe('EditContactDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('bubbles the backend error message from result.error', async () => {
+    mockUpsertAddressBook.mockResolvedValue({
+      error: { status: 422, data: { message: 'Name contains invalid characters' } },
+    })
+
+    render(<EditContactDialog entry={entry} onClose={jest.fn()} />)
+    await submitForm()
+
+    expect(await screen.findByText('Name contains invalid characters')).toBeInTheDocument()
+  })
+
+  it('bubbles the backend error message when the mutation throws', async () => {
+    mockUpsertAddressBook.mockRejectedValue({ status: 422, data: { message: 'Invalid characters in name' } })
+
+    render(<EditContactDialog entry={entry} onClose={jest.fn()} />)
+    await submitForm()
+
+    expect(await screen.findByText('Invalid characters in name')).toBeInTheDocument()
+  })
+
+  it('falls back to a generic error when the backend provides no message', async () => {
+    mockUpsertAddressBook.mockResolvedValue({ error: { status: 500, data: {} } })
+
+    render(<EditContactDialog entry={entry} onClose={jest.fn()} />)
+    await submitForm()
+
+    expect(await screen.findByText(/Something went wrong \(500\)/)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/UpdateSpaceForm.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/UpdateSpaceForm.test.tsx
@@ -150,8 +150,8 @@ describe('UpdateSpaceForm', () => {
     })
   })
 
-  it('should display error message when update fails', async () => {
-    mockUnwrap.mockRejectedValue(new Error('Network error'))
+  it('should display the backend error message when update fails', async () => {
+    mockUnwrap.mockRejectedValue({ status: 422, data: { message: 'Name contains invalid characters' } })
     setupForm(mockSpace, true)
 
     changeSpaceName('New Space Name')
@@ -160,7 +160,7 @@ describe('UpdateSpaceForm', () => {
     fireEvent.click(saveButton)
 
     await waitFor(() => {
-      expect(screen.getByText('Error updating the workspace. Please try again.')).toBeInTheDocument()
+      expect(screen.getByText('Name contains invalid characters')).toBeInTheDocument()
     })
   })
 
@@ -178,7 +178,9 @@ describe('UpdateSpaceForm', () => {
   })
 
   it('should clear error message when user retries after error', async () => {
-    mockUnwrap.mockRejectedValueOnce(new Error('Network error')).mockResolvedValueOnce({})
+    mockUnwrap
+      .mockRejectedValueOnce({ status: 422, data: { message: 'Name contains invalid characters' } })
+      .mockResolvedValueOnce({})
     setupForm(mockSpace, true)
 
     // First attempt fails
@@ -187,7 +189,7 @@ describe('UpdateSpaceForm', () => {
     fireEvent.click(saveButton)
 
     await waitFor(() => {
-      expect(screen.getByText('Error updating the workspace. Please try again.')).toBeInTheDocument()
+      expect(screen.getByText('Name contains invalid characters')).toBeInTheDocument()
     })
 
     // Second attempt succeeds
@@ -195,7 +197,7 @@ describe('UpdateSpaceForm', () => {
     fireEvent.click(saveButton)
 
     await waitFor(() => {
-      expect(screen.queryByText('Error updating the workspace. Please try again.')).not.toBeInTheDocument()
+      expect(screen.queryByText('Name contains invalid characters')).not.toBeInTheDocument()
     })
   })
 })

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/useUpdateSpace.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/useUpdateSpace.test.tsx
@@ -65,15 +65,26 @@ describe('useUpdateSpace', () => {
     expect(last.groupKey).toBe('space-update-name')
   })
 
-  it('sets an error message when the mutation rejects', async () => {
-    mockUnwrap.mockRejectedValue(new Error('network'))
+  it('bubbles the backend error message when the mutation rejects', async () => {
+    mockUnwrap.mockRejectedValue({ status: 422, data: { message: 'Name contains invalid characters' } })
     const { result } = renderWithStore()
 
     await act(async () => {
       await result.current.handleUpdate({ name: 'Renamed' })
     })
 
-    expect(result.current.error).toBe('Error updating the workspace. Please try again.')
+    expect(result.current.error).toBe('Name contains invalid characters')
+  })
+
+  it('falls back to a generic error when the backend provides no message', async () => {
+    mockUnwrap.mockRejectedValue({ status: 500, data: {} })
+    const { result } = renderWithStore()
+
+    await act(async () => {
+      await result.current.handleUpdate({ name: 'Renamed' })
+    })
+
+    expect(result.current.error).toMatch(/Something went wrong \(500\)/)
   })
 
   it('clears a previous error before a new attempt', async () => {

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
+import type { SerializedError } from '@reduxjs/toolkit'
 import { type GetSpaceResponse, useSpacesUpdateV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useIsAdmin } from '@/features/spaces'
+import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
 import { useAppDispatch } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
 import { Input } from '@/components/ui/input'
@@ -56,7 +59,7 @@ const IdentitySection = ({ space }: { space: GetSpaceResponse | undefined }) => 
     } catch (e) {
       console.error(e)
       isAwaitingCacheSync.current = false
-      setError("Couldn't update workspace. Please try again.")
+      setError(getRtkQueryErrorMessage(e as FetchBaseQueryError | SerializedError))
     }
   }
 

--- a/apps/web/src/features/spaces/components/SpaceSettings/useUpdateSpace.ts
+++ b/apps/web/src/features/spaces/components/SpaceSettings/useUpdateSpace.ts
@@ -1,7 +1,10 @@
 import { useState } from 'react'
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
+import type { SerializedError } from '@reduxjs/toolkit'
 import { useAppDispatch } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
 import { type GetSpaceResponse, useSpacesUpdateV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
 
 export type UpdateSpaceFormData = {
   name: string
@@ -31,7 +34,7 @@ export const useUpdateSpace = (space: GetSpaceResponse | undefined) => {
       )
     } catch (e) {
       console.error(e)
-      setError('Error updating the workspace. Please try again.')
+      setError(getRtkQueryErrorMessage(e as FetchBaseQueryError | SerializedError))
     }
   }
 


### PR DESCRIPTION
## What it solves

Resolves: [WA-2748](https://linear.app/safe-global/issue/WA-2748/show-backend-error-msg-instead-of-generic-error-on-name-validation)

Several workspace dialogs swallowed backend validation errors (e.g. "invalid characters" in a name) and showed a generic "Please try again" message instead, leaving users unable to tell why an action failed.

## How this PR fixes it

Replaces the hardcoded error strings with the shared `getRtkQueryErrorMessage` helper, which returns the backend's own `data.message` when present and falls back to friendly copy for transport-level failures. Applied to the accept-invite, edit-contact, edit-member, and workspace-rename flows.

## How to test it

1. Trigger any of these actions with input the backend rejects (e.g. a name with invalid characters): accept a workspace invite, edit a contact, edit a member's role, or rename a workspace.
2. Confirm the alert now shows the backend's specific message, not "Please try again".

## Affected flows

- Accept workspace invite (`AcceptInviteDialog`)
- Edit shared contact (`EditContactDialog`)
- Edit member role (`EditMemberDialog`)
- Rename workspace (`IdentitySection`, `useUpdateSpace` / `UpdateSpaceForm`)

## Blast radius

- Reuses the existing shared helper `getRtkQueryErrorMessage` (`apps/web/src/utils/rtkQuery.ts`) — no change to the helper itself.
- Touches only the catch/`result.error` branches of the four flows above; success paths unchanged.
- No API contract, feature flag, route, persistence, or shared-package (mobile) changes.

## Risks / not checked

- Lower-priority non-text actions (delete/leave/reject/remove dialogs) left showing generic copy.

## Visual summary

<img width="707" height="523" alt="image" src="https://github.com/user-attachments/assets/2c2c3103-14ea-4706-9804-f67469750b42" />
<img width="782" height="234" alt="image" src="https://github.com/user-attachments/assets/4c9c157c-f83f-4cd0-9c96-12c4dd47b3ea" />


```mermaid
flowchart LR
  A[Mutation fails] --> B{getRtkQueryErrorMessage}
  B -->|backend data.message| C[Show specific error<br/>e.g. invalid characters]
  B -->|network / timeout / no message| D[Friendly fallback copy]
```

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
