### PR TITLE
feat(web): apply a Safe's name across all its networks (WA-2755)

### DIFF
--- a/apps/web/src/features/spaces/components/RenameSafe/RenameSafeDialog.tsx
+++ b/apps/web/src/features/spaces/components/RenameSafe/RenameSafeDialog.tsx
@@ -9,20 +9,18 @@ import {
   type SxProps,
   type Theme,
 } from '@mui/material'
-import { Controller, FormProvider, useForm } from 'react-hook-form'
-import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import { FormProvider, useForm } from 'react-hook-form'
 import ModalDialog from '@/components/common/ModalDialog'
 import NameInput from '@/components/common/NameInput'
 import AddressInputReadOnly from '@/components/common/AddressInputReadOnly'
-import NetworkMultiSelectorInput from '@/components/common/NetworkSelector/NetworkMultiSelectorInput'
-import useChains from '@/hooks/useChains'
 import { useAppDispatch } from '@/store'
 import { upsertAddressBookEntries } from '@/store/addressBookSlice'
 import { showNotification } from '@/store/notificationsSlice'
 import { useAddressBooksUpsertAddressBookItemsV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { useMergedAddressBooks } from '@/hooks/useAllAddressBooks'
 import type { RenameTarget } from './types'
 
-type FormValues = { name: string; networks: Chain[] }
+type FormValues = { name: string }
 
 const GENERIC_ERROR = 'Something went wrong. Please try again.'
 const SUCCESS_NOTIFICATION = {
@@ -40,39 +38,33 @@ export interface RenameSafeDialogProps {
 
 const RenameSafeDialog = ({ target, onClose, sx }: RenameSafeDialogProps): ReactElement => {
   const dispatch = useAppDispatch()
-  const { configs } = useChains()
   const [error, setError] = useState<string>()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [upsertSpaceAddressBook] = useAddressBooksUpsertAddressBookItemsV1Mutation()
-
-  // The selector is scoped to the chains THIS Safe is on (not all Safe-supported chains),
-  // and defaults to all of them; the user can narrow which of the Safe's chains the name applies to.
-  const safeChains = target.chainIds
-    .map((chainId) => (configs ?? []).find((chain) => chain.chainId === chainId))
-    .filter((chain): chain is Chain => Boolean(chain))
+  const { getFromSpaceByAddress } = useMergedAddressBooks()
 
   const methods = useForm<FormValues>({
     mode: 'onChange',
-    defaultValues: { name: target.currentName, networks: safeChains },
+    defaultValues: { name: target.currentName },
   })
-  const { handleSubmit, formState, control } = methods
-  const { errors } = formState
+  const { handleSubmit, formState } = methods
 
-  const onSubmit = handleSubmit(async ({ name, networks }) => {
+  const onSubmit = handleSubmit(async ({ name }) => {
     setError(undefined)
-    // Fall back to the Safe's chains when the selector never rendered (single-chain Safe) or configs
-    // hadn't loaded when the dialog mounted — never write an empty chainIds set.
-    const selectedChainIds = networks.map((network) => network.chainId)
-    const chainIds = selectedChainIds.length > 0 ? selectedChainIds : target.chainIds
     const { spaceId } = target
 
     if (!target.isSpaceSafe || !spaceId) {
-      dispatch(upsertAddressBookEntries({ name, address: target.address, chainIds }))
+      // Local: one name across networks — write it to ALL the Safe's chains.
+      dispatch(upsertAddressBookEntries({ name, address: target.address, chainIds: target.chainIds }))
       dispatch(showNotification(SUCCESS_NOTIFICATION))
       onClose()
       return
     }
 
+    // Space (cloud): the CGW row is keyed by (space, address) — one name. Only change the name and
+    // PRESERVE the existing chain_ids (the upsert API replaces them, so re-send the row's current
+    // set). A brand-new entry has none yet → use the Safe's chains.
+    const chainIds = getFromSpaceByAddress(target.address)?.chainIds ?? target.chainIds
     try {
       setIsSubmitting(true)
       const result = await upsertSpaceAddressBook({
@@ -108,25 +100,6 @@ const RenameSafeDialog = ({ target, onClose, sx }: RenameSafeDialogProps): React
               <AddressInputReadOnly address={target.address} chainId={target.chainIds[0]} />
 
               <NameInput data-testid="name-input" name="name" label="Name" autoFocus required />
-
-              {/* Only offer a chain picker when the Safe spans more than one chain. */}
-              {safeChains.length > 1 && (
-                <Controller
-                  name="networks"
-                  control={control}
-                  rules={{ required: true }}
-                  render={({ field }) => (
-                    <NetworkMultiSelectorInput
-                      name="networks"
-                      showSelectAll
-                      chains={safeChains}
-                      value={field.value || []}
-                      error={!!errors.networks}
-                      helperText={errors.networks ? 'Select at least one network' : ''}
-                    />
-                  )}
-                />
-              )}
             </Stack>
 
             {error && (

--- a/apps/web/src/features/spaces/components/RenameSafe/RenameSafeDialog.tsx
+++ b/apps/web/src/features/spaces/components/RenameSafe/RenameSafeDialog.tsx
@@ -97,7 +97,7 @@ const RenameSafeDialog = ({ target, onClose, sx }: RenameSafeDialogProps): React
         <form onSubmit={onSubmit}>
           <DialogContent>
             <Stack spacing={3} sx={{ pt: 1 }}>
-              <AddressInputReadOnly address={target.address} chainId={target.chainIds[0]} />
+              <AddressInputReadOnly address={target.address} chainId={target.chainIds[0] ?? ''} />
 
               <NameInput data-testid="name-input" name="name" label="Name" autoFocus required />
             </Stack>

--- a/apps/web/src/features/spaces/components/RenameSafe/__tests__/RenameSafeDialog.test.tsx
+++ b/apps/web/src/features/spaces/components/RenameSafe/__tests__/RenameSafeDialog.test.tsx
@@ -9,17 +9,15 @@ jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
   useAddressBooksUpsertAddressBookItemsV1Mutation: () => [mockUpsertSpace, {}],
 }))
 
-// The dialog defaults the network selector to the Safe's chains, resolved from useChains configs.
-const mockConfigs = [
-  { chainId: '1', chainName: 'Ethereum', shortName: 'eth' },
-  { chainId: '137', chainName: 'Polygon', shortName: 'matic' },
-]
-// Lets a test simulate configs not being loaded yet (empty array).
-let mockConfigsOverride: typeof mockConfigs | null = null
-jest.mock('@/hooks/useChains', () => ({
+// The dialog reads the existing space row's chain_ids (to preserve them) via getFromSpaceByAddress.
+// Stub the exports the render tree uses (RenameSafeDialog + EthHashInfo inside AddressInputReadOnly);
+// requireActual here trips a circular init, so provide them explicitly.
+const mockGetFromSpaceByAddress = jest.fn((): { chainIds: string[] } | undefined => undefined)
+jest.mock('@/hooks/useAllAddressBooks', () => ({
   __esModule: true,
-  default: () => ({ configs: mockConfigsOverride ?? mockConfigs }),
-  useChain: (chainId: string) => (mockConfigsOverride ?? mockConfigs).find((chain) => chain.chainId === chainId),
+  useMergedAddressBooks: () => ({ getFromSpaceByAddress: mockGetFromSpaceByAddress }),
+  useAddressBookItem: () => undefined,
+  ContactSource: { space: 'space', local: 'local' },
 }))
 
 const address = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
@@ -35,13 +33,13 @@ const baseTarget: RenameTarget = {
 // Reads the local address book so the test asserts resulting state, not dispatched actions.
 function Probe({ chainId }: { chainId: string }) {
   const name = useAppSelector((s) => s.addressBook[chainId]?.[address] ?? '')
-  return <div data-testid="probe">{name}</div>
+  return <div data-testid={`probe-${chainId}`}>{name}</div>
 }
 
 describe('RenameSafeDialog', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockConfigsOverride = null
+    mockGetFromSpaceByAddress.mockReturnValue(undefined)
     mockUpsertSpace.mockResolvedValue({ data: {} })
   })
 
@@ -50,44 +48,35 @@ describe('RenameSafeDialog', () => {
     expect(screen.getByDisplayValue('Old name')).toBeInTheDocument()
   })
 
-  it('writes the LOCAL address book for a non-space target', async () => {
+  it('renders no network picker — the name applies to all the Safe chains', () => {
+    render(<RenameSafeDialog target={baseTarget} onClose={jest.fn()} />) // multichain target
+    expect(screen.queryByTestId('select-all-checkbox')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('network-checkbox')).not.toBeInTheDocument()
+  })
+
+  it('writes the LOCAL name to ALL the Safe chains for a non-space target', async () => {
     const onClose = jest.fn()
     const { user } = renderWithUserEvent(
       <>
         <RenameSafeDialog target={baseTarget} onClose={onClose} />
         <Probe chainId="1" />
+        <Probe chainId="137" />
       </>,
     )
     const input = screen.getByDisplayValue('Old name')
     await user.clear(input)
     await user.type(input, 'New name')
     await user.click(screen.getByTestId('save-btn'))
-    await waitFor(() => expect(screen.getByTestId('probe')).toHaveTextContent('New name'))
+    await waitFor(() => expect(screen.getByTestId('probe-1')).toHaveTextContent('New name'))
+    expect(screen.getByTestId('probe-137')).toHaveTextContent('New name')
     expect(mockUpsertSpace).not.toHaveBeenCalled()
     expect(onClose).toHaveBeenCalled()
   })
 
-  it('falls back to the Safe chains when configs are not loaded (never writes empty chainIds)', async () => {
-    mockConfigsOverride = []
+  it('writes the SPACE address book with the Safe chains for a brand-new entry', async () => {
+    mockGetFromSpaceByAddress.mockReturnValue(undefined) // no existing space row
     const { user } = renderWithUserEvent(
-      <>
-        <RenameSafeDialog target={baseTarget} onClose={jest.fn()} />
-        <Probe chainId="1" />
-      </>,
-    )
-    const input = screen.getByDisplayValue('Old name')
-    await user.clear(input)
-    await user.type(input, 'Fallback name')
-    await user.click(screen.getByTestId('save-btn'))
-    // Empty configs → the chain selector never renders; the write must still target the Safe's
-    // own chains (target.chainIds) rather than an empty set, so the name lands on chain '1'.
-    await waitFor(() => expect(screen.getByTestId('probe')).toHaveTextContent('Fallback name'))
-  })
-
-  it('writes the SPACE address book for a space target with all chainIds', async () => {
-    const onClose = jest.fn()
-    const { user } = renderWithUserEvent(
-      <RenameSafeDialog target={{ ...baseTarget, isSpaceSafe: true, spaceId: 'space-uuid' }} onClose={onClose} />,
+      <RenameSafeDialog target={{ ...baseTarget, isSpaceSafe: true, spaceId: 'space-uuid' }} onClose={jest.fn()} />,
     )
     const input = screen.getByDisplayValue('Old name')
     await user.clear(input)
@@ -99,7 +88,23 @@ describe('RenameSafeDialog', () => {
         upsertAddressBookItemsDto: { items: [{ name: 'Shared name', address, chainIds: ['1', '137'] }] },
       }),
     )
-    await waitFor(() => expect(onClose).toHaveBeenCalled())
+  })
+
+  it('PRESERVES the existing space chain_ids on rename (does not expand to the Safe chains)', async () => {
+    mockGetFromSpaceByAddress.mockReturnValue({ chainIds: ['1'] }) // existing row scoped to chain 1
+    const { user } = renderWithUserEvent(
+      <RenameSafeDialog target={{ ...baseTarget, isSpaceSafe: true, spaceId: 'space-uuid' }} onClose={jest.fn()} />,
+    )
+    const input = screen.getByDisplayValue('Old name')
+    await user.clear(input)
+    await user.type(input, 'Shared name')
+    await user.click(screen.getByTestId('save-btn'))
+    await waitFor(() =>
+      expect(mockUpsertSpace).toHaveBeenCalledWith({
+        spaceId: 'space-uuid',
+        upsertAddressBookItemsDto: { items: [{ name: 'Shared name', address, chainIds: ['1'] }] },
+      }),
+    )
   })
 
   it('keeps the dialog open and shows an error if the space write fails', async () => {

--- a/apps/web/src/features/spaces/components/SafeAccounts/SafeCardReadOnly.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/SafeCardReadOnly.tsx
@@ -65,13 +65,11 @@ const SafeCardReadOnly = ({
   const spaces = useLoadFeature(SpacesFeature)
   const chain = useChain(singleSafe?.chainId || '')
   // On space surfaces (preferSpaceName), let the shared (space) name win, then fall back to the
-  // existing (local) resolution. The space book is checked across ALL of the Safe's chains — a
-  // multichain Safe may carry the shared name on a different chain than the first one. `getFromSpace`
-  // is source-independent, so this works even though the page renders under the spaceOnly source.
-  const { getFromSpace } = useMergedAddressBooks(singleSafe?.chainId)
-  const spaceName = preferSpaceName
-    ? safes.map((s) => getFromSpace(safe.address, s.chainId)?.name).find(Boolean)
-    : undefined
+  // existing (local) resolution. `getFromSpaceByAddress` is address-level (one name per address,
+  // any chain) and source-independent, so it works even though the page renders under the spaceOnly
+  // source and the rebuilt safe item only carries a local name.
+  const { getFromSpaceByAddress } = useMergedAddressBooks(singleSafe?.chainId)
+  const spaceName = preferSpaceName ? getFromSpaceByAddress(safe.address)?.name : undefined
   const displayName = useSafeDisplayName(safe.address, singleSafe?.chainId || '', spaceName ?? name)
   const currency = useAppSelector(selectCurrency)
   const { address: walletAddress } = useWallet() || {}

--- a/apps/web/src/features/spaces/components/SafeAccounts/SpaceSafeContextMenu.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/SpaceSafeContextMenu.tsx
@@ -25,14 +25,15 @@ const SpaceSafeContextMenu = ({ safeItem }: { safeItem: SafeItem | MultiChainSaf
   const { openRename, renameDialog } = useRenameSafe()
 
   const allAddressBooks = useAppSelector(selectAllAddressBooks)
-  const { getFromSpace } = useMergedAddressBooks()
+  const { getFromSpaceByAddress } = useMergedAddressBooks()
   const chainIds = isMultiChainSafeItem(safeItem) ? safeItem.safes.map((safe) => safe.chainId) : [safeItem.chainId]
-  // Rename here writes the shared (space) name, so prefill that — looked up across the Safe's chains
-  // — and only fall back to the local name. Without this the dialog opens with the personal local name.
+  // Rename here writes the shared (space) name, so prefill that — resolved address-level (one name
+  // per address) — and only fall back to the local name. Without this the dialog opens with the
+  // personal local name.
   const localName = isMultiChainSafeItem(safeItem)
     ? safeItem.name
     : allAddressBooks[safeItem.chainId]?.[safeItem.address]
-  const spaceName = chainIds.map((chainId) => getFromSpace(safeItem.address, chainId)?.name).find(Boolean)
+  const spaceName = getFromSpaceByAddress(safeItem.address)?.name
   const name = spaceName ?? localName
 
   // Rename + Remove are both admin-only in a space; with no actions there is nothing to show.

--- a/apps/web/src/features/spaces/components/SafeAccounts/SpaceSafeContextMenu.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/SpaceSafeContextMenu.tsx
@@ -10,8 +10,6 @@ import MenuItem from '@mui/material/MenuItem'
 import ContextMenu from '@/components/common/ContextMenu'
 import DeleteIcon from '@/public/images/common/delete.svg'
 import EditIcon from '@/public/images/common/edit.svg'
-import { useAppSelector } from '@/store'
-import { selectAllAddressBooks } from '@/store/addressBookSlice'
 import { useMergedAddressBooks } from '@/hooks/useAllAddressBooks'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { trackEvent } from '@/services/analytics'
@@ -24,15 +22,13 @@ const SpaceSafeContextMenu = ({ safeItem }: { safeItem: SafeItem | MultiChainSaf
   const spaceId = useCurrentSpaceId()
   const { openRename, renameDialog } = useRenameSafe()
 
-  const allAddressBooks = useAppSelector(selectAllAddressBooks)
-  const { getFromSpaceByAddress } = useMergedAddressBooks()
+  const { getFromSpaceByAddress, getFromLocalAnyChain } = useMergedAddressBooks()
   const chainIds = isMultiChainSafeItem(safeItem) ? safeItem.safes.map((safe) => safe.chainId) : [safeItem.chainId]
   // Rename here writes the shared (space) name, so prefill that — resolved address-level (one name
-  // per address) — and only fall back to the local name. Without this the dialog opens with the
-  // personal local name.
-  const localName = isMultiChainSafeItem(safeItem)
-    ? safeItem.name
-    : allAddressBooks[safeItem.chainId]?.[safeItem.address]
+  // per address) — and only fall back to the local name. Both lookups are address-level and lowercase
+  // the address, so casing never causes a miss. Without this the dialog opens with the personal local
+  // name.
+  const localName = isMultiChainSafeItem(safeItem) ? safeItem.name : getFromLocalAnyChain(safeItem.address)?.name
   const spaceName = getFromSpaceByAddress(safeItem.address)?.name
   const name = spaceName ?? localName
 

--- a/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeContextMenu.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeContextMenu.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import SpaceSafeContextMenu from '../SpaceSafeContextMenu'
-import { useAppSelector } from '@/store'
 import { isMultiChainSafeItem, type SafeItem, type MultiChainSafeItem } from '@/hooks/safes'
 import { useIsAdmin } from '@/features/spaces'
 import { trackEvent } from '@/services/analytics'
@@ -19,10 +18,15 @@ jest.mock('@/hooks/safes', () => ({
   isMultiChainSafeItem: jest.fn(),
 }))
 
-// Space-first name resolution; defaults to no space name so the local fallback is asserted.
+// Space-first name resolution; both helpers are address-level. Defaults to no space name so the
+// (address-level, lowercased) local fallback is asserted.
 const mockGetFromSpaceByAddress = jest.fn((): { name: string } | undefined => undefined)
+const mockGetFromLocalAnyChain = jest.fn((): { name: string } | undefined => undefined)
 jest.mock('@/hooks/useAllAddressBooks', () => ({
-  useMergedAddressBooks: () => ({ getFromSpaceByAddress: mockGetFromSpaceByAddress }),
+  useMergedAddressBooks: () => ({
+    getFromSpaceByAddress: mockGetFromSpaceByAddress,
+    getFromLocalAnyChain: mockGetFromLocalAnyChain,
+  }),
 }))
 
 jest.mock('../RemoveSafeDialog', () => {
@@ -50,16 +54,11 @@ describe('SpaceSafeContextMenu', () => {
     lastVisited: 0,
   }
 
-  const mockAddressBooks = {
-    '5': {
-      '0x123': 'Test Safe Name',
-    },
-  }
-
   beforeEach(() => {
     jest.clearAllMocks()
     mockGetFromSpaceByAddress.mockReturnValue(undefined)
-    ;(useAppSelector as jest.Mock).mockReturnValue(mockAddressBooks)
+    // Local name for the single-chain Safe, resolved address-level (any chain).
+    mockGetFromLocalAnyChain.mockReturnValue({ name: 'Test Safe Name' })
     // Rename + Remove are admin-only in a space, so default to admin to render the menu.
     ;(useIsAdmin as jest.Mock).mockReturnValue(true)
     ;(isMultiChainSafeItem as unknown as jest.Mock).mockImplementation(

--- a/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeContextMenu.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeContextMenu.test.tsx
@@ -20,9 +20,9 @@ jest.mock('@/hooks/safes', () => ({
 }))
 
 // Space-first name resolution; defaults to no space name so the local fallback is asserted.
-const mockGetFromSpace = jest.fn((): { name: string } | undefined => undefined)
+const mockGetFromSpaceByAddress = jest.fn((): { name: string } | undefined => undefined)
 jest.mock('@/hooks/useAllAddressBooks', () => ({
-  useMergedAddressBooks: () => ({ getFromSpace: mockGetFromSpace }),
+  useMergedAddressBooks: () => ({ getFromSpaceByAddress: mockGetFromSpaceByAddress }),
 }))
 
 jest.mock('../RemoveSafeDialog', () => {
@@ -58,7 +58,7 @@ describe('SpaceSafeContextMenu', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    mockGetFromSpace.mockReturnValue(undefined)
+    mockGetFromSpaceByAddress.mockReturnValue(undefined)
     ;(useAppSelector as jest.Mock).mockReturnValue(mockAddressBooks)
     // Rename + Remove are admin-only in a space, so default to admin to render the menu.
     ;(useIsAdmin as jest.Mock).mockReturnValue(true)
@@ -108,7 +108,7 @@ describe('SpaceSafeContextMenu', () => {
   })
 
   it('prefills the shared (space) name, not the local one, when a space name exists', async () => {
-    mockGetFromSpace.mockReturnValue({ name: 'Cloud Name' })
+    mockGetFromSpaceByAddress.mockReturnValue({ name: 'Cloud Name' })
     render(<SpaceSafeContextMenu safeItem={mockSafeItem} />)
     fireEvent.click(screen.getByRole('button'))
     await waitFor(() => fireEvent.click(screen.getByText('Rename')))

--- a/apps/web/src/hooks/__tests__/useAllAddressBooks.test.ts
+++ b/apps/web/src/hooks/__tests__/useAllAddressBooks.test.ts
@@ -145,6 +145,8 @@ describe('useAllAddressBooks', () => {
     afterEach(() => {
       remoteContacts = []
       localAddressBook = {}
+      localAddressBooksByChain = {}
+      mockAddressBookSource = 'merged'
       signedIn = false
       jest.clearAllMocks()
     })
@@ -180,6 +182,74 @@ describe('useAllAddressBooks', () => {
       const { result } = renderHook(() => useAddressBookItem('0xB', undefined))
 
       expect(result.current).toBeUndefined()
+    })
+
+    it('resolves the space name by address regardless of chain (spaceOnly + merged)', () => {
+      signedIn = true
+      remoteContacts = [
+        {
+          name: 'Shared',
+          address: '0xA',
+          chainIds: ['1'], // named only on chain 1
+          createdBy: '',
+          createdByUserId: 0,
+          lastUpdatedBy: '',
+          lastUpdatedByUserId: 0,
+          createdAt: '',
+          updatedAt: '',
+          source: ContactSource.space,
+        },
+      ]
+
+      mockAddressBookSource = 'spaceOnly'
+      const spaceOnly = renderHook(() => useAddressBookItem('0xA', '137')) // a chain NOT in chainIds
+      expect(spaceOnly.result.current?.name).toBe('Shared')
+
+      mockAddressBookSource = 'merged'
+      const merged = renderHook(() => useAddressBookItem('0xA', '137'))
+      expect(merged.result.current?.name).toBe('Shared')
+
+      // The address-level helper keeps the full chainIds of the underlying row.
+      const m = renderHook(() => useMergedAddressBooks('137'))
+      expect(m.result.current.getFromSpaceByAddress('0xA')?.chainIds).toEqual(['1'])
+    })
+
+    it('inherits a local name across chains under merged, but not under localOnly', () => {
+      signedIn = true
+      remoteContacts = []
+      localAddressBook = {} // no entry on the currently-viewed chain (137)
+      localAddressBooksByChain = { '1': { '0xL': 'Local' } } // name set only on chain 1
+
+      mockAddressBookSource = 'merged'
+      const merged = renderHook(() => useAddressBookItem('0xL', '137'))
+      expect(merged.result.current?.name).toBe('Local') // inherited via any-chain fallback
+
+      mockAddressBookSource = 'localOnly'
+      const localOnly = renderHook(() => useAddressBookItem('0xL', '137'))
+      expect(localOnly.result.current).toBeUndefined() // localOnly stays strictly per-chain
+    })
+
+    it('prefers the space name over a local name for the same address (merged)', () => {
+      signedIn = true
+      remoteContacts = [
+        {
+          name: 'Shared',
+          address: '0xA',
+          chainIds: ['1'],
+          createdBy: '',
+          createdByUserId: 0,
+          lastUpdatedBy: '',
+          lastUpdatedByUserId: 0,
+          createdAt: '',
+          updatedAt: '',
+          source: ContactSource.space,
+        },
+      ]
+      localAddressBooksByChain = { '1': { '0xA': 'Local' } }
+      mockAddressBookSource = 'merged'
+
+      const { result } = renderHook(() => useAddressBookItem('0xA', '1'))
+      expect(result.current?.name).toBe('Shared')
     })
   })
 

--- a/apps/web/src/hooks/useAllAddressBooks.ts
+++ b/apps/web/src/hooks/useAllAddressBooks.ts
@@ -94,7 +94,12 @@ export const useMergedAddressBooks = (chainId?: string): MergedAddressBook => {
       }
     }
 
-    // Address-level local from EVERY chain: the current chain's name wins, otherwise any chain's.
+    // Address-level local name from EVERY chain, for cross-chain inheritance. Tie-break is
+    // deterministic: the currently-viewed chain's entry always wins; otherwise the first chain
+    // encountered is kept (Object.entries on the chain-keyed book yields ascending chainId order).
+    // In practice a local rename writes the same name to all of a Safe's chains, so the per-chain
+    // names agree and this only has to pick a winner in the rare case the same address was named
+    // differently on different chains.
     for (const [cid, book] of Object.entries(allLocalBooks)) {
       for (const localContact of mapLocalToContacts(book, cid)) {
         const addrKey = localContact.address.toLowerCase()
@@ -119,6 +124,9 @@ export const useMergedAddressBooks = (chainId?: string): MergedAddressBook => {
     const getFromLocal = (address: string, cid: string) => byKeyLocal.get(addressBookKey(address, cid))
     const getFromSpaceByAddress = (address: string) =>
       typeof address === 'string' ? byAddressSpace.get(address.toLowerCase()) : undefined
+    // Address-level local lookup for cross-chain inheritance. The returned contact's `chainIds`
+    // reflect the chain the name was actually stored on, NOT the chain it's being inherited onto, so
+    // callers showing an inherited name should read `.name` only — never `.chainIds`.
     const getFromLocalAnyChain = (address: string) =>
       typeof address === 'string' ? byAddressLocal.get(address.toLowerCase()) : undefined
 

--- a/apps/web/src/hooks/useAllAddressBooks.ts
+++ b/apps/web/src/hooks/useAllAddressBooks.ts
@@ -46,6 +46,10 @@ export type MergedAddressBook = {
   get: (address: string, chainId: string) => ExtendedContact | undefined
   getFromSpace: (address: string, chainId: string) => ExtendedContact | undefined
   getFromLocal: (address: string, chainId: string) => ExtendedContact | undefined
+  /** Space contact for this address regardless of chain (one name per address, full chainIds). */
+  getFromSpaceByAddress: (address: string) => ExtendedContact | undefined
+  /** Local contact for this address from any chain — cross-chain inheritance fallback. */
+  getFromLocalAnyChain: (address: string) => ExtendedContact | undefined
   has: (address: string, chainId: string) => boolean
 }
 
@@ -54,17 +58,24 @@ export const useMergedAddressBooks = (chainId?: string): MergedAddressBook => {
   const actualChainId = chainId ?? fallbackChainId
   const spaceAddressBook = useGetSpaceAddressBook()
   const localAddressBook = useAppSelector((state) => selectAddressBookByChain(state, actualChainId))
+  // Every chain's local book, for address-level (cross-chain) fallback so a name set on one chain
+  // is inherited when the same Safe appears on another chain.
+  const allLocalBooks = useAppSelector(selectAllAddressBooks)
 
   return useMemo<MergedAddressBook>(() => {
     const byKeyMerged = new Map<string, ExtendedContact>()
     const byKeySpace = new Map<string, ExtendedContact>()
     const byKeyLocal = new Map<string, ExtendedContact>()
+    // Address-level (chain-agnostic) maps: one entry per address.
+    const byAddressSpace = new Map<string, ExtendedContact>()
+    const byAddressLocal = new Map<string, ExtendedContact>()
 
     const spaceContacts = mapSpaceToContacts(spaceAddressBook)
     const localContacts = mapLocalToContacts(localAddressBook, actualChainId)
 
     // Priority 1: Space contacts (highest)
     for (const spaceContact of spaceContacts) {
+      byAddressSpace.set(spaceContact.address.toLowerCase(), spaceContact) // full chainIds preserved
       for (const chainId of spaceContact.chainIds) {
         const key = addressBookKey(spaceContact.address, chainId)
         byKeySpace.set(key, { ...spaceContact, chainIds: [chainId] })
@@ -83,6 +94,16 @@ export const useMergedAddressBooks = (chainId?: string): MergedAddressBook => {
       }
     }
 
+    // Address-level local from EVERY chain: the current chain's name wins, otherwise any chain's.
+    for (const [cid, book] of Object.entries(allLocalBooks)) {
+      for (const localContact of mapLocalToContacts(book, cid)) {
+        const addrKey = localContact.address.toLowerCase()
+        if (cid === actualChainId || !byAddressLocal.has(addrKey)) {
+          byAddressLocal.set(addrKey, localContact)
+        }
+      }
+    }
+
     // Build list: space + non-duplicate local
     const filteredLocal = localContacts.filter(
       (local) =>
@@ -96,9 +117,13 @@ export const useMergedAddressBooks = (chainId?: string): MergedAddressBook => {
     const has = (address: string, chainId: string) => byKeyMerged.has(addressBookKey(address, chainId))
     const getFromSpace = (address: string, cid: string) => byKeySpace.get(addressBookKey(address, cid))
     const getFromLocal = (address: string, cid: string) => byKeyLocal.get(addressBookKey(address, cid))
+    const getFromSpaceByAddress = (address: string) =>
+      typeof address === 'string' ? byAddressSpace.get(address.toLowerCase()) : undefined
+    const getFromLocalAnyChain = (address: string) =>
+      typeof address === 'string' ? byAddressLocal.get(address.toLowerCase()) : undefined
 
-    return { list, get, has, getFromSpace, getFromLocal }
-  }, [actualChainId, localAddressBook, spaceAddressBook])
+    return { list, get, has, getFromSpace, getFromLocal, getFromSpaceByAddress, getFromLocalAnyChain }
+  }, [actualChainId, localAddressBook, spaceAddressBook, allLocalBooks])
 }
 
 /**
@@ -108,27 +133,27 @@ export const useMergedAddressBooks = (chainId?: string): MergedAddressBook => {
  * @param chainId
  */
 export const useAddressBookItem = (address: string, chainId: string | undefined): ExtendedContact | undefined => {
-  const { get, getFromLocal } = useMergedAddressBooks(chainId)
+  const { getFromSpaceByAddress, getFromLocal, getFromLocalAnyChain } = useMergedAddressBooks(chainId)
   const source = useAddressBookSource()
 
   return useMemo<ExtendedContact | undefined>(() => {
     if (!chainId) return undefined
 
+    // Local book view: strictly per-chain (editing a specific chain's entry).
     if (source === 'localOnly') {
       return getFromLocal(address, chainId)
     }
 
-    if (source === 'merged') {
-      return get(address, chainId)
-    }
+    // Space name resolves by address (one name per address, shown on every chain).
+    const spaceItem = getFromSpaceByAddress(address)
 
     if (source === 'spaceOnly') {
-      const item = get(address, chainId)
-      return item?.source === ContactSource.space ? item : undefined
+      return spaceItem
     }
 
-    return undefined
-  }, [chainId, source, getFromLocal, address, get])
+    // merged: space (any chain) > local (this chain) > local (any chain, for cross-chain inheritance)
+    return spaceItem ?? getFromLocal(address, chainId) ?? getFromLocalAnyChain(address)
+  }, [chainId, source, address, getFromSpaceByAddress, getFromLocal, getFromLocalAnyChain])
 }
 
 /**
@@ -148,7 +173,7 @@ export const useSafeNameResolver = (): ((
   chainId: string | undefined,
   preferredName?: string,
 ) => string) => {
-  const { get } = useMergedAddressBooks()
+  const { getFromSpaceByAddress } = useMergedAddressBooks()
   const allLocal = useAppSelector(selectAllAddressBooks)
   const source = useAddressBookSource()
 
@@ -164,18 +189,29 @@ export const useSafeNameResolver = (): ((
     return map
   }, [allLocal])
 
+  // Address-level local lookup (any chain) for cross-chain inheritance.
+  const localByAddress = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const [, book] of Object.entries(allLocal)) {
+      for (const [addr, name] of Object.entries(book)) {
+        map.set(addr.toLowerCase(), name)
+      }
+    }
+    return map
+  }, [allLocal])
+
   return useCallback(
     (address, chainId, preferredName) => {
       if (preferredName) return preferredName
       if (!chainId) return ''
-      const localName = localByKey.get(addressBookKey(address, chainId))
-      if (source === 'localOnly') return localName ?? ''
-      const item = get(address, chainId)
-      if (source === 'spaceOnly') return item?.source === ContactSource.space ? (item.name ?? '') : ''
-      // merged: space (cross-chain) takes priority, then any chain's local
-      return item?.name ?? localName ?? ''
+      const localThisChain = localByKey.get(addressBookKey(address, chainId))
+      if (source === 'localOnly') return localThisChain ?? ''
+      const spaceName = getFromSpaceByAddress(address)?.name
+      if (source === 'spaceOnly') return spaceName ?? ''
+      // merged: space (any chain) > local (this chain) > local (any chain)
+      return spaceName ?? localThisChain ?? localByAddress.get(address.toLowerCase()) ?? ''
     },
-    [get, source, localByKey],
+    [getFromSpaceByAddress, source, localByKey, localByAddress],
   )
 }
 


### PR DESCRIPTION
## What it solves

Resolves: [WA-2755](https://linear.app/safe-global/issue/WA-2755/apply-safe-name-across-all-networks-when-added)

A Safe's name was treated **per-network**. If you named a Safe on some networks (or renamed it on one chain), the same Safe on its other chains — same address — showed a different name or just the raw address. Switching chains in the Safe selector could change the displayed name, and a newly-added network started blank. This fragments a single Safe's identity across chains.

**Goal (WA-2755):** one name per address, applied across all the networks the Safe is on — selected or not — shared (space) name first, then local.

> Scoped as **phase 1**: this delivers the canonical "one name per address" *behaviour* at the resolution layer, without physically re-keying the address-book storage. A literal storage re-key (drop `chainId` from the key) is a larger, separate change (phase 2) and is **not** required for any of WA-2755's acceptance tests.

## How this PR fixes it

The displayed name is resolved **address-level** (chain-agnostic), with priority `space-by-address ?? local-this-chain ?? local-any-chain`. Stores stay per-`(chainId, address)`; only resolution changes — so a name follows the Safe to every chain (including newly-added ones) for free, on any path.

- **`useAllAddressBooks`** — add `getFromSpaceByAddress(address)` (space contact by address, full `chainIds` preserved) and `getFromLocalAnyChain(address)` (local cross-chain fallback). `useAddressBookItem` / `useSafeNameResolver` now resolve `space-by-address ?? local-this-chain ?? local-any-chain` under `merged`; `spaceOnly` resolves space-by-address only (in-space still shows the shared name, no personal-local fallback); `localOnly` stays strictly per-chain. `get`/`has`/`list` are untouched, so the address-book pages' listing is unchanged.
- **`RenameSafeDialog`** — drop the per-network picker. **Local** rename writes the name to **all** the Safe's chains (fan-out). **Space** rename only changes the `name` and **preserves the existing `chain_ids`** (the CGW upsert replaces them, so we re-send the row's current set; a brand-new entry uses the Safe's chains). Renaming never adds/removes a contact's chains.
- **`SafeCardReadOnly` / `SpaceSafeContextMenu`** — resolve the card display and the rename prefill via `getFromSpaceByAddress` (so the Safe accounts card and the rename dialog show the shared name, not a stale local one).

Backend note: the CGW space address book (`space_address_book_items`) is already keyed `(space, address)` — one name per address — so **no backend change** is needed.

## How to test it

In a workspace (space) with a multichain Safe that has a shared name:
1. Open the Safe and switch chains in the selector → the name stays the same on every chain (previously it could differ / show the address on chains outside the name's `chain_ids`).
2. Safe accounts ⋮ → Rename → the dialog shows the **shared (cloud) name** prefilled and has **no network picker**. Save → the name is consistent across all the Safe's chains.
3. After renaming a space Safe, open Workspace contacts → the contact's **Chains are unchanged** (rename only changed the name).
4. Non-space (My accounts): rename a multichain Safe → the name shows on all its chains; add the same address on a new network → it inherits the existing name.
5. `/address-book` page (localOnly) is unchanged — still a per-chain local editor.

## Affected flows

- Safe **name display** in any space (`spaceOnly`) or `merged` context — Safe accounts, the Safe selector dropdown/trigger, account cards.
- Safe **rename** — dropdown, space Safe accounts ⋮, My accounts, Trusted Safes, sidebar (all share `RenameSafeDialog`).
- New-network / add-Safe naming inherits the existing name via resolution (no write needed).

## Blast radius

- **`useAllAddressBooks`** (`useMergedAddressBooks` / `useAddressBookItem` / `useSafeNameResolver`) is the shared name resolver — this change affects **every** Safe/contact name rendered in a `spaceOnly` or `merged` context. Intentional behaviour change: a space contact's name now shows on **all** chains regardless of its `chain_ids` (one name per address); a local name now shows cross-chain (any-chain fallback) under `merged`.
- `useMergedAddressBooks` now also reads `selectAllAddressBooks` (all chains' local book) for the fallback.
- `RenameSafeDialog` no longer renders `NetworkMultiSelectorInput`; `FormValues` dropped the `networks` field.
- No change to the address-book **page listing** (`get`/`has`/`list` kept), the CGW backend, or the `localOnly` editor.
- Supersedes the prior "Safe selector trigger is per-active-chain by design" decision — the new requirement is explicit cross-chain consistency/inheritance.

## Risks / not checked

- The `merged`-context behaviour change (space/local names now resolve cross-chain) is intentional but broad; reviewers should sanity-check recipient/contact name display in non-space views.
- **Did not** physically re-key storage by address (phase 2) — stores remain per-`(chainId, address)`; address-keying is achieved at the resolution layer.
- Browser-verified the **space** path (cross-chain trigger name, rename prefill + no picker, contacts' chains untouched) on a live workspace. The local fan-out write, cloud `chain_ids` preservation on save, and new-network inheritance are covered by unit tests, not a manual click-through.
- Did not test on mobile (web-only; shared packages untouched).

## Visual summary

Address-level name resolution (one name per address, shared-first):

```mermaid
flowchart TD
  A[Resolve name for address + current chain] --> S{Space name<br/>for this address?}
  S -->|yes| SN[Show space name<br/>on EVERY chain]
  S -->|no| L{Local name<br/>on this chain?}
  L -->|yes| LN[Show local name]
  L -->|no| LA{Local name on<br/>ANY chain?}
  LA -->|yes| LAN[Show it — inherited on the new chain]
  LA -->|no| ADDR[Show address]
```

Rename write paths (no picker):

```mermaid
flowchart LR
  R[Rename Safe] --> Q{In a space?}
  Q -->|yes, admin| SP[Space upsert:<br/>change name only,<br/>preserve existing chain_ids]
  Q -->|no| LO[Local upsert:<br/>write name to ALL<br/>the Safe's chains]
```

<!-- Screenshots: rename dialog (no picker, shared name prefilled); same Safe name on Ethereum/Sepolia/Polygon. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 <!-- no new events -->
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).