### PR TITLE
feat(web): unify Safe accounts into a tabbed table and redesign the s…

### DIFF
--- a/apps/web/src/components/common/AddressWithCopy/index.tsx
+++ b/apps/web/src/components/common/AddressWithCopy/index.tsx
@@ -3,14 +3,37 @@ import { shortenAddress } from '@safe-global/utils/utils/formatters'
 import CopyAddressIconButton from '../CopyAddressIconButton'
 
 /**
- * Shortened address + inline copy button, laid out consistently for shadcn
- * account rows/cards. Keeps spacing, truncation, and typography aligned across
- * the surfaces that show a Safe address.
+ * Address + inline copy button, laid out consistently for shadcn account
+ * rows/cards. Shows a shortened address by default; pass `full` to render the
+ * complete address. Keeps spacing and typography aligned across the surfaces
+ * that show a Safe address.
  */
-const AddressWithCopy = ({ address, 'data-testid': testId }: { address: string; 'data-testid'?: string }) => (
+const AddressWithCopy = ({
+  address,
+  full = false,
+  'data-testid': testId,
+}: {
+  address: string
+  full?: boolean
+  'data-testid'?: string
+}) => (
   <div className="flex min-w-0 items-center gap-1.5">
-    <Typography data-testid={testId} variant="paragraph-mini" color="muted" className="truncate">
-      {shortenAddress(address)}
+    <Typography
+      data-testid={testId}
+      variant="paragraph-mini"
+      color="muted"
+      className={full ? 'break-all font-mono' : 'truncate'}
+    >
+      {full ? (
+        <>
+          {/* Bold the first 4 and last 6 chars (in mono) so addresses are easy to verify at a glance. */}
+          <span className="text-foreground font-bold">{address.slice(0, 4)}</span>
+          {address.slice(4, -6)}
+          <span className="text-foreground font-bold">{address.slice(-6)}</span>
+        </>
+      ) : (
+        shortenAddress(address)
+      )}
     </Typography>
     <CopyAddressIconButton address={address} />
   </div>

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSafeBarSafes.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSafeBarSafes.ts
@@ -1,8 +1,9 @@
 import { useMemo } from 'react'
-import { useIsQualifiedSafe, useSpaceSafes } from '@/features/spaces'
+import { useIsQualifiedSafe, useSpaceSafes, useCurrentSpaceId } from '@/features/spaces'
 import { useAllSafes, useAllSafesGrouped, getComparator, type AllSafeItems } from '@/hooks/safes'
 import type { SafeItem, MultiChainSafeItem } from '@/hooks/safes'
 import { useAppSelector } from '@/store'
+import { isAuthenticated } from '@/store/authSlice'
 import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
 import useChainId from '@/hooks/useChainId'
 import useSafeInfo from '@/hooks/useSafeInfo'
@@ -42,6 +43,10 @@ export function useSafeBarSafes() {
   const isQualifiedSafe = useIsQualifiedSafe()
   const isSpaceRoute = useIsSpaceRoute()
   const isInSpaceContext = isQualifiedSafe || isSpaceRoute
+  const isSignedIn = useAppSelector(isAuthenticated)
+  const spaceId = useCurrentSpaceId()
+  // Whether there's a workspace to show in the Workspace tab (signed in + a current space).
+  const hasWorkspace = isSignedIn && Boolean(spaceId)
   const { allSafes: spaceSafes } = useSpaceSafes()
   const urlSafeAddress = useSafeAddressFromUrl()
   const { safeAddress: reduxSafeAddress } = useSafeInfo()
@@ -104,6 +109,9 @@ export function useSafeBarSafes() {
     return orderDropdownSafes(spaceSafes, safeAddress, comparator, current)
   }, [spaceSafes, safeAddress, fallbackCurrentSafe, comparator])
 
+  // Local tab = trusted (pinned) safes only, sorted — no current-safe injection.
+  const trustedSafes = useMemo<AllSafeItems>(() => [...pinnedSafes].sort(comparator), [pinnedSafes, comparator])
+
   // Same for chain selector.
   const chainSelectorSafes = useMemo<AllSafeItems>(() => {
     if (!safeAddress) return allKnownSafes
@@ -116,6 +124,10 @@ export function useSafeBarSafes() {
   return {
     dropdownSafes: isInSpaceContext ? spaceDropdownSafes : dropdownSafes,
     chainSelectorSafes: isInSpaceContext ? spaceSafes : chainSelectorSafes,
+    // Both lists exposed so the dropdown can show them under separate tabs.
+    workspaceSafes: spaceDropdownSafes,
+    trustedSafes,
+    hasWorkspace,
     // Expose so the header label stays in sync with which list is shown
     isInSpaceContext,
   }

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceSafeSelectorItems.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceSafeSelectorItems.ts
@@ -2,7 +2,7 @@ import { useMemo, useCallback } from 'react'
 import { useRouter } from 'next/router'
 import { useCurrentSpaceId } from '@/features/spaces'
 import { isMultiChainSafeItem, flattenSafeItems } from '@/hooks/safes'
-import type { SafeItem, MultiChainSafeItem } from '@/hooks/safes'
+import type { SafeItem, MultiChainSafeItem, AllSafeItems } from '@/hooks/safes'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import useChainId from '@/hooks/useChainId'
 import useChains from '@/hooks/useChains'
@@ -133,7 +133,7 @@ function buildSingleChainItem(
 }
 
 export function useSpaceSafeSelectorItems() {
-  const { dropdownSafes: allSafes, isInSpaceContext } = useSafeBarSafes()
+  const { workspaceSafes, trustedSafes, isInSpaceContext, hasWorkspace } = useSafeBarSafes()
   const { safe, safeAddress: reduxSafeAddress } = useSafeInfo()
   const urlSafeAddress = useSafeAddressFromUrl()
   const effectiveSafeAddress = urlSafeAddress || reduxSafeAddress
@@ -145,7 +145,20 @@ export function useSpaceSafeSelectorItems() {
   const { address: walletAddress } = useWallet() || {}
   const spaceId = useCurrentSpaceId()
 
-  const flatSafes = useMemo(() => flattenSafeItems(allSafes), [allSafes])
+  // Dedupe the union of both lists so the overviews query fetches each safe once.
+  const combinedSafes = useMemo<AllSafeItems>(() => {
+    const seen = new Set<string>()
+    const out: AllSafeItems = []
+    for (const item of [...workspaceSafes, ...trustedSafes]) {
+      const key = item.address.toLowerCase()
+      if (seen.has(key)) continue
+      seen.add(key)
+      out.push(item)
+    }
+    return out
+  }, [workspaceSafes, trustedSafes])
+
+  const flatSafes = useMemo(() => flattenSafeItems(combinedSafes), [combinedSafes])
 
   const {
     data: overviews,
@@ -154,26 +167,41 @@ export function useSpaceSafeSelectorItems() {
     refetch: refetchOverviews,
   } = useGetMultipleSafeOverviewsQuery(flatSafes.length > 0 ? { safes: flatSafes, currency, walletAddress } : skipToken)
 
-  const items: SafeItemData[] = useMemo(() => {
-    return allSafes.map((item) => {
-      const isCurrentSafe = sameAddress(item.address, effectiveSafeAddress)
+  const buildItems = useCallback(
+    (safes: AllSafeItems): SafeItemData[] =>
+      safes.map((item) => {
+        const isCurrentSafe = sameAddress(item.address, effectiveSafeAddress)
 
-      if (isMultiChainSafeItem(item)) {
-        return buildMultiChainItem(
+        if (isMultiChainSafeItem(item)) {
+          return buildMultiChainItem(
+            item,
+            isCurrentSafe,
+            currentChainId,
+            overviews,
+            overviewsLoading,
+            safe,
+            chainConfigs,
+            undeployedSafes,
+          )
+        }
+
+        return buildSingleChainItem(
           item,
           isCurrentSafe,
-          currentChainId,
           overviews,
           overviewsLoading,
           safe,
           chainConfigs,
           undeployedSafes,
         )
-      }
+      }),
+    [effectiveSafeAddress, currentChainId, safe, overviews, overviewsLoading, chainConfigs, undeployedSafes],
+  )
 
-      return buildSingleChainItem(item, isCurrentSafe, overviews, overviewsLoading, safe, chainConfigs, undeployedSafes)
-    })
-  }, [allSafes, effectiveSafeAddress, currentChainId, safe, overviews, overviewsLoading, chainConfigs, undeployedSafes])
+  const workspaceItems = useMemo(() => buildItems(workspaceSafes), [buildItems, workspaceSafes])
+  const localItems = useMemo(() => buildItems(trustedSafes), [buildItems, trustedSafes])
+  // Trigger + selection use the contextual list (same behaviour as before).
+  const items = isInSpaceContext ? workspaceItems : localItems
 
   const selectedItemId = effectiveSafeAddress ? `${currentChainId}:${effectiveSafeAddress}` : ''
 
@@ -202,6 +230,9 @@ export function useSpaceSafeSelectorItems() {
 
   return {
     items,
+    workspaceItems,
+    localItems,
+    hasWorkspace,
     selectedItemId,
     handleItemSelect,
     isLoading: overviewsLoading || itemsNotReady,

--- a/apps/web/src/components/common/SpaceSafeBar/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.tsx
@@ -1,24 +1,17 @@
-import { useContext, useState } from 'react'
+import { useContext } from 'react'
 import { usePathname } from 'next/navigation'
 import { useRouter } from 'next/router'
 import { TxModalContext } from '@/components/tx-flow'
-import { ChevronRight, Wallet } from 'lucide-react'
 import { AppRoutes } from '@/config/routes'
 import { useIsQualifiedSafe, SafeSelectorDropdown } from '@/features/spaces'
 import TrustedSafesModal from '@/components/common/TrustedSafesModal'
 import useTrustedSafesModal from '@/components/common/TrustedSafesModal/useTrustedSafesModal'
-import { Button } from '@/components/ui/button'
-import { useAppSelector } from '@/store'
-import { selectAllAddedSafes } from '@/store/addedSafesSlice'
-import useWallet from '@/hooks/wallets/useWallet'
-import useConnectWallet from '@/components/common/ConnectWallet/useConnectWallet'
 import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
 import { useSpaceSafeSelectorItems } from './hooks/useSpaceSafeSelectorItems'
 import { useSpaceBackLink } from './hooks/useSpaceBackLink'
 import SpaceBackLink from './SpaceBackLink'
 import SpaceChainSelector from './SpaceChainSelector'
 import SpaceNestedSafesButton from './SpaceNestedSafesButton'
-import AccountsModal from './AccountsModal'
 
 const HIDDEN_ROUTES = [
   AppRoutes.welcome.accounts,
@@ -36,59 +29,24 @@ const HIDDEN_ROUTES = [
   AppRoutes['_offline'],
 ]
 
-function DropdownHeader({ label, testId }: { label: string; testId?: string }) {
-  return (
-    <div className="flex items-center gap-1 px-4 pt-3 pb-2">
-      <span className="text-sm font-semibold text-secondary-foreground" data-testid={testId}>
-        {label}
-      </span>
-    </div>
-  )
-}
-
-function DropdownFooter({ onOpen, label }: { onOpen: () => void; label: string }) {
-  return (
-    <div className="px-4 py-3">
-      <Button variant="secondary" size="sm" className="w-full" onClick={onOpen} data-testid="all-accounts-btn">
-        {label}
-        <ChevronRight className="size-4" />
-      </Button>
-    </div>
-  )
-}
-
-function ConnectWalletFooter({ onConnect, onClose }: { onConnect: () => void; onClose: () => void }) {
-  return (
-    <div className="px-4 py-3">
-      <Button
-        variant="secondary"
-        size="sm"
-        className="w-full"
-        data-testid="safe-selector-connect-wallet-btn"
-        onClick={() => {
-          onClose()
-          onConnect()
-        }}
-      >
-        <Wallet className="size-4" />
-        Connect wallet
-      </Button>
-    </div>
-  )
-}
-
 function SpaceSafeBar() {
   const pathname = usePathname()
   const router = useRouter()
   const urlSafeAddress = useSafeAddressFromUrl()
   const isQualifiedSafe = useIsQualifiedSafe()
-  const { items, selectedItemId, handleItemSelect, isLoading, isError, refetch, isInSpaceContext } =
-    useSpaceSafeSelectorItems()
+  const {
+    items,
+    workspaceItems,
+    localItems,
+    hasWorkspace,
+    selectedItemId,
+    handleItemSelect,
+    isLoading,
+    isError,
+    refetch,
+    isInSpaceContext,
+  } = useSpaceSafeSelectorItems()
   const { space, handleBackToSpace } = useSpaceBackLink()
-  const [accountsModalOpen, setAccountsModalOpen] = useState(false)
-  const addedSafes = useAppSelector(selectAllAddedSafes)
-  const wallet = useWallet()
-  const connectWallet = useConnectWallet()
   const { txFlow } = useContext(TxModalContext)
   const trustedSafesModal = useTrustedSafesModal()
 
@@ -97,34 +55,6 @@ function SpaceSafeBar() {
   if (HIDDEN_ROUTES.includes(router.pathname)) return null
   // /settings/* serves both per-safe (URL has ?safe=) and global pages — hide when no safe context.
   if (pathname?.startsWith(AppRoutes.settings.index) && !urlSafeAddress) return null
-
-  const handleOpenAccountsModal = () => {
-    setAccountsModalOpen(true)
-  }
-
-  // Match the header to the list shown: useSafeBarSafes renders workspace safes in any space
-  // context, not just for a qualified safe — so the label must track isInSpaceContext too.
-  const dropdownHeader = isInSpaceContext ? (
-    <DropdownHeader label="Safes in this workspace" testId="workspace-header" />
-  ) : (
-    <DropdownHeader label="Trusted Safes" />
-  )
-
-  const hasPinnedSafes = Object.values(addedSafes).some((chain) => Object.keys(chain).length > 0)
-  const showConnectWallet = !wallet && !hasPinnedSafes
-
-  const dropdownFooter =
-    showConnectWallet && !isQualifiedSafe
-      ? (close: () => void) => <ConnectWalletFooter onConnect={connectWallet} onClose={close} />
-      : (close: () => void) => (
-          <DropdownFooter
-            label={isQualifiedSafe ? 'Explore other Safes' : 'All Accounts'}
-            onOpen={() => {
-              close()
-              handleOpenAccountsModal()
-            }}
-          />
-        )
 
   return (
     <div data-testid="safe-level-navigation" className="flex flex-wrap items-center gap-2 max-[899px]:justify-end">
@@ -136,23 +66,23 @@ function SpaceSafeBar() {
         <div className="contents max-[429px]:block max-[429px]:order-[10000] max-[429px]:min-w-0 max-[429px]:basis-full">
           <SafeSelectorDropdown
             items={items}
+            workspaceItems={workspaceItems}
+            localItems={localItems}
+            hasWorkspace={hasWorkspace}
+            workspaceName={space?.name}
+            isInSpaceContext={isInSpaceContext}
             selectedItemId={selectedItemId}
             onItemSelect={handleItemSelect}
             isLoading={isLoading}
             isError={isError}
             onRetry={refetch}
-            header={dropdownHeader}
-            footer={dropdownFooter}
+            onManageTrustedSafes={trustedSafesModal.open}
+            onSignIn={() => router.push(AppRoutes.welcome.spaces)}
           />
         </div>
       </div>
       <SpaceNestedSafesButton />
       <SpaceChainSelector isLoading={isLoading} />
-      <AccountsModal
-        open={accountsModalOpen}
-        onClose={() => setAccountsModalOpen(false)}
-        onManageTrustedSafes={trustedSafesModal.open}
-      />
       <TrustedSafesModal modal={trustedSafesModal} />
     </div>
   )

--- a/apps/web/src/components/common/TrustedSafesModal/MultiChainSelectionItem.tsx
+++ b/apps/web/src/components/common/TrustedSafesModal/MultiChainSelectionItem.tsx
@@ -1,9 +1,15 @@
-import { useState, type MouseEvent } from 'react'
-import classnames from 'classnames'
 import type { SelectableMultiChainSafe } from './useTrustedSafesModal.types'
-import { useMultiAccountItemData, useSafeItemData, AccountItem } from '@/features/myAccounts'
+import { useMultiAccountItemData, AccountItem } from '@/features/myAccounts'
+import { FiatBalance } from '@/features/spaces'
+import Identicon from '@/components/common/Identicon'
+import AddressWithCopy from '@/components/common/AddressWithCopy'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Typography } from '@/components/ui/typography'
+import { shortenAddress } from '@safe-global/utils/utils/formatters'
+import { cn } from '@/utils/cn'
 import SimilarityWarning from './SimilarityWarning'
-import css from './styles.module.css'
+import { MODAL_SAFE_GRID } from './constants'
+import { ThresholdBadge } from './ThresholdBadge'
 
 interface MultiChainSelectionItemProps {
   multiSafe: SelectableMultiChainSafe
@@ -11,125 +17,61 @@ interface MultiChainSelectionItemProps {
 }
 
 /**
- * Sub-item for each chain in a multichain group
- */
-function MultiChainSubItem({
-  safe,
-  onToggle,
-}: {
-  safe: SelectableMultiChainSafe['safes'][number]
-  onToggle: (address: string) => void
-}) {
-  const { chain, safeOverview, isActivating, threshold, owners, undeployedSafe } = useSafeItemData(safe)
-
-  const handleClick = (e: MouseEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    onToggle(safe.address)
-  }
-
-  const hasQueuedItems =
-    !safe.isReadOnly && safeOverview && ((safeOverview.queued ?? 0) > 0 || (safeOverview.awaitingConfirmation ?? 0) > 0)
-
-  return (
-    <AccountItem.Button onClick={handleClick}>
-      <AccountItem.Icon
-        address={safe.address}
-        chainId={safe.chainId}
-        threshold={threshold}
-        owners={owners.length}
-        isMultiChainItem
-      />
-      <AccountItem.Info address={safe.address} chainId={safe.chainId} chainName={chain?.chainName}>
-        <AccountItem.StatusChip
-          undeployedSafe={!!undeployedSafe}
-          isActivating={isActivating}
-          isReadOnly={safe.isReadOnly}
-        />
-        {hasQueuedItems && (
-          <AccountItem.QueueActions
-            safeAddress={safeOverview.address.value}
-            chainShortName={chain?.shortName || ''}
-            queued={safeOverview.queued ?? 0}
-            awaitingConfirmation={safeOverview.awaitingConfirmation ?? 0}
-          />
-        )}
-      </AccountItem.Info>
-      <AccountItem.Balance fiatTotal={safeOverview?.fiatTotal} isLoading={!safeOverview && !undeployedSafe} />
-    </AccountItem.Button>
-  )
-}
-
-/**
- * Multichain safe group item for the selection modal
- * Shows a header with the address and multichain badge, with expandable sub-items for each chain
+ * Multichain safe row in the selection modal. Selecting trusts the address across all its
+ * chains, so it's a single selectable row (the Chains column shows every network) — matching
+ * how multichain safes appear in the SafesTable.
  */
 const MultiChainSelectionItem = ({ multiSafe, onToggle }: MultiChainSelectionItemProps) => {
-  const [expanded, setExpanded] = useState(false)
-
-  // Use multiSafe.safes directly as they're already SelectableSafe[]
-  // Only use hook for computed values like sharedSetup and totalFiatValue
   const { sharedSetup, totalFiatValue } = useMultiAccountItemData(multiSafe)
   const { address, safes, name } = multiSafe
 
-  const handleToggle = (e: MouseEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    onToggle(address)
-  }
-
-  const toggleExpand = (e: MouseEvent) => {
-    e.stopPropagation()
-    setExpanded((prev) => !prev)
-  }
-
-  const statusChips = <>{multiSafe.similarityGroup && <SimilarityWarning />}</>
+  const displayName = name || shortenAddress(address)
 
   return (
-    <div data-testid="safe-list-item" className={classnames(css.multiListItem, css.listItem, 'my-0.5')}>
-      <div data-testid="multichain-selection-item">
-        <div onClick={toggleExpand} className="flex items-center">
-          <div className="min-w-0 flex-1" onClick={handleToggle}>
-            <AccountItem.Content data-testid="multichain-selection-content">
-              <AccountItem.Checkbox checked={multiSafe.isSelected} address={address} />
-              <AccountItem.Icon
-                address={address}
-                chainId={safes[0]?.chainId ?? '1'}
-                threshold={sharedSetup?.threshold}
-                owners={sharedSetup?.owners.length}
-              />
-              <AccountItem.Info
-                address={address}
-                chainId={safes[0]?.chainId ?? '1'}
-                name={name}
-                fullAddress
-                showCopyButton
-                hasExplorer
-                showPrefix={false}
-                highlight4bytes={!!multiSafe.similarityGroup}
-              >
-                {statusChips}
-              </AccountItem.Info>
-              <AccountItem.ChainBadge safes={safes} />
-              <AccountItem.Balance fiatTotal={totalFiatValue?.toString()} isLoading={totalFiatValue === undefined} />
-              <AccountItem.ContextMenu
-                address={address}
-                chainId={safes[0]?.chainId ?? '1'}
-                name={name}
-                isReplayable={false}
-                undeployedSafe={false}
-                hideNestedSafes
-              />
-            </AccountItem.Content>
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onToggle(address)}
+      data-testid="safe-list-item"
+      className={cn(
+        MODAL_SAFE_GRID,
+        'group border-muted hover:bg-muted/40 cursor-pointer border-b px-3 py-2 transition-colors',
+        multiSafe.isSelected && 'bg-primary/5',
+      )}
+    >
+      <Checkbox
+        checked={multiSafe.isSelected}
+        tabIndex={-1}
+        aria-hidden
+        className="pointer-events-none"
+        data-testid={`safe-item-checkbox-${multiSafe.address}`}
+      />
+
+      <div className="flex min-w-0 items-center gap-3">
+        <span className="inline-flex shrink-0">
+          <Identicon address={address} />
+        </span>
+        <div className="flex min-w-0 flex-col">
+          <div className="flex items-center gap-1.5">
+            <Typography variant="paragraph-small-bold" className="text-foreground truncate">
+              {displayName}
+            </Typography>
+            {multiSafe.similarityGroup && <SimilarityWarning />}
           </div>
+          <AddressWithCopy address={address} full />
         </div>
-        {expanded && (
-          <div className="px-3" data-testid="multichain-subaccounts-container">
-            {safes.map((safeItem) => (
-              <MultiChainSubItem key={`${safeItem.chainId}:${safeItem.address}`} safe={safeItem} onToggle={onToggle} />
-            ))}
-          </div>
-        )}
+      </div>
+
+      <div className="flex min-w-0 items-center">
+        <AccountItem.ChainBadge safes={safes} />
+      </div>
+
+      <div className="flex items-center justify-end">
+        <FiatBalance value={totalFiatValue?.toString()} />
+      </div>
+
+      <div className="flex items-center justify-end">
+        <ThresholdBadge threshold={sharedSetup?.threshold} owners={sharedSetup?.owners.length} />
       </div>
     </div>
   )

--- a/apps/web/src/components/common/TrustedSafesModal/SecurityBanner.tsx
+++ b/apps/web/src/components/common/TrustedSafesModal/SecurityBanner.tsx
@@ -30,7 +30,7 @@ const SecurityBanner = ({ title, className }: SecurityBannerProps) => {
         <ExternalLink
           href={HelpCenterArticle.ADDRESS_POISONING}
           noIcon
-          sx={{ textDecoration: 'underline', '.dark &': { color: 'inherit' } }}
+          sx={{ color: 'inherit', fontWeight: 500, textDecoration: 'underline', textUnderlineOffset: '2px' }}
         >
           Learn more about address poisoning
         </ExternalLink>

--- a/apps/web/src/components/common/TrustedSafesModal/ThresholdBadge.tsx
+++ b/apps/web/src/components/common/TrustedSafesModal/ThresholdBadge.tsx
@@ -1,0 +1,12 @@
+import PeopleIcon from '@mui/icons-material/PeopleAltOutlined'
+
+export const ThresholdBadge = ({ threshold, owners }: { threshold?: number; owners?: number }) => {
+  if (!owners) return null
+
+  return (
+    <span className="bg-muted text-muted-foreground inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium">
+      <PeopleIcon sx={{ fontSize: 12 }} />
+      {threshold}/{owners}
+    </span>
+  )
+}

--- a/apps/web/src/components/common/TrustedSafesModal/TrustedSafesItem.tsx
+++ b/apps/web/src/components/common/TrustedSafesModal/TrustedSafesItem.tsx
@@ -1,7 +1,16 @@
-import type { MouseEvent } from 'react'
+import type { Ref } from 'react'
 import type { SelectableSafe } from './useTrustedSafesModal.types'
 import { useSafeItemData, AccountItem } from '@/features/myAccounts'
+import { FiatBalance } from '@/features/spaces'
+import Identicon from '@/components/common/Identicon'
+import AddressWithCopy from '@/components/common/AddressWithCopy'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Typography } from '@/components/ui/typography'
+import { shortenAddress } from '@safe-global/utils/utils/formatters'
+import { cn } from '@/utils/cn'
 import SimilarityWarning from './SimilarityWarning'
+import { MODAL_SAFE_GRID } from './constants'
+import { ThresholdBadge } from './ThresholdBadge'
 
 interface TrustedSafesItemProps {
   safe: SelectableSafe
@@ -9,70 +18,85 @@ interface TrustedSafesItemProps {
 }
 
 /**
- * Individual safe item in the selection modal
- * Uses AccountItem compound components for consistent styling.
- * Includes balance, signers, status chips, queue actions, and rename menu.
- * Allows selecting/deselecting safes including already-pinned ones.
+ * Single safe row in the selection modal, laid out like the SafesTable rows for visual
+ * consistency. The whole row toggles selection; the checkbox is purely visual.
  */
 const TrustedSafesItem = ({ safe, onToggle }: TrustedSafesItemProps) => {
-  // Get rich data (balance, threshold, owners, etc.)
   const { chain, name, safeOverview, isActivating, threshold, owners, undeployedSafe, elementRef } =
     useSafeItemData(safe)
 
-  const handleClick = (e: MouseEvent) => {
-    e.preventDefault()
-    onToggle(safe.address)
-  }
+  const displayName = name || shortenAddress(safe.address)
 
-  // Check for queued transactions
   const hasQueuedItems =
     !safe.isReadOnly && safeOverview && ((safeOverview.queued ?? 0) > 0 || (safeOverview.awaitingConfirmation ?? 0) > 0)
 
-  const statusChips = (
-    <>
-      <AccountItem.StatusChip
-        isActivating={isActivating}
-        isReadOnly={safe.isReadOnly}
-        undeployedSafe={!!undeployedSafe}
-      />
-      {hasQueuedItems && (
-        <AccountItem.QueueActions
-          safeAddress={safeOverview.address.value}
-          chainShortName={chain?.shortName || ''}
-          queued={safeOverview.queued ?? 0}
-          awaitingConfirmation={safeOverview.awaitingConfirmation ?? 0}
-        />
-      )}
-      {safe.similarityGroup && <SimilarityWarning />}
-    </>
-  )
+  const showStatus = isActivating || !!undeployedSafe || !!hasQueuedItems
 
   return (
-    <AccountItem.Button onClick={handleClick} elementRef={elementRef}>
-      <AccountItem.Checkbox checked={safe.isSelected} address={safe.address} />
-      <AccountItem.Icon address={safe.address} chainId={safe.chainId} threshold={threshold} owners={owners.length} />
-      <AccountItem.Info
-        address={safe.address}
-        chainId={safe.chainId}
-        name={name}
-        fullAddress
-        showCopyButton
-        hasExplorer
-        highlight4bytes={!!safe.similarityGroup}
-      >
-        {statusChips}
-      </AccountItem.Info>
-      <AccountItem.ChainBadge chainId={safe.chainId} />
-      <AccountItem.Balance fiatTotal={safeOverview?.fiatTotal} isLoading={!safeOverview && !undeployedSafe} />
-      <AccountItem.ContextMenu
-        address={safe.address}
-        chainId={safe.chainId}
-        name={name}
-        isReplayable={false}
-        undeployedSafe={!!undeployedSafe}
-        hideNestedSafes
+    <div
+      ref={elementRef as Ref<HTMLDivElement>}
+      role="button"
+      tabIndex={0}
+      onClick={() => onToggle(safe.address)}
+      data-testid="safe-list-item"
+      className={cn(
+        MODAL_SAFE_GRID,
+        'group border-muted hover:bg-muted/40 cursor-pointer border-b px-3 py-2 transition-colors',
+        safe.isSelected && 'bg-primary/5',
+      )}
+    >
+      <Checkbox
+        checked={safe.isSelected}
+        tabIndex={-1}
+        aria-hidden
+        className="pointer-events-none"
+        data-testid={`safe-item-checkbox-${safe.address}`}
       />
-    </AccountItem.Button>
+
+      <div className="flex min-w-0 items-center gap-3">
+        <span className="inline-flex shrink-0">
+          <Identicon address={safe.address} />
+        </span>
+        <div className="flex min-w-0 flex-col">
+          <div className="flex items-center gap-1.5">
+            <Typography variant="paragraph-small-bold" className="text-foreground truncate">
+              {displayName}
+            </Typography>
+            {safe.similarityGroup && <SimilarityWarning />}
+          </div>
+          <AddressWithCopy address={safe.address} full />
+          {showStatus && (
+            <div className="mt-1 flex flex-wrap items-center gap-1">
+              <AccountItem.StatusChip
+                isActivating={isActivating}
+                isReadOnly={false}
+                undeployedSafe={!!undeployedSafe}
+              />
+              {hasQueuedItems && (
+                <AccountItem.QueueActions
+                  safeAddress={safeOverview.address.value}
+                  chainShortName={chain?.shortName || ''}
+                  queued={safeOverview.queued ?? 0}
+                  awaitingConfirmation={safeOverview.awaitingConfirmation ?? 0}
+                />
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex min-w-0 items-center">
+        <AccountItem.ChainBadge chainId={safe.chainId} />
+      </div>
+
+      <div className="flex items-center justify-end">
+        <FiatBalance value={safeOverview?.fiatTotal} />
+      </div>
+
+      <div className="flex items-center justify-end">
+        <ThresholdBadge threshold={threshold} owners={owners.length} />
+      </div>
+    </div>
   )
 }
 

--- a/apps/web/src/components/common/TrustedSafesModal/TrustedSafesList.tsx
+++ b/apps/web/src/components/common/TrustedSafesModal/TrustedSafesList.tsx
@@ -2,10 +2,14 @@ import { useMemo } from 'react'
 import { Search } from 'lucide-react'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group'
 import { Spinner } from '@/components/ui/spinner'
+import { cn } from '@/utils/cn'
 import TrustedSafesItem from './TrustedSafesItem'
 import MultiChainSelectionItem from './MultiChainSelectionItem'
+import { MODAL_SAFE_GRID } from './constants'
 import type { SelectableSafe, SelectableItem } from './useTrustedSafesModal.types'
 import { isSelectableMultiChainSafe } from './useTrustedSafesModal.types'
+
+const columnLabel = 'text-muted-foreground text-xs font-semibold uppercase tracking-wide'
 
 interface TrustedSafesListProps {
   items: SelectableItem[]
@@ -13,6 +17,8 @@ interface TrustedSafesListProps {
   searchQuery: string
   onSearchChange: (query: string) => void
   onToggle: (address: string) => void
+  /** When false, the search input is rendered by the caller (e.g. in a shared toolbar). */
+  showSearchInput?: boolean
 }
 
 interface SimilarityGroupData {
@@ -73,20 +79,15 @@ const SimilarityGroupContainer = ({
   onToggle: (address: string) => void
 }) => {
   return (
-    <div
-      className="my-0.5 overflow-hidden rounded-md border border-border/50"
-      data-testid={`similarity-group-${group.groupKey}`}
-    >
+    <div data-testid={`similarity-group-${group.groupKey}`}>
       <div className="bg-yellow-50 px-3 py-1.5 dark:bg-[var(--color-warning-background)]">
         <span className="text-xs font-medium text-yellow-800 dark:text-[var(--color-warning1-contrast-text)]">
           Similar addresses – verify carefully
         </span>
       </div>
-      <div className="mb-4 bg-background p-2">
-        {group.items.map((item) => (
-          <SelectionItem key={item.address} item={item} onToggle={onToggle} />
-        ))}
-      </div>
+      {group.items.map((item) => (
+        <SelectionItem key={item.address} item={item} onToggle={onToggle} />
+      ))}
     </div>
   )
 }
@@ -95,7 +96,14 @@ const SimilarityGroupContainer = ({
  * List of safes for selection
  * Groups similar addresses together with visual highlighting
  */
-const TrustedSafesList = ({ items, isLoading, searchQuery, onSearchChange, onToggle }: TrustedSafesListProps) => {
+const TrustedSafesList = ({
+  items,
+  isLoading,
+  searchQuery,
+  onSearchChange,
+  onToggle,
+  showSearchInput = true,
+}: TrustedSafesListProps) => {
   const { groups, ungroupedItems } = useMemo(() => groupItemsBySimilarity(items), [items])
 
   const sortedUngroupedItems = useMemo(
@@ -111,7 +119,7 @@ const TrustedSafesList = ({ items, isLoading, searchQuery, onSearchChange, onTog
     )
   }
 
-  const showSearch = items.length > 0 || Boolean(searchQuery)
+  const showSearch = showSearchInput && (items.length > 0 || Boolean(searchQuery))
 
   return (
     <div>
@@ -129,29 +137,31 @@ const TrustedSafesList = ({ items, isLoading, searchQuery, onSearchChange, onTog
         </InputGroup>
       )}
 
-      <div>
-        {items.length === 0 ? (
-          <div className="py-8 text-center">
-            <span className="text-sm text-muted-foreground">
-              {searchQuery ? 'No safes found matching your search' : 'No safes available'}
-            </span>
+      {items.length === 0 ? (
+        <div className="py-8 text-center">
+          <span className="text-sm text-muted-foreground">
+            {searchQuery ? 'No safes found matching your search' : 'No safes available'}
+          </span>
+        </div>
+      ) : (
+        <div className="border-border overflow-hidden rounded-2xl border">
+          <div className={cn(MODAL_SAFE_GRID, 'border-border bg-muted/30 border-b px-3 py-2.5')}>
+            <span />
+            <span className={columnLabel}>Account</span>
+            <span className={columnLabel}>Chains</span>
+            <span className={cn(columnLabel, 'text-right')}>Balance</span>
+            <span className={cn(columnLabel, 'text-right')}>Threshold</span>
           </div>
-        ) : (
-          <>
-            {/* Render similarity groups first */}
-            {groups.map((group) => (
-              <SimilarityGroupContainer key={group.groupKey} group={group} onToggle={onToggle} />
-            ))}
 
-            {/* Render ungrouped items */}
-            {sortedUngroupedItems.map((item) => (
-              <div key={item.address} className="my-0.5">
-                <SelectionItem item={item} onToggle={onToggle} />
-              </div>
-            ))}
-          </>
-        )}
-      </div>
+          {/* Similarity groups first, then the rest */}
+          {groups.map((group) => (
+            <SimilarityGroupContainer key={group.groupKey} group={group} onToggle={onToggle} />
+          ))}
+          {sortedUngroupedItems.map((item) => (
+            <SelectionItem key={item.address} item={item} onToggle={onToggle} />
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/common/TrustedSafesModal/TrustedSafesModal.test.tsx
+++ b/apps/web/src/components/common/TrustedSafesModal/TrustedSafesModal.test.tsx
@@ -207,25 +207,25 @@ describe('TrustedSafesModal', () => {
     expect(screen.getByText('Similar address detected')).toBeInTheDocument()
   })
 
-  it('should display Select All and Deselect All buttons', () => {
+  it('should display Select all and Deselect all buttons', () => {
     render(<TrustedSafesModal modal={mockModal} />)
 
-    expect(screen.getByText('Select All')).toBeInTheDocument()
-    expect(screen.getByText('Deselect All')).toBeInTheDocument()
+    expect(screen.getByText('Select all')).toBeInTheDocument()
+    expect(screen.getByText('Deselect all')).toBeInTheDocument()
   })
 
-  it('should call selectAll when Select All clicked', () => {
+  it('should call selectAll when Select all clicked', () => {
     render(<TrustedSafesModal modal={mockModal} />)
 
-    fireEvent.click(screen.getByText('Select All'))
+    fireEvent.click(screen.getByText('Select all'))
 
     expect(mockModal.selectAll).toHaveBeenCalled()
   })
 
-  it('should call deselectAll when Deselect All clicked', () => {
+  it('should call deselectAll when Deselect all clicked', () => {
     render(<TrustedSafesModal modal={mockModal} />)
 
-    fireEvent.click(screen.getByText('Deselect All'))
+    fireEvent.click(screen.getByText('Deselect all'))
 
     expect(mockModal.deselectAll).toHaveBeenCalled()
   })
@@ -233,7 +233,8 @@ describe('TrustedSafesModal', () => {
   it('should show selection count', () => {
     render(<TrustedSafesModal modal={mockModal} />)
 
-    expect(screen.getByText('1 of 2 selected')).toBeInTheDocument()
+    // The count is split across spans (the number is emphasised), so match on combined text content.
+    expect(screen.getByText((_, el) => el?.textContent === '1 of 2 selected')).toBeInTheDocument()
   })
 
   it('should show select all confirmation dialog when pendingSelectAllConfirmation is true', () => {

--- a/apps/web/src/components/common/TrustedSafesModal/constants.ts
+++ b/apps/web/src/components/common/TrustedSafesModal/constants.ts
@@ -1,0 +1,3 @@
+/** Grid template for the Manage Trusted Safes modal rows — mirrors the SafesTable layout
+ *  (with a leading selection-checkbox column) so the modal feels consistent with the table. */
+export const MODAL_SAFE_GRID = 'grid grid-cols-[24px_minmax(0,1fr)_110px_120px_88px] items-center gap-3'

--- a/apps/web/src/components/common/TrustedSafesModal/index.tsx
+++ b/apps/web/src/components/common/TrustedSafesModal/index.tsx
@@ -1,8 +1,10 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Info } from 'lucide-react'
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group'
+import { Info, Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useIsQualifiedSafe } from '@/features/spaces'
+import useWallet from '@/hooks/wallets/useWallet'
+import useConnectWallet from '@/components/common/ConnectWallet/useConnectWallet'
 import SecurityBanner from './SecurityBanner'
 import TrustedSafesList from './TrustedSafesList'
 import SimilarityConfirmDialog from './SimilarityConfirmDialog'
@@ -40,6 +42,8 @@ const TrustedSafesModal = ({ modal }: TrustedSafesModalProps) => {
   } = modal
 
   const isInSpace = useIsQualifiedSafe()
+  const isConnected = Boolean(useWallet())
+  const connectWallet = useConnectWallet()
 
   const pendingItem = pendingConfirmation
     ? availableItems.find((s) => s.address.toLowerCase() === pendingConfirmation)
@@ -53,31 +57,71 @@ const TrustedSafesModal = ({ modal }: TrustedSafesModalProps) => {
             <DialogTitle className="font-bold">Manage trusted Safes</DialogTitle>
           </DialogHeader>
 
-          <div className="min-h-0 flex-1 overflow-y-auto px-6 pt-4">
+          <div className="min-h-0 flex-1 overflow-y-auto px-6 pt-5">
             <SecurityBanner title="Verify before you trust" />
 
+            {/* Lightweight contextual helpers — kept slim so they don't compete with the list. */}
             {isInSpace && (
-              <Alert className="mb-4 border-transparent bg-[var(--color-info-background)]" data-testid="space-notice">
-                <Info />
-                <AlertDescription className="text-current">
-                  Trusted Safes aren&apos;t added to this workspace automatically — add them separately.
-                </AlertDescription>
-              </Alert>
+              <p className="text-muted-foreground mb-4 flex items-start gap-1.5 text-xs" data-testid="space-notice">
+                <Info className="mt-0.5 size-3.5 shrink-0" />
+                <span>Trusted Safes aren&apos;t added to this workspace automatically — add them separately.</span>
+              </p>
             )}
 
-            <div className="mb-4 flex items-center justify-between">
-              <span className="text-sm text-muted-foreground">
-                {selectedCount} of {totalSafesCount} selected
-              </span>
-              <div className="flex gap-2">
-                <Button size="sm" variant="outline" onClick={selectAll} disabled={allSelected || isLoading}>
-                  Select All
-                </Button>
-                <Button size="sm" variant="outline" onClick={deselectAll} disabled={selectedCount === 0 || isLoading}>
-                  Deselect All
+            {!isConnected && (
+              <div
+                className="border-border bg-muted/40 mb-4 flex items-center justify-between gap-3 rounded-xl border px-4 py-2.5"
+                data-testid="trusted-connect-wallet"
+              >
+                <span className="text-muted-foreground text-sm">
+                  Connect your wallet to see and manage owned Safes.
+                </span>
+                <Button size="sm" variant="outline" onClick={connectWallet} data-testid="trusted-connect-wallet-button">
+                  Connect wallet
                 </Button>
               </div>
-            </div>
+            )}
+
+            {/* Toolbar: search + selection controls, aligned on one row above the list. Hidden when
+                there's nothing to search or select. */}
+            {(availableItems.length > 0 || Boolean(searchQuery)) && (
+              <div className="mb-4 flex flex-wrap items-center gap-x-4 gap-y-2">
+                <InputGroup className="border-border min-w-[220px] flex-1 rounded-md shadow-none">
+                  <InputGroupAddon>
+                    <Search className="size-4" />
+                  </InputGroupAddon>
+                  <InputGroupInput
+                    placeholder="Search by name or full address"
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    autoComplete="off"
+                    data-testid="trusted-safes-search"
+                  />
+                </InputGroup>
+                <div className="text-muted-foreground ml-auto flex items-center gap-3 text-sm">
+                  <span className="whitespace-nowrap">
+                    <span className="text-foreground font-medium">{selectedCount}</span> of {totalSafesCount} selected
+                  </span>
+                  <span className="bg-border h-4 w-px" aria-hidden />
+                  <button
+                    type="button"
+                    onClick={selectAll}
+                    disabled={allSelected || isLoading}
+                    className="text-primary hover:text-primary/80 cursor-pointer font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    Select all
+                  </button>
+                  <button
+                    type="button"
+                    onClick={deselectAll}
+                    disabled={selectedCount === 0 || isLoading}
+                    className="text-primary hover:text-primary/80 cursor-pointer font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    Deselect all
+                  </button>
+                </div>
+              </div>
+            )}
 
             <TrustedSafesList
               items={availableItems}
@@ -85,6 +129,7 @@ const TrustedSafesModal = ({ modal }: TrustedSafesModalProps) => {
               searchQuery={searchQuery}
               onSearchChange={setSearchQuery}
               onToggle={toggleSelection}
+              showSearchInput={false}
             />
           </div>
 

--- a/apps/web/src/features/myAccounts/components/SafesTable/MultiChainSafeTableRow.tsx
+++ b/apps/web/src/features/myAccounts/components/SafesTable/MultiChainSafeTableRow.tsx
@@ -1,0 +1,272 @@
+import { useEffect, useState } from 'react'
+import NextLink from 'next/link'
+import { Pencil, Plus } from 'lucide-react'
+import Identicon from '@/components/common/Identicon'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Button } from '@/components/ui/button'
+import AddressWithCopy from '@/components/common/AddressWithCopy'
+import Track from '@/components/common/Track'
+import { FiatBalance } from '@/features/spaces'
+import { AccountItem as BaseAccountItem } from '../AccountItem'
+import { AddNetworkButton } from '../AddNetworkButton'
+import { useMultiAccountItemData } from '../../hooks/useMultiAccountItemData'
+import { useSafeItemData } from '../../hooks/useSafeItemData'
+import { OVERVIEW_EVENTS, OVERVIEW_LABELS, trackEvent } from '@/services/analytics'
+import type { MultiChainSafeItem, SafeItem } from '@/hooks/safes'
+import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
+import { shortenAddress } from '@safe-global/utils/utils/formatters'
+import { Typography } from '@/components/ui/typography'
+import { Skeleton } from '@/components/ui/skeleton'
+import { cn } from '@/utils/cn'
+import { SAFE_TABLE_GRID } from './constants'
+import { ThresholdBadge } from './ThresholdBadge'
+
+const SubRow = ({
+  safeItem,
+  safeOverview,
+  onLinkClick,
+}: {
+  safeItem: SafeItem
+  safeOverview?: SafeOverview
+  onLinkClick?: () => void
+}) => {
+  const { chain, href, elementRef, trackingLabel, isCurrentSafe, undeployedSafe, isActivating, threshold, owners } =
+    useSafeItemData(safeItem, { safeOverview })
+
+  const hasQueuedItems =
+    !safeItem.isReadOnly &&
+    safeOverview &&
+    ((safeOverview.queued ?? 0) > 0 || (safeOverview.awaitingConfirmation ?? 0) > 0)
+
+  return (
+    <Track {...OVERVIEW_EVENTS.OPEN_SAFE} label={trackingLabel}>
+      <NextLink
+        ref={elementRef as React.Ref<HTMLAnchorElement>}
+        href={href}
+        onClick={onLinkClick}
+        className={cn(
+          SAFE_TABLE_GRID,
+          'border-muted hover:bg-muted/40 border-b px-4 py-2 transition-colors',
+          isCurrentSafe && 'bg-muted/40',
+        )}
+      >
+        {/* Account column — chain name, indented to sit under the parent name */}
+        <div className="flex min-w-0 items-center gap-2 pl-10">
+          <Typography variant="paragraph-small-medium" className="text-foreground truncate">
+            {chain?.chainName ?? shortenAddress(safeItem.address)}
+          </Typography>
+          <BaseAccountItem.StatusChip
+            isActivating={isActivating}
+            isReadOnly={false}
+            undeployedSafe={!!undeployedSafe}
+          />
+          {hasQueuedItems && (
+            <BaseAccountItem.QueueActions
+              safeAddress={safeOverview.address.value}
+              chainShortName={chain?.shortName || ''}
+              queued={safeOverview.queued ?? 0}
+              awaitingConfirmation={safeOverview.awaitingConfirmation ?? 0}
+            />
+          )}
+        </div>
+
+        {/* Chains column — the single chain logo */}
+        <div className="flex min-w-0 items-center">
+          <BaseAccountItem.ChainBadge chainId={safeItem.chainId} />
+        </div>
+
+        {/* Balance column */}
+        <div className="flex items-center justify-end">
+          {safeOverview || undeployedSafe ? (
+            <FiatBalance value={safeOverview?.fiatTotal} />
+          ) : (
+            <Skeleton className="h-4 w-16" />
+          )}
+        </div>
+
+        {/* Threshold column */}
+        <div className="flex items-center justify-end">
+          <ThresholdBadge threshold={threshold} owners={owners.length} />
+        </div>
+
+        <span />
+      </NextLink>
+    </Track>
+  )
+}
+
+type MultiChainSafeTableRowProps = {
+  multiSafeAccountItem: MultiChainSafeItem
+  onLinkClick?: () => void
+  isSpaceSafe?: boolean
+  selectable?: boolean
+  selected?: boolean
+  onToggleSelect?: () => void
+  onRename?: () => void
+  onAddToWorkspace?: () => void
+  onBalanceResolved?: (value: number | undefined) => void
+}
+
+const MultiChainSafeTableRow = ({
+  multiSafeAccountItem,
+  onLinkClick,
+  isSpaceSafe = false,
+  selectable = false,
+  selected = false,
+  onToggleSelect,
+  onRename,
+  onAddToWorkspace,
+  onBalanceResolved,
+}: MultiChainSafeTableRowProps) => {
+  const {
+    address,
+    name,
+    sortedSafes,
+    safeOverviews,
+    totalFiatValue,
+    hasReplayableSafe,
+    isCurrentSafe,
+    isReadOnly,
+    sharedSetup,
+    isWelcomePage,
+    isSpaceRoute,
+  } = useMultiAccountItemData(multiSafeAccountItem)
+
+  const [expanded, setExpanded] = useState(isCurrentSafe)
+
+  // Report the aggregated balance up so the table can sort by the same value it displays.
+  useEffect(() => {
+    onBalanceResolved?.(totalFiatValue)
+  }, [totalFiatValue, onBalanceResolved])
+
+  const trackingLabel = isWelcomePage ? OVERVIEW_LABELS.login_page : OVERVIEW_LABELS.sidebar
+  const displayName = multiSafeAccountItem.name || name || shortenAddress(address)
+
+  const toggleExpand = () =>
+    setExpanded((prev) => {
+      if (!prev && !isSpaceRoute) {
+        trackEvent({ ...OVERVIEW_EVENTS.EXPAND_MULTI_SAFE, label: trackingLabel })
+      }
+      return !prev
+    })
+
+  return (
+    <div
+      className={cn('border-muted border-b', isCurrentSafe && 'bg-muted/30', selected && 'bg-primary/5')}
+      data-testid="safe-list-item"
+    >
+      <button
+        type="button"
+        onClick={selectable ? () => onToggleSelect?.() : toggleExpand}
+        data-testid="multichain-item-summary"
+        className={cn(
+          SAFE_TABLE_GRID,
+          'group hover:bg-muted/40 w-full cursor-pointer px-4 py-2 text-left transition-colors',
+        )}
+      >
+        <div className="flex min-w-0 items-center gap-3">
+          {selectable && (
+            <Checkbox
+              checked={selected}
+              tabIndex={-1}
+              aria-hidden
+              className="pointer-events-none"
+              data-testid="select-safe-checkbox"
+            />
+          )}
+          <span className="inline-flex shrink-0">
+            <Identicon address={address} />
+          </span>
+          <div className="flex min-w-0 flex-col" data-testid="group-address">
+            <div className="flex items-center gap-1">
+              <Typography variant="paragraph-small-bold" className="text-foreground truncate">
+                {displayName}
+              </Typography>
+              {onRename && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    onRename()
+                  }}
+                  className="text-muted-foreground hover:text-foreground shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
+                  aria-label="Rename Safe"
+                  data-testid="rename-safe-btn"
+                >
+                  <Pencil className="size-3.5" />
+                </button>
+              )}
+            </div>
+            <span onClick={(e) => e.stopPropagation()}>
+              <AddressWithCopy address={address} full />
+            </span>
+          </div>
+        </div>
+
+        <div className="flex min-w-0 items-center">
+          <BaseAccountItem.ChainBadge safes={sortedSafes} />
+        </div>
+
+        <div className="flex items-center justify-end" data-testid="group-balance">
+          <FiatBalance value={totalFiatValue?.toString()} />
+        </div>
+
+        <div className="flex items-center justify-end">
+          {sharedSetup ? <ThresholdBadge threshold={sharedSetup.threshold} owners={sharedSetup.owners.length} /> : null}
+        </div>
+
+        {!isSpaceSafe && onAddToWorkspace ? (
+          <div className="flex items-center justify-end" onClick={(e) => e.stopPropagation()}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                onAddToWorkspace()
+              }}
+              data-testid="add-to-workspace-btn"
+            >
+              <Plus className="size-3.5" />
+              Add to Workspace
+            </Button>
+          </div>
+        ) : (
+          <span />
+        )}
+      </button>
+
+      {expanded && (
+        <div data-testid="subacounts-container" className="bg-muted/20">
+          {sortedSafes.map((safeItem) => {
+            const overview = safeOverviews?.find(
+              (o) => o.chainId === safeItem.chainId && sameAddress(o.address.value, safeItem.address),
+            )
+            return (
+              <SubRow
+                key={`${safeItem.chainId}:${safeItem.address}`}
+                safeItem={safeItem}
+                safeOverview={overview}
+                onLinkClick={onLinkClick}
+              />
+            )
+          })}
+
+          {!isReadOnly && hasReplayableSafe && !isSpaceSafe && (
+            <div className="flex items-center justify-center px-4 py-2">
+              <AddNetworkButton
+                currentName={multiSafeAccountItem.name ?? ''}
+                safeAddress={address}
+                deployedChains={sortedSafes.map((s) => s.chainId)}
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default MultiChainSafeTableRow

--- a/apps/web/src/features/myAccounts/components/SafesTable/SafeTableHeader.tsx
+++ b/apps/web/src/features/myAccounts/components/SafesTable/SafeTableHeader.tsx
@@ -1,0 +1,47 @@
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward'
+import type { SafeListSortColumn, SafeListSortDirection } from '@/hooks/safes'
+import { cn } from '@/utils/cn'
+import { SAFE_TABLE_GRID } from './constants'
+
+type SafeTableHeaderProps = {
+  column: SafeListSortColumn
+  direction: SafeListSortDirection
+  onSort: (column: SafeListSortColumn) => void
+}
+
+const SortIcon = ({ active, direction }: { active: boolean; direction: SafeListSortDirection }) => {
+  if (!active) return null
+  const Icon = direction === 'asc' ? ArrowUpwardIcon : ArrowDownwardIcon
+  return <Icon sx={{ fontSize: 14 }} />
+}
+
+const labelCls = 'text-muted-foreground text-xs font-semibold uppercase tracking-wide'
+
+const SafeTableHeader = ({ column, direction, onSort }: SafeTableHeaderProps) => (
+  <div className={cn(SAFE_TABLE_GRID, 'bg-card border-border sticky top-0 z-10 border-b px-4 py-2.5')}>
+    <button
+      type="button"
+      onClick={() => onSort('name')}
+      className={cn(labelCls, 'hover:text-foreground flex items-center gap-1')}
+      data-testid="sort-by-name"
+    >
+      Account
+      <SortIcon active={column === 'name'} direction={direction} />
+    </button>
+    <span className={labelCls}>Chains</span>
+    <button
+      type="button"
+      onClick={() => onSort('balance')}
+      className={cn(labelCls, 'hover:text-foreground flex items-center justify-end gap-1')}
+      data-testid="sort-by-balance"
+    >
+      Balance
+      <SortIcon active={column === 'balance'} direction={direction} />
+    </button>
+    <span className={cn(labelCls, 'text-right')}>Threshold</span>
+    <span />
+  </div>
+)
+
+export default SafeTableHeader

--- a/apps/web/src/features/myAccounts/components/SafesTable/SafeTableRow.tsx
+++ b/apps/web/src/features/myAccounts/components/SafesTable/SafeTableRow.tsx
@@ -1,0 +1,209 @@
+import { useEffect } from 'react'
+import NextLink from 'next/link'
+import { Pencil, Plus } from 'lucide-react'
+import Identicon from '@/components/common/Identicon'
+import { Button } from '@/components/ui/button'
+import AddressWithCopy from '@/components/common/AddressWithCopy'
+import Track from '@/components/common/Track'
+import { FiatBalance } from '@/features/spaces'
+import { AccountItem as BaseAccountItem } from '../AccountItem'
+import { useSafeItemData } from '../../hooks/useSafeItemData'
+import { OVERVIEW_EVENTS } from '@/services/analytics'
+import type { SafeItem } from '@/hooks/safes'
+import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { shortenAddress } from '@safe-global/utils/utils/formatters'
+import { Typography } from '@/components/ui/typography'
+import { Checkbox } from '@/components/ui/checkbox'
+import { cn } from '@/utils/cn'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { SAFE_TABLE_GRID } from './constants'
+import { ThresholdBadge } from './ThresholdBadge'
+
+type SafeTableRowProps = {
+  safeItem: SafeItem
+  safeOverview?: SafeOverview
+  onLinkClick?: () => void
+  isSpaceSafe?: boolean
+  selectable?: boolean
+  selected?: boolean
+  onToggleSelect?: () => void
+  onRename?: () => void
+  onAddToWorkspace?: () => void
+  onBalanceResolved?: (value: number | undefined) => void
+}
+
+const SafeTableRow = ({
+  safeItem,
+  safeOverview: provided,
+  onLinkClick,
+  isSpaceSafe = false,
+  selectable = false,
+  selected = false,
+  onToggleSelect,
+  onRename,
+  onAddToWorkspace,
+  onBalanceResolved,
+}: SafeTableRowProps) => {
+  const {
+    chain,
+    name,
+    href,
+    safeOverview,
+    isCurrentSafe,
+    threshold,
+    owners,
+    undeployedSafe,
+    elementRef,
+    trackingLabel,
+  } = useSafeItemData(safeItem, { safeOverview: provided, isSpaceSafe })
+
+  const displayName = (isSpaceSafe ? safeItem.name : name) || shortenAddress(safeItem.address)
+
+  const hasQueuedItems =
+    !safeItem.isReadOnly &&
+    safeOverview &&
+    ((safeOverview.queued ?? 0) > 0 || (safeOverview.awaitingConfirmation ?? 0) > 0)
+
+  // Report the resolved balance up so the table can sort by the same value it displays.
+  useEffect(() => {
+    onBalanceResolved?.(safeOverview ? Number(safeOverview.fiatTotal) : undefined)
+  }, [safeOverview, onBalanceResolved])
+
+  // Read-only chip intentionally omitted; undeployed safes are conveyed by greying the row + a
+  // hover hint (rather than a "Not activated" chip that adds a second line and row height).
+  const rowClass = cn(
+    SAFE_TABLE_GRID,
+    'group border-muted hover:bg-muted/40 border-b px-4 py-2 transition-colors',
+    isCurrentSafe && 'bg-muted/30',
+    selected && 'bg-primary/5',
+    undeployedSafe && 'opacity-60',
+  )
+
+  const cells = (
+    <>
+      <div className="flex min-w-0 items-center gap-3">
+        {selectable && (
+          <Checkbox
+            checked={selected}
+            tabIndex={-1}
+            aria-hidden
+            className="pointer-events-none"
+            data-testid="select-safe-checkbox"
+          />
+        )}
+        <span className="inline-flex shrink-0">
+          <Identicon address={safeItem.address} />
+        </span>
+        <div className="flex min-w-0 flex-col">
+          <div className="flex items-center gap-1">
+            <Typography variant="paragraph-small-bold" className="text-foreground truncate">
+              {displayName}
+            </Typography>
+            {onRename && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  onRename()
+                }}
+                className="text-muted-foreground hover:text-foreground shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
+                aria-label="Rename Safe"
+                data-testid="rename-safe-btn"
+              >
+                <Pencil className="size-3.5" />
+              </button>
+            )}
+          </div>
+          <AddressWithCopy address={safeItem.address} full />
+          {hasQueuedItems && (
+            <div className="mt-1 flex flex-wrap items-center gap-1">
+              <BaseAccountItem.QueueActions
+                safeAddress={safeOverview.address.value}
+                chainShortName={chain?.shortName || ''}
+                queued={safeOverview.queued ?? 0}
+                awaitingConfirmation={safeOverview.awaitingConfirmation ?? 0}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex min-w-0 items-center">
+        <BaseAccountItem.ChainBadge chainId={safeItem.chainId} />
+      </div>
+
+      <div className="flex items-center justify-end">
+        <FiatBalance value={safeOverview?.fiatTotal} />
+      </div>
+
+      <div className="flex items-center justify-end">
+        <ThresholdBadge threshold={threshold} owners={owners.length} />
+      </div>
+
+      {!isSpaceSafe && onAddToWorkspace ? (
+        <div className="flex items-center justify-end" onClick={(e) => e.stopPropagation()}>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              onAddToWorkspace()
+            }}
+            data-testid="add-to-workspace-btn"
+          >
+            <Plus className="size-3.5" />
+            Add to Workspace
+          </Button>
+        </div>
+      ) : (
+        <span />
+      )}
+    </>
+  )
+
+  // Undeployed safes get a fast app tooltip (the native `title` attribute has a ~1s browser delay).
+  const withDeployTooltip = (node: React.ReactElement) =>
+    undeployedSafe ? (
+      <Tooltip>
+        <TooltipTrigger render={node} />
+        <TooltipContent>Safe not deployed</TooltipContent>
+      </Tooltip>
+    ) : (
+      node
+    )
+
+  // In manage mode the row selects instead of navigating.
+  if (selectable) {
+    return withDeployTooltip(
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => onToggleSelect?.()}
+        className={cn(rowClass, 'cursor-pointer text-left')}
+        data-testid="safe-list-item"
+      >
+        {cells}
+      </div>,
+    )
+  }
+
+  return (
+    <Track {...OVERVIEW_EVENTS.OPEN_SAFE} label={trackingLabel}>
+      {withDeployTooltip(
+        <NextLink
+          ref={elementRef as React.Ref<HTMLAnchorElement>}
+          href={href}
+          onClick={onLinkClick}
+          data-testid="safe-list-item"
+          className={rowClass}
+        >
+          {cells}
+        </NextLink>,
+      )}
+    </Track>
+  )
+}
+
+export default SafeTableRow

--- a/apps/web/src/features/myAccounts/components/SafesTable/ThresholdBadge.tsx
+++ b/apps/web/src/features/myAccounts/components/SafesTable/ThresholdBadge.tsx
@@ -1,0 +1,12 @@
+import PeopleIcon from '@mui/icons-material/PeopleAltOutlined'
+
+export const ThresholdBadge = ({ threshold, owners }: { threshold: number; owners: number }) => {
+  if (!owners) return null
+
+  return (
+    <span className="bg-muted text-muted-foreground inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium">
+      <PeopleIcon sx={{ fontSize: 12 }} />
+      {threshold}/{owners}
+    </span>
+  )
+}

--- a/apps/web/src/features/myAccounts/components/SafesTable/constants.ts
+++ b/apps/web/src/features/myAccounts/components/SafesTable/constants.ts
@@ -1,0 +1,2 @@
+/** Shared grid template so the header and every row column align. */
+export const SAFE_TABLE_GRID = 'grid grid-cols-[minmax(0,1fr)_110px_130px_96px_180px] items-center gap-4'

--- a/apps/web/src/features/myAccounts/components/SafesTable/index.test.tsx
+++ b/apps/web/src/features/myAccounts/components/SafesTable/index.test.tsx
@@ -1,0 +1,72 @@
+import { render } from '@/tests/test-utils'
+import { screen, within, fireEvent } from '@testing-library/react'
+import SafesTable from './index'
+import { useAllSafesGrouped, useSafesSearch, type SafeItem } from '@/hooks/safes'
+
+// Render rows as simple markers so we can assert grouping without the heavy data hooks.
+jest.mock('./SafeTableRow', () => ({
+  __esModule: true,
+  default: ({ safeItem }: { safeItem: SafeItem }) => <div data-testid="row">{safeItem.name ?? safeItem.address}</div>,
+}))
+jest.mock('./MultiChainSafeTableRow', () => ({
+  __esModule: true,
+  default: ({ multiSafeAccountItem }: { multiSafeAccountItem: { name?: string; address: string } }) => (
+    <div data-testid="row">{multiSafeAccountItem.name ?? multiSafeAccountItem.address}</div>
+  ),
+}))
+
+jest.mock('@/hooks/safes', () => {
+  const actual = jest.requireActual('@/hooks/safes')
+  return { ...actual, useAllSafesGrouped: jest.fn(), useSafesSearch: jest.fn() }
+})
+jest.mock('@/components/common/TrustedSafesModal', () => ({ __esModule: true, default: () => null }))
+jest.mock('../MigrationPrompt', () => ({ __esModule: true, default: () => null }))
+jest.mock('@/components/common/TrustedSafesModal/useTrustedSafesModal', () => ({
+  __esModule: true,
+  default: () => ({ open: jest.fn() }),
+}))
+jest.mock('../../hooks/useMigrationPrompt', () => ({
+  __esModule: true,
+  default: () => ({ shouldShowPrompt: false, hasPinnedSafes: true }),
+}))
+
+jest.mock('@/hooks/wallets/useWallet', () => ({
+  __esModule: true,
+  default: () => ({ address: '0x1234567890123456789012345678901234567890' }),
+}))
+
+const mockedGrouped = useAllSafesGrouped as jest.Mock
+const mockedSearch = useSafesSearch as jest.Mock
+
+const safe = (overrides: Partial<SafeItem> = {}): SafeItem => ({
+  chainId: '1',
+  address: '0x0',
+  isReadOnly: true,
+  isPinned: false,
+  lastVisited: 0,
+  name: undefined,
+  ...overrides,
+})
+
+describe('SafesTable', () => {
+  beforeEach(() => {
+    mockedSearch.mockReturnValue([])
+    mockedGrouped.mockReturnValue({ allMultiChainSafes: [], allSingleSafes: [] })
+  })
+
+  it('shows workspace safes in the Workspace tab and trusted safes under the Local tab', () => {
+    mockedGrouped.mockReturnValue({
+      allMultiChainSafes: [],
+      allSingleSafes: [safe({ address: '0xtrust', name: 'TrustedSafe', isPinned: true })],
+    })
+
+    render(<SafesTable workspaceSafes={[safe({ address: '0xws', name: 'WorkspaceSafe', isReadOnly: false })]} />)
+
+    // Workspace tab is the default
+    expect(within(screen.getByTestId('workspace-safes-section')).getByText('WorkspaceSafe')).toBeInTheDocument()
+
+    // Trusted safes live under the Local tab
+    fireEvent.click(screen.getByTestId('local-safes-tab'))
+    expect(within(screen.getByTestId('trusted-safes-section')).getByText('TrustedSafe')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/myAccounts/components/SafesTable/index.tsx
+++ b/apps/web/src/features/myAccounts/components/SafesTable/index.tsx
@@ -1,0 +1,402 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { Search, Settings2, ShieldCheck, Trash2, TriangleAlert } from 'lucide-react'
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group'
+import { getFlaggedSimilarAddressSet } from '@safe-global/utils/utils/addressSimilarity'
+import useWallet from '@/hooks/wallets/useWallet'
+import {
+  type AllSafeItems,
+  type SafeItem,
+  type MultiChainSafeItem,
+  type SafeListSortColumn,
+  type SafeListSortDirection,
+  getSafeListComparator,
+  isMultiChainSafeItem,
+  useAllSafesGrouped,
+  useSafesSearch,
+} from '@/hooks/safes'
+import { Typography } from '@/components/ui/typography'
+import { Button } from '@/components/ui/button'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import ConnectWalletPrompt from '../ConnectWalletPrompt'
+import MigrationPrompt from '../MigrationPrompt'
+import TrustedSafesModal from '@/components/common/TrustedSafesModal'
+import useTrustedSafesModal from '@/components/common/TrustedSafesModal/useTrustedSafesModal'
+import useMigrationPrompt from '../../hooks/useMigrationPrompt'
+import { buildAddressSet, groupSafesByPrecedence } from '../../utils/groupSafes'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import EntryDialog from '@/components/address-book/EntryDialog'
+import SafeTableHeader from './SafeTableHeader'
+import SafeTableRow from './SafeTableRow'
+import MultiChainSafeTableRow from './MultiChainSafeTableRow'
+
+const getChainIds = (item: SafeItem | MultiChainSafeItem): string[] =>
+  isMultiChainSafeItem(item) ? item.safes.map((s) => s.chainId) : [item.chainId]
+
+type SafeTab = 'workspace' | 'local'
+
+/** Stable per-row key used to track each row's reported balance. */
+const itemKey = (item: SafeItem | MultiChainSafeItem): string =>
+  isMultiChainSafeItem(item) ? item.address.toLowerCase() : `${item.chainId}:${item.address}`.toLowerCase()
+
+type SafesTableProps = {
+  /** Safes belonging to the current workspace (passed in so this component doesn't import the spaces feature). */
+  workspaceSafes?: AllSafeItems
+  /** When true, workspace rows become multi-selectable for bulk removal. */
+  manageMode?: boolean
+  /** Called with the selected workspace safes when the user confirms removal. */
+  onRemoveFromWorkspace?: (items: AllSafeItems) => void
+  /** When true (admin), local rows show an "Add to Workspace" action. */
+  canAddToWorkspace?: boolean
+  /** Adds a single local safe (all its chains) to the current workspace. */
+  onAddToWorkspace?: (item: SafeItem | MultiChainSafeItem) => void
+  /**
+   * Page-level action buttons rendered on the row beneath the tabs, alongside the search.
+   * May be a render function receiving the active tab + a tab setter so callers can vary the
+   * buttons per tab and switch tabs (e.g. jump to the Local tab).
+   */
+  headerActions?: ReactNode | ((tab: SafeTab, setTab: (tab: SafeTab) => void) => ReactNode)
+  onLinkClick?: () => void
+}
+
+const TrustedSafesHeader = ({ onManage }: { onManage: () => void }) => (
+  <div className="bg-muted/30 border-muted flex items-center gap-2 border-b px-4 py-2.5">
+    <Tooltip>
+      <TooltipTrigger render={<div className="flex w-fit cursor-help items-center gap-1.5" />}>
+        <ShieldCheck className="size-4 text-green-600" />
+        <Typography variant="paragraph-small-bold" color="muted">
+          Trusted Safes
+        </Typography>
+      </TooltipTrigger>
+      <TooltipContent>Verified Safe accounts you selected</TooltipContent>
+    </Tooltip>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            aria-label="Manage trusted Safes"
+            data-testid="add-more-safes-button"
+            onClick={onManage}
+            className="text-muted-foreground hover:text-foreground hover:bg-muted inline-flex size-7 cursor-pointer items-center justify-center rounded-md transition-colors"
+          />
+        }
+      >
+        <Settings2 className="size-4" />
+      </TooltipTrigger>
+      <TooltipContent>Manage trusted Safes</TooltipContent>
+    </Tooltip>
+  </div>
+)
+
+const EmptyRow = ({ children }: { children: ReactNode }) => (
+  <Typography variant="paragraph-small" color="muted" align="center" className="py-4">
+    {children}
+  </Typography>
+)
+
+const TableShell = ({
+  column,
+  direction,
+  onSort,
+  children,
+}: {
+  column: SafeListSortColumn
+  direction: SafeListSortDirection
+  onSort: (column: SafeListSortColumn) => void
+  children: ReactNode
+}) => (
+  <div className="bg-card border-border overflow-hidden rounded-2xl border">
+    <SafeTableHeader column={column} direction={direction} onSort={onSort} />
+    <div className="max-h-[640px] overflow-y-auto">{children}</div>
+  </div>
+)
+
+const SafesTable = ({
+  workspaceSafes = [],
+  manageMode = false,
+  onRemoveFromWorkspace,
+  canAddToWorkspace = false,
+  onAddToWorkspace,
+  headerActions,
+  onLinkClick,
+}: SafesTableProps) => {
+  const wallet = useWallet()
+  const isConnected = Boolean(wallet)
+
+  // Page-scoped search lives on the actions row beneath the tabs (matches the Address book).
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const modal = useTrustedSafesModal()
+  const migration = useMigrationPrompt()
+
+  // Workspace (current Space) safes form the top group and are excluded from the others.
+  const workspaceAddresses = useMemo(() => buildAddressSet(workspaceSafes), [workspaceSafes])
+
+  // The complete personal list (pinned + owned + undeployed + watched), grouped multi/single.
+  const grouped = useAllSafesGrouped()
+  const globalSafes = useMemo<AllSafeItems>(
+    () => [...(grouped.allMultiChainSafes ?? []), ...(grouped.allSingleSafes ?? [])],
+    [grouped.allMultiChainSafes, grouped.allSingleSafes],
+  )
+
+  const { trusted, owned, local } = useMemo(
+    () => groupSafesByPrecedence(globalSafes, workspaceAddresses, isConnected),
+    [globalSafes, workspaceAddresses, isConnected],
+  )
+
+  const allItems = useMemo<AllSafeItems>(
+    () => [...workspaceSafes, ...trusted, ...owned, ...local],
+    [workspaceSafes, trusted, owned, local],
+  )
+
+  // Each row reports the balance it actually displays; we sort on that so the order always
+  // matches what the user sees (keyed by the row's stable itemKey).
+  const [balances, setBalances] = useState<Record<string, number>>({})
+  const reportBalance = useCallback(
+    (key: string) => (value: number | undefined) =>
+      setBalances((prev) => (value === undefined || prev[key] === value ? prev : { ...prev, [key]: value })),
+    [],
+  )
+
+  const [sort, setSort] = useState<{ column: SafeListSortColumn; direction: SafeListSortDirection }>({
+    column: 'name',
+    direction: 'asc',
+  })
+  const comparator = useMemo(() => {
+    if (sort.column === 'balance') {
+      return (a: SafeItem | MultiChainSafeItem, b: SafeItem | MultiChainSafeItem) => {
+        const diff = (balances[itemKey(a)] ?? 0) - (balances[itemKey(b)] ?? 0)
+        return sort.direction === 'desc' ? -diff : diff
+      }
+    }
+    return getSafeListComparator(sort.column, sort.direction)
+  }, [sort, balances])
+  const toggleSort = (column: SafeListSortColumn) =>
+    setSort((prev) =>
+      prev.column === column
+        ? { column, direction: prev.direction === 'asc' ? 'desc' : 'asc' }
+        : { column, direction: column === 'balance' ? 'desc' : 'asc' },
+    )
+
+  const sortedWorkspace = useMemo(() => [...workspaceSafes].sort(comparator), [workspaceSafes, comparator])
+  const sortedTrusted = useMemo(() => [...trusted].sort(comparator), [trusted, comparator])
+
+  // "Local" tab lists only your Trusted (pinned) safes — owned/other are managed via the modal.
+  const localCount = trusted.length
+
+  // Search filters within each tab independently.
+  const filteredWorkspace = useSafesSearch(workspaceSafes, searchQuery)
+  const filteredLocal = useSafesSearch(trusted, searchQuery)
+  const sortedFilteredWorkspace = useMemo(
+    () => [...filteredWorkspace].sort(comparator),
+    [filteredWorkspace, comparator],
+  )
+  const sortedFilteredLocal = useMemo(() => [...filteredLocal].sort(comparator), [filteredLocal, comparator])
+
+  const [tab, setTab] = useState<SafeTab>('workspace')
+
+  // Risky look-alike addresses are hidden by default and only shown on demand.
+  const flaggedSet = useMemo(() => getFlaggedSimilarAddressSet(allItems.map((item) => item.address)), [allItems])
+  const isFlagged = (item: SafeItem | MultiChainSafeItem) => flaggedSet.has(item.address.toLowerCase())
+  const [showFlagged, setShowFlagged] = useState(false)
+
+  // Inline rename target (opens EntryDialog across all the safe's chains).
+  const [renameTarget, setRenameTarget] = useState<SafeItem | MultiChainSafeItem | null>(null)
+
+  // Multi-select state for manage mode (keyed by lowercased address).
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  useEffect(() => {
+    if (!manageMode) setSelected(new Set())
+  }, [manageMode])
+
+  const toggleSelect = (address: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev)
+      const key = address.toLowerCase()
+      next.has(key) ? next.delete(key) : next.add(key)
+      return next
+    })
+
+  const handleRemoveSelected = () => {
+    const items = sortedWorkspace.filter((item) => selected.has(item.address.toLowerCase()))
+    if (items.length === 0) return
+    onRemoveFromWorkspace?.(items)
+    setSelected(new Set())
+  }
+
+  const renderRow = (item: SafeItem | MultiChainSafeItem, { isSpaceSafe }: { isSpaceSafe: boolean }) => {
+    const selectable = isSpaceSafe && manageMode
+    const isSelected = selected.has(item.address.toLowerCase())
+    const onRename = () => setRenameTarget(item)
+    // "Add to Workspace" only applies to local (non-workspace) safes, admin-gated.
+    const onAdd = !isSpaceSafe && canAddToWorkspace && onAddToWorkspace ? () => onAddToWorkspace(item) : undefined
+    const onBalanceResolved = reportBalance(itemKey(item))
+
+    return isMultiChainSafeItem(item) ? (
+      <MultiChainSafeTableRow
+        key={item.address}
+        multiSafeAccountItem={item}
+        onLinkClick={onLinkClick}
+        isSpaceSafe={isSpaceSafe}
+        selectable={selectable}
+        selected={isSelected}
+        onToggleSelect={() => toggleSelect(item.address)}
+        onRename={onRename}
+        onAddToWorkspace={onAdd}
+        onBalanceResolved={onBalanceResolved}
+      />
+    ) : (
+      <SafeTableRow
+        key={`${item.chainId}:${item.address}`}
+        safeItem={item}
+        onLinkClick={onLinkClick}
+        isSpaceSafe={isSpaceSafe}
+        selectable={selectable}
+        selected={isSelected}
+        onToggleSelect={() => toggleSelect(item.address)}
+        onRename={onRename}
+        onAddToWorkspace={onAdd}
+        onBalanceResolved={onBalanceResolved}
+      />
+    )
+  }
+
+  const renderFlaggedSection = (items: AllSafeItems, isSpaceSafe: boolean) => {
+    if (items.length === 0) return null
+    const plural = items.length === 1 ? '' : 's'
+    return (
+      <section data-testid="flagged-safes-section">
+        <button
+          type="button"
+          onClick={() => setShowFlagged((prev) => !prev)}
+          className="border-muted hover:bg-muted/40 flex w-full items-center gap-2 border-b px-4 py-2 text-left text-sm font-medium text-amber-700 transition-colors"
+          data-testid="toggle-flagged-safes"
+        >
+          <TriangleAlert className="size-4 shrink-0" />
+          {items.length} Safe{plural} hidden — flagged as possible look-alike{plural}
+          <span className="text-muted-foreground ml-auto font-normal">{showFlagged ? 'Hide' : 'Show'}</span>
+        </button>
+        {showFlagged && items.map((item) => renderRow(item, { isSpaceSafe }))}
+      </section>
+    )
+  }
+
+  // Nothing to show and no wallet — guide the user to connect.
+  if (!isConnected && allItems.length === 0) {
+    return <ConnectWalletPrompt />
+  }
+
+  // Search shows raw matches; otherwise flagged look-alikes are pulled out into a hidden group.
+  const workspaceRows = searchQuery ? sortedFilteredWorkspace : sortedWorkspace
+  const workspaceVisible = searchQuery ? workspaceRows : workspaceRows.filter((i) => !isFlagged(i))
+  const workspaceFlagged = searchQuery ? [] : workspaceRows.filter(isFlagged)
+  const trustedRows = searchQuery ? sortedFilteredLocal : sortedTrusted
+  const trustedVisible = searchQuery ? trustedRows : trustedRows.filter((i) => !isFlagged(i))
+  const trustedFlagged = searchQuery ? [] : trustedRows.filter(isFlagged)
+
+  return (
+    <>
+      {migration.shouldShowPrompt && <MigrationPrompt onProceed={modal.open} />}
+
+      <Tabs value={tab} onValueChange={(value) => setTab(value as 'workspace' | 'local')}>
+        {/* Tabs on top — like the Address book. */}
+        <TabsList variant="line" className="mb-4">
+          <TabsTrigger value="workspace" className="cursor-pointer" data-testid="workspace-safes-tab">
+            Workspace Safe accounts ({sortedWorkspace.length})
+          </TabsTrigger>
+          <TabsTrigger value="local" className="cursor-pointer" data-testid="local-safes-tab">
+            Local Safe accounts ({localCount})
+          </TabsTrigger>
+        </TabsList>
+
+        {/* Buttons + search on the row beneath the tabs. */}
+        <div className="mb-4 flex flex-wrap items-center gap-3">
+          {typeof headerActions === 'function' ? headerActions(tab, setTab) : headerActions}
+          <div className="w-full max-w-xs">
+            <InputGroup className="bg-card rounded-lg px-3">
+              <InputGroupAddon align="inline-start">
+                <Search />
+              </InputGroupAddon>
+              <InputGroupInput
+                id="safe-accounts-search"
+                placeholder="Search this page"
+                aria-label="Search Safe accounts on this page"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+            </InputGroup>
+          </div>
+        </div>
+
+        <TabsContent value="workspace">
+          {manageMode && (
+            <div
+              className="border-border bg-muted/40 mb-3 flex items-center justify-between gap-3 rounded-lg border px-4 py-2"
+              data-testid="workspace-manage-bar"
+            >
+              <Typography variant="paragraph-small" color="muted">
+                {selected.size} selected
+              </Typography>
+              <div className="flex items-center gap-2">
+                {selected.size > 0 && (
+                  <Button variant="ghost" size="sm" onClick={() => setSelected(new Set())}>
+                    Clear
+                  </Button>
+                )}
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  disabled={selected.size === 0}
+                  onClick={handleRemoveSelected}
+                  data-testid="remove-from-workspace-btn"
+                >
+                  <Trash2 className="size-4" />
+                  Remove from workspace ({selected.size})
+                </Button>
+              </div>
+            </div>
+          )}
+          <TableShell column={sort.column} direction={sort.direction} onSort={toggleSort}>
+            <section data-testid="workspace-safes-section">
+              {workspaceVisible.length > 0 ? (
+                workspaceVisible.map((item) => renderRow(item, { isSpaceSafe: true }))
+              ) : workspaceFlagged.length === 0 ? (
+                <EmptyRow>{searchQuery ? 'No results' : 'No Safes in this workspace yet'}</EmptyRow>
+              ) : null}
+            </section>
+            {renderFlaggedSection(workspaceFlagged, true)}
+          </TableShell>
+        </TabsContent>
+
+        <TabsContent value="local">
+          <TableShell column={sort.column} direction={sort.direction} onSort={toggleSort}>
+            <section data-testid="trusted-safes-section">
+              <TrustedSafesHeader onManage={modal.open} />
+              {trustedVisible.length > 0 ? (
+                trustedVisible.map((item) => renderRow(item, { isSpaceSafe: false }))
+              ) : trustedFlagged.length === 0 ? (
+                <EmptyRow>
+                  {searchQuery ? 'No results' : 'No trusted Safes yet — use “Manage trusted Safes” to add some.'}
+                </EmptyRow>
+              ) : null}
+            </section>
+            {renderFlaggedSection(trustedFlagged, false)}
+          </TableShell>
+        </TabsContent>
+      </Tabs>
+
+      <TrustedSafesModal modal={modal} />
+
+      {renameTarget && (
+        <EntryDialog
+          handleClose={() => setRenameTarget(null)}
+          defaultValues={{ name: renameTarget.name ?? '', address: renameTarget.address }}
+          chainIds={getChainIds(renameTarget)}
+          disableAddressInput
+        />
+      )}
+    </>
+  )
+}
+
+export default SafesTable

--- a/apps/web/src/features/myAccounts/contract.ts
+++ b/apps/web/src/features/myAccounts/contract.ts
@@ -28,6 +28,7 @@ import type SafesList from './components/SafesList'
 import type AccountsNavigation from './components/AccountsNavigation'
 import type MyAccounts from './components/MyAccounts'
 import type MyAccountsV2 from './components/MyAccountsV2'
+import type SafesTable from './components/SafesTable'
 import type NonPinnedWarning from './components/NonPinnedWarning'
 import type AccountsWidget from './components/AccountsWidget/AccountsWidget'
 
@@ -35,6 +36,7 @@ export interface MyAccountsContract {
   // Main component
   MyAccounts: typeof MyAccounts
   MyAccountsV2: typeof MyAccountsV2
+  SafesTable: typeof SafesTable
 
   // Externally used components (PascalCase → stub renders null)
   AccountItemButton: typeof AccountItemButton

--- a/apps/web/src/features/myAccounts/feature.ts
+++ b/apps/web/src/features/myAccounts/feature.ts
@@ -13,6 +13,7 @@ import type { MyAccountsContract } from './contract'
 // Direct component imports (already lazy-loaded at feature level)
 import MyAccounts from './components/MyAccounts'
 import MyAccountsV2 from './components/MyAccountsV2'
+import SafesTable from './components/SafesTable'
 import AccountItemButton from './components/AccountItem/AccountItemButton'
 import AccountItemLink from './components/AccountItem/AccountItemLink'
 import AccountItemCheckbox from './components/AccountItem/AccountItemCheckbox'
@@ -36,6 +37,7 @@ const feature: MyAccountsContract = {
   // Main component
   MyAccounts,
   MyAccountsV2,
+  SafesTable,
 
   // Externally used components (individual exports to avoid compound component issues)
   AccountItemButton,

--- a/apps/web/src/features/myAccounts/utils/groupSafes.test.ts
+++ b/apps/web/src/features/myAccounts/utils/groupSafes.test.ts
@@ -1,0 +1,120 @@
+import type { MultiChainSafeItem, SafeItem } from '@/hooks/safes'
+import { buildAddressSet, groupSafesByPrecedence } from './groupSafes'
+
+const makeSafe = (overrides: Partial<SafeItem> = {}): SafeItem => ({
+  chainId: '1',
+  address: '0x0000000000000000000000000000000000000001',
+  isReadOnly: true,
+  isPinned: false,
+  lastVisited: 0,
+  name: undefined,
+  ...overrides,
+})
+
+const makeMulti = (
+  address: string,
+  safes: SafeItem[],
+  overrides: Partial<MultiChainSafeItem> = {},
+): MultiChainSafeItem => ({
+  address,
+  safes,
+  isPinned: safes.some((s) => s.isPinned),
+  lastVisited: 0,
+  name: undefined,
+  ...overrides,
+})
+
+describe('groupSafesByPrecedence', () => {
+  it('puts pinned safes in trusted', () => {
+    const pinned = makeSafe({ address: '0xAAA', isPinned: true })
+    const { trusted, owned, local } = groupSafesByPrecedence([pinned], new Set(), true)
+
+    expect(trusted).toEqual([pinned])
+    expect(owned).toHaveLength(0)
+    expect(local).toHaveLength(0)
+  })
+
+  it('puts owned (non-readonly) safes in owned when connected', () => {
+    const ownedSafe = makeSafe({ address: '0xBBB', isReadOnly: false })
+    const { trusted, owned, local } = groupSafesByPrecedence([ownedSafe], new Set(), true)
+
+    expect(owned).toEqual([ownedSafe])
+    expect(trusted).toHaveLength(0)
+    expect(local).toHaveLength(0)
+  })
+
+  it('does not populate owned when wallet is disconnected', () => {
+    const ownedSafe = makeSafe({ address: '0xBBB', isReadOnly: false })
+    const { owned, local } = groupSafesByPrecedence([ownedSafe], new Set(), false)
+
+    expect(owned).toHaveLength(0)
+    expect(local).toEqual([ownedSafe])
+  })
+
+  it('puts everything else in local storage', () => {
+    const watched = makeSafe({ address: '0xCCC', isReadOnly: true })
+    const { trusted, owned, local } = groupSafesByPrecedence([watched], new Set(), true)
+
+    expect(local).toEqual([watched])
+    expect(trusted).toHaveLength(0)
+    expect(owned).toHaveLength(0)
+  })
+
+  it('prefers trusted over owned for a pinned + owned safe', () => {
+    const pinnedAndOwned = makeSafe({ address: '0xDDD', isReadOnly: false, isPinned: true })
+    const { trusted, owned } = groupSafesByPrecedence([pinnedAndOwned], new Set(), true)
+
+    expect(trusted).toEqual([pinnedAndOwned])
+    expect(owned).toHaveLength(0)
+  })
+
+  it('excludes workspace addresses from all buckets (case-insensitive)', () => {
+    const inWorkspace = makeSafe({ address: '0xEee', isReadOnly: false })
+    const other = makeSafe({ address: '0xFFF', isPinned: true })
+    const workspaceAddresses = new Set(['0xeee'])
+
+    const { trusted, owned, local } = groupSafesByPrecedence([inWorkspace, other], workspaceAddresses, true)
+
+    expect([...trusted, ...owned, ...local]).toEqual([other])
+  })
+
+  it('treats a multi-chain safe owned on any chain as owned', () => {
+    const multi = makeMulti('0x111', [
+      makeSafe({ chainId: '1', address: '0x111', isReadOnly: true }),
+      makeSafe({ chainId: '137', address: '0x111', isReadOnly: false }),
+    ])
+    const { owned, local } = groupSafesByPrecedence([multi], new Set(), true)
+
+    expect(owned).toEqual([multi])
+    expect(local).toHaveLength(0)
+  })
+
+  it('keeps a read-only multi-chain safe in local', () => {
+    const multi = makeMulti('0x222', [
+      makeSafe({ chainId: '1', address: '0x222', isReadOnly: true }),
+      makeSafe({ chainId: '137', address: '0x222', isReadOnly: true }),
+    ])
+    const { owned, local } = groupSafesByPrecedence([multi], new Set(), true)
+
+    expect(local).toEqual([multi])
+    expect(owned).toHaveLength(0)
+  })
+
+  it('places each safe in exactly one bucket', () => {
+    const items = [
+      makeSafe({ address: '0x1', isPinned: true, isReadOnly: false }),
+      makeSafe({ address: '0x2', isReadOnly: false }),
+      makeSafe({ address: '0x3', isReadOnly: true }),
+    ]
+    const { trusted, owned, local } = groupSafesByPrecedence(items, new Set(), true)
+
+    expect(trusted.length + owned.length + local.length).toBe(items.length)
+  })
+})
+
+describe('buildAddressSet', () => {
+  it('lowercases addresses', () => {
+    const set = buildAddressSet([makeSafe({ address: '0xAbCdEf' })])
+    expect(set.has('0xabcdef')).toBe(true)
+  })
+})

--- a/apps/web/src/features/myAccounts/utils/groupSafes.ts
+++ b/apps/web/src/features/myAccounts/utils/groupSafes.ts
@@ -1,0 +1,46 @@
+import { type AllSafeItems, type MultiChainSafeItem, type SafeItem, isMultiChainSafeItem } from '@/hooks/safes'
+
+export type GroupedSafes = {
+  trusted: AllSafeItems
+  owned: AllSafeItems
+  local: AllSafeItems
+}
+
+/** A safe is "owned" if the connected wallet signs for it on at least one chain. */
+const isOwnedItem = (item: SafeItem | MultiChainSafeItem): boolean =>
+  isMultiChainSafeItem(item) ? item.safes.some((safe) => !safe.isReadOnly) : !item.isReadOnly
+
+/** Lowercased address set, used to exclude Workspace safes from the other buckets. */
+export const buildAddressSet = (items: AllSafeItems): Set<string> =>
+  new Set(items.map((item) => item.address.toLowerCase()))
+
+/**
+ * Splits the global safe list into the Trusted / Owned / Local Storage buckets for the
+ * unified accounts table. Workspace safes are rendered separately and excluded here.
+ *
+ * Each safe lands in exactly one bucket by precedence: Workspace › Trusted › Owned › Local.
+ * The Owned bucket is only populated when a wallet is connected.
+ */
+export const groupSafesByPrecedence = (
+  global: AllSafeItems,
+  workspaceAddresses: Set<string>,
+  isConnected: boolean,
+): GroupedSafes => {
+  const trusted: AllSafeItems = []
+  const owned: AllSafeItems = []
+  const local: AllSafeItems = []
+
+  for (const item of global) {
+    if (workspaceAddresses.has(item.address.toLowerCase())) continue
+
+    if (item.isPinned) {
+      trusted.push(item)
+    } else if (isConnected && isOwnedItem(item)) {
+      owned.push(item)
+    } else {
+      local.push(item)
+    }
+  }
+
+  return { trusted, owned, local }
+}

--- a/apps/web/src/features/spaces/components/AddAccountsChooser/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccountsChooser/index.tsx
@@ -2,7 +2,7 @@ import { useState, type ReactNode } from 'react'
 import { useRouter } from 'next/router'
 import { AppRoutes } from '@/config/routes'
 import { buildCurrentNextUrl } from '@/utils/nextUrl'
-import { ChevronRight, CirclePlus, Plus, Search } from 'lucide-react'
+import { ChevronRight, CirclePlus, ListChecks, Plus, Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { cn } from '@/utils/cn'
@@ -18,10 +18,20 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 
 type EntryPoint = 'dashboard' | 'safe_accounts'
 
+/**
+ * - `all`: chooser with add-existing + see-all + create (default; used on the dashboard)
+ * - `add`: chooser with just add-existing + create (the "Add new Safe" CTA)
+ * - `manage`: skips the chooser and opens the "see all / manage" modal directly (the "Manage Safes" CTA)
+ */
+type ChooserMode = 'all' | 'add' | 'manage'
+
 interface AddAccountsChooserProps {
   buttonVariant?: 'outline' | 'default'
   buttonLabel?: string
   entryPoint: EntryPoint
+  mode?: ChooserMode
+  /** When provided (mode `add`), shows an extra option that jumps to the Local Safe accounts tab. */
+  onShowLocalSafes?: () => void
 }
 
 type SubModal = 'find' | 'add' | null
@@ -89,6 +99,8 @@ const AddAccountsChooser = ({
   buttonVariant = 'outline',
   buttonLabel = 'Add accounts',
   entryPoint,
+  mode = 'all',
+  onShowLocalSafes,
 }: AddAccountsChooserProps) => {
   const [chooserOpen, setChooserOpen] = useState(false)
   const [subModal, setSubModal] = useState<SubModal>(null)
@@ -117,13 +129,21 @@ const AddAccountsChooser = ({
     setSubModal('add')
   }
 
+  const handleAddManually = () => {
+    setChooserOpen(false)
+    router.push({
+      pathname: AppRoutes.newSafe.load,
+      query: { next: buildCurrentNextUrl(router.pathname, router.query) },
+    })
+  }
+
   return (
     <>
       <Button
         size="lg"
         variant={buttonVariant}
         className="font-normal px-4 py-0"
-        onClick={() => setChooserOpen(true)}
+        onClick={() => (mode === 'manage' ? setSubModal('find') : setChooserOpen(true))}
         data-testid="open-add-accounts-chooser-button"
       >
         <Plus
@@ -137,27 +157,55 @@ const AddAccountsChooser = ({
       <Dialog open={chooserOpen} onOpenChange={setChooserOpen}>
         <DialogContent showCloseButton className="max-w-[440px] p-6 dark:border dark:border-border">
           <DialogHeader className="p-0 pb-3">
-            <DialogTitle className="font-bold">Manage Safe accounts</DialogTitle>
+            <DialogTitle className="font-bold">
+              {mode === 'add' ? 'Add a Safe account' : 'Manage Safe accounts'}
+            </DialogTitle>
           </DialogHeader>
           <div className="flex flex-col gap-2">
-            <ChooserRow
-              icon={<Plus className="size-4" />}
-              title="Add Safe accounts to this workspace"
-              subtitle="Add your owned and trusted Safes to this workspace"
-              onClick={handleAdd}
-              disabled={!isAdmin}
-              disabledTooltip="You need to be an Admin to add accounts"
-              testId="add-safe-accounts-to-workspace-button"
-            />
-            <ChooserRow
-              icon={<Search className="size-4" />}
-              title="See all Safe accounts"
-              subtitle="Your trusted and owned Safes"
-              onClick={() => {
-                setChooserOpen(false)
-                setSubModal('find')
-              }}
-            />
+            {mode === 'add' ? (
+              <>
+                <ChooserRow
+                  icon={<Plus className="size-4" />}
+                  title="Add Safe manually"
+                  subtitle="Enter a Safe address manually"
+                  onClick={handleAddManually}
+                  testId="add-safe-manually-button"
+                />
+                {onShowLocalSafes && (
+                  <ChooserRow
+                    icon={<ListChecks className="size-4" />}
+                    title="Add from Local Safe account"
+                    subtitle="Pick from your trusted and owned Safes"
+                    onClick={() => {
+                      setChooserOpen(false)
+                      onShowLocalSafes()
+                    }}
+                    testId="add-from-local-safes-button"
+                  />
+                )}
+              </>
+            ) : (
+              <ChooserRow
+                icon={<Plus className="size-4" />}
+                title="Add existing Safe"
+                subtitle="Add your owned and trusted Safes to this workspace"
+                onClick={handleAdd}
+                disabled={!isAdmin}
+                disabledTooltip="You need to be an Admin to add accounts"
+                testId="add-safe-accounts-to-workspace-button"
+              />
+            )}
+            {mode === 'all' && (
+              <ChooserRow
+                icon={<Search className="size-4" />}
+                title="See all Safe accounts"
+                subtitle="Your trusted and owned Safes"
+                onClick={() => {
+                  setChooserOpen(false)
+                  setSubModal('find')
+                }}
+              />
+            )}
             <ChooserRow
               icon={<CirclePlus className="size-4" />}
               title="Create new Safe"

--- a/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
@@ -1,101 +1,152 @@
-import AddAccountsChooser from '../AddAccountsChooser'
-import EmptySafeAccounts from './EmptySafeAccounts'
-import { Stack } from '@mui/material'
+import { useState } from 'react'
+import { TriangleAlert, RotateCw, ListChecks } from 'lucide-react'
 import { Typography } from '@/components/ui/typography'
-import { useMemo } from 'react'
-import { useAppSelector } from '@/store'
-import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
+import { Button } from '@/components/ui/button'
+import { useSpaceSafes, useIsInvited, useCurrentSpaceId, useIsAdmin } from '@/features/spaces'
+import { isMultiChainSafeItem, type AllSafeItems, type MultiChainSafeItem, type SafeItem } from '@/hooks/safes'
 import {
-  type AllSafeItems,
-  type SafeItem,
-  _getMultiChainAccounts,
-  _getSingleChainAccounts,
-  getComparator,
-  useSafeItemBuilder,
-} from '@/hooks/safes'
-import { getFlaggedSimilarAddressSet } from '@safe-global/utils/utils/addressSimilarity'
-import { useSpaceSafes, useIsInvited } from '@/features/spaces'
+  useSpaceSafesCreateV1Mutation,
+  useSpaceSafesDeleteV1Mutation,
+} from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { useAppDispatch } from '@/store'
+import { showNotification } from '@/store/notificationsSlice'
 import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
-import { TriangleAlert, RotateCw } from 'lucide-react'
+import { trackEvent } from '@/services/analytics'
 import PreviewInvite from '../InviteBanner/PreviewInvite'
 import { SPACE_LABELS, SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import Track from '@/components/common/Track'
-import AccountsSafesList from './AccountsSafesList'
+import AddAccountsChooser from '../AddAccountsChooser'
+import { MyAccountsFeature } from '@/features/myAccounts'
+import { useLoadFeature } from '@/features/__core__'
 
-const _groupAndSort = (
-  items: SafeItem[],
-  sortComparator: (a: AllSafeItems[number], b: AllSafeItems[number]) => number,
-): AllSafeItems => {
-  const multi = _getMultiChainAccounts(items)
-  const single = _getSingleChainAccounts(items, multi)
-  return [...multi, ...single].sort(sortComparator)
-}
+const toSafeAccounts = (items: AllSafeItems) =>
+  items.flatMap((item) =>
+    isMultiChainSafeItem(item)
+      ? item.safes.map((safe) => ({ chainId: safe.chainId, address: safe.address }))
+      : [{ chainId: item.chainId, address: item.address }],
+  )
 
 const SpaceSafeAccounts = () => {
-  const { allSafes, isError: isSpaceSafesError, error: spaceSafesError, refetch: refetchSpaceSafes } = useSpaceSafes()
+  const {
+    allSafes: workspaceSafes,
+    isError: isSpaceSafesError,
+    error: spaceSafesError,
+    refetch: refetchSpaceSafes,
+  } = useSpaceSafes()
   const isInvited = useIsInvited()
+  const isAdmin = useIsAdmin()
+  const spaceId = useCurrentSpaceId()
+  const dispatch = useAppDispatch()
+  const [removeSafeAccounts] = useSpaceSafesDeleteV1Mutation()
+  const [addSafesToSpace] = useSpaceSafesCreateV1Mutation()
 
-  // Use same organization logic as onboarding
-  const { orderBy } = useAppSelector(selectOrderByPreference)
-  const sortComparator = getComparator(orderBy)
-  const { buildSafeItem } = useSafeItemBuilder()
+  const { SafesTable } = useLoadFeature(MyAccountsFeature)
 
-  const spaceSafeItems = useMemo(() => {
-    // Only include safes that are part of the current space
-    const spaceSafes = allSafes?.flatMap((item) => ('safes' in item ? item.safes : [item])) || []
+  const [manageMode, setManageMode] = useState(false)
 
-    return spaceSafes.map((safe) => buildSafeItem(safe.chainId, safe.address))
-  }, [buildSafeItem, allSafes])
+  const handleAddToWorkspace = async (item: SafeItem | MultiChainSafeItem) => {
+    const safes = toSafeAccounts([item])
+    const result = await addSafesToSpace({ spaceId: spaceId ?? '', createSpaceSafesDto: { safes } })
 
-  const similarAddresses = useMemo<Set<string>>(
-    () => getFlaggedSimilarAddressSet(spaceSafeItems.map((s) => s.address)),
-    [spaceSafeItems],
-  )
+    if ('error' in result) {
+      dispatch(showNotification({ message: 'Failed to add Safe to workspace', variant: 'error', groupKey: '' }))
+      return
+    }
 
-  // Group and sort
-  const displaySafes = useMemo<AllSafeItems>(
-    () => _groupAndSort(spaceSafeItems, sortComparator),
-    [spaceSafeItems, sortComparator],
-  )
+    dispatch(showNotification({ message: 'Added Safe to workspace', variant: 'success', groupKey: '' }))
+    refetchSpaceSafes()
+  }
 
-  const hasResults = displaySafes.length > 0
+  const handleRemoveFromWorkspace = async (items: AllSafeItems) => {
+    const safes = toSafeAccounts(items)
+    trackEvent({ ...SPACE_EVENTS.DELETE_ACCOUNT })
+
+    const result = await removeSafeAccounts({ spaceId: spaceId ?? '', deleteSpaceSafesDto: { safes } })
+
+    if ('error' in result) {
+      dispatch(showNotification({ message: 'Failed to remove Safes from workspace', variant: 'error', groupKey: '' }))
+      return
+    }
+
+    safes.forEach(({ chainId, address }) =>
+      trackEvent(
+        { ...SPACE_EVENTS.WORKSPACE_SAFE_UNLINKED, label: spaceId },
+        { workspace_id: spaceId, safe_address: address, chain_id: chainId },
+      ),
+    )
+    dispatch(
+      showNotification({
+        message: `Removed ${safes.length} Safe account${safes.length === 1 ? '' : 's'} from workspace`,
+        variant: 'success',
+        groupKey: '',
+      }),
+    )
+    setManageMode(false)
+    refetchSpaceSafes()
+  }
 
   return (
     <>
       {isInvited && <PreviewInvite />}
-      <div className="mb-6 flex flex-col gap-6">
+      <div className="mb-6">
         <Typography variant="h2" className="font-bold leading-[1] tracking-tight">
           Safe accounts
         </Typography>
-        <Stack direction="row" justifyContent="flex-start">
-          <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.accounts_page}>
-            <AddAccountsChooser buttonVariant="default" buttonLabel="Manage accounts" entryPoint="safe_accounts" />
-          </Track>
-        </Stack>
       </div>
 
       {isSpaceSafesError ? (
-        <div className="flex items-center gap-3 rounded-2xl border border-destructive/30 bg-destructive/5 px-5 py-4">
-          <TriangleAlert className="size-5 shrink-0 text-destructive" />
+        <div className="border-destructive/30 bg-destructive/5 flex items-center gap-3 rounded-2xl border px-5 py-4">
+          <TriangleAlert className="text-destructive size-5 shrink-0" />
           <div className="flex flex-col gap-1">
-            <span className="text-sm font-medium text-destructive">Failed to load Safe accounts</span>
-            <span className="text-xs text-muted-foreground">
+            <span className="text-destructive text-sm font-medium">Failed to load Safe accounts</span>
+            <span className="text-muted-foreground text-xs">
               {spaceSafesError ? getRtkQueryErrorMessage(spaceSafesError) : 'Please try again.'}
             </span>
           </div>
           <button
             onClick={refetchSpaceSafes}
-            className="ml-auto flex cursor-pointer items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm text-destructive transition-colors hover:bg-destructive/10"
+            className="text-destructive hover:bg-destructive/10 ml-auto flex cursor-pointer items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm transition-colors"
             type="button"
           >
             <RotateCw className="size-3.5" />
             Retry
           </button>
         </div>
-      ) : !hasResults && allSafes && allSafes.length === 0 ? (
-        <EmptySafeAccounts />
       ) : (
-        <AccountsSafesList safes={displaySafes} similarAddresses={similarAddresses} />
+        <SafesTable
+          workspaceSafes={workspaceSafes}
+          manageMode={manageMode}
+          onRemoveFromWorkspace={handleRemoveFromWorkspace}
+          canAddToWorkspace={isAdmin}
+          onAddToWorkspace={handleAddToWorkspace}
+          headerActions={(tab, setTab) => (
+            <>
+              <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.accounts_page}>
+                <AddAccountsChooser
+                  mode="add"
+                  buttonVariant="default"
+                  buttonLabel="Add new Safe"
+                  entryPoint="safe_accounts"
+                  onShowLocalSafes={tab === 'workspace' ? () => setTab('local') : undefined}
+                />
+              </Track>
+
+              {/* "Manage Safes" (workspace multiselect/remove) only applies to the Workspace tab. */}
+              {tab === 'workspace' && (
+                <Button
+                  size="lg"
+                  variant={manageMode ? 'default' : 'outline'}
+                  className="font-normal"
+                  onClick={() => setManageMode((prev) => !prev)}
+                  data-testid="manage-safes-btn"
+                >
+                  {manageMode ? 'Done' : <ListChecks className="size-4" />}
+                  {manageMode ? null : 'Manage Safes'}
+                </Button>
+              )}
+            </>
+          )}
+        />
       )}
     </>
   )

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/SafeSelectorDropdown.stories.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/SafeSelectorDropdown.stories.tsx
@@ -99,13 +99,24 @@ const createMockItems = (count: number): SafeItemData[] =>
 
 const mockItemsLong = createMockItems(7)
 
+// Shared defaults for the tabbed dropdown (Workspace / Local).
+const dropdownDefaults = {
+  hasWorkspace: true,
+  isInSpaceContext: true,
+  onManageTrustedSafes: action('Manage trusted Safes'),
+  onSignIn: action('Sign in'),
+}
+
 // Interactive wrapper component to manage state
 const InteractiveWrapper = ({ items, initialItemId }: { items: SafeItemData[]; initialItemId: string }) => {
   const [selectedItemId, setSelectedItemId] = useState(initialItemId)
 
   return (
     <SafeSelectorDropdown
+      {...dropdownDefaults}
       items={items}
+      workspaceItems={items}
+      localItems={items}
       selectedItemId={selectedItemId}
       onItemSelect={(itemId: string) => {
         action('Item selected')(itemId)
@@ -233,7 +244,10 @@ export const MixedActivationStates: Story = {
 export const Loading: Story = {
   render: () => (
     <SafeSelectorDropdown
+      {...dropdownDefaults}
       items={[mockItems[0]]}
+      workspaceItems={[mockItems[0]]}
+      localItems={[mockItems[0]]}
       selectedItemId={mockItems[0].id}
       isLoading
       onItemSelect={action('Item selected')}
@@ -246,7 +260,10 @@ export const Loading: Story = {
 export const Error: Story = {
   render: () => (
     <SafeSelectorDropdown
+      {...dropdownDefaults}
       items={[mockItems[0]]}
+      workspaceItems={[mockItems[0]]}
+      localItems={[mockItems[0]]}
       selectedItemId={mockItems[0].id}
       isError
       onRetry={action('Retry')}
@@ -256,84 +273,36 @@ export const Error: Story = {
   args: {} as any,
 }
 
-/** Loading state with header and footer (non-space context). */
-export const LoadingWithHeaderFooter: Story = {
-  render: () => {
-    const header = (
-      <div className="flex items-center gap-1 px-4 pt-3 pb-2">
-        <span className="text-sm font-semibold text-secondary-foreground">Trusted Safes</span>
-      </div>
-    )
-    const footer = (
-      <div className="px-4 py-3">
-        <button className="w-full rounded-md border px-3 py-1.5 text-sm">All accounts &rsaquo;</button>
-      </div>
-    )
-    return (
-      <SafeSelectorDropdown
-        items={[mockItems[0]]}
-        selectedItemId={mockItems[0].id}
-        isLoading
-        onItemSelect={action('Item selected')}
-        header={header}
-        footer={footer}
-      />
-    )
-  },
-  args: {} as any,
-}
-
-/** Many safes with header + footer — exercises the scrollbar and the bottom scroll-hint fade. */
-export const ManySafesWithFooter: Story = {
+/** Many safes — exercises the scrollbar and the bottom scroll-hint fade. */
+export const ManySafes: Story = {
   render: () => {
     const items = createMockItems(13)
-    const header = (
-      <div className="flex items-center gap-1 px-4 pt-3 pb-2">
-        <span className="text-sm font-semibold text-secondary-foreground">Safes in this workspace</span>
-      </div>
-    )
-    const footer = (
-      <div className="px-4 py-3">
-        <button className="w-full rounded-md border px-3 py-1.5 text-sm">Explore other Safes &rsaquo;</button>
-      </div>
-    )
     return (
       <SafeSelectorDropdown
+        {...dropdownDefaults}
         items={items}
+        workspaceItems={items}
+        localItems={items}
         selectedItemId={items[1].id}
         onItemSelect={action('Item selected')}
-        header={header}
-        footer={footer}
       />
     )
   },
   args: {} as any,
 }
 
-/** Error state with header and footer (non-space context). */
-export const ErrorWithHeaderFooter: Story = {
-  render: () => {
-    const header = (
-      <div className="flex items-center gap-1 px-4 pt-3 pb-2">
-        <span className="text-sm font-semibold text-secondary-foreground">Trusted Safes</span>
-      </div>
-    )
-    const footer = (
-      <div className="px-4 py-3">
-        <button className="w-full rounded-md border px-3 py-1.5 text-sm">All accounts &rsaquo;</button>
-      </div>
-    )
-    return (
-      <SafeSelectorDropdown
-        items={[mockItems[0]]}
-        selectedItemId={mockItems[0].id}
-        isError
-        onRetry={action('Retry')}
-        onItemSelect={action('Item selected')}
-        header={header}
-        footer={footer}
-      />
-    )
-  },
+/** Workspace tab prompts to sign in when the user isn't in a workspace. */
+export const NoWorkspace: Story = {
+  render: () => (
+    <SafeSelectorDropdown
+      {...dropdownDefaults}
+      hasWorkspace={false}
+      items={[mockItems[0]]}
+      workspaceItems={[]}
+      localItems={[mockItems[0]]}
+      selectedItemId={mockItems[0].id}
+      onItemSelect={action('Item selected')}
+    />
+  ),
   args: {} as any,
 }

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/AddSafeChooser.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/AddSafeChooser.tsx
@@ -1,0 +1,86 @@
+import { type ReactNode } from 'react'
+import { useRouter } from 'next/router'
+import { ChevronRight, CirclePlus, Plus } from 'lucide-react'
+import { AppRoutes } from '@/config/routes'
+import { buildCurrentNextUrl } from '@/utils/nextUrl'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { cn } from '@/utils/cn'
+
+interface AddSafeChooserProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const ChooserRow = ({
+  icon,
+  title,
+  subtitle,
+  onClick,
+  testId,
+}: {
+  icon: ReactNode
+  title: string
+  subtitle: string
+  onClick: () => void
+  testId?: string
+}) => (
+  <button
+    type="button"
+    data-testid={testId}
+    onClick={onClick}
+    className={cn(
+      'group text-sidebar-foreground flex w-full items-center gap-3 rounded-md p-3 text-left text-sm transition-colors',
+      'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground cursor-pointer [&_svg]:[stroke-width:2] [&_svg]:transition-colors hover:[&_svg]:text-green-500',
+    )}
+  >
+    <span className="shrink-0">{icon}</span>
+    <span className="min-w-0 flex-1">
+      <span className="block font-semibold">{title}</span>
+      <span className="text-muted-foreground group-hover:text-sidebar-accent-foreground/70 mt-1 block text-xs">
+        {subtitle}
+      </span>
+    </span>
+    <ChevronRight className="size-3.5 shrink-0" />
+  </button>
+)
+
+/**
+ * Lightweight "Add a Safe account" chooser for the safe-selector dropdown. Rendered outside the
+ * base-ui `Select` so it survives the dropdown closing, mirroring the page-level chooser.
+ */
+const AddSafeChooser = ({ open, onOpenChange }: AddSafeChooserProps) => {
+  const router = useRouter()
+
+  const go = (pathname: string) => {
+    onOpenChange(false)
+    router.push({ pathname, query: { next: buildCurrentNextUrl(router.pathname, router.query) } })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent showCloseButton className="dark:border-border max-w-[440px] p-6 dark:border">
+        <DialogHeader className="p-0 pb-3">
+          <DialogTitle className="font-bold">Add a Safe account</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-2">
+          <ChooserRow
+            icon={<Plus className="size-4" />}
+            title="Add existing Safe"
+            subtitle="Watch or import a Safe by its address"
+            onClick={() => go(AppRoutes.newSafe.load)}
+            testId="dropdown-add-existing-safe"
+          />
+          <ChooserRow
+            icon={<CirclePlus className="size-4" />}
+            title="Create new Safe"
+            subtitle="Create a new Safe account"
+            onClick={() => go(AppRoutes.newSafe.create)}
+            testId="dropdown-create-safe"
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default AddSafeChooser

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/MultiChainSafeItemRow.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/MultiChainSafeItemRow.tsx
@@ -7,7 +7,6 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Typography } from '@/components/ui/typography'
 import { useSafeDisplayName } from '@/hooks/useSafeDisplayName'
 import SafeInfoDisplay from './SafeInfoDisplay'
-import BalanceDisplay from './BalanceDisplay'
 import ChainLogo from './ChainLogo'
 import NotActivatedBadge from '@/components/common/NotActivatedBadge'
 import type { SafeItemData, SafeItemDataChain } from '../types'
@@ -35,6 +34,10 @@ const MultiChainSafeItemRow = ({ item }: MultiChainSafeItemRowProps) => {
   const chainId = item.chains[0]?.chainId ?? ''
   const resolvedName = useSafeDisplayName(item.address, chainId, item.name)
 
+  // Aggregate balance across the safe's chains so the summary row always shows a meaningful total.
+  const totalBalance = item.chains.reduce((sum, chain) => sum + Number(chain.balance ?? 0), 0)
+  const balanceLoading = item.chains.some((chain) => chain.isLoading)
+
   return (
     <Collapsible className="my-1 rounded-lg">
       <CollapsibleTrigger className="flex w-full items-center gap-3 rounded-lg px-4 py-4 text-left outline-none hover:bg-muted/30 focus-visible:ring-2 focus-visible:ring-ring cursor-pointer">
@@ -58,7 +61,15 @@ const MultiChainSafeItemRow = ({ item }: MultiChainSafeItemRowProps) => {
             </span>
           )}
         </div>
-        <BalanceDisplay balance={<FiatValue value={item.balance} />} isLoading={item.isLoading} />
+        <div className="flex w-[88px] shrink-0 items-center justify-end text-right">
+          {balanceLoading ? (
+            <Skeleton className="h-4 w-14 rounded" />
+          ) : (
+            <Typography variant="paragraph-mini-medium" color="muted" className="whitespace-nowrap">
+              <FiatValue value={totalBalance} />
+            </Typography>
+          )}
+        </div>
       </CollapsibleTrigger>
 
       <CollapsibleContent>

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -1,16 +1,21 @@
-import { RotateCw, Search } from 'lucide-react'
+import { Plus, RotateCw, Search, Settings2 } from 'lucide-react'
 import { useState } from 'react'
 import { SelectContent, SelectItem } from '@/components/ui/select'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Button } from '@/components/ui/button'
+import { Typography } from '@/components/ui/typography'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { useSafeNameResolver } from '@/hooks/useAllAddressBooks'
 import { useBottomScrollFade } from '@/hooks/useBottomScrollFade'
 import useWallet from '@/hooks/wallets/useWallet'
+import { cn } from '@/utils/cn'
 import SafeItem from './SafeItem'
 import MultiChainSafeItemRow from './MultiChainSafeItemRow'
 import SafeListSortToggle from '@/components/common/SafeListSortToggle'
 import type { SafeItemData } from '../types'
+
+type DropdownTab = 'workspace' | 'local'
 
 const matchesSearch = (item: SafeItemData, displayName: string, query: string): boolean => {
   const name = displayName.toLowerCase()
@@ -22,14 +27,19 @@ const matchesSearch = (item: SafeItemData, displayName: string, query: string): 
 }
 
 export interface SafeDropdownContainerProps {
-  items: SafeItemData[]
+  workspaceItems: SafeItemData[]
+  localItems: SafeItemData[]
+  hasWorkspace: boolean
+  workspaceName?: string
+  isInSpaceContext: boolean
   selectedItemId?: string
   onItemSelect: (itemId: string) => void
   isLoading?: boolean
   isError?: boolean
   onRetry?: () => void
-  header?: React.ReactNode
-  footer?: React.ReactNode | ((close: () => void) => React.ReactNode)
+  onManageTrustedSafes: () => void
+  onSignIn: () => void
+  onAddSafe: () => void
   closeDropdown: () => void
 }
 
@@ -67,36 +77,58 @@ function DropdownContentError({ onRetry }: { onRetry?: () => void }) {
 
 const SKELETON_COUNT = 4
 
+const tabClass = (active: boolean) =>
+  cn(
+    'flex-1 rounded-md px-2 py-1 text-xs font-semibold transition-colors cursor-pointer',
+    active ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
+  )
+
 const SafeDropdownContainer = ({
-  items,
+  workspaceItems,
+  localItems,
+  hasWorkspace,
+  workspaceName,
+  isInSpaceContext,
   selectedItemId,
   isLoading,
   isError,
   onRetry,
-  header,
-  footer,
+  onManageTrustedSafes,
+  onSignIn,
+  onAddSafe,
   closeDropdown,
 }: SafeDropdownContainerProps) => {
+  const [tab, setTab] = useState<DropdownTab>(isInSpaceContext ? 'workspace' : 'local')
   const [search, setSearch] = useState('')
   const query = search.trim().toLowerCase()
   const resolveName = useSafeNameResolver()
   const wallet = useWallet()
 
+  const showWorkspacePrompt = tab === 'workspace' && !hasWorkspace
+  const sourceItems = tab === 'workspace' ? workspaceItems : localItems
+
   // Multi-chain items stay visible even when currently selected so the user can expand and switch chains.
-  const structuralItems = items.filter((item) => item.chains.length > 1 || item.id !== selectedItemId)
+  const structuralItems = sourceItems.filter((item) => item.chains.length > 1 || item.id !== selectedItemId)
   const filteredItems = query
     ? structuralItems.filter((item) =>
         matchesSearch(item, resolveName(item.address, item.chains[0]?.chainId, item.name), query),
       )
     : structuralItems
 
-  // Key the search bar to displayable rows, so it's hidden when there's nothing to filter.
-  const showSearch = !isError && structuralItems.length > 0
+  const showSearch = !isError && !showWorkspacePrompt && structuralItems.length > 0
+  // "Add a Safe account" only belongs on the Local tab — adding/creating Safes for a workspace is
+  // a workspace-level action handled on the Safe accounts page, not here.
+  const showAddFooter = !isError && tab === 'local'
 
   // Bottom-fade scroll hint, shown only while more rows lie below the fold.
-  const { setScrollNode, showFade: showScrollHint } = useBottomScrollFade([filteredItems.length, isLoading, isError])
+  const { setScrollNode, showFade: showScrollHint } = useBottomScrollFade([
+    filteredItems.length,
+    isLoading,
+    isError,
+    tab,
+  ])
 
-  const renderContent = () => {
+  const renderList = () => {
     if (isError) {
       return <DropdownContentError onRetry={onRetry} />
     }
@@ -110,9 +142,11 @@ const SafeDropdownContainer = ({
         <p className="px-4 py-6 text-center text-sm text-muted-foreground" data-testid="dropdown-empty">
           {query
             ? 'No safes match your search'
-            : wallet
-              ? 'No safes yet'
-              : 'Connect a wallet to find your Safe accounts'}
+            : tab === 'local'
+              ? 'No trusted Safes yet'
+              : wallet
+                ? 'No safes in this workspace'
+                : 'Connect a wallet to find your Safe accounts'}
         </p>
       )
     }
@@ -138,64 +172,141 @@ const SafeDropdownContainer = ({
       align="start"
       side="bottom"
       alignItemWithTrigger={false}
-      // outline-hidden: base-ui focuses the popup on open; typing in the search field makes that
-      // :focus-visible and would otherwise draw the browser's blue outline around the whole popup.
       className="w-[430px] max-w-[calc(100vw-2rem)] overflow-hidden bg-card border-0 ring-0 outline-hidden rounded-lg [&_[data-slot=select-scroll-down-button]]:hidden [&_[data-slot=select-scroll-up-button]]:hidden"
       sideOffset={20}
       alignOffset={9}
       collisionAvoidance={{ side: 'none', align: 'shift' }}
     >
-      {/* Fallback to 34rem: until base-ui sets --available-height the clamp must still apply, else the
-          list expands to full height, measures as non-overflowing, and the scroll-hint fade is missed. */}
-      <div className="flex max-h-[min(34rem,var(--available-height,34rem))] flex-col">
-        {(header || showSearch) && (
-          <div className="shrink-0 bg-card">
-            {header}
-            {showSearch && (
-              <div className="flex items-center gap-2 px-3 pb-2 pt-1">
-                <InputGroup className="flex-1 rounded-md border-gray-100 shadow-none">
-                  <InputGroupAddon>
-                    <Search className="size-4" />
-                  </InputGroupAddon>
-                  <InputGroupInput
-                    placeholder="by name, address or network"
-                    value={search}
-                    onChange={(e) => setSearch(e.target.value)}
-                    // Stop keystrokes reaching base-ui Select's typeahead, which would hijack typing.
-                    // Trade-off: arrows/Enter stay in the input (no list nav); Escape still closes.
-                    onKeyDown={(e) => {
-                      if (e.key !== 'Escape') e.stopPropagation()
-                    }}
-                    autoComplete="off"
-                    data-testid="safe-dropdown-search-input"
-                  />
-                </InputGroup>
-                <SafeListSortToggle />
-              </div>
-            )}
+      {/* Single scroll container: the list scrolls while the header and the add-footer stay pinned
+          via sticky positioning (base-ui's List manages its own scroll, so a flex-pinned footer
+          would overlap the list — sticky is robust against that). */}
+      <div
+        ref={setScrollNode}
+        data-testid="dropdown-scroll-area"
+        className="flex max-h-[min(40rem,var(--available-height,40rem))] flex-col overflow-y-auto overscroll-y-none [scrollbar-width:thin] [scrollbar-color:var(--border)_transparent] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border"
+      >
+        {/* Sticky header: compact tabs + (search/sort) + trusted-manage. Stop keystrokes reaching
+            base-ui Select's typeahead, which would otherwise hijack typing and the tab buttons. */}
+        <div className="bg-card sticky top-0 z-20" onKeyDown={(e) => e.key !== 'Escape' && e.stopPropagation()}>
+          <div className="px-3 pb-2 pt-3">
+            <div className="flex gap-1 rounded-lg bg-muted p-0.5">
+              <button
+                type="button"
+                className={cn(tabClass(tab === 'workspace'), 'min-w-0')}
+                onClick={() => setTab('workspace')}
+                data-testid="dropdown-workspace-tab"
+                title={workspaceName?.trim() || 'Workspace'}
+              >
+                <span className="block truncate">{workspaceName?.trim() || 'Workspace'}</span>
+              </button>
+              <button
+                type="button"
+                className={tabClass(tab === 'local')}
+                onClick={() => setTab('local')}
+                data-testid="dropdown-local-tab"
+              >
+                Local
+              </button>
+            </div>
           </div>
-        )}
 
-        <div
-          ref={setScrollNode}
-          data-testid="dropdown-scroll-area"
-          className="min-h-0 flex-1 overflow-y-auto overscroll-y-none px-1 [scrollbar-width:thin] [scrollbar-color:var(--border)_transparent] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border"
-        >
-          {renderContent()}
+          {showSearch && (
+            <div className="flex items-center gap-2 px-3 pb-2">
+              <InputGroup className="flex-1 rounded-md border-gray-100 shadow-none">
+                <InputGroupAddon>
+                  <Search className="size-4" />
+                </InputGroupAddon>
+                <InputGroupInput
+                  placeholder="by name, address or network"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  autoComplete="off"
+                  data-testid="safe-dropdown-search-input"
+                />
+              </InputGroup>
+              <SafeListSortToggle />
+            </div>
+          )}
+
+          {tab === 'local' && !showWorkspacePrompt && (
+            <div className="flex items-center justify-between px-4 pb-2 pt-1">
+              <Typography variant="paragraph-small-bold" color="muted">
+                Trusted Safes
+              </Typography>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <button
+                      type="button"
+                      aria-label="Manage trusted Safes"
+                      data-testid="dropdown-manage-trusted-btn"
+                      className="text-muted-foreground hover:text-foreground hover:bg-muted inline-flex size-7 cursor-pointer items-center justify-center rounded-md transition-colors"
+                      onClick={() => {
+                        closeDropdown()
+                        onManageTrustedSafes()
+                      }}
+                    />
+                  }
+                >
+                  <Settings2 className="size-4" />
+                </TooltipTrigger>
+                <TooltipContent>Manage trusted Safes</TooltipContent>
+              </Tooltip>
+            </div>
+          )}
         </div>
 
-        {footer && (
-          <div className="relative shrink-0 bg-card">
-            {showScrollHint && (
-              <div
-                data-testid="scroll-hint"
-                aria-hidden
-                // Fade the last visible row into the dropdown background. `card` isn't a :root color
-                // token (so `to-card` renders transparent) — reference the paper var it resolves to.
-                className="pointer-events-none absolute inset-x-0 -top-16 h-16 bg-gradient-to-b from-transparent to-[var(--color-background-paper)]"
-              />
-            )}
-            {typeof footer === 'function' ? footer(closeDropdown) : footer}
+        {/* Reserve space at the end so the last row clears the sticky add-footer when fully scrolled. */}
+        <div className={cn('px-1', showAddFooter && 'pb-16')}>
+          {showWorkspacePrompt ? (
+            <div
+              className="flex flex-col items-center gap-2 px-4 py-8 text-center"
+              data-testid="dropdown-signin-prompt"
+            >
+              <p className="text-sm font-semibold">Sign in to a workspace</p>
+              <p className="text-xs text-muted-foreground">Sign in to see the Safes in your workspace.</p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-1"
+                data-testid="dropdown-signin-btn"
+                onClick={() => {
+                  closeDropdown()
+                  onSignIn()
+                }}
+              >
+                Sign in
+              </Button>
+            </div>
+          ) : (
+            renderList()
+          )}
+        </div>
+
+        {/* Bottom-fade hint signalling more rows below. Sits at z-10 so the sticky footer (z-20)
+            renders on top, leaving the fade peeking just above it. */}
+        {showScrollHint && (
+          <div
+            data-testid="scroll-hint"
+            aria-hidden
+            className="pointer-events-none sticky bottom-0 z-10 -mt-16 h-16 bg-gradient-to-b from-transparent to-[var(--color-background-paper)]"
+          />
+        )}
+
+        {showAddFooter && (
+          <div className="border-border bg-card sticky bottom-0 z-20 border-t p-2">
+            <button
+              type="button"
+              data-testid="dropdown-add-safe-btn"
+              onClick={() => {
+                closeDropdown()
+                onAddSafe()
+              }}
+              className="bg-muted/60 text-foreground hover:bg-muted flex w-full cursor-pointer items-center justify-center gap-2 rounded-md py-2.5 text-sm font-semibold transition-colors"
+            >
+              <Plus className="size-4 text-green-500" />
+              Add Safe account
+            </button>
           </div>
         )}
       </div>

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeInfoDisplay.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeInfoDisplay.tsx
@@ -1,6 +1,7 @@
 import { blo } from 'blo'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Typography } from '@/components/ui/typography'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { cn } from '@/utils/cn'
 import { getInitials, getSafeDisplayInfo } from '../utils'
 import ThresholdBadge from './ThresholdBadge'
@@ -16,7 +17,7 @@ export interface SafeInfoDisplayProps {
 }
 
 const SafeInfoDisplay = ({ name, address, className, threshold, owners }: SafeInfoDisplayProps) => {
-  const { shortAddress, displayName } = getSafeDisplayInfo(name, address)
+  const { displayName } = getSafeDisplayInfo(name, address)
 
   return (
     <div className={cn('flex items-center gap-3', className)}>
@@ -32,9 +33,25 @@ const SafeInfoDisplay = ({ name, address, className, threshold, owners }: SafeIn
           {displayName}
         </Typography>
         <div className="flex items-center gap-1 min-w-0">
-          <Typography variant="paragraph-mini" color="muted" className="truncate">
-            {shortAddress}
-          </Typography>
+          {/* Center-truncated address with bold ends; hover reveals the full address. */}
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <span className="w-fit min-w-0 cursor-help whitespace-nowrap font-mono text-xs text-muted-foreground" />
+              }
+            >
+              <span className="text-foreground font-semibold">{address.slice(0, 4)}</span>…
+              <span className="text-foreground font-semibold">{address.slice(-6)}</span>
+            </TooltipTrigger>
+            <TooltipContent
+              side="top"
+              className="max-w-[min(100vw-2rem,22rem)] font-mono text-[11px] leading-snug break-all"
+            >
+              <span className="font-bold">{address.slice(0, 4)}</span>
+              {address.slice(4, -6)}
+              <span className="font-bold">{address.slice(-6)}</span>
+            </TooltipContent>
+          </Tooltip>
           <CopyAddressButton address={address} testId="safe-item-copy-address" />
         </div>
       </div>

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeItem.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeItem.tsx
@@ -1,9 +1,9 @@
 import FiatValue from '@/components/common/FiatValue'
 import { cn } from '@/utils/cn'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Typography } from '@/components/ui/typography'
 import { useSafeDisplayName } from '@/hooks/useSafeDisplayName'
 import SafeInfoDisplay from './SafeInfoDisplay'
-import BalanceDisplay from './BalanceDisplay'
-import RowEndColumn from './RowEndColumn'
 import ChainLogo from './ChainLogo'
 import NotActivatedBadge from '@/components/common/NotActivatedBadge'
 import type { SafeItemData } from '../types'
@@ -25,24 +25,23 @@ const SafeItem = ({ name, address, threshold, owners, chains, balance, isLoading
         threshold={threshold}
         owners={owners}
       />
-      <div className="flex items-center gap-2 bg-muted rounded-full p-0.5 shrink-0">
-        {chains.slice(0, 3).map((chainItem, index) => (
-          <span
-            key={chainItem.chainId}
-            className="size-6 rounded-full border-2 border-card overflow-hidden shrink-0 inline-flex items-center justify-center"
-            style={{ marginLeft: index > 0 ? '-8px' : '0' }}
-          >
-            <ChainLogo chainId={chainItem.chainId} />
-          </span>
-        ))}
+      {/* Fixed-width network + balance columns so they line up across every row. */}
+      <div className="flex w-[44px] shrink-0 justify-end">
+        <span className="size-6 overflow-hidden rounded-full inline-flex items-center justify-center shrink-0">
+          <ChainLogo chainId={chainId} />
+        </span>
       </div>
-      {isUndeployed ? (
-        <RowEndColumn>
+      <div className="flex w-[88px] shrink-0 items-center justify-end text-right">
+        {isUndeployed ? (
           <NotActivatedBadge isActivating={isActivating} />
-        </RowEndColumn>
-      ) : (
-        <BalanceDisplay balance={<FiatValue value={balance} />} isLoading={isLoading} />
-      )}
+        ) : isLoading ? (
+          <Skeleton className="h-4 w-14 rounded" />
+        ) : (
+          <Typography variant="paragraph-mini-medium" color="muted" className="whitespace-nowrap">
+            <FiatValue value={balance ?? '0'} />
+          </Typography>
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeDropdownContainer.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeDropdownContainer.test.tsx
@@ -1,11 +1,9 @@
 import React, { act } from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import SafeDropdownContainer from '../SafeDropdownContainer'
+import SafeDropdownContainer, { type SafeDropdownContainerProps } from '../SafeDropdownContainer'
 import type { SafeItemData } from '../../types'
 
-// Resolver is exercised in its own unit test; here we stub it so the component renders without a
-// store. Default behaviour mirrors production: the safe's own name wins, else the address-book name.
 const mockAddressBookNames: Record<string, string> = {}
 const mockUseWallet = jest.fn()
 jest.mock('@/hooks/wallets/useWallet', () => ({
@@ -20,8 +18,6 @@ jest.mock('@/hooks/useAllAddressBooks', () => ({
       preferredName || mockAddressBookNames[address.toLowerCase()] || '',
 }))
 
-// jsdom doesn't implement ResizeObserver; the component uses one to catch popup
-// size changes. A noop stub is enough since tests drive scroll state explicitly.
 class ResizeObserverStub {
   observe() {}
   unobserve() {}
@@ -29,8 +25,6 @@ class ResizeObserverStub {
 }
 ;(globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver = ResizeObserverStub
 
-// Render SelectContent as a plain div carrying the `data-slot` marker that the
-// component's `closest()` lookup relies on, so the scroll-hint effect can find it.
 jest.mock('@/components/ui/select', () => ({
   __esModule: true,
   SelectContent: ({ children, className }: { children?: React.ReactNode; className?: string }) => (
@@ -55,7 +49,6 @@ jest.mock('../MultiChainSafeItemRow', () => ({
   default: ({ item }: { item: SafeItemData }) => <div data-testid="multi-chain-row">{item.name}</div>,
 }))
 
-// Redux-backed; stubbed here so the container test doesn't need a store.
 jest.mock('@/components/common/SafeListSortToggle', () => ({
   __esModule: true,
   default: () => <div data-testid="safe-list-sort-toggle" />,
@@ -71,6 +64,21 @@ const createItem = (overrides: Partial<SafeItemData> = {}): SafeItemData => ({
   chains: [{ chainId: '1', chainName: 'Ethereum', chainLogoUri: null, shortName: 'eth' }],
   ...overrides,
 })
+
+const baseProps: SafeDropdownContainerProps = {
+  workspaceItems: [],
+  localItems: [],
+  hasWorkspace: true,
+  isInSpaceContext: false, // default tab = Local
+  onItemSelect: jest.fn(),
+  onManageTrustedSafes: jest.fn(),
+  onSignIn: jest.fn(),
+  onAddSafe: jest.fn(),
+  closeDropdown: jest.fn(),
+}
+
+const renderContainer = (props: Partial<SafeDropdownContainerProps> = {}) =>
+  render(<SafeDropdownContainer {...baseProps} {...props} />)
 
 const setScrollMetrics = (
   el: HTMLElement,
@@ -90,61 +98,45 @@ const fireScroll = (el: HTMLElement) => {
 describe('SafeDropdownContainer', () => {
   beforeEach(() => {
     mockUseWallet.mockReturnValue({ address: '0x1234567890123456789012345678901234567890' })
+    for (const key of Object.keys(mockAddressBookNames)) delete mockAddressBookNames[key]
+  })
+
+  describe('tabs', () => {
+    it('renders both tabs', () => {
+      renderContainer()
+      expect(screen.getByTestId('dropdown-workspace-tab')).toBeInTheDocument()
+      expect(screen.getByTestId('dropdown-local-tab')).toBeInTheDocument()
+    })
+
+    it('shows a Manage trusted Safes button on the Local tab', () => {
+      const onManageTrustedSafes = jest.fn()
+      const closeDropdown = jest.fn()
+      renderContainer({ localItems: [createItem()], onManageTrustedSafes, closeDropdown })
+
+      fireEvent.click(screen.getByTestId('dropdown-manage-trusted-btn'))
+      expect(closeDropdown).toHaveBeenCalled()
+      expect(onManageTrustedSafes).toHaveBeenCalled()
+    })
+
+    it('prompts to sign in on the Workspace tab when there is no workspace', () => {
+      const onSignIn = jest.fn()
+      renderContainer({ isInSpaceContext: true, hasWorkspace: false, onSignIn })
+
+      expect(screen.getByTestId('dropdown-signin-prompt')).toBeInTheDocument()
+      fireEvent.click(screen.getByTestId('dropdown-signin-btn'))
+      expect(onSignIn).toHaveBeenCalled()
+    })
   })
 
   describe('empty state', () => {
-    it('prompts to connect a wallet when there are no safes and no wallet is connected', () => {
-      mockUseWallet.mockReturnValue(null)
-
-      render(<SafeDropdownContainer items={[]} onItemSelect={jest.fn()} closeDropdown={jest.fn()} />)
-
-      expect(screen.getByTestId('dropdown-empty')).toHaveTextContent('Connect a wallet to find your Safe accounts')
+    it('shows "No trusted Safes yet" on the Local tab when there are none', () => {
+      renderContainer({ localItems: [] })
+      expect(screen.getByTestId('dropdown-empty')).toHaveTextContent('No trusted Safes yet')
     })
 
-    it('shows "No safes yet" when there are no safes but a wallet is connected', () => {
-      mockUseWallet.mockReturnValue({ address: '0x1234567890123456789012345678901234567890' })
-
-      render(<SafeDropdownContainer items={[]} onItemSelect={jest.fn()} closeDropdown={jest.fn()} />)
-
-      expect(screen.getByTestId('dropdown-empty')).toHaveTextContent('No safes yet')
-    })
-  })
-
-  describe('footer', () => {
-    it('renders the footer node when provided', () => {
-      render(
-        <SafeDropdownContainer
-          items={[createItem()]}
-          onItemSelect={jest.fn()}
-          closeDropdown={jest.fn()}
-          footer={<div data-testid="footer-node">All Accounts</div>}
-        />,
-      )
-
-      expect(screen.getByTestId('footer-node')).toBeInTheDocument()
-    })
-
-    it('invokes the footer callback with closeDropdown when footer is a function', () => {
-      const closeDropdown = jest.fn()
-      const footerFn = jest.fn(() => <div data-testid="footer-node">FooterFn</div>)
-
-      render(
-        <SafeDropdownContainer
-          items={[createItem()]}
-          onItemSelect={jest.fn()}
-          closeDropdown={closeDropdown}
-          footer={footerFn}
-        />,
-      )
-
-      expect(footerFn).toHaveBeenCalledWith(closeDropdown)
-      expect(screen.getByTestId('footer-node')).toBeInTheDocument()
-    })
-
-    it('does not render the footer wrapper when no footer prop is passed', () => {
-      render(<SafeDropdownContainer items={[createItem()]} onItemSelect={jest.fn()} closeDropdown={jest.fn()} />)
-
-      expect(screen.queryByTestId('scroll-hint')).not.toBeInTheDocument()
+    it('shows "No safes in this workspace" on the Workspace tab when in a workspace with none', () => {
+      renderContainer({ isInSpaceContext: true, hasWorkspace: true, workspaceItems: [] })
+      expect(screen.getByTestId('dropdown-empty')).toHaveTextContent('No safes in this workspace')
     })
   })
 
@@ -162,12 +154,7 @@ describe('SafeDropdownContainer', () => {
       chains: [{ chainId: '137', chainName: 'Polygon', chainLogoUri: null, shortName: 'matic' }],
     })
 
-    const renderWithSearch = () =>
-      render(<SafeDropdownContainer items={[itemA, itemB]} onItemSelect={jest.fn()} closeDropdown={jest.fn()} />)
-
-    beforeEach(() => {
-      for (const key of Object.keys(mockAddressBookNames)) delete mockAddressBookNames[key]
-    })
+    const renderWithSearch = () => renderContainer({ localItems: [itemA, itemB] })
 
     it('renders the search input when there are items', () => {
       renderWithSearch()
@@ -175,36 +162,14 @@ describe('SafeDropdownContainer', () => {
     })
 
     it('hides the search input when the only safe is the currently-selected one', () => {
-      render(
-        <SafeDropdownContainer
-          items={[createItem({ id: '1:0xaaaa', address: '0xaaaa' })]}
-          selectedItemId="1:0xaaaa"
-          onItemSelect={jest.fn()}
-          closeDropdown={jest.fn()}
-        />,
-      )
+      renderContainer({ localItems: [createItem({ id: '1:0xaaaa', address: '0xaaaa' })], selectedItemId: '1:0xaaaa' })
 
       expect(screen.queryByTestId('safe-dropdown-search-input')).not.toBeInTheDocument()
-      expect(screen.getByTestId('dropdown-empty')).toHaveTextContent('No safes yet')
-    })
-
-    it('keeps the search input visible when a query matches nothing', async () => {
-      renderWithSearch()
-      await userEvent.type(screen.getByTestId('safe-dropdown-search-input'), 'nonexistent')
-
-      expect(screen.getByTestId('safe-dropdown-search-input')).toBeInTheDocument()
+      expect(screen.getByTestId('dropdown-empty')).toHaveTextContent('No trusted Safes yet')
     })
 
     it('does not render the search input on error', () => {
-      render(
-        <SafeDropdownContainer
-          items={[itemA]}
-          onItemSelect={jest.fn()}
-          closeDropdown={jest.fn()}
-          isError
-          onRetry={jest.fn()}
-        />,
-      )
+      renderContainer({ localItems: [itemA], isError: true, onRetry: jest.fn() })
       expect(screen.queryByTestId('safe-dropdown-search-input')).not.toBeInTheDocument()
     })
 
@@ -232,14 +197,6 @@ describe('SafeDropdownContainer', () => {
       expect(screen.queryByText('Alpha Treasury')).not.toBeInTheDocument()
     })
 
-    it('filters by chain short name', async () => {
-      renderWithSearch()
-      await userEvent.type(screen.getByTestId('safe-dropdown-search-input'), 'matic')
-
-      expect(screen.getByText('Beta Ops')).toBeInTheDocument()
-      expect(screen.queryByText('Alpha Treasury')).not.toBeInTheDocument()
-    })
-
     it('filters by the address-book name when the safe itself is unnamed', async () => {
       const unnamed = createItem({
         id: '1:0xcccccccccccccccccccccccccccccccccccccccc',
@@ -249,10 +206,9 @@ describe('SafeDropdownContainer', () => {
       })
       mockAddressBookNames['0xcccccccccccccccccccccccccccccccccccccccc'] = 'Cold Storage'
 
-      render(<SafeDropdownContainer items={[itemA, unnamed]} onItemSelect={jest.fn()} closeDropdown={jest.fn()} />)
+      renderContainer({ localItems: [itemA, unnamed] })
       await userEvent.type(screen.getByTestId('safe-dropdown-search-input'), 'cold')
 
-      // The unnamed safe (resolved via address book) survives; the named one is filtered out.
       expect(screen.queryByText('Alpha Treasury')).not.toBeInTheDocument()
       expect(screen.getByTestId('safe-item')).toBeInTheDocument()
     })
@@ -265,11 +221,11 @@ describe('SafeDropdownContainer', () => {
       expect(screen.queryByTestId('safe-item')).not.toBeInTheDocument()
     })
 
-    it('stops character keystrokes from bubbling to the popup (defeats base-ui typeahead) but lets Escape through', () => {
+    it('stops character keystrokes from bubbling to the popup but lets Escape through', () => {
       const onKeyDownSpy = jest.fn()
       render(
         <div onKeyDown={onKeyDownSpy}>
-          <SafeDropdownContainer items={[itemA, itemB]} onItemSelect={jest.fn()} closeDropdown={jest.fn()} />
+          <SafeDropdownContainer {...baseProps} localItems={[itemA, itemB]} />
         </div>,
       )
       const input = screen.getByTestId('safe-dropdown-search-input')
@@ -284,14 +240,7 @@ describe('SafeDropdownContainer', () => {
 
   describe('scroll hint', () => {
     it('hides the hint when content does not overflow', () => {
-      render(
-        <SafeDropdownContainer
-          items={[createItem()]}
-          onItemSelect={jest.fn()}
-          closeDropdown={jest.fn()}
-          footer={<div>Footer</div>}
-        />,
-      )
+      renderContainer({ localItems: [createItem()] })
 
       const scroller = screen.getByTestId('dropdown-scroll-area')
       setScrollMetrics(scroller, { scrollHeight: 200, clientHeight: 320, scrollTop: 0 })
@@ -301,14 +250,7 @@ describe('SafeDropdownContainer', () => {
     })
 
     it('shows the hint when content overflows and the user has not scrolled to the bottom', () => {
-      render(
-        <SafeDropdownContainer
-          items={[createItem()]}
-          onItemSelect={jest.fn()}
-          closeDropdown={jest.fn()}
-          footer={<div>Footer</div>}
-        />,
-      )
+      renderContainer({ localItems: [createItem()] })
 
       const scroller = screen.getByTestId('dropdown-scroll-area')
       setScrollMetrics(scroller, { scrollHeight: 1000, clientHeight: 320, scrollTop: 0 })
@@ -318,14 +260,7 @@ describe('SafeDropdownContainer', () => {
     })
 
     it('hides the hint once the user reaches the bottom', () => {
-      render(
-        <SafeDropdownContainer
-          items={[createItem()]}
-          onItemSelect={jest.fn()}
-          closeDropdown={jest.fn()}
-          footer={<div>Footer</div>}
-        />,
-      )
+      renderContainer({ localItems: [createItem()] })
 
       const scroller = screen.getByTestId('dropdown-scroll-area')
       setScrollMetrics(scroller, { scrollHeight: 1000, clientHeight: 320, scrollTop: 0 })

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeInfoDisplay.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeInfoDisplay.test.tsx
@@ -30,14 +30,16 @@ describe('SafeInfoDisplay', () => {
     expect(screen.getByTestId('safe-item-copy-address')).toBeInTheDocument()
   })
 
-  it('shows the shortened address on the address line', () => {
+  it('shows the bold-truncated address (first 4 + last 6) on the address line', () => {
     render(<SafeInfoDisplay {...baseProps} />)
-    expect(screen.getByText(shortenAddress(address))).toBeInTheDocument()
+    expect(screen.getByText(address.slice(0, 4))).toBeInTheDocument()
+    expect(screen.getByText(address.slice(-6))).toBeInTheDocument()
   })
 
-  it('shows the shortened address on both lines when the name is empty', () => {
+  it('falls back to the shortened address on the name line when the name is empty', () => {
     render(<SafeInfoDisplay name="" address={address} />)
-    // No name → the name line falls back to the address, so it appears on both the name and address lines.
-    expect(screen.getAllByText(shortenAddress(address))).toHaveLength(2)
+    // No name → the name line falls back to the shortened address; the address line shows the bold ends.
+    expect(screen.getByText(shortenAddress(address))).toBeInTheDocument()
+    expect(screen.getByText(address.slice(-6))).toBeInTheDocument()
   })
 })

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeItem.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeItem.test.tsx
@@ -12,12 +12,6 @@ jest.mock('../SafeInfoDisplay', () => {
   return { __esModule: true, default: Mock }
 })
 
-jest.mock('../BalanceDisplay', () => {
-  const Mock = () => <div data-testid="balance-display" />
-  Mock.displayName = 'BalanceDisplay'
-  return { __esModule: true, default: Mock }
-})
-
 jest.mock('../ChainLogo', () => {
   const Mock = ({ chainId }: { chainId: string }) => <div data-testid={`chain-logo-${chainId}`} />
   Mock.displayName = 'ChainLogo'
@@ -25,7 +19,7 @@ jest.mock('../ChainLogo', () => {
 })
 
 jest.mock('@/components/common/FiatValue', () => {
-  const Mock = () => <span />
+  const Mock = ({ value }: { value: string | number | null }) => <span data-testid="fiat-value">{String(value)}</span>
   Mock.displayName = 'FiatValue'
   return { __esModule: true, default: Mock }
 })
@@ -53,7 +47,7 @@ describe('SafeItem undeployed state', () => {
     render(<SafeItem {...createItem(makeChain({ isUndeployed: true }))} />)
 
     expect(screen.getByLabelText('Inactive')).toBeInTheDocument()
-    expect(screen.queryByTestId('balance-display')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('fiat-value')).not.toBeInTheDocument()
   })
 
   it('renders the Activating label for an activating chain', () => {
@@ -65,13 +59,7 @@ describe('SafeItem undeployed state', () => {
   it('renders the balance for a deployed chain', () => {
     render(<SafeItem {...createItem(makeChain())} />)
 
-    expect(screen.getByTestId('balance-display')).toBeInTheDocument()
+    expect(screen.getByTestId('fiat-value')).toBeInTheDocument()
     expect(screen.queryByTestId('not-activated-badge')).not.toBeInTheDocument()
-  })
-
-  it('renders the activation status in the shared row-end column (same trailing slot as the balance)', () => {
-    render(<SafeItem {...createItem(makeChain({ isUndeployed: true }))} />)
-
-    expect(screen.getByTestId('row-end-column')).toContainElement(screen.getByTestId('not-activated-badge'))
   })
 })

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/index.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { cn } from '@/utils/cn'
 import SafeSelectorTriggerContent from './components/SafeSelectorTriggerContent'
 import SafeDropdownContainer from './components/SafeDropdownContainer'
+import AddSafeChooser from './components/AddSafeChooser'
 import InlineRetryError from '@/components/common/InlineRetryError'
 import { useSafeSelectorState } from './hooks/useSafeSelectorState'
 import { useIsSafeBarControlDisabled } from '@/hooks/useIsSafeBarControlDisabled'
@@ -57,15 +58,21 @@ function SafeSelectorDropdownSkeleton() {
 
 function SafeSelectorDropdown({
   items,
+  workspaceItems = items,
+  localItems = items,
+  hasWorkspace = true,
+  workspaceName,
+  isInSpaceContext = false,
   selectedItemId,
   onItemSelect,
   isLoading,
   isError,
   onRetry,
-  header,
-  footer,
+  onManageTrustedSafes = () => {},
+  onSignIn = () => {},
 }: SafeSelectorDropdownProps) {
-  const hasDropdownContent = Boolean(header) || Boolean(footer) || isLoading || isError
+  // The dropdown always has the tabs UI, so it's always openable.
+  const hasDropdownContent = true
   // Force-openable so `isSingleSafe` can't hide the chevron when only one other safe exists.
   const willUseFallbackTrigger =
     items.length > 0 && Boolean(selectedItemId) && !items.some((item) => item.id === selectedItemId)
@@ -86,6 +93,9 @@ function SafeSelectorDropdown({
   })
   const [mounted, setMounted] = useState(false)
   useEffect(() => setMounted(true), [])
+
+  // "Add a Safe account" chooser lives outside the Select so it survives the dropdown closing.
+  const [addSafeChooserOpen, setAddSafeChooserOpen] = useState(false)
 
   const variants = getSafeSelectorClassVariants(isSingleSafe)
   const safeSelectValue = selectedItemId ?? selectedItem?.id
@@ -138,14 +148,19 @@ function SafeSelectorDropdown({
       </SelectTrigger>
 
       <SafeDropdownContainer
-        items={items}
+        workspaceItems={workspaceItems}
+        localItems={localItems}
+        hasWorkspace={hasWorkspace}
+        workspaceName={workspaceName}
+        isInSpaceContext={isInSpaceContext}
         selectedItemId={safeSelectValue}
         onItemSelect={safeItemSelect}
         isLoading={isLoading}
         isError={isError}
         onRetry={onRetry}
-        header={header}
-        footer={footer}
+        onManageTrustedSafes={onManageTrustedSafes}
+        onSignIn={onSignIn}
+        onAddSafe={() => setAddSafeChooserOpen(true)}
         closeDropdown={closeDropdown}
       />
     </Select>
@@ -161,6 +176,7 @@ function SafeSelectorDropdown({
     <>
       <div className="pointer-events-none absolute inset-1 rounded-md bg-muted/30 opacity-0 group-hover:opacity-100" />
       {selectElement}
+      <AddSafeChooser open={addSafeChooserOpen} onOpenChange={setAddSafeChooserOpen} />
     </>
   )
 

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/types.ts
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/types.ts
@@ -28,12 +28,24 @@ export interface SafeItemData {
 }
 
 export interface SafeSelectorDropdownProps {
+  /** Contextual list used for the trigger + current-safe selection. */
   items: SafeItemData[]
+  /** Safes in the current workspace (Workspace tab). Defaults to `items`. */
+  workspaceItems?: SafeItemData[]
+  /** Trusted (pinned) safes (Local tab). Defaults to `items`. */
+  localItems?: SafeItemData[]
+  /** Whether a workspace is available; when false the Workspace tab shows a sign-in prompt. */
+  hasWorkspace?: boolean
+  /** Current workspace name; labels the Workspace tab (falls back to "Workspace"). */
+  workspaceName?: string
+  isInSpaceContext?: boolean
   selectedItemId?: string
   onItemSelect?: (itemId: string) => void
   isLoading?: boolean
   isError?: boolean
   onRetry?: () => void
-  header?: React.ReactNode
-  footer?: React.ReactNode | ((close: () => void) => React.ReactNode)
+  /** Opens the Manage Trusted Safes modal (Local tab). */
+  onManageTrustedSafes?: () => void
+  /** Navigates to the workspace sign-in page (Workspace tab prompt). */
+  onSignIn?: () => void
 }

--- a/apps/web/src/hooks/safes/__tests__/comparators.test.ts
+++ b/apps/web/src/hooks/safes/__tests__/comparators.test.ts
@@ -1,0 +1,29 @@
+import type { MultiChainSafeItem, SafeItem } from '@/hooks/safes'
+import { getSafeListComparator } from '../comparators'
+
+const makeSafe = (overrides: Partial<SafeItem> = {}): SafeItem => ({
+  chainId: '1',
+  address: '0x0000000000000000000000000000000000000001',
+  isReadOnly: true,
+  isPinned: false,
+  lastVisited: 0,
+  name: undefined,
+  ...overrides,
+})
+
+type Item = SafeItem | MultiChainSafeItem
+
+const sortNames = (items: Item[], comparator: (a: Item, b: Item) => number) =>
+  [...items].sort(comparator).map((i) => i.name)
+
+describe('getSafeListComparator', () => {
+  it('sorts A→Z ascending and puts undefined names last', () => {
+    const items = [makeSafe({ name: 'Charlie' }), makeSafe({ name: undefined }), makeSafe({ name: 'Alpha' })]
+    expect(sortNames(items, getSafeListComparator('name', 'asc'))).toEqual(['Alpha', 'Charlie', undefined])
+  })
+
+  it('reverses for descending', () => {
+    const items = [makeSafe({ name: 'Alpha' }), makeSafe({ name: 'Charlie' })]
+    expect(sortNames(items, getSafeListComparator('name', 'desc'))).toEqual(['Charlie', 'Alpha'])
+  })
+})

--- a/apps/web/src/hooks/safes/comparators.ts
+++ b/apps/web/src/hooks/safes/comparators.ts
@@ -17,3 +17,20 @@ export const lastVisitedComparator = (a: SafeItem | MultiChainSafeItem, b: SafeI
 export const getComparator = (orderBy: OrderByOption) => {
   return orderBy === OrderByOption.NAME ? nameComparator : lastVisitedComparator
 }
+
+/**
+ * Sort state for the unified Safe accounts table (SafesTable). Kept separate from the shared
+ * `getComparator` / `orderByPreferenceSlice` so the table owns its own sort.
+ *
+ * Balance sorting is handled by the table itself (from the live balances each row reports), so
+ * this helper only produces the name comparator with a direction.
+ */
+export type SafeListSortColumn = 'name' | 'balance'
+export type SafeListSortDirection = 'asc' | 'desc'
+
+export const getSafeListComparator = (_column: SafeListSortColumn, direction: SafeListSortDirection) => {
+  return (a: SafeItem | MultiChainSafeItem, b: SafeItem | MultiChainSafeItem) => {
+    const result = nameComparator(a, b)
+    return direction === 'desc' ? -result : result
+  }
+}

--- a/apps/web/src/hooks/safes/index.ts
+++ b/apps/web/src/hooks/safes/index.ts
@@ -23,7 +23,8 @@ export { useSafesSearch } from './useSafesSearch'
 export { useGetHref } from './useGetHref'
 
 // Comparators/utilities
-export { getComparator, nameComparator, lastVisitedComparator } from './comparators'
+export { getComparator, nameComparator, lastVisitedComparator, getSafeListComparator } from './comparators'
+export type { SafeListSortColumn, SafeListSortDirection } from './comparators'
 
 // Types
 export type { SafeItem, SafeItems } from './useAllSafes'


### PR DESCRIPTION
…afe selector

Rework the workspace Safe accounts page and the safe-selector dropdown into one consistent listing experience, and polish the Manage trusted Safes modal.

Safe accounts page
- One tabbed table (Workspace / Local) — each Safe appears once; multichain rows expand per-chain; full addresses; no security column; sort by name and balance.
- Admin "Add to Workspace" action on local rows; inline rename across networks.
- Look-alike (address-poisoning) Safes hidden by default behind a toggle.
- "Trusted Safes" section header: shield icon + hover tooltip, compact gear "Manage trusted Safes" placed next to the title.
- Undeployed Safes render at normal row height (greyed, fast "Safe not deployed" tooltip).
- Page chooser gains "Add from Local Safe account" (jumps to the Local tab).

Safe-selector dropdown
- Compact Workspace / Local tabs; Workspace tab labelled with the workspace name and shows a sign-in prompt when not in a workspace.
- List rows with full center-truncated addresses (bold first 4 / last 6), single-chain threshold on the identicon, multichain expand-on-click; search + sort retained.
- Pinned, clearly-labelled "Add Safe account" footer on the Local tab (opens an Add existing / Create new chooser); footer no longer hides the last row when scrolling.
- Single sticky-header/footer scroll container so the header and add CTA stay pinned.

Manage trusted Safes modal
- One prominent security banner, slimmed contextual helpers, and a single aligned toolbar (search + selection count + Select all / Deselect all); sentence-case copy.

Shared
- Addresses render in a mono font with bold first 4 / last 6 across table, dropdown, and modal for easier verification.

## What it solves

Resolves:

## How this PR fixes it

## How to test it

## Affected flows

<!-- The primary user journey(s) this PR intentionally changes. One bullet per flow. Example: "Owner adds a new signer from Settings > Signers". -->

## Blast radius

<!--
List the surfaces touched by this change and who else depends on them. Think in dependency terms, not files.
Include where relevant:
- Shared hooks / components / selectors / slices touched and their known consumers
- RTK Query endpoints / API contracts
- Feature flags / chain configs
- Persistence / cache / migration implications
- Routes or layouts affected indirectly
- Mobile impact (shared packages)
-->

## Risks / not checked

<!--
Be explicit about what you did NOT verify. This exposes false confidence and helps reviewers target their attention.
Example:
- Did not verify behavior with feature flag X disabled
- Did not test on mobile
- Did not exercise the retry / error path manually
-->

## Visual summary

<!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
