### PR TITLE
fix(swap): pass baseUrl to CoW widget to match communicator origin

### DIFF
--- a/apps/web/src/features/swap/components/SwapWidget/index.tsx
+++ b/apps/web/src/features/swap/components/SwapWidget/index.tsx
@@ -70,6 +70,9 @@ const SwapWidget = ({ sell }: Params) => {
 
   const [params, setParams] = useState<CowSwapWidgetParams>({
     appCode: 'Safe Wallet Swaps', // Name of your app (max 50 characters)
+    // Must match appData.url (used as the communicator's allowed origin) or the Safe Apps SDK
+    // handshake is dropped and the widget can't auto-connect the Safe
+    baseUrl: cowSwapBaseUrl,
     width: '100%', // Width in pixels (or 100% to use all available space)
     height: '860px',
     chainId: cowChainId,
@@ -227,6 +230,7 @@ const SwapWidget = ({ sell }: Params) => {
   useEffect(() => {
     setParams((params) => ({
       ...params,
+      baseUrl: cowSwapBaseUrl,
       chainId: cowChainId,
       theme: {
         baseTheme: darkMode ? 'dark' : 'light',
@@ -241,7 +245,7 @@ const SwapWidget = ({ sell }: Params) => {
         alert: palette.warning.main,
       },
     }))
-  }, [palette, darkMode, cowChainId])
+  }, [palette, darkMode, cowChainId, cowSwapBaseUrl])
 
   useEffect(() => {
     if (!sell) return


### PR DESCRIPTION
## What it solves

Resolves: [WA-2768](https://linear.app/safe-global/issue/WA-2768/native-cow-swap-widget-does-not-auto-connect-the-safe-on-devstaging)

The native CoW Swap widget stopped auto-connecting the Safe on dev/staging (production unaffected). When `NATIVE_SWAPS_USE_COW_STAGING_SERVER` is on, `appData.url` becomes `https://staging.swap.cow.fi` and drives the `AppCommunicator`'s allowed origin — but the widget had no `baseUrl`, so its iframe loaded the default `https://swap.cow.fi`. The origin mismatch made the communicator drop the Safe Apps SDK `getSafeInfo` handshake, so the widget couldn't connect the Safe.

## How this PR fixes it

Pass `baseUrl: cowSwapBaseUrl` to the widget params (initial + theme/chain sync effect) so the iframe loads the same origin the communicator trusts. No-op on production (flag off → `baseUrl` unchanged).

## How to test it

Reproducible on localhost with the staging CoW server (`NATIVE_SWAPS_USE_COW_STAGING_SERVER` on) after the CoW widget update in [cowprotocol/cowswap#7784](https://github.com/cowprotocol/cowswap/pull/7784). Open a Safe → Swap: the widget should auto-connect the Safe (no "Connect wallet" button). Optionally verify in DevTools that `document.querySelector('#swapWidget iframe').src` and the `getSafeInfo` message origin are both `https://staging.swap.cow.fi`.

## Affected flows

- Native Swap (CoW widget) wallet auto-connect on dev/staging (`NATIVE_SWAPS` + `NATIVE_SWAPS_COW` on, staging-server flag on).

## Blast radius

- `apps/web/src/features/swap/components/SwapWidget/index.tsx` only — one config field to `@cowprotocol/widget-react`.
- Gated by `NATIVE_SWAPS_USE_COW_STAGING_SERVER`; production value is unchanged (no-op there).
- No API/endpoint/route/persisted-state/shared-hook changes. Web-only (no mobile impact).

## Risks / not checked

- A separate iframe-tracking issue (`fromTrackedIframe: false`) is under investigation and **not** addressed here; may need a follow-up.
- No automated test (single config value to a third-party widget, only exercisable against the live CoW app).

## Visual summary

```mermaid
flowchart LR
  A["appData.url = staging.swap.cow.fi\n(communicator allowed origin)"]
  B["Widget iframe origin"]
  A -->|"before: no baseUrl → iframe = swap.cow.fi → mismatch → handshake dropped ❌"| B
  A -->|"after: baseUrl = staging.swap.cow.fi → origins match → Safe auto-connects ✅"| B
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — N/A, web-only
- [x] I've documented how it affects the analytics (if at all) 📊 — no impact
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — see Risks
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
