### PR TITLE
hotfix: bring back the header to the Accounts tab

### DIFF
--- a/apps/web/src/components/common/PageLayout/index.test.tsx
+++ b/apps/web/src/components/common/PageLayout/index.test.tsx
@@ -222,11 +222,11 @@ describe('PageLayout', () => {
       expect(screen.getByTestId('topbar')).toBeInTheDocument()
     })
 
-    it('hides Topbar on /welcome/accounts when the user is signed out (mirrors /welcome/spaces)', () => {
+    it('renders Topbar on /welcome/accounts when the user is signed out (Classic view keeps its Topbar)', () => {
       useIsRequireLoginEnabledModule.useIsRequireLoginEnabled.mockReturnValue(false)
       mockUseIsSignedIn.mockReturnValue(false)
       renderLayout(AppRoutes.welcome.accounts)
-      expect(screen.queryByTestId('topbar')).not.toBeInTheDocument()
+      expect(screen.getByTestId('topbar')).toBeInTheDocument()
     })
   })
 

--- a/apps/web/src/components/common/PageLayout/index.tsx
+++ b/apps/web/src/components/common/PageLayout/index.tsx
@@ -62,14 +62,11 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
   // legacy workspaces list when signed in — only the list needs the Topbar.
   const isLoginPath = pathname === AppRoutes.welcome.spaces || pathname === AppRoutes.index
   const isWelcomeWorskpacePage = pathname === AppRoutes.welcome.spaces
-  // The Accounts and Workspaces tabs share a header row; keep the Topbar gating in sync
-  // so switching tabs while signed out doesn't shift the row vertically.
-  const isWelcomeAccountsPage = pathname === AppRoutes.welcome.accounts
   const hideHeader =
     NO_HEADER_ROUTES.includes(pathname) ||
     Boolean(isRequireLoginEnabled && isLoginPath) ||
     Boolean(isRequireLoginEnabled && isWelcomeWorskpacePage) ||
-    ((isWelcomeWorskpacePage || isWelcomeAccountsPage) && !isSignedIn) ||
+    (isWelcomeWorskpacePage && !isSignedIn) ||
     // While the gate is still resolving, keep the Topbar off the login paths so it
     // can't flash an empty safe-selector skeleton before it (often) gets hidden.
     (isRequireLoginEnabled === undefined && isLoginPath)


### PR DESCRIPTION
## What it solves

Brings back the header to the Accounts tab.

##  How to test 
Header should be visible on the `/welcome/accounts` page.

## Visual summary

Before:
<img width="1500" height="742" alt="image" src="https://github.com/user-attachments/assets/caca2c27-8f90-4567-9882-6d7532989e0d" />


After:
<img width="752" height="360" alt="image" src="https://github.com/user-attachments/assets/66855c3d-6026-40a4-80be-42da9b0c4f21" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
