### PR TITLE
chore: ignore .cache-tmp/ generated by container tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,8 @@ apps/web-tanstack/dist/
 # beads
 .beads/
 
-# Yarn v4
+# Yarn v4 / tooling cache (redirected inside workspace in container envs)
+.cache-tmp/
 .yarn/*
 !.yarn/patches
 !.yarn/plugins


### PR DESCRIPTION
## What it solves
`.cache-tmp/` was appearing as an untracked directory in git status. It is generated at runtime by Yarn 4 and `Corepack` when running inside `container/sandbox` environments where standard `XDG` cache paths (`~/.cache`) are not writable — they redirect their global cache, temp directories, and Corepack binaries into `.cache-tmp/` inside the workspace root instead.
  
Contents:
- `.cache-tmp/corepack/` — Corepack's downloaded Yarn 4 binary
- `.cache-tmp/tmp/xfs-*/` — Yarn's ephemeral zip extraction temp dirs
- `.cache-tmp/tmp/node-compile-cache/` — Node.js V8 bytecode cache
- `.cache-tmp/yarn-global/` — Yarn's global package store
- `.cache-tmp/xdg/` — XDG base dir cache

##  How this PR fixes it
Adds `.cache-tmp/` to `.gitignore`, grouped under the Yarn v4 section since it is tooling-generated.