### PR TITLE
fix(web): right-align Inactive/Read-only badge in account selector sub-rows

### DIFF
--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/MultiChainSafeItemRow.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/MultiChainSafeItemRow.tsx
@@ -73,12 +73,10 @@ const MultiChainSafeItemRow = ({ item }: MultiChainSafeItemRowProps) => {
                 className="flex items-center gap-3 rounded-md px-3 py-2 cursor-pointer data-[state=checked]:bg-muted hover:bg-muted/30 [&>span.absolute]:hidden"
               >
                 <ChainLogo chainId={chain.chainId} />
-                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                  <Typography variant="paragraph-small-medium" className="truncate">
-                    {chain.chainName}
-                  </Typography>
-                  <StatusBadge chain={chain} />
-                </div>
+                <Typography variant="paragraph-small-medium" className="min-w-0 flex-1 truncate">
+                  {chain.chainName}
+                </Typography>
+                <StatusBadge chain={chain} />
                 {hasQueued && (
                   <Badge variant="secondary" className="text-xs whitespace-nowrap">
                     {chain.queued} pending


### PR DESCRIPTION
## What it solves

Resolves: the "Inactive" status icon looking broken/orphaned in the topbar account-selector dropdown.

When a multi-chain Safe is **expanded** in the account selector, each per-chain sub-row rendered its status badge (Inactive / Activating / Read-only) **stacked under the chain name on the left**. That was fine while the badge was a labeled pill ("Not activated"), but once #8013 swapped it for an **icon-only** badge, the lone warning icon read as broken — see the reported screenshot where the ⚠ icon hangs under "Ethereum" on the left. It should sit on the right, next to the balance.

The collapsed multi-chain summary row was already fixed to right-align this badge (via `RowEndColumn`), but the **expanded per-chain sub-rows** were never updated — so the bug only shows in the expanded state.

## How this PR fixes it

In `MultiChainSafeItemRow`'s expanded sub-row, `StatusBadge` is pulled out of the left `flex-col` and made a **right-aligned sibling**. The chain name now takes `flex-1` and truncates, so `StatusBadge` → `pending` → balance all line up on the right.

This matches both the collapsed summary row and the component's own comment, which already documented the intent: _"this row uses its own right-aligned StatusBadge / queued count / balance"_.

```diff
-                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                  <Typography variant="paragraph-small-medium" className="truncate">
-                    {chain.chainName}
-                  </Typography>
-                  <StatusBadge chain={chain} />
-                </div>
+                <Typography variant="paragraph-small-medium" className="min-w-0 flex-1 truncate">
+                  {chain.chainName}
+                </Typography>
+                <StatusBadge chain={chain} />
```

## How to test it

1. Connect a wallet that owns a **multi-chain Safe with at least one counterfactual (undeployed) chain**.
2. Open the account selector dropdown in the topbar.
3. **Expand** that multi-chain Safe.
4. The **Inactive** (or **Activating**) icon for the undeployed chain now appears **right-aligned**, in line with the balance column — not stacked under the chain name.
5. For a **read-only** chain, the "Read-only" pill is likewise right-aligned.
6. Long chain names still truncate; `N pending` badge and balance still align right.

## Affected flows

- Account selector dropdown → expand a multi-chain Safe → per-chain sub-row: status-badge placement (Inactive / Activating / Read-only).

## Blast radius

- **`MultiChainSafeItemRow`** (the `CollapsibleContent` per-chain sub-row) only. Its sole consumer is **`SafeDropdownContainer`** (the topbar account dropdown) — no other consumers.
- **`StatusBadge`** handles both branches and both move right: `isUndeployed` → `NotActivatedBadge` (icon) and `isReadOnly` → "Read-only" pill.
- No shared hooks / selectors / slices / RTK Query endpoints / feature flags / routes touched.
- Web-only component → no mobile or shared-package (`packages/**`) impact.

## Risks / not checked

- Pixel-exact alignment vs. the collapsed summary row — visual check only.
- Not tested on mobile — this component is web-only (N/A).
- Read-only sub-row right-alignment confirmed by reasoning + reviewer's in-app check; if a read-only multi-chain Safe is handy, worth a glance.
- Layout/position is not unit-testable in jsdom (no layout engine); covered by in-app verification on a running build.

## Visual summary

UI change — layout of the expanded per-chain sub-row:

```
Before:  [logo]  chainName ........................   [balance]
                 ⚠            ← icon orphaned on the left

After:   [logo]  chainName .............  ⚠  [N pending]  [balance]
                                          ↑ right-aligned with the trailing column
```

```mermaid
flowchart LR
  subgraph Before["Before — sub-row"]
    L1[ChainLogo] --> C1["flex-col: chainName / StatusBadge (stacked, left)"]
    C1 --> B1[balance]
  end
  subgraph After["After — sub-row"]
    L2[ChainLogo] --> N2["chainName (flex-1, truncate)"]
    N2 --> S2[StatusBadge]
    S2 --> P2[pending]
    P2 --> B2[balance]
  end
```

<img width="472" height="313" alt="Screenshot 2026-06-30 at 12 05 35" src="https://github.com/user-attachments/assets/5dc5dd93-afbe-43ba-903b-62541fd28daf" />


## Checklist

- [ ] I've tested the branch on mobile 📱 — N/A (web-only component)
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics change
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — existing `MultiChainSafeItemRow.test.tsx` covers badge presence/label; layout position is not unit-testable in jsdom
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).