### PR TITLE
fix(web/UI): Activate Account btn on the collapsed sidebar; autofocus on the name field in the Space creation flow

### DIFF
--- a/apps/web/src/features/counterfactual/components/ActivateAccountButton/index.test.tsx
+++ b/apps/web/src/features/counterfactual/components/ActivateAccountButton/index.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@/tests/test-utils'
+import ActivateAccountButton from './index'
+import * as useSafeInfoHook from '@/hooks/useSafeInfo'
+import * as store from '@/store'
+import { PendingSafeStatus } from '@safe-global/utils/features/counterfactual/store/types'
+import type { ReactElement } from 'react'
+
+jest.mock('@/components/common/CheckWallet', () => ({
+  __esModule: true,
+  default: ({ children }: { children: (ok: boolean) => ReactElement }) => children(true),
+}))
+
+describe('ActivateAccountButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest
+      .spyOn(useSafeInfoHook, 'default')
+      .mockReturnValue({ safe: { chainId: '1' }, safeAddress: '0x123' } as ReturnType<typeof useSafeInfoHook.default>)
+  })
+
+  it('renders the "Activate now" label with a rocket icon when awaiting execution', () => {
+    jest.spyOn(store, 'useAppSelector').mockReturnValue({ status: { status: PendingSafeStatus.AWAITING_EXECUTION } })
+
+    render(<ActivateAccountButton />)
+
+    const button = screen.getByTestId('activate-account-btn-cf')
+    expect(button).toHaveTextContent('Activate now')
+    expect(button).not.toBeDisabled()
+    expect(button.querySelector('svg.lucide-rocket')).toBeInTheDocument()
+  })
+
+  it('shows the processing state and disables the button while activating', () => {
+    jest.spyOn(store, 'useAppSelector').mockReturnValue({ status: { status: PendingSafeStatus.PROCESSING } })
+
+    render(<ActivateAccountButton />)
+
+    const button = screen.getByTestId('activate-account-btn-cf')
+    expect(button).toHaveTextContent('Processing')
+    expect(button).toBeDisabled()
+  })
+})

