### PR TITLE
feat(web): disconnect connected wallet on workspace logout (WA-2742)

### DIFF
--- a/apps/web/src/hooks/__tests__/useLogout.test.ts
+++ b/apps/web/src/hooks/__tests__/useLogout.test.ts
@@ -1,10 +1,20 @@
 import { renderHook, act } from '@testing-library/react'
 import useLogout from '@/hooks/useLogout'
 import { LOGGING_OUT_KEY } from '@/hooks/useLogoutCallback'
+import useOnboard from '@/hooks/wallets/useOnboard'
+import useWallet from '@/hooks/wallets/useWallet'
+import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
+import type { OnboardAPI } from '@web3-onboard/core'
 
 jest.mock('@/config/gateway', () => ({
   GATEWAY_URL: 'https://safe-client.safe.global',
 }))
+
+jest.mock('@/hooks/wallets/useOnboard')
+jest.mock('@/hooks/wallets/useWallet')
+
+const mockUseOnboard = useOnboard as jest.MockedFunction<typeof useOnboard>
+const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>
 
 describe('useLogout', () => {
   const originalLocation = window.location
@@ -12,11 +22,16 @@ describe('useLogout', () => {
   let appendChildSpy: jest.SpyInstance
   let removeChildSpy: jest.SpyInstance
   let capturedForm: HTMLFormElement | null = null
+  let disconnectWalletSpy: jest.Mock
 
   beforeEach(() => {
     jest.clearAllMocks()
     sessionStorage.clear()
     capturedForm = null
+
+    disconnectWalletSpy = jest.fn().mockResolvedValue(undefined)
+    mockUseOnboard.mockReturnValue({ disconnectWallet: disconnectWalletSpy } as unknown as OnboardAPI)
+    mockUseWallet.mockReturnValue(null)
 
     Object.defineProperty(window, 'location', {
       writable: true,
@@ -77,5 +92,33 @@ describe('useLogout', () => {
     })
 
     expect(removeChildSpy).toHaveBeenCalledWith(capturedForm)
+  })
+
+  it('should disconnect the connected wallet before submitting the logout form', async () => {
+    mockUseWallet.mockReturnValue({ label: 'MetaMask' } as ConnectedWallet)
+
+    const { result } = renderHook(() => useLogout())
+
+    await act(async () => {
+      await result.current.logout()
+    })
+
+    expect(disconnectWalletSpy).toHaveBeenCalledWith({ label: 'MetaMask' })
+    expect(disconnectWalletSpy.mock.invocationCallOrder[0]).toBeLessThan(submitSpy.mock.invocationCallOrder[0])
+    expect(submitSpy).toHaveBeenCalled()
+    expect(sessionStorage.getItem(LOGGING_OUT_KEY)).toBe('1')
+  })
+
+  it('should not attempt to disconnect when no wallet is connected', async () => {
+    mockUseWallet.mockReturnValue(null)
+
+    const { result } = renderHook(() => useLogout())
+
+    await act(async () => {
+      await result.current.logout()
+    })
+
+    expect(disconnectWalletSpy).not.toHaveBeenCalled()
+    expect(submitSpy).toHaveBeenCalled()
   })
 })

--- a/apps/web/src/hooks/useLogout.ts
+++ b/apps/web/src/hooks/useLogout.ts
@@ -2,6 +2,8 @@ import { useCallback } from 'react'
 import { GATEWAY_URL } from '@/config/gateway'
 import { AppRoutes } from '@/config/routes'
 import { LOGGING_OUT_KEY } from '@/hooks/useLogoutCallback'
+import useOnboard from '@/hooks/wallets/useOnboard'
+import useWallet from '@/hooks/wallets/useWallet'
 
 const LOGOUT_REDIRECT_PATH = '/v1/auth/logout/redirect'
 
@@ -14,9 +16,19 @@ const LOGOUT_REDIRECT_PATH = '/v1/auth/logout/redirect'
  *
  * Sets a transient flag in sessionStorage so that after the redirect lands back in the app,
  * `useLogoutCallback` can reconcile with the backend via /v1/auth/me.
+ *
+ * Disconnects the connected wallet first: the logout triggers a full page navigation, so without
+ * this the wallet would be auto-reconnected on the next load via the `lastWallet` storage key.
  */
 const useLogout = () => {
-  const logout = useCallback(() => {
+  const onboard = useOnboard()
+  const wallet = useWallet()
+
+  const logout = useCallback(async () => {
+    if (onboard && wallet) {
+      await onboard.disconnectWallet({ label: wallet.label })
+    }
+
     sessionStorage.setItem(LOGGING_OUT_KEY, '1')
 
     const redirectUrl = new URL(AppRoutes.welcome.spaces, window.location.origin).toString()
@@ -36,7 +48,7 @@ const useLogout = () => {
     document.body.appendChild(form)
     form.submit()
     document.body.removeChild(form)
-  }, [])
+  }, [onboard, wallet])
 
   return { logout }
 }


### PR DESCRIPTION
## What it solves

Resolves: [WA-2742](https://linear.app/safe-global/issue/WA-2742/disconnect-connected-wallet-on-workspace-logout)

When a user logs out of a workspace, the connected wallet stayed connected. Worse, because workspace logout performs a full top-level page navigation (a hidden-form `POST` to `/v1/auth/logout/redirect`), the wallet would **auto-reconnect** on the next app load via the `lastWallet` localStorage key — so the wallet effectively survived logout.

## How this PR fixes it

`useLogout` is the single hook every logout entry point funnels through (sidebar profile, account settings, spaces-list popover, profile popover). It now disconnects the connected wallet **before** submitting the redirect form:

```ts
if (onboard && wallet) {
  await onboard.disconnectWallet({ label: wallet.label })
}
```

Disconnecting before navigation lets the existing `useInitOnboard` subscription clear the `lastWallet` storage key, which is what prevents the auto-reconnect on reload. The call is awaited so it (and the WalletConnect peer-disconnect message) completes before the page navigates away. The disconnect is silent and runs on every explicit logout, regardless of sign-in method (SIWE or OIDC).

## How to test it

1. Sign in to a workspace and connect a wallet (e.g. MetaMask or WalletConnect).
2. Log out via any entry point (sidebar profile menu, account settings, or the spaces-list account popover).
3. After the redirect lands on `/welcome/spaces`, confirm the wallet is **disconnected** and does **not** auto-reconnect.
4. Repeat while signed in via email (OIDC) with a wallet connected — the wallet should still be disconnected.
5. Log out with **no** wallet connected — logout should still complete normally.

## Affected flows

- Workspace logout (all four entry points: sidebar profile section, account settings page, spaces-list account popover, profile popover) — now additionally disconnects the connected wallet.

## Blast radius

- **`useLogout` hook** — the only file with a logic change. Consumed by `SidebarProfileSection`, `SpaceSettings/AccountPage`, `SpacesList/AccountInfo`, and `ProfilePopoverContent`. `logout` is now `async`; all callers fire-and-forget it, so the change is backward-compatible.
- **`useOnboard` / `useWallet`** — consumed read-only; no signature change.
- Relies on the existing `useInitOnboard` wallet subscription to clear the `lastWallet` localStorage key (unchanged behaviour, same path the manual "Disconnect" button uses).
- **No** RTK Query endpoint, slice, feature flag, route, or shared-package contract changed. **No** mobile impact (`useLogout` is web-only).

## Risks / not checked

- Did not exercise a real WalletConnect peer disconnect end-to-end (covered by unit mocks); awaiting `disconnectWallet` is expected to complete quickly, but a hung peer could in theory delay the redirect.
- Did not change the **session-expiry auto-logout** path (`setUnauthenticated`) — out of scope; this PR covers explicit user logout only, per the ticket.
- Did not test on mobile (not applicable — web-only hook).
- Pre-existing, unrelated type errors in `.next/types/validator.ts` and the `web-tanstack` workspace were confirmed present on `dev` before this change and are not touched here.

## Visual summary

```mermaid
sequenceDiagram
    actor User
    participant Logout as useLogout
    participant Onboard as Web3-Onboard
    participant Sub as useInitOnboard sub
    participant CGW as CGW /auth/logout/redirect

    User->>Logout: click "Sign out"
    alt wallet connected
        Logout->>Onboard: await disconnectWallet({ label })
        Onboard-->>Sub: wallets = []
        Sub->>Sub: saveLastWallet('') (clears lastWallet)
    end
    Logout->>CGW: POST redirect form (full navigation)
    CGW-->>User: 303 to /welcome/spaces
    Note over User,Sub: On reload, connectLastWallet finds no lastWallet so there is no auto-reconnect
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — N/A, `useLogout` is web-only
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics change; logout tracking is unchanged in callers
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — extended `useLogout.test.ts`
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
