### PR TITLE
fix(mobile): subscribe SafeAccountInput to importedSafeResult via useWatch

### DIFF
--- a/apps/mobile/src/components/SafeAccountInput/index.test.tsx
+++ b/apps/mobile/src/components/SafeAccountInput/index.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { Pressable } from 'react-native'
+import { FormProvider, useForm } from 'react-hook-form'
+import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { render, fireEvent, waitFor } from '@/src/tests/test-utils'
+import type { FormValues } from '@/src/features/ImportReadOnly/types'
+import SafeAccountInput from './index'
+
+// useImportSafe runs RTK Query lookups and writes importedSafeResult itself.
+// Stub it so the test drives importedSafeResult deterministically via setValue.
+jest.mock('./hooks/useImportSafe', () => ({ useImportSafe: jest.fn() }))
+
+const VALID_ADDRESS = '0x2f3e600a3F38b66aDcbe6530B191F2BE55c2Fbb6'
+
+const safeOverview: SafeOverview = {
+  address: { value: VALID_ADDRESS, name: null, logoUri: null },
+  awaitingConfirmation: null,
+  chainId: '1',
+  fiatTotal: '0',
+  owners: [],
+  queued: 0,
+  threshold: 1,
+}
+
+// importedSafeResult is not in defaultValues and is populated only via setValue,
+// so this harness reproduces the exact scenario that the watch() method missed.
+const Harness = () => {
+  const methods = useForm<FormValues>({
+    defaultValues: { name: '', safeAddress: VALID_ADDRESS },
+  })
+
+  return (
+    <FormProvider {...methods}>
+      <SafeAccountInput />
+      <Pressable
+        testID="set-result"
+        onPress={() =>
+          methods.setValue('importedSafeResult', { data: [safeOverview], isFetching: false, error: undefined })
+        }
+      />
+    </FormProvider>
+  )
+}
+
+describe('SafeAccountInput', () => {
+  it('renders the success icon when importedSafeResult is set after mount', async () => {
+    const { queryByTestId, getByTestId } = render(<Harness />)
+
+    // No result yet → no success icon.
+    expect(queryByTestId('success-icon')).toBeNull()
+
+    // useImportSafe would normally do this; simulate the result arriving.
+    fireEvent.press(getByTestId('set-result'))
+
+    // useWatch must re-render this child so the icon appears.
+    await waitFor(() => expect(getByTestId('success-icon')).toBeTruthy())
+  })
+})

--- a/apps/mobile/src/components/SafeAccountInput/index.test.tsx
+++ b/apps/mobile/src/components/SafeAccountInput/index.test.tsx
@@ -1,18 +1,20 @@
 import React from 'react'
 import { Pressable } from 'react-native'
 import { FormProvider, useForm } from 'react-hook-form'
-import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import { render, fireEvent, waitFor } from '@/src/tests/test-utils'
 import type { FormValues } from '@/src/features/ImportReadOnly/types'
 import SafeAccountInput from './index'
 
-// useImportSafe runs RTK Query lookups and writes importedSafeResult itself.
-// Stub it so the test drives importedSafeResult deterministically via setValue.
+// Stub useImportSafe so the test drives importedSafeResult via setValue.
 jest.mock('./hooks/useImportSafe', () => ({ useImportSafe: jest.fn() }))
+
+// Derive fixture types from the form contract, not the auto-generated gateway module.
+type ImportedSafeResult = NonNullable<FormValues['importedSafeResult']>
+type SafeOverviewItem = NonNullable<ImportedSafeResult['data']>[number]
 
 const VALID_ADDRESS = '0x2f3e600a3F38b66aDcbe6530B191F2BE55c2Fbb6'
 
