### PR TITLE
feat(Hypernative): HN badge in Safe Selector

### DIFF
--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/__tests__/SafeSelectorTriggerContent.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/__tests__/SafeSelectorTriggerContent.test.tsx
@@ -1,0 +1,79 @@
+import { render } from '@/tests/test-utils'
+import SafeSelectorTriggerContent from '../components/SafeSelectorTriggerContent'
+import * as useIsHypernativeGuard from '@/features/hypernative'
+import * as coreFeatures from '@/features/__core__'
+import { SafeHeaderHnTooltip } from '@/features/hypernative'
+import type { SafeItemData } from '../types'
+
+jest.mock('@/features/hypernative/hooks/useIsHypernativeGuard')
+jest.mock('@/features/__core__', () => ({
+  ...jest.requireActual('@/features/__core__'),
+  useLoadFeature: jest.fn(),
+}))
+
+jest.mock('@/hooks/useChains', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ configs: [] })),
+  useChain: jest.fn(() => undefined),
+}))
+
+jest.mock('@/hooks/useSafeDisplayName', () => ({
+  useSafeDisplayName: jest.fn(() => ''),
+}))
+
+jest.mock('../components/SafeBalanceBlock', () => ({ __esModule: true, default: () => null }))
+jest.mock('../components/CopyAddressButton', () => ({ __esModule: true, default: () => null }))
+jest.mock('../components/ExplorerLinkButton', () => ({ __esModule: true, default: () => null }))
+jest.mock('@/components/settings/EnvironmentVariables/EnvHintButton', () => ({ __esModule: true, default: () => null }))
+
+const mockUseLoadFeature = coreFeatures.useLoadFeature as jest.Mock
+
+const SELECTED_CHAIN_ID = '1'
+
+const selectedItem: SafeItemData = {
+  id: `eth:0x0000000000000000000000000000000000005AFE`,
+  name: '',
+  address: '0x0000000000000000000000000000000000005AFE',
+  threshold: 1,
+  owners: 1,
+  balance: '100',
+  chains: [{ chainId: SELECTED_CHAIN_ID, chainName: 'Ethereum', chainLogoUri: null, shortName: 'eth' }],
+}
+
+describe('SafeSelectorTriggerContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    jest.spyOn(useIsHypernativeGuard, 'useIsHypernativeGuard').mockReturnValue({
+      isHypernativeGuard: false,
+      loading: false,
+    })
+
+    mockUseLoadFeature.mockReturnValue({
+      SafeHeaderHnTooltip,
+      $isDisabled: false,
+      $isReady: true,
+    })
+  })
+
+  it('renders the Hypernative shield icon when the active Safe has a Hypernative guard', () => {
+    jest.spyOn(useIsHypernativeGuard, 'useIsHypernativeGuard').mockReturnValue({
+      isHypernativeGuard: true,
+      loading: false,
+    })
+
+    const { container } = render(
+      <SafeSelectorTriggerContent selectedItem={selectedItem} selectedChainId={SELECTED_CHAIN_ID} />,
+    )
+
+    expect(container.querySelector('[class*="MuiSvgIcon"]')).not.toBeNull()
+  })
+
+  it('does not render the Hypernative shield icon when the active Safe has no Hypernative guard', () => {
+    const { container } = render(
+      <SafeSelectorTriggerContent selectedItem={selectedItem} selectedChainId={SELECTED_CHAIN_ID} />,
+    )
+
+    expect(container.querySelector('[class*="MuiSvgIcon"]')).toBeNull()
+  })
+})

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeSelectorTriggerContent.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeSelectorTriggerContent.tsx
@@ -12,6 +12,8 @@ import type { SafeItemData } from '../types'
 import EnvHintButton from '@/components/settings/EnvironmentVariables/EnvHintButton'
 import { useChain } from '@/hooks/useChains'
 import { getBlockExplorerLink } from '@safe-global/utils/utils/chains'