--- a/apps/web/src/features/counterfactual/components/ActivateAccountButton/index.tsx
+++ b/apps/web/src/features/counterfactual/components/ActivateAccountButton/index.tsx
@@ -2,6 +2,7 @@ import { OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
 import dynamic from 'next/dynamic'
 import React, { useContext } from 'react'
 import { Button, CircularProgress, Tooltip, Typography } from '@mui/material'
+import { Rocket } from 'lucide-react'
 import { TxModalContext } from '@/components/tx-flow'
 import { selectUndeployedSafe } from '../../store/undeployedSafesSlice'
 import useSafeInfo from '@/hooks/useSafeInfo'
@@ -24,7 +25,7 @@ const ActivateAccountButton = () => {
   }
 
   return (
-    <Tooltip title={isProcessing ? 'The safe activation is already in process' : undefined}>
+    <Tooltip title={isProcessing ? 'The safe activation is already in process' : 'Activate now'}>
       <span>
         <CheckWallet allowNonOwner allowUndeployedSafe>
           {(isOk) => (
@@ -35,16 +36,20 @@ const ActivateAccountButton = () => {
               fullWidth
               onClick={activateAccount}
               disabled={isProcessing || !isOk}
+              className="group-data-[collapsible=icon]:!min-w-9 group-data-[collapsible=icon]:!w-9 group-data-[collapsible=icon]:!px-0"
             >
               {isProcessing ? (
                 <>
-                  <Typography variant="body2" component="span" mr={1}>
+                  <Typography variant="body2" component="span" mr={1} className="group-data-[collapsible=icon]:hidden">
                     Processing
                   </Typography>
                   <CircularProgress size={16} />
                 </>
               ) : (
-                'Activate now'
+                <>
+                  <Rocket className="hidden size-4 shrink-0 group-data-[collapsible=icon]:block" />
+                  <span className="group-data-[collapsible=icon]:hidden">Activate now</span>
+                </>
               )}
             </Button>
           )}

--- a/apps/web/src/features/spaces/components/CreateSpaceOnboarding/index.test.tsx
+++ b/apps/web/src/features/spaces/components/CreateSpaceOnboarding/index.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import CreateSpaceOnboarding from './index'
+
+let mockIsCheckingAccess: boolean | undefined = false
+let mockExistingSpace: {
+  spaceId: string | undefined
+  isEditMode: boolean
+  isSpaceLoading: boolean
+  existingSpace: { name: string } | undefined
+} = { spaceId: undefined, isEditMode: false, isSpaceLoading: false, existingSpace: undefined }
+
+jest.mock('@/hooks/useRouterGuard', () => ({
+  useIsCheckingAccess: () => mockIsCheckingAccess,
+}))
+
+jest.mock('./hooks/useExistingSpace', () => ({
+  __esModule: true,
+  default: () => mockExistingSpace,
+}))
+
+jest.mock('./hooks/useOnboardingExit', () => ({
+  __esModule: true,
+  default: () => ({ onExit: jest.fn(), hasNoSpaces: false }),
+}))
+
+jest.mock('./hooks/useSpaceSubmit', () => ({
+  __esModule: true,
+  default: () => ({ error: undefined, isSubmitting: false, onSubmit: jest.fn() }),
+}))
+
+jest.mock('../../hooks/useSpaceSafes', () => ({
+  useSpaceSafes: () => ({ allSafes: [] }),
+}))
+
+jest.mock('../../hooks/useOnboardingStepCount', () => ({
+  useOnboardingStepCount: () => 2,
+}))
+
+jest.mock('../OnboardingLayout', () => ({
+  OnboardingLayout: ({ main }: { main: React.ReactNode }) => <div>{main}</div>,
+  StepCounter: () => null,
+  SafeAppMockup: () => null,
+  deriveSidePanelAccountsFromSpace: () => [],
+  useSafeNameLookup: () => ({}),
+}))
+
+jest.mock('@/hooks/safes', () => ({
+  flattenSafeItems: () => [],
+}))
+
+describe('CreateSpaceOnboarding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsCheckingAccess = false
+    mockExistingSpace = { spaceId: undefined, isEditMode: false, isSpaceLoading: false, existingSpace: undefined }
+  })
+
+  it('focuses the workspace name input on load in create mode', async () => {
+    render(<CreateSpaceOnboarding />)
+
+    await waitFor(() => expect(screen.getByTestId('space-name-input')).toHaveFocus())
+  })
+
+  it('focuses the input once access checking finishes', async () => {
+    mockIsCheckingAccess = true
+    const { rerender } = render(<CreateSpaceOnboarding />)
+
+    expect(screen.getByTestId('space-name-input')).not.toHaveFocus()
+
+    mockIsCheckingAccess = false
+    rerender(<CreateSpaceOnboarding />)
+
+    await waitFor(() => expect(screen.getByTestId('space-name-input')).toHaveFocus())
+  })
+
+  it('does not focus the input in edit mode', async () => {
+    mockExistingSpace = {
+      spaceId: '1',
+      isEditMode: true,
+      isSpaceLoading: false,
+      existingSpace: { name: 'Existing' },
+    }
+    render(<CreateSpaceOnboarding />)
+
+    await waitFor(() => expect(screen.getByTestId('space-name-input')).not.toHaveFocus())
+  })
+})

--- a/apps/web/src/features/spaces/components/CreateSpaceOnboarding/index.tsx
+++ b/apps/web/src/features/spaces/components/CreateSpaceOnboarding/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ReactElement } from 'react'
+import { useEffect, useMemo, useState, type ReactElement } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -35,6 +35,7 @@ const CreateSpaceOnboarding = (): ReactElement => {
     control,
     formState: { isValid, errors },
     setValue,
+    setFocus,
   } = useForm<{ name: string }>({ mode: 'onChange', defaultValues: { name: '' } })
 
   const { spaceId, isEditMode, isSpaceLoading, existingSpace } = useExistingSpace(setValue)
@@ -57,6 +58,13 @@ const CreateSpaceOnboarding = (): ReactElement => {
     pattern: { value: /^[a-zA-Z0-9 ]+$/, message: 'Workspace name must not contain special characters' },
     validate: (value) => value?.trim() !== '',
   })
+
+  const isInputDisabled = isCheckingAccess || isSpaceLoading
+  useEffect(() => {
+    if (!isEditMode && !isInputDisabled) {
+      setFocus('name')
+    }
+  }, [isEditMode, isInputDisabled, setFocus])
 
   // spaceId gate avoids leaking lastUsedSpace's safes into a fresh "create" landing.
   const { allSafes } = useSpaceSafes()