-const safeOverview: SafeOverview = {
+const safeOverview: SafeOverviewItem = {
   address: { value: VALID_ADDRESS, name: null, logoUri: null },
   awaitingConfirmation: null,
   chainId: '1',
@@ -22,37 +24,46 @@ const safeOverview: SafeOverview = {
   threshold: 1,
 }
 
-// importedSafeResult is not in defaultValues and is populated only via setValue,
-// so this harness reproduces the exact scenario that the watch() method missed.
-const Harness = () => {
+// Without `seed`, the result is applied via setValue after mount (the scenario the
+// watch() method missed); with `seed` it is in defaultValues from the start.
+const Harness = ({ result, seed = false }: { result: ImportedSafeResult; seed?: boolean }) => {
   const methods = useForm<FormValues>({
-    defaultValues: { name: '', safeAddress: VALID_ADDRESS },
+    defaultValues: { name: '', safeAddress: VALID_ADDRESS, ...(seed ? { importedSafeResult: result } : {}) },
   })
 
   return (
     <FormProvider {...methods}>
       <SafeAccountInput />
-      <Pressable
-        testID="set-result"
-        onPress={() =>
-          methods.setValue('importedSafeResult', { data: [safeOverview], isFetching: false, error: undefined })
-        }
-      />
+      <Pressable testID="set-result" onPress={() => methods.setValue('importedSafeResult', result)} />
     </FormProvider>
   )
 }
 
 describe('SafeAccountInput', () => {
   it('renders the success icon when importedSafeResult is set after mount', async () => {
-    const { queryByTestId, getByTestId } = render(<Harness />)
+    const { queryByTestId, getByTestId } = render(
+      <Harness result={{ data: [safeOverview], isFetching: false, error: undefined }} />,
+    )
 
-    // No result yet → no success icon.
     expect(queryByTestId('success-icon')).toBeNull()
 
-    // useImportSafe would normally do this; simulate the result arriving.
     fireEvent.press(getByTestId('set-result'))
 
     // useWatch must re-render this child so the icon appears.
     await waitFor(() => expect(getByTestId('success-icon')).toBeTruthy())
+  })
+
+  it('does not render the success icon while the lookup is still fetching', () => {
+    const { queryByTestId } = render(
+      <Harness result={{ data: [safeOverview], isFetching: true, error: undefined }} seed />,
+    )
+
+    expect(queryByTestId('success-icon')).toBeNull()
+  })
+
+  it('does not render the success icon when the lookup returns no Safes', () => {
+    const { queryByTestId } = render(<Harness result={{ data: [], isFetching: false, error: undefined }} seed />)
+
+    expect(queryByTestId('success-icon')).toBeNull()
   })
 })

--- a/apps/mobile/src/components/SafeAccountInput/index.tsx
+++ b/apps/mobile/src/components/SafeAccountInput/index.tsx
@@ -16,8 +16,7 @@ function SafeAccountInput() {
 
   useImportSafe()
 
-  // useWatch (not the watch method) subscribes this child component to the field,
-  // so it re-renders when useImportSafe writes the result via setValue.
+  // useWatch subscribes this child to the field; the watch() method only re-renders the form root.
   const result = useWatch({ control, name: 'importedSafeResult' })
 
   return (

--- a/apps/mobile/src/components/SafeAccountInput/index.tsx
+++ b/apps/mobile/src/components/SafeAccountInput/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { SafeInput } from '../SafeInput'
-import { useFormContext } from 'react-hook-form'
+import { useFormContext, useWatch } from 'react-hook-form'
 import { Controller } from 'react-hook-form'
 import { FormValues } from '@/src/features/ImportReadOnly/types'
 import { parsePrefixedAddress } from '@safe-global/utils/utils/addresses'
@@ -12,12 +12,13 @@ function SafeAccountInput() {
   const {
     control,
     formState: { errors, dirtyFields },
-    watch,
   } = useFormContext<FormValues>()
 
   useImportSafe()
 
-  const result = watch('importedSafeResult')
+  // useWatch (not the watch method) subscribes this child component to the field,
+  // so it re-renders when useImportSafe writes the result via setValue.
+  const result = useWatch({ control, name: 'importedSafeResult' })
 
   return (
     <Controller


### PR DESCRIPTION
## What it solves

When importing a read-only Safe, the success check icon never appeared next to the address input — `importedSafeResult` was always `undefined` in `SafeAccountInput`.

## How this PR fixes it

`importedSafeResult` is written only via `setValue` in `useImportSafe` and isn't in the form's `defaultValues`. `SafeAccountInput` read it with the `watch()` method, which subscribes the form root (the component calling `useForm()`), not this child — so the child never re-rendered when the field changed and kept its initial `undefined`.

`useWatch({ control, name: 'importedSafeResult' })` subscribes the child itself, so it re-renders on `setValue` and the icon shows once a Safe is found. (Sibling `ImportAccountFormView` already uses `useWatch`.)

<img width="374" height="843" alt="image" src="https://github.com/user-attachments/assets/573c37df-b790-4a11-8440-7748bf8fdcbd" />

## How to test it

1. Add account → import a read-only Safe.
2. Paste a valid, deployed Safe address → success check icon (`success-icon`) appears.
3. Paste an invalid/undeployed address → error shown instead.

## Affected flows

- Import read-only Safe: address input success/error indicator.

## Blast radius

- Only `SafeAccountInput` changes; no API/signature change. Reads the `importedSafeResult` field already populated by `useImportSafe` — hook, schema, and `defaultValues` untouched. Mobile-only, no shared-package impact.

## Risks / not checked

- Verified via type-check + lint only; not run on simulator/device.
- No unit test added; error path not exercised manually.

## Visual summary

```mermaid
flowchart LR
  subgraph Before
    H1[useImportSafe setValue] --> R1[form root re-renders]
    C1[SafeAccountInput watch] -. not subscribed .-> X1[stays undefined → no icon]
  end
  subgraph After
    H2[useImportSafe setValue] --> S2[field subject emits]
    S2 --> C2[SafeAccountInput useWatch] --> OK[re-renders → icon shows]
  end