+import { HypernativeFeature, useIsHypernativeGuard } from '@/features/hypernative'
+import { useLoadFeature } from '@/features/__core__'
 
 export interface SafeSelectorTriggerContentProps {
   selectedItem: SafeItemData
@@ -29,6 +31,9 @@ function SafeSelectorTriggerContent({ selectedItem, selectedChainId }: SafeSelec
   const chainConfig = useChain(selectedChain?.chainId ?? '')
   const blockExplorerLink = chainConfig ? getBlockExplorerLink(chainConfig, selectedItem.address) : undefined
 
+  const { SafeHeaderHnTooltip } = useLoadFeature(HypernativeFeature)
+  const { isHypernativeGuard } = useIsHypernativeGuard()
+
   return (
     <div className="flex items-center gap-2 sm:gap-4 w-full">
       <div className="relative shrink-0">
@@ -39,9 +44,12 @@ function SafeSelectorTriggerContent({ selectedItem, selectedChainId }: SafeSelec
         <ThresholdBadge threshold={selectedItem.threshold} owners={selectedItem.owners} />
       </div>
       <div className="flex flex-col items-start flex-1 min-w-0" data-testid="safe-selector-trigger-details">
-        <Typography data-testid="safe-selector-trigger-name" variant="paragraph-small-medium" className="truncate">
-          {displayName}
-        </Typography>
+        <div className="flex items-center gap-1 min-w-0">
+          <Typography data-testid="safe-selector-trigger-name" variant="paragraph-small-medium" className="truncate">
+            {displayName}
+          </Typography>
+          {isHypernativeGuard && <SafeHeaderHnTooltip />}
+        </div>
         <div className="flex items-center gap-1 min-w-0">
           <Typography data-testid="safe-selector-trigger-address" variant="paragraph-mini" color="muted">
             {shortAddress}

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeSelectorTriggerContent.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeSelectorTriggerContent.test.tsx
@@ -4,6 +4,7 @@ import type { SafeItemData } from '../../types'
 
 const mockUseSafeDisplayName = jest.fn()
 const mockUseChain = jest.fn()
+const mockUseIsHypernativeGuard = jest.fn()
 
 jest.mock('@/hooks/useSafeDisplayName', () => ({
   useSafeDisplayName: (...args: unknown[]) => mockUseSafeDisplayName(...args),
@@ -12,6 +13,18 @@ jest.mock('@/hooks/useSafeDisplayName', () => ({
 jest.mock('@/hooks/useChains', () => ({
   __esModule: true,
   useChain: (...args: unknown[]) => mockUseChain(...args),
+  useHasFeature: () => false,
+}))
+
+jest.mock('@/features/hypernative', () => ({
+  __esModule: true,
+  HypernativeFeature: {},
+  useIsHypernativeGuard: (...args: unknown[]) => mockUseIsHypernativeGuard(...args),
+}))
+
+jest.mock('@/features/__core__', () => ({
+  __esModule: true,
+  useLoadFeature: () => ({ SafeHeaderHnTooltip: () => null }),
 }))
 
 jest.mock('../SafeBalanceBlock', () => {
@@ -45,6 +58,7 @@ describe('SafeSelectorTriggerContent', () => {
     jest.resetAllMocks()
     mockUseSafeDisplayName.mockReturnValue('')
     mockUseChain.mockReturnValue(undefined)
+    mockUseIsHypernativeGuard.mockReturnValue({ isHypernativeGuard: false, loading: false })
   })
 
   it('resolves name per chain without using the cross-chain item name', () => {


### PR DESCRIPTION
## What it solves

The Hypernative (HN) shield badge was missing from the Safe selector trigger in the header.
Resolves: [WA-2717](https://linear.app/safe-global/issue/WA-2717/hypernative-badge-no-longer-shows-for-guarded-safes)

## How this PR fixes it

Re-adds the HN badge to `SafeSelectorTriggerContent`: loads `SafeHeaderHnTooltip` via `useLoadFeature(HypernativeFeature)` and renders it next to the Safe name when `useIsHypernativeGuard()` reports the active Safe has a Hypernative guard installed.

## How to test it

1. Open the app with a Safe that has a Hypernative guard installed.
2. Confirm the HN shield badge appears next to the Safe name in the header's Safe selector.
3. Switch to a Safe without an HN guard — the badge should not render.

## Affected flows

- Viewing the Safe selector in the header for a Safe with a Hypernative guard.

## Blast radius

- `SafeSelectorTriggerContent` (header Safe selector trigger) — only consumer of this change.
- New dependencies: `useIsHypernativeGuard` (reads current Safe via `useSafeInfo`) and `SafeHeaderHnTooltip` from the lazy-loaded `HypernativeFeature`.
- Feature flag: badge depends on `FEATURES.HYPERNATIVE` being enabled (feature stubs out otherwise).
- No API, persistence, or shared-package changes; no mobile impact.

## Risks / not checked

- Did not verify behavior with the `HYPERNATIVE` feature flag disabled.
- Did not test on mobile.
- Badge reflects the active Safe (`useSafeInfo`), not necessarily the `selectedItem` row — not exercised across multi-Safe switching.

## Visual summary

```mermaid
flowchart LR
  A[SafeSelectorTriggerContent] --> B[useIsHypernativeGuard]
  A --> C[useLoadFeature HypernativeFeature]
  B --> D{isHypernativeGuard?}
  D -->|Yes| E[Render SafeHeaderHnTooltip badge]
  D -->|No| F[No badge]
```

## Visual summary

<img width="449" height="101" alt="image" src="https://github.com/user-attachments/assets/b3f4c2ac-8940-418f-aa5c-8a8d8762c25c" />

<img width="449" height="100" alt="image" src="https://github.com/user-attachments/assets/cf581e0d-1cf4-4996-b067-26d54862acf0" />

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
