### PR TITLE
fix(mobile): FeesBreakdown not displayed on non gtf chains

### DIFF
--- a/apps/mobile/src/features/ConfirmTx/components/TransactionInfo/FeesBreakdown.test.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionInfo/FeesBreakdown.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react-native'
+import { TamaguiProvider } from 'tamagui'
+import config from '@/src/theme/tamagui.config'
+import { FeesBreakdown } from './FeesBreakdown'
+import type { MultisigExecutionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+
+const mockHasFeature = jest.fn()
+
+jest.mock('@/src/store/hooks/activeSafe', () => ({
+  useDefinedActiveSafe: () => ({ address: '0xSafe', chainId: '137' }),
+}))
+
+jest.mock('@/src/store/hooks', () => ({
+  useAppSelector: (selector: unknown) => (typeof selector === 'function' ? selector() : selector),
+}))
+
+jest.mock('@/src/store/chains', () => ({
+  selectChainById: () => ({ chainId: '137', features: [] }),
+  selectActiveChainCurrency: () => ({ symbol: 'MATIC', decimals: 18 }),
+}))
+
+jest.mock('@/src/store/settingsSlice', () => ({
+  selectCurrency: () => 'usd',
+}))
+
+jest.mock('@safe-global/utils/utils/chains', () => ({
+  ...jest.requireActual('@safe-global/utils/utils/chains'),
+  hasFeature: (...args: unknown[]) => mockHasFeature(...args),
+}))
+
+jest.mock('@/src/hooks/useBalances', () => ({
+  useBalances: () => ({ balances: undefined }),
+}))
+
+jest.mock('@/src/hooks/useTokenDetails/useTokenDetails', () => ({
+  useTokenDetails: () => ({ value: '0', decimals: undefined }),
+}))
+
+jest.mock('./useFeesBreakdown', () => ({
+  useFeesBreakdown: () => ({
+    paidFromSafe: true,
+    gasNotYetKnown: false,
+    maxGasFee: { amount: '1000', symbol: 'MATIC', decimals: 18, address: '0x0' },
+    maxGasFeeFiat: undefined,
+    totalOutgoing: [{ amount: '1000', symbol: 'MATIC', decimals: 18, address: '0x0' }],
+    totalOutgoingFiat: undefined,
+  }),
+}))
+
+const detailedExecutionInfo = { type: 'MULTISIG' } as unknown as MultisigExecutionDetails
+
+const renderWithTheme = () =>
+  render(
+    <TamaguiProvider config={config} defaultTheme="light">
+      <FeesBreakdown detailedExecutionInfo={detailedExecutionInfo} />
+    </TamaguiProvider>,
+  )
+
+describe('FeesBreakdown — GTF gating', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('renders nothing when the GTF feature is disabled', () => {
+    mockHasFeature.mockReturnValue(false)
+    renderWithTheme()
+    expect(screen.queryByTestId('fees-breakdown')).toBeNull()
+  })
+
+  it('renders the fees block when the GTF feature is enabled', () => {
+    mockHasFeature.mockReturnValue(true)
+    renderWithTheme()
+    expect(screen.getByTestId('fees-breakdown')).toBeTruthy()
+  })
+})

--- a/apps/mobile/src/features/ConfirmTx/components/TransactionInfo/FeesBreakdown.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionInfo/FeesBreakdown.tsx
@@ -9,7 +9,10 @@ import type {
 import { Container } from '@/src/components/Container'
 import { TokenAmount } from '@/src/components/TokenAmount'
 import { useAppSelector } from '@/src/store/hooks'
-import { selectActiveChainCurrency } from '@/src/store/chains'
+import { RootState } from '@/src/store'
+import { selectActiveChainCurrency, selectChainById } from '@/src/store/chains'
+import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
+import { FEATURES, hasFeature } from '@safe-global/utils/utils/chains'
 import { selectCurrency } from '@/src/store/settingsSlice'
 import { useBalances } from '@/src/hooks/useBalances'
 import { useTokenDetails } from '@/src/hooks/useTokenDetails/useTokenDetails'
@@ -27,6 +30,9 @@ export function FeesBreakdown({
   detailedExecutionInfo: MultisigExecutionDetails
   txDetails?: TransactionDetails
 }) {
+  const activeSafe = useDefinedActiveSafe()
+  const activeChain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
+  const isGtfEnabled = hasFeature(activeChain, FEATURES.GTF)
   const nativeCurrency = useAppSelector(selectActiveChainCurrency)
   const currency = useAppSelector(selectCurrency)
   const { balances } = useBalances()
@@ -52,7 +58,8 @@ export function FeesBreakdown({
 
   const breakdown = useFeesBreakdown({ detailedExecutionInfo, outgoing, balances })
 
-  if (!breakdown) {
+  // The fees block is part of the GTF rollout, hide it entirely on chains where GTF is disabled
+  if (!isGtfEnabled || !breakdown) {
     return null
   }
 


### PR DESCRIPTION
## What it solves

The `FeesBreakdown` component now checks if the GTF feature is enabled for the active chain using the `hasFeature` utility and only renders the fees breakdown if enabled. [[1]](diffhunk://#diff-2e24d80c8ef6cab00233992b51b2e06a0ee556f8da9892d6e279a1f7c4ee8f0bL12-R15) [[2]](diffhunk://#diff-2e24d80c8ef6cab00233992b51b2e06a0ee556f8da9892d6e279a1f7c4ee8f0bR33-R35) [[3]](diffhunk://#diff-2e24d80c8ef6cab00233992b51b2e06a0ee556f8da9892d6e279a1f7c4ee8f0bL55-R62)
