### PR TITLE
fix(web/UI): Address Book table columns + mobile view

### DIFF
--- a/apps/web/src/features/myAccounts/components/AccountItem/AccountItemChainBadge.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItem/AccountItemChainBadge.tsx
@@ -23,12 +23,9 @@ function AccountItemChainBadge({ chainId, safes, className, imageSize = 24 }: Ac
             <NetworkLogosList networks={safes} showHasMore />
           </TooltipTrigger>
           <TooltipContent>
-            <div data-testid="multichain-tooltip">
-              <p className="text-sm">Multichain account on:</p>
+            <div data-testid="multichain-tooltip" className="flex flex-col gap-1">
               {safes.map((safeItem) => (
-                <div key={safeItem.chainId} className="py-1">
-                  <ChainIndicator imageSize={imageSize} chainId={safeItem.chainId} />
-                </div>
+                <ChainIndicator key={safeItem.chainId} imageSize={imageSize} chainId={safeItem.chainId} />
               ))}
             </div>
           </TooltipContent>

--- a/apps/web/src/features/myAccounts/components/AccountItem/__tests__/AccountItemChainBadge.test.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItem/__tests__/AccountItemChainBadge.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@/tests/test-utils'
+import AccountItemChainBadge from '../AccountItemChainBadge'
+import type { SafeItem } from '@/hooks/safes'
+
+jest.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+jest.mock('@/features/multichain', () => ({
+  NetworkLogosList: () => <span data-testid="network-logos" />,
+}))
+jest.mock('@/components/common/ChainIndicator', () => {
+  const ChainIndicator = ({ chainId }: { chainId: string }) => (
+    <span data-testid="chain-indicator" data-chain-id={chainId} />
+  )
+  return ChainIndicator
+})
+
+const createSafeItem = (chainId: string): SafeItem => ({
+  address: '0x1234567890123456789012345678901234567890',
+  chainId,
+  isReadOnly: false,
+  isPinned: false,
+  lastVisited: 0,
+  name: undefined,
+})
+
+describe('AccountItemChainBadge', () => {
+  it('renders one ChainIndicator per safe in the multichain tooltip without the heading', () => {
+    const safes = [createSafeItem('1'), createSafeItem('137'), createSafeItem('10')]
+
+    render(<AccountItemChainBadge safes={safes} />)
+
+    expect(screen.queryByText('Multichain account on:')).not.toBeInTheDocument()
+    expect(screen.getAllByTestId('chain-indicator')).toHaveLength(3)
+  })
+
+  it('renders a single ChainIndicator without the heading in single-chain mode', () => {
+    render(<AccountItemChainBadge chainId="1" />)
+
+    expect(screen.queryByText('Multichain account on:')).not.toBeInTheDocument()
+    expect(screen.getAllByTestId('chain-indicator')).toHaveLength(1)
+  })
+})

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react'
+import { useMediaQuery } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -34,6 +36,8 @@ function PendingRequestsTable({ requests }: PendingRequestsTableProps) {
   const spaceId = useCurrentSpaceId()
   const dispatch = useAppDispatch()
   const spaceAddressBook = useGetSpaceAddressBook()
+  const theme = useTheme()
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('lg'))
   const [approveRequest] = useAddressBookRequestsApproveRequestV1Mutation()
   const [rejectRequest] = useAddressBookRequestsRejectRequestV1Mutation()
   const [loadingId, setLoadingId] = useState<number | null>(null)
@@ -100,8 +104,8 @@ function PendingRequestsTable({ requests }: PendingRequestsTableProps) {
       <TableHeader>
         <TableRow>
           <TableHead className="w-[20%]">Name</TableHead>
-          <TableHead className="w-[30%]">Address</TableHead>
-          <TableHead className="w-[15%]">Chains</TableHead>
+          <TableHead className={isSmallScreen ? 'w-[30%]' : 'w-[37%]'}>Address</TableHead>
+          <TableHead className={isSmallScreen ? 'w-[15%]' : 'w-[8%]'}>Chains</TableHead>
           <TableHead className="w-[20%]">Requested by</TableHead>
           <TableHead className="w-[15%]" />
         </TableRow>
@@ -123,12 +127,13 @@ function PendingRequestsTable({ requests }: PendingRequestsTableProps) {
             </TableCell>
 
             <TableCell>
-              <div className="text-[0.8em]">
+              <div className="text-[0.8em] font-mono">
                 <EthHashInfo
                   address={req.address}
                   shortAddress={false}
                   showPrefix={false}
                   showName={false}
+                  highlight4bytes
                   hasExplorer
                   showCopyButton
                   avatarSize={24}
@@ -143,7 +148,11 @@ function PendingRequestsTable({ requests }: PendingRequestsTableProps) {
                     {chains.configs.length === req.chainIds.length ? (
                       <Badge variant="secondary">All</Badge>
                     ) : (
-                      <NetworkLogosList networks={req.chainIds.map((chainId) => ({ chainId }))} />
+                      <NetworkLogosList
+                        networks={req.chainIds.map((chainId) => ({ chainId }))}
+                        showHasMore
+                        maxVisible={3}
+                      />
                     )}
                   </span>
                 </TooltipTrigger>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
@@ -101,11 +101,11 @@ function PendingRequestsTable({ requests }: PendingRequestsTableProps) {
   }
 
   return (
-    <Table className="table-fixed">
+    <Table className="table-fixed min-w-[720px]">
       <TableHeader>
         <TableRow>
-          <TableHead className="w-[20%]">Name</TableHead>
-          <TableHead className={isSmallScreen ? 'w-[30%]' : 'w-[32%]'}>Address</TableHead>
+          <TableHead className={isSmallScreen ? 'w-[15%]' : 'w-[20%]'}>Name</TableHead>
+          <TableHead className={isSmallScreen ? 'w-[40%]' : 'w-[32%]'}>Address</TableHead>
           <TableHead className={isSmallScreen ? 'w-[15%]' : 'w-[13%]'}>Chains</TableHead>
           <TableHead className="w-[20%]">Requested by</TableHead>
           <TableHead className="w-[15%]" />

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { Spinner } from '@/components/ui/spinner'
+import { isAddress } from 'ethers'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { NetworkLogosList } from '@/features/multichain'
 import ChainIndicator from '@/components/common/ChainIndicator'
@@ -168,13 +169,32 @@ function PendingRequestsTable({ requests }: PendingRequestsTableProps) {
 
             <TableCell>
               {req.requestedBy && (
-                <EthHashInfo
-                  address={req.requestedBy}
-                  avatarSize={20}
-                  onlyName
-                  showPrefix={false}
-                  showCopyButton={false}
-                />
+                <Tooltip>
+                  <TooltipTrigger render={<span className="inline-flex min-w-0" />}>
+                    {isAddress(req.requestedBy) ? (
+                      <div className="text-[0.8em] font-mono">
+                        <EthHashInfo
+                          address={req.requestedBy}
+                          shortAddress={false}
+                          showPrefix={false}
+                          showName={false}
+                          highlight4bytes
+                          showCopyButton={false}
+                          avatarSize={20}
+                        />
+                      </div>
+                    ) : (
+                      <EthHashInfo
+                        address={req.requestedBy}
+                        avatarSize={20}
+                        onlyName
+                        showPrefix={false}
+                        showCopyButton={false}
+                      />
+                    )}
+                  </TooltipTrigger>
+                  <TooltipContent>{req.requestedBy}</TooltipContent>
+                </Tooltip>
               )}
             </TableCell>
 

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
@@ -105,8 +105,8 @@ function PendingRequestsTable({ requests }: PendingRequestsTableProps) {
       <TableHeader>
         <TableRow>
           <TableHead className="w-[20%]">Name</TableHead>
-          <TableHead className={isSmallScreen ? 'w-[30%]' : 'w-[37%]'}>Address</TableHead>
-          <TableHead className={isSmallScreen ? 'w-[15%]' : 'w-[8%]'}>Chains</TableHead>
+          <TableHead className={isSmallScreen ? 'w-[30%]' : 'w-[32%]'}>Address</TableHead>
+          <TableHead className={isSmallScreen ? 'w-[15%]' : 'w-[13%]'}>Chains</TableHead>
           <TableHead className="w-[20%]">Requested by</TableHead>
           <TableHead className="w-[15%]" />
         </TableRow>
@@ -193,7 +193,7 @@ function PendingRequestsTable({ requests }: PendingRequestsTableProps) {
                       />
                     )}
                   </TooltipTrigger>
-                  <TooltipContent>{req.requestedBy}</TooltipContent>
+                  <TooltipContent side="bottom">{req.requestedBy}</TooltipContent>
                 </Tooltip>
               )}
             </TableCell>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -78,8 +78,8 @@ function SpaceAddressBookTable({
         <TableHeader>
           <TableRow>
             <TableHead className="w-[20%]">Name</TableHead>
-            <TableHead className={isSmallScreen ? 'w-[30%]' : 'w-[37%]'}>Address</TableHead>
-            <TableHead className={isSmallScreen ? 'w-[15%]' : 'w-[8%]'}>Chains</TableHead>
+            <TableHead className={isSmallScreen ? 'w-[30%]' : 'w-[32%]'}>Address</TableHead>
+            <TableHead className={isSmallScreen ? 'w-[15%]' : 'w-[13%]'}>Chains</TableHead>
             {hasMiddleColumn && <TableHead className="w-[20%]">{showAddedBy ? 'Added by' : 'Last updated'}</TableHead>}
             <TableHead className={hasMiddleColumn ? 'w-[15%]' : 'w-[35%]'} />
           </TableRow>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -78,8 +78,8 @@ function SpaceAddressBookTable({
         <TableHeader>
           <TableRow>
             <TableHead className="w-[20%]">Name</TableHead>
-            <TableHead className="w-[30%]">Address</TableHead>
-            <TableHead className="w-[15%]">Chains</TableHead>
+            <TableHead className={isSmallScreen ? 'w-[30%]' : 'w-[37%]'}>Address</TableHead>
+            <TableHead className={isSmallScreen ? 'w-[15%]' : 'w-[8%]'}>Chains</TableHead>
             {hasMiddleColumn && <TableHead className="w-[20%]">{showAddedBy ? 'Added by' : 'Last updated'}</TableHead>}
             <TableHead className={hasMiddleColumn ? 'w-[15%]' : 'w-[35%]'} />
           </TableRow>
@@ -101,7 +101,9 @@ function SpaceAddressBookTable({
                     {entry.isLocal && <HardDrive className="text-muted-foreground size-4 flex-shrink-0" />}
                     <span className="min-w-0 truncate">{entry.name}</span>
                   </TooltipTrigger>
-                  <TooltipContent>{entry.name}</TooltipContent>
+                  <TooltipContent align="start" alignOffset={6}>
+                    {entry.name}
+                  </TooltipContent>
                 </Tooltip>
               </TableCell>
 

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -97,7 +97,10 @@ function SpaceAddressBookTable({
       cell: (entry) => (
         <div className={cn('flex items-center gap-1.5 overflow-hidden', entry.isDuplicate && 'line-through')}>
           {entry.isLocal && <HardDrive className="text-muted-foreground size-4 flex-shrink-0" />}
-          <span className="min-w-0 truncate">{entry.name}</span>
+          <Tooltip>
+            <TooltipTrigger className="min-w-0 truncate text-left">{entry.name}</TooltipTrigger>
+            <TooltipContent>{entry.name}</TooltipContent>
+          </Tooltip>
         </div>
       ),
     },

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -74,11 +74,11 @@ function SpaceAddressBookTable({
 
   return (
     <>
-      <Table className="table-fixed">
+      <Table className="table-fixed min-w-[720px]">
         <TableHeader>
           <TableRow>
-            <TableHead className="w-[20%]">Name</TableHead>
-            <TableHead className={isSmallScreen ? 'w-[30%]' : 'w-[32%]'}>Address</TableHead>
+            <TableHead className={isSmallScreen ? 'w-[15%]' : 'w-[20%]'}>Name</TableHead>
+            <TableHead className={isSmallScreen ? 'w-[40%]' : 'w-[32%]'}>Address</TableHead>
             <TableHead className={isSmallScreen ? 'w-[15%]' : 'w-[13%]'}>Chains</TableHead>
             {hasMiddleColumn && <TableHead className="w-[20%]">{showAddedBy ? 'Added by' : 'Last updated'}</TableHead>}
             <TableHead className={hasMiddleColumn ? 'w-[15%]' : 'w-[35%]'} />

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/PendingRequestsTable.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/PendingRequestsTable.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react'
+import { faker } from '@faker-js/faker'
+import PendingRequestsTable from '../PendingRequestsTable'
+import type { AddressBookRequestItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { Builder } from '@/tests/Builder'
+
+jest.mock('@/hooks/useChains', () => () => ({ configs: [] }))
+jest.mock('@/features/spaces', () => ({
+  useCurrentSpaceId: () => '1',
+  useIsAdmin: () => true,
+  useGetSpaceAddressBook: () => [],
+}))
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
+  useAddressBookRequestsApproveRequestV1Mutation: () => [jest.fn()],
+  useAddressBookRequestsRejectRequestV1Mutation: () => [jest.fn()],
+}))
+jest.mock('@/store', () => ({
+  useAppDispatch: () => jest.fn(),
+}))
+jest.mock('@/components/common/EthHashInfo', () => {
+  const EthHashInfo = ({
+    address,
+    highlight4bytes,
+    onlyName,
+  }: {
+    address: string
+    highlight4bytes?: boolean
+    onlyName?: boolean
+  }) => (
+    <span
+      data-testid="eth-hash-info"
+      data-highlight={String(Boolean(highlight4bytes))}
+      data-only-name={String(Boolean(onlyName))}
+    >
+      {address}
+    </span>
+  )
+  return EthHashInfo
+})
+jest.mock('@/features/multichain', () => ({
+  NetworkLogosList: ({ networks }: { networks: { chainId: string }[] }) => (
+    <span data-testid="network-logos" data-count={networks.length} />
+  ),
+}))
+jest.mock('@/components/common/ChainIndicator', () => {
+  const ChainIndicator = () => <span data-testid="chain-indicator" />
+  return ChainIndicator
+})
+
+const requestBuilder = () =>
+  Builder.new<AddressBookRequestItemDto>().with({
+    id: faker.number.int(),
+    name: faker.person.fullName(),
+    address: faker.finance.ethereumAddress(),
+    chainIds: ['1'],
+    requestedBy: faker.finance.ethereumAddress(),
+  })
+
+describe('PendingRequestsTable', () => {
+  it('renders a highlighted full address in the "Requested by" cell when requestedBy is an address', () => {
+    const requestedBy = faker.finance.ethereumAddress()
+    render(<PendingRequestsTable requests={[requestBuilder().with({ requestedBy }).build()]} />)
+
+    const requestedByCell = screen.getAllByTestId('eth-hash-info').find((el) => el.textContent === requestedBy)
+    expect(requestedByCell).toHaveAttribute('data-highlight', 'true')
+    expect(requestedByCell).toHaveAttribute('data-only-name', 'false')
+  })
+
+  it('renders the name/email variant in the "Requested by" cell when requestedBy is an email', () => {
+    const requestedBy = faker.internet.email()
+    render(<PendingRequestsTable requests={[requestBuilder().with({ requestedBy }).build()]} />)
+
+    const requestedByCell = screen.getAllByTestId('eth-hash-info').find((el) => el.textContent === requestedBy)
+    expect(requestedByCell).toHaveAttribute('data-only-name', 'true')
+    expect(requestedByCell).toHaveAttribute('data-highlight', 'false')
+  })
+})

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/SpaceAddressBookTable.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/SpaceAddressBookTable.test.tsx
@@ -162,9 +162,16 @@ describe('SpaceAddressBookTable', () => {
     const entry = entryBuilder().with({ isDuplicate: true }).build()
     render(<SpaceAddressBookTable entries={[entry]} />)
 
-    const nameSpan = screen.getByText(entry.name)
-    expect(nameSpan.closest('tr')).toHaveClass('opacity-50')
-    expect(nameSpan.parentElement).toHaveClass('line-through')
+    const nameTrigger = screen.getByRole('button', { name: entry.name })
+    expect(nameTrigger.closest('tr')).toHaveClass('opacity-50')
+    expect(nameTrigger.closest('div')).toHaveClass('line-through')
+  })
+
+  it('exposes the full name via a tooltip trigger in the Name column', () => {
+    const name = 'A very long contact name that would overflow the Name column'
+    render(<SpaceAddressBookTable entries={[entryBuilder().with({ name }).build()]} />)
+
+    expect(screen.getByRole('button', { name })).toBeInTheDocument()
   })
 
   it('shortens the address on mobile and shows it in full on desktop', () => {

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
@@ -206,7 +206,7 @@ const SpaceAddressBook = () => {
                   )}
                 </TabsContent>
 
-                <TabsContent value="pending">
+                <TabsContent value="pending" className="mt-4 sm:mt-0">
                   <PendingRequestsTable requests={pendingRequests} />
                 </TabsContent>
               </>


### PR DESCRIPTION
## What it solves

Resolves: [WA-2715](https://linear.app/safe-global/issue/WA-2715/address-book-and-accounts-ui-feedback)
Resolves: [WA-2649](https://linear.app/safe-global/issue/WA-2649/address-book-long-contact-names-not-truncated-text-overflows-into)

Address Book & Accounts UI polish — cropped addresses, inconsistent chain tooltips, and non-scrollable tables on mobile.

## How this PR fixes it

- **Full addresses**: widened the Address column on desktop across all Address Book tabs (Workspace / My contacts / Pending) so the full address is visible; bolded the first/last 4 bytes (`highlight4bytes`) in the Pending tab to match the other tabs.
- **Chains column**: shows the first 3 chain logos + a `+N` badge (`showHasMore maxVisible={3}`) consistently on all tabs, and widened the column so 4+ chains no longer wrap.
- **Requested by**: renders an address like the Address column (full, bold ends) or the name/email variant otherwise, with a hover tooltip (below the row) showing the full value.
- **Accounts tooltip**: removed the "Multichain account on:" heading and reused the Address Book's chain-list layout so both show only the network names.
- **Mobile**: gave all three tables a `min-w` so the existing `overflow-x-auto` container scrolls consistently (Workspace previously didn't), widened the Address column on small screens, and added spacing under the Pending tab.

## How to test it

1. Open a Workspace → Address Book on a wide desktop window — full addresses visible on Workspace / My contacts / Pending.
2. Add a contact spanning 4+ chains — Chains column shows 3 logos + `+N`, no wrapping.
3. Pending tab: "Requested by" shows a bold address (or name/email), full value on hover below the row.
4. Accounts list with a multichain Safe — tooltip lists network names only, no heading.
5. Narrow the viewport / open on mobile — all three tables scroll horizontally; extra margin under the Pending tab.

## Affected flows

- Workspace Address Book: Workspace contacts, My contacts, and Pending requests tabs (view, chains display).
- My Accounts list: multichain account chain badge tooltip.

## Blast radius

- Feature-level changes only: `SpaceAddressBookTable`, `PendingRequestsTable`, `SpaceAddressBook/index`, `AccountItemChainBadge`.
- Reuses shared `EthHashInfo`, `NetworkLogosList`, `ChainIndicator`, and `ui/tooltip`/`ui/table` — no shared primitives modified.
- No API, feature-flag, persistence, or mobile-package changes. `NetworkLogosList` `+N` behavior was already supported via props.

## Risks / not checked

- Did not verify with the private address book feature flag disabled (hides My contacts / Pending tabs).

## Visual summary

**Before:**
<img width="1252" height="182" alt="image" src="https://github.com/user-attachments/assets/5cc363c2-32b7-4d6a-9f62-f4ebfc6487b8" />

**After:**
<img width="1258" height="167" alt="image" src="https://github.com/user-attachments/assets/46ce5c2f-4cc7-4fa7-9aef-6f90c04e1e96" />

**Before:**
<img width="815" height="303" alt="image" src="https://github.com/user-attachments/assets/178cdf48-703b-4da1-abcb-ea3f53ee3036" />

**After:**
- Full addresses
- Tooltip on long names
<img width="847" height="355" alt="image" src="https://github.com/user-attachments/assets/9f49ac2c-f7ac-46a7-8f23-80df3c0b16bd" />




## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