@@ -92,8 +100,7 @@ const CreateSpaceOnboarding = (): ReactElement => {
             data-testid="space-name-input"
             placeholder="e.g. Treasury Ops, DeFi Team"
             autoComplete="off"
-            autoFocus={!isEditMode}
-            disabled={isCheckingAccess || isSpaceLoading}
+            disabled={isInputDisabled}
             className="mt-2 h-11 rounded-sm bg-card px-4"
             {...nameReg}
             onChange={(e) => {


### PR DESCRIPTION
## What it solves

Resolves: [WA-2443](https://linear.app/safe-global/issue/WA-2443/activate-nowproceeding-are-displayed-in-the-collapsed-sidebar)
Resolves: [WA-2638](https://linear.app/safe-global/issue/WA-2638/nice-to-have-default-focus-on-workspace-name-field)

Two small UI fixes:

1. **Activate Account button (collapsed sidebar):** when the sidebar is collapsed to icon-only mode, the "Activate now" button overflowed/looked broken because it still rendered its full text label.
2. **Create workspace onboarding:** the workspace name input did not reliably receive focus when landing on the create step, because `autoFocus` only fires on initial mount and the input is initially disabled while access/space data is loading.

## How this PR fixes it

- **ActivateAccountButton:** added a `Rocket` icon that shows only when the sidebar is collapsed (`group-data-[collapsible=icon]`), hides the text label and "Processing" label in collapsed mode, and constrains the button to a 36px square so it matches the other icon-only sidebar buttons. The tooltip now always reads "Activate now" (was empty when not processing).
- **CreateSpaceOnboarding:** replaced the static `autoFocus={!isEditMode}` prop with a `useEffect` that calls `setFocus('name')` once the input is no longer disabled (i.e. after `isCheckingAccess`/`isSpaceLoading` resolve) and only in create mode. This guarantees focus lands on the name field once it becomes interactive.

## How to test it

1. **Collapsed sidebar icon:** Open a counterfactual (undeployed) Safe so the "Activate now" button shows in the sidebar. Collapse the sidebar to icon-only mode → the button should render as a square rocket icon with a tooltip "Activate now", not clipped text. Expand again → full "Activate now" text returns. Trigger activation → "Processing" label is hidden in collapsed mode, spinner still shows.
2. **Onboarding autofocus:** Start the create-workspace onboarding flow. The "Workspace name" input should be focused automatically once it becomes editable. In edit mode, the input should NOT auto-focus.

## Affected flows

- Counterfactual Safe activation — sidebar "Activate now" button (collapsed + expanded sidebar states).
- Workspace creation onboarding — name input focus behaviour.

## Blast radius

- `ActivateAccountButton` — rendered in the sidebar for undeployed (counterfactual) Safes only. Change is presentational (Tailwind `group-data-[collapsible=icon]` classes + a `lucide-react` Rocket icon); no behavioural/logic change to the activation flow itself.
- `CreateSpaceOnboarding` — switched from `autoFocus` prop to a `setFocus` effect from `react-hook-form`. Affects only the create path (`!isEditMode`); edit mode is explicitly excluded. No shared hooks/selectors/slices/endpoints touched.
- No RTK Query, feature flag, chain config, persistence, or routing changes.
- No shared `packages/**` changes → no mobile impact.

## Risks / not checked

- Did not test on mobile (no shared-package changes; web-only sidebar/onboarding UI).
- Did not verify analytics — no analytics calls were added or changed.
- Collapsed-sidebar styling relies on the `group-data-[collapsible=icon]` Tailwind variant being present on the sidebar wrapper; verified against the existing sidebar pattern but not exercised across every breakpoint.

## Visual summary

<!-- UI change — attach before/after screenshots:
  - Sidebar "Activate now" button: collapsed (rocket icon) vs expanded (full text)
  - Onboarding workspace-name input focused on landing
-->

```mermaid
flowchart LR
  subgraph Sidebar["ActivateAccountButton"]
    A[Sidebar state] -->|expanded| B["Activate now" text]
    A -->|collapsed icon| C[Rocket icon + tooltip]
  end
  subgraph Onboarding["CreateSpaceOnboarding"]
    D[Input disabled while loading] --> E{isCheckingAccess / isSpaceLoading?}
    E -->|resolved & create mode| F[setFocus name]
    E -->|edit mode| G[no focus]
  end
```

## Visual summary

Before:
<img width="72" height="207" alt="image" src="https://github.com/user-attachments/assets/54f5d902-0f28-4eff-9ec9-9f70b2cc7c25" />

After:
<img width="127" height="207" alt="image" src="https://github.com/user-attachments/assets/225b9ee9-9936-4c15-aabd-2320a96cef49" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
