### PR TITLE
feat(web): add plans upsell CTA banners (home, tx history, tx-executed)

### DIFF
--- a/apps/web/src/components/common/UpsellBanner/UpsellBanner.tsx
+++ b/apps/web/src/components/common/UpsellBanner/UpsellBanner.tsx
@@ -14,7 +14,6 @@ type UpsellBannerProps = {
   'data-testid'?: string
 }
 
-/** Shared horizontal "Get flat pricing" upsell card: icon · caller-supplied text · CTA. */
 export const UpsellBanner = ({
   children,
   ctaLabel,

--- a/apps/web/src/components/common/UpsellBanner/UpsellBanner.tsx
+++ b/apps/web/src/components/common/UpsellBanner/UpsellBanner.tsx
@@ -1,0 +1,46 @@
+import type { ReactElement, ReactNode } from 'react'
+import NextLink from 'next/link'
+import { Box, Button } from '@mui/material'
+import { TicketPercent } from 'lucide-react'
+import { cn } from '@/utils/cn'
+import css from './styles.module.css'
+
+type UpsellBannerProps = {
+  children: ReactNode
+  ctaLabel: string
+  ctaHref: string
+  onCtaClick?: () => void
+  elevation?: 'md' | 'lg'
+  'data-testid'?: string
+}
+
+/** Shared horizontal "Get flat pricing" upsell card: icon · caller-supplied text · CTA. */
+export const UpsellBanner = ({
+  children,
+  ctaLabel,
+  ctaHref,
+  onCtaClick,
+  elevation = 'lg',
+  'data-testid': testId,
+}: UpsellBannerProps): ReactElement => (
+  <Box className={cn(css.banner, elevation === 'md' ? css.elevationMd : css.elevationLg)} data-testid={testId}>
+    <Box aria-hidden className={css.glow} />
+
+    <Box className={css.iconBadge}>
+      <TicketPercent size={16} />
+    </Box>
+
+    <Box className={css.content}>{children}</Box>
+
+    <Button
+      variant="contained"
+      component={NextLink}
+      href={ctaHref}
+      onClick={onCtaClick}
+      className={css.ctaButton}
+      data-testid="upsell-banner-cta"
+    >
+      {ctaLabel}
+    </Button>
+  </Box>
+)

--- a/apps/web/src/components/common/UpsellBanner/__tests__/UpsellBanner.test.tsx
+++ b/apps/web/src/components/common/UpsellBanner/__tests__/UpsellBanner.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from '@/tests/test-utils'
+import type { ReactNode } from 'react'
+import { UpsellBanner } from '../UpsellBanner'
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, onClick, children }: { href: string; onClick?: () => void; children: ReactNode }) => (
+    <a href={href} onClick={onClick}>
+      {children}
+    </a>
+  ),
+}))
+
+describe('UpsellBanner', () => {
+  it('renders the supplied content and a CTA link', () => {
+    render(
+      <UpsellBanner ctaLabel="Explore plans" ctaHref="/spaces/billing">
+        <span>Custom content</span>
+      </UpsellBanner>,
+    )
+
+    expect(screen.getByText('Custom content')).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: 'Explore plans' })
+    expect(link).toHaveAttribute('href', '/spaces/billing')
+  })
+
+  it('fires onCtaClick when the CTA is clicked', () => {
+    const onCtaClick = jest.fn()
+    render(
+      <UpsellBanner ctaLabel="Go" ctaHref="/x" onCtaClick={onCtaClick}>
+        content
+      </UpsellBanner>,
+    )
+
+    fireEvent.click(screen.getByRole('link', { name: 'Go' }))
+    expect(onCtaClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies the requested elevation', () => {
+    render(
+      <UpsellBanner ctaLabel="Go" ctaHref="/x" elevation="md" data-testid="banner">
+        content
+      </UpsellBanner>,
+    )
+
+    expect(screen.getByTestId('banner').className).toContain('elevationMd')
+  })
+})

--- a/apps/web/src/components/common/UpsellBanner/index.ts
+++ b/apps/web/src/components/common/UpsellBanner/index.ts
@@ -1,0 +1,1 @@
+export { UpsellBanner } from './UpsellBanner'

--- a/apps/web/src/components/common/UpsellBanner/styles.module.css
+++ b/apps/web/src/components/common/UpsellBanner/styles.module.css
@@ -1,0 +1,62 @@
+.banner {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 16px;
+  border-radius: 16px;
+  background-color: var(--color-background-muted-secondary);
+  color: var(--color-text-primary);
+}
+
+.elevationLg {
+  box-shadow:
+    0 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0 4px 6px -4px rgba(0, 0, 0, 0.1);
+}
+
+.elevationMd {
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -2px rgba(0, 0, 0, 0.1);
+}
+
+.glow {
+  position: absolute;
+  top: -390px;
+  left: 15%;
+  right: -15%;
+  z-index: -1;
+  height: 367px;
+  background-color: rgba(18, 255, 128, 0.7);
+  opacity: 0.5;
+  filter: blur(116px);
+  pointer-events: none;
+}
+
+.iconBadge {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 9999px;
+  background-color: var(--color-secondary-background);
+  color: var(--color-secondary-main);
+}
+
+.content {
+  display: flex;
+  flex: 1 0 0;
+  min-width: 0;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ctaButton {
+  flex-shrink: 0;
+  border-radius: 12px;
+}

--- a/apps/web/src/components/transactions/HistoryUpsellBanner/HistoryUpsellBanner.tsx
+++ b/apps/web/src/components/transactions/HistoryUpsellBanner/HistoryUpsellBanner.tsx
@@ -1,0 +1,40 @@
+import { type ReactElement } from 'react'
+import { Typography } from '@mui/material'
+import { useIsBillingVisible, useCurrentSpaceId } from '@/features/spaces'
+import { trackEvent } from '@/services/analytics'
+import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import { AppRoutes } from '@/config/routes'
+import { UpsellBanner } from '@/components/common/UpsellBanner'
+
+// TODO(PLA-1681 / PLA-1555): replace these static placeholders with the real 30-day tier-status figures.
+const PLACEHOLDER = { periodDays: 30, movedUsd: '$432K', txCount: '41', feesUsd: '$70' }
+
+const HistoryUpsellBanner = (): ReactElement | null => {
+  const isBillingVisible = useIsBillingVisible()
+  const spaceId = useCurrentSpaceId()
+
+  // TODO(PLA-1699): also hide for active-plan Spaces once subscription data is wired outside the billing page.
+  if (isBillingVisible !== true) {
+    return null
+  }
+
+  return (
+    <UpsellBanner
+      elevation="lg"
+      ctaLabel="Explore plans"
+      ctaHref={spaceId ? `${AppRoutes.spaces.billing}?spaceId=${spaceId}` : AppRoutes.spaces.billing}
+      onCtaClick={() => trackEvent(SPACE_EVENTS.EXPLORE_PLANS_CLICKED)}
+      data-testid="history-upsell-banner"
+    >
+      <Typography fontWeight={600} sx={{ fontSize: 18, lineHeight: '27px' }}>
+        Get flat pricing
+      </Typography>
+      <Typography sx={{ fontSize: 16, lineHeight: '24px' }}>
+        In the past {PLACEHOLDER.periodDays} days, you moved <strong>{PLACEHOLDER.movedUsd}</strong> across{' '}
+        <strong>{PLACEHOLDER.txCount}</strong> transactions and spent {PLACEHOLDER.feesUsd} in fees.
+      </Typography>
+    </UpsellBanner>
+  )
+}
+
+export default HistoryUpsellBanner

--- a/apps/web/src/components/transactions/HistoryUpsellBanner/HistoryUpsellBanner.tsx
+++ b/apps/web/src/components/transactions/HistoryUpsellBanner/HistoryUpsellBanner.tsx
@@ -5,15 +5,16 @@ import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { AppRoutes } from '@/config/routes'
 import { UpsellBanner } from '@/components/common/UpsellBanner'
+import css from './styles.module.css'
 
-// TODO(PLA-1681 / PLA-1555): replace these static placeholders with the real 30-day tier-status figures.
+// TODO: replace these static placeholders with the real 30-day tier-status figures.
 const PLACEHOLDER = { periodDays: 30, movedUsd: '$432K', txCount: '41', feesUsd: '$70' }
 
 const HistoryUpsellBanner = (): ReactElement | null => {
   const isBillingVisible = useIsBillingVisible()
   const spaceId = useCurrentSpaceId()
 
-  // TODO(PLA-1699): also hide for active-plan Spaces once subscription data is wired outside the billing page.
+  // TODO: also hide for active-plan Spaces once subscription data is wired outside the billing page.
   if (isBillingVisible !== true) {
     return null
   }
@@ -26,10 +27,10 @@ const HistoryUpsellBanner = (): ReactElement | null => {
       onCtaClick={() => trackEvent(SPACE_EVENTS.EXPLORE_PLANS_CLICKED)}
       data-testid="history-upsell-banner"
     >
-      <Typography fontWeight={600} sx={{ fontSize: 18, lineHeight: '27px' }}>
+      <Typography variant="inherit" className={css.title}>
         Get flat pricing
       </Typography>
-      <Typography sx={{ fontSize: 16, lineHeight: '24px' }}>
+      <Typography variant="inherit" className={css.description}>
         In the past {PLACEHOLDER.periodDays} days, you moved <strong>{PLACEHOLDER.movedUsd}</strong> across{' '}
         <strong>{PLACEHOLDER.txCount}</strong> transactions and spent {PLACEHOLDER.feesUsd} in fees.
       </Typography>

--- a/apps/web/src/components/transactions/HistoryUpsellBanner/__tests__/HistoryUpsellBanner.test.tsx
+++ b/apps/web/src/components/transactions/HistoryUpsellBanner/__tests__/HistoryUpsellBanner.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, fireEvent } from '@/tests/test-utils'
+import type { ReactNode } from 'react'
+import HistoryUpsellBanner from '../HistoryUpsellBanner'
+
+let mockIsBillingVisible: boolean | undefined = true
+let mockSpaceId: string | null = 'space-1'
+const mockTrackEvent = jest.fn()
+
+jest.mock('@/features/spaces', () => ({
+  useIsBillingVisible: () => mockIsBillingVisible,
+  useCurrentSpaceId: () => mockSpaceId,
+}))
+jest.mock('@/services/analytics', () => ({ trackEvent: (...args: unknown[]) => mockTrackEvent(...args) }))
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, onClick, children }: { href: string; onClick?: () => void; children: ReactNode }) => (
+    <a href={href} onClick={onClick}>
+      {children}
+    </a>
+  ),
+}))
+
+describe('HistoryUpsellBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsBillingVisible = true
+    mockSpaceId = 'space-1'
+  })
+
+  it('renders the static value prop and Explore plans CTA when billing is visible', () => {
+    render(<HistoryUpsellBanner />)
+
+    const banner = screen.getByTestId('history-upsell-banner')
+    expect(screen.getByText('Get flat pricing')).toBeInTheDocument()
+    expect(banner).toHaveTextContent('In the past 30 days')
+    expect(banner).toHaveTextContent('transactions and spent')
+    expect(banner).toHaveTextContent('in fees.')
+
+    const link = screen.getByRole('link', { name: 'Explore plans' })
+    expect(link).toHaveAttribute('href', '/spaces/billing?spaceId=space-1')
+
+    fireEvent.click(link)
+    expect(mockTrackEvent).toHaveBeenCalledWith({ action: 'Explore plans clicked', category: 'spaces' })
+  })
+
+  it('links to billing without a query when there is no space', () => {
+    mockSpaceId = null
+    render(<HistoryUpsellBanner />)
+    expect(screen.getByRole('link', { name: 'Explore plans' })).toHaveAttribute('href', '/spaces/billing')
+  })
+
+  it('renders nothing when billing is not visible', () => {
+    mockIsBillingVisible = false
+    render(<HistoryUpsellBanner />)
+    expect(screen.queryByTestId('history-upsell-banner')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing while chains are still loading (undefined)', () => {
+    mockIsBillingVisible = undefined
+    render(<HistoryUpsellBanner />)
+    expect(screen.queryByTestId('history-upsell-banner')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/transactions/HistoryUpsellBanner/index.ts
+++ b/apps/web/src/components/transactions/HistoryUpsellBanner/index.ts
@@ -1,0 +1,1 @@
+export { default } from './HistoryUpsellBanner'

--- a/apps/web/src/components/transactions/HistoryUpsellBanner/styles.module.css
+++ b/apps/web/src/components/transactions/HistoryUpsellBanner/styles.module.css
@@ -1,0 +1,10 @@
+.title {
+  font-weight: 600;
+  font-size: 18px;
+  line-height: 27px;
+}
+
+.description {
+  font-size: 16px;
+  line-height: 24px;
+}

--- a/apps/web/src/components/tx-flow/flows/SuccessScreen/PostExecUpsellBanner.module.css
+++ b/apps/web/src/components/tx-flow/flows/SuccessScreen/PostExecUpsellBanner.module.css
@@ -1,0 +1,11 @@
+.title {
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.description {
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--color-text-secondary);
+}

--- a/apps/web/src/components/tx-flow/flows/SuccessScreen/PostExecUpsellBanner.tsx
+++ b/apps/web/src/components/tx-flow/flows/SuccessScreen/PostExecUpsellBanner.tsx
@@ -1,0 +1,41 @@
+import { type ReactElement } from 'react'
+import { Box, Typography } from '@mui/material'
+import { useIsBillingVisible, useCurrentSpaceId } from '@/features/spaces'
+import { trackEvent } from '@/services/analytics'
+import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import { AppRoutes } from '@/config/routes'
+import { UpsellBanner } from '@/components/common/UpsellBanner'
+
+// TODO(PLA-1690 / PLA-1691): replace the static placeholder with the real per-tx fee snapshot.
+const PLACEHOLDER_FEE = '$12.40'
+
+const PostExecUpsellBanner = ({ className }: { className?: string }): ReactElement | null => {
+  const isBillingVisible = useIsBillingVisible()
+  const spaceId = useCurrentSpaceId()
+
+  // TODO(PLA-1699): also hide for active-plan Spaces once subscription data is wired outside the billing page.
+  if (isBillingVisible !== true) {
+    return null
+  }
+
+  return (
+    <Box className={className}>
+      <UpsellBanner
+        elevation="md"
+        ctaLabel="Compare plans"
+        ctaHref={spaceId ? `${AppRoutes.spaces.billing}?spaceId=${spaceId}` : AppRoutes.spaces.billing}
+        onCtaClick={() => trackEvent(SPACE_EVENTS.COMPARE_PLANS_CLICKED)}
+        data-testid="post-exec-upsell-banner"
+      >
+        <Typography fontWeight={600} sx={{ fontSize: 14, lineHeight: '20px' }}>
+          Get flat pricing
+        </Typography>
+        <Typography color="text.secondary" sx={{ fontSize: 12, lineHeight: '16px' }}>
+          You paid <strong>{PLACEHOLDER_FEE}</strong> in fees for this transaction.
+        </Typography>
+      </UpsellBanner>
+    </Box>
+  )
+}
+
+export default PostExecUpsellBanner

--- a/apps/web/src/components/tx-flow/flows/SuccessScreen/PostExecUpsellBanner.tsx
+++ b/apps/web/src/components/tx-flow/flows/SuccessScreen/PostExecUpsellBanner.tsx
@@ -5,15 +5,16 @@ import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { AppRoutes } from '@/config/routes'
 import { UpsellBanner } from '@/components/common/UpsellBanner'
+import css from './PostExecUpsellBanner.module.css'
 
-// TODO(PLA-1690 / PLA-1691): replace the static placeholder with the real per-tx fee snapshot.
+// TODO: replace the static placeholder with the real per-tx fee snapshot.
 const PLACEHOLDER_FEE = '$12.40'
 
 const PostExecUpsellBanner = ({ className }: { className?: string }): ReactElement | null => {
   const isBillingVisible = useIsBillingVisible()
   const spaceId = useCurrentSpaceId()
 
-  // TODO(PLA-1699): also hide for active-plan Spaces once subscription data is wired outside the billing page.
+  // TODO: also hide for active-plan Spaces once subscription data is wired outside the billing page.
   if (isBillingVisible !== true) {
     return null
   }
@@ -27,10 +28,10 @@ const PostExecUpsellBanner = ({ className }: { className?: string }): ReactEleme
         onCtaClick={() => trackEvent(SPACE_EVENTS.COMPARE_PLANS_CLICKED)}
         data-testid="post-exec-upsell-banner"
       >
-        <Typography fontWeight={600} sx={{ fontSize: 14, lineHeight: '20px' }}>
+        <Typography variant="inherit" className={css.title}>
           Get flat pricing
         </Typography>
-        <Typography color="text.secondary" sx={{ fontSize: 12, lineHeight: '16px' }}>
+        <Typography variant="inherit" className={css.description}>
           You paid <strong>{PLACEHOLDER_FEE}</strong> in fees for this transaction.
         </Typography>
       </UpsellBanner>

--- a/apps/web/src/components/tx-flow/flows/SuccessScreen/__tests__/PostExecUpsellBanner.test.tsx
+++ b/apps/web/src/components/tx-flow/flows/SuccessScreen/__tests__/PostExecUpsellBanner.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, fireEvent } from '@/tests/test-utils'
+import type { ReactNode } from 'react'
+import PostExecUpsellBanner from '../PostExecUpsellBanner'
+
+let mockIsBillingVisible: boolean | undefined = true
+let mockSpaceId: string | null = 'space-1'
+const mockTrackEvent = jest.fn()
+
+jest.mock('@/features/spaces', () => ({
+  useIsBillingVisible: () => mockIsBillingVisible,
+  useCurrentSpaceId: () => mockSpaceId,
+}))
+jest.mock('@/services/analytics', () => ({ trackEvent: (...args: unknown[]) => mockTrackEvent(...args) }))
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, onClick, children }: { href: string; onClick?: () => void; children: ReactNode }) => (
+    <a href={href} onClick={onClick}>
+      {children}
+    </a>
+  ),
+}))
+
+describe('PostExecUpsellBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsBillingVisible = true
+    mockSpaceId = 'space-1'
+  })
+
+  it('renders the fee value prop and Compare plans CTA when billing is visible', () => {
+    render(<PostExecUpsellBanner />)
+
+    const banner = screen.getByTestId('post-exec-upsell-banner')
+    expect(screen.getByText('Get flat pricing')).toBeInTheDocument()
+    expect(banner).toHaveTextContent('in fees for this transaction.')
+
+    const link = screen.getByRole('link', { name: 'Compare plans' })
+    expect(link).toHaveAttribute('href', '/spaces/billing?spaceId=space-1')
+
+    fireEvent.click(link)
+    expect(mockTrackEvent).toHaveBeenCalledWith({ action: 'Compare plans clicked', category: 'spaces' })
+  })
+
+  it('renders nothing when billing is not visible', () => {
+    mockIsBillingVisible = false
+    render(<PostExecUpsellBanner />)
+    expect(screen.queryByTestId('post-exec-upsell-banner')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/tx-flow/flows/SuccessScreen/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/SuccessScreen/index.tsx
@@ -21,6 +21,7 @@ import { usePredictSafeAddressFromTxDetails } from '@/hooks/usePredictSafeAddres
 import { AppRoutes } from '@/config/routes'
 import { NESTED_SAFE_EVENTS, NESTED_SAFE_LABELS } from '@/services/analytics/events/nested-safes'
 import Track from '@/components/common/Track'
+import PostExecUpsellBanner from './PostExecUpsellBanner'
 
 interface Props {
   /** The ID assigned to the transaction in the client-gateway */
@@ -98,6 +99,7 @@ const SuccessScreen = ({ txId, txHash }: Props) => {
       {!error && (
         <>
           <Divider />
+          <PostExecUpsellBanner className={css.upsellBanner} />
           <div className={css.row}>
             <StatusStepper status={status} txHash={localTxHash} />
           </div>

--- a/apps/web/src/components/tx-flow/flows/SuccessScreen/styles.module.css
+++ b/apps/web/src/components/tx-flow/flows/SuccessScreen/styles.module.css
@@ -3,8 +3,6 @@
   padding: var(--space-4) var(--space-7);
 }
 
-/* Upsell banner sits between the divider and the status stepper. Aligns with .row sides;
-   negative bottom offsets the stepper .row's --space-4 top to the design's --space-3 gap. */
 .upsellBanner {
   width: 100%;
   padding: var(--space-3) var(--space-7) 0;

--- a/apps/web/src/components/tx-flow/flows/SuccessScreen/styles.module.css
+++ b/apps/web/src/components/tx-flow/flows/SuccessScreen/styles.module.css
@@ -3,9 +3,22 @@
   padding: var(--space-4) var(--space-7);
 }
 
+/* Upsell banner sits between the divider and the status stepper. Aligns with .row sides;
+   negative bottom offsets the stepper .row's --space-4 top to the design's --space-3 gap. */
+.upsellBanner {
+  width: 100%;
+  padding: var(--space-3) var(--space-7) 0;
+  margin-bottom: calc(var(--space-3) - var(--space-4));
+  text-align: left;
+}
+
 @media (max-width: 599.95px) {
   .row {
     padding: var(--space-2);
+  }
+
+  .upsellBanner {
+    padding: var(--space-3) var(--space-2) 0;
   }
 }
 

--- a/apps/web/src/features/spaces/components/Sidebar/GetFlatPricingBanner/GetFlatPricingBanner.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/GetFlatPricingBanner/GetFlatPricingBanner.tsx
@@ -1,0 +1,66 @@
+import type { ReactElement } from 'react'
+import Link from 'next/link'
+import { TicketPercent, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Typography } from '@/components/ui/typography'
+import { SidebarMenuItem } from '@/components/ui/sidebar'
+import { cn } from '@/utils/cn'
+import useLocalStorage from '@/services/local-storage/useLocalStorage'
+import { trackEvent } from '@/services/analytics'
+import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import { AppRoutes } from '@/config/routes'
+import useIsBillingVisible from '../../../hooks/useIsBillingVisible'
+import { useCurrentSpaceId } from '../../../hooks/useCurrentSpaceId'
+import css from './styles.module.css'
+
+const DISMISSED_KEY = 'get-flat-pricing-banner-dismissed'
+
+export const GetFlatPricingBanner = (): ReactElement | null => {
+  const [dismissed, setDismissed] = useLocalStorage<boolean>(DISMISSED_KEY)
+  const isBillingVisible = useIsBillingVisible()
+  const spaceId = useCurrentSpaceId()
+
+  if (dismissed || isBillingVisible !== true) {
+    return null
+  }
+
+  const billingHref = { pathname: AppRoutes.spaces.billing, query: spaceId ? { spaceId } : {} }
+
+  return (
+    <SidebarMenuItem>
+      <div className={cn(css.banner, 'group-data-[collapsible=icon]:hidden')} data-testid="pricing-cta-sidebar">
+        <div aria-hidden className={css.glow} />
+
+        <div className="flex w-full items-start justify-between">
+          <div className={css.iconBadge}>
+            <TicketPercent className="size-4" />
+          </div>
+          <button
+            className="shrink-0 text-muted-foreground hover:text-foreground"
+            onClick={() => setDismissed(true)}
+            aria-label="Dismiss"
+            data-testid="pricing-cta-dismiss"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <Typography variant="paragraph-small-bold">Get flat pricing</Typography>
+          <Typography variant="paragraph-small-medium" color="muted">
+            Upgrade to a plan with included fee-free volume.
+          </Typography>
+        </div>
+
+        <Button
+          size="xs"
+          className="w-auto self-start rounded-xl px-3 font-normal"
+          data-testid="pricing-cta-compare"
+          render={<Link href={billingHref} onClick={() => trackEvent(SPACE_EVENTS.COMPARE_PLANS_CLICKED)} />}
+        >
+          Compare plans
+        </Button>
+      </div>
+    </SidebarMenuItem>
+  )
+}

--- a/apps/web/src/features/spaces/components/Sidebar/GetFlatPricingBanner/__tests__/GetFlatPricingBanner.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/GetFlatPricingBanner/__tests__/GetFlatPricingBanner.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { cloneElement, type ReactElement, type ReactNode } from 'react'
+import { GetFlatPricingBanner } from '../GetFlatPricingBanner'
+
+const mockSetDismissed = jest.fn()
+let mockDismissed: boolean | undefined = undefined
+let mockIsBillingVisible: boolean | undefined = true
+let mockSpaceId: string | null = 'space-1'
+const mockTrackEvent = jest.fn()
+
+jest.mock('@/services/local-storage/useLocalStorage', () => jest.fn(() => [mockDismissed, mockSetDismissed]))
+jest.mock('../../../../hooks/useIsBillingVisible', () => ({ __esModule: true, default: () => mockIsBillingVisible }))
+jest.mock('../../../../hooks/useCurrentSpaceId', () => ({ useCurrentSpaceId: () => mockSpaceId }))
+
+jest.mock('@/services/analytics', () => ({
+  trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}))
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, onClick, children }: { href: unknown; onClick?: () => void; children: ReactNode }) => {
+    const pathname = typeof href === 'object' && href ? (href as { pathname: string }).pathname : String(href)
+    const query = typeof href === 'object' && href ? (href as { query?: { spaceId?: string } }).query : undefined
+    const url = query?.spaceId ? `${pathname}?spaceId=${query.spaceId}` : pathname
+    return (
+      <a href={url} onClick={onClick}>
+        {children}
+      </a>
+    )
+  },
+}))
+
+jest.mock('@/components/ui/sidebar', () => ({
+  SidebarMenuItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@/components/ui/button', () => ({
+  Button: ({ children, render: renderProp }: { children: ReactNode; render?: ReactElement }) =>
+    renderProp ? cloneElement(renderProp, {}, children) : <button>{children}</button>,
+}))
+
+describe('GetFlatPricingBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDismissed = undefined
+    mockIsBillingVisible = true
+    mockSpaceId = 'space-1'
+  })
+
+  it('renders title, subtitle and CTA when billing is visible and not dismissed', () => {
+    render(<GetFlatPricingBanner />)
+
+    expect(screen.getByTestId('pricing-cta-sidebar')).toBeInTheDocument()
+    expect(screen.getByText('Get flat pricing')).toBeInTheDocument()
+    expect(screen.getByText('Upgrade to a plan with included fee-free volume.')).toBeInTheDocument()
+  })
+
+  it('links "Compare plans" to the billing page with the current space and tracks the click', () => {
+    render(<GetFlatPricingBanner />)
+
+    const link = screen.getByRole('link', { name: /Compare plans/i })
+    expect(link).toHaveAttribute('href', '/spaces/billing?spaceId=space-1')
+
+    fireEvent.click(link)
+    expect(mockTrackEvent).toHaveBeenCalledWith({ action: 'Compare plans clicked', category: 'spaces' })
+  })
+
+  it('links to billing without a query when there is no space', () => {
+    mockSpaceId = null
+    render(<GetFlatPricingBanner />)
+
+    expect(screen.getByRole('link', { name: /Compare plans/i })).toHaveAttribute('href', '/spaces/billing')
+  })
+
+  it('dismisses permanently when the ✕ is clicked', () => {
+    render(<GetFlatPricingBanner />)
+
+    fireEvent.click(screen.getByTestId('pricing-cta-dismiss'))
+    expect(mockSetDismissed).toHaveBeenCalledWith(true)
+  })
+
+  it('renders nothing when dismissed', () => {
+    mockDismissed = true
+    render(<GetFlatPricingBanner />)
+
+    expect(screen.queryByTestId('pricing-cta-sidebar')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when billing is not visible', () => {
+    mockIsBillingVisible = false
+    render(<GetFlatPricingBanner />)
+
+    expect(screen.queryByTestId('pricing-cta-sidebar')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing while chains are still loading (undefined)', () => {
+    mockIsBillingVisible = undefined
+    render(<GetFlatPricingBanner />)
+
+    expect(screen.queryByTestId('pricing-cta-sidebar')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/Sidebar/GetFlatPricingBanner/index.ts
+++ b/apps/web/src/features/spaces/components/Sidebar/GetFlatPricingBanner/index.ts
@@ -1,0 +1,1 @@
+export { GetFlatPricingBanner } from './GetFlatPricingBanner'

--- a/apps/web/src/features/spaces/components/Sidebar/GetFlatPricingBanner/styles.module.css
+++ b/apps/web/src/features/spaces/components/Sidebar/GetFlatPricingBanner/styles.module.css
@@ -14,7 +14,6 @@
     0 4px 6px -4px rgba(0, 0, 0, 0.1);
 }
 
-/* Green glow blob, top-right (mirrors Figma node 13002:41745) */
 .glow {
   position: absolute;
   top: -60px;

--- a/apps/web/src/features/spaces/components/Sidebar/GetFlatPricingBanner/styles.module.css
+++ b/apps/web/src/features/spaces/components/Sidebar/GetFlatPricingBanner/styles.module.css
@@ -1,0 +1,42 @@
+.banner {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 16px;
+  background-color: var(--color-background-muted-secondary);
+  color: var(--color-foreground);
+  box-shadow:
+    0 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0 4px 6px -4px rgba(0, 0, 0, 0.1);
+}
+
+/* Green glow blob, top-right (mirrors Figma node 13002:41745) */
+.glow {
+  position: absolute;
+  top: -60px;
+  right: -20px;
+  z-index: -1;
+  width: 160px;
+  height: 160px;
+  transform: rotate(126.72deg);
+  background-color: rgba(18, 255, 128, 0.8);
+  opacity: 0.5;
+  filter: blur(115px);
+  pointer-events: none;
+}
+
+.iconBadge {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 9999px;
+  background-color: var(--color-secondary-background);
+  color: var(--color-secondary-main);
+}

--- a/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/SidebarCommonFooter.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/SidebarCommonFooter.tsx
@@ -15,6 +15,7 @@ import { CookieAndTermType, hasConsentFor } from '@/store/cookiesAndTermsSlice'
 import { openCookieBanner } from '@/store/popupSlice'
 import { BEAMER_SELECTOR } from '@/services/beamer'
 import { ApiCtaSidebar } from '../ApiCtaSidebar'
+import { GetFlatPricingBanner } from '../GetFlatPricingBanner'
 import { SidebarIndexingStatus } from '../SidebarIndexingStatus'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import { LS_KEY } from '@/config/gateway'
@@ -72,6 +73,7 @@ export const SidebarCommonFooter = ({ isSafeSidebar = false }: { isSafeSidebar?:
       )}
 
       <SidebarMenu className="gap-0.5">
+        {!isSafeSidebar && <GetFlatPricingBanner />}
         <ApiCtaSidebar />
 
         <SidebarMenuItem className={css.footerHelpRow}>

--- a/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/__tests__/SidebarCommonFooter.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/__tests__/SidebarCommonFooter.test.tsx
@@ -121,6 +121,10 @@ jest.mock('../../ApiCtaSidebar', () => ({
   ApiCtaSidebar: () => <div data-testid="api-cta-sidebar" />,
 }))
 
+jest.mock('../../GetFlatPricingBanner', () => ({
+  GetFlatPricingBanner: () => <div data-testid="pricing-cta-sidebar" />,
+}))
+
 jest.mock('../../SidebarIndexingStatus', () => ({
   SidebarIndexingStatus: () => <div data-testid="indexing-status" />,
 }))

--- a/apps/web/src/pages/transactions/history.tsx
+++ b/apps/web/src/pages/transactions/history.tsx
@@ -14,6 +14,7 @@ import { BRAND_NAME } from '@/config/constants'
 import CsvTxExportButton from '@/components/transactions/CsvTxExportButton'
 import { useHasFeature } from '@/hooks/useChains'
 import { FEATURES } from '@safe-global/utils/utils/chains'
+import HistoryUpsellBanner from '@/components/transactions/HistoryUpsellBanner'
 
 const History: NextPage = () => {
   const [filter] = useTxFilter()
@@ -86,6 +87,10 @@ const History: NextPage = () => {
         >
           <TxFilterForm onClose={handleFilterClose} />
         </Popover>
+
+        <Box mb={1.5}>
+          <HistoryUpsellBanner />
+        </Box>
 
         <Box mb={4}>
           <PaginatedTxns useTxns={useTxHistory} />

--- a/apps/web/src/services/analytics/events/spaces.ts
+++ b/apps/web/src/services/analytics/events/spaces.ts
@@ -3,6 +3,14 @@ import { EventType } from '@/services/analytics/types'
 const SPACE_CATEGORY = 'spaces'
 
 export const SPACE_EVENTS = {
+  COMPARE_PLANS_CLICKED: {
+    action: 'Compare plans clicked',
+    category: SPACE_CATEGORY,
+  },
+  EXPLORE_PLANS_CLICKED: {
+    action: 'Explore plans clicked',
+    category: SPACE_CATEGORY,
+  },
   SIGN_IN_BUTTON: {
     action: 'Open sign in message',
     category: SPACE_CATEGORY,


### PR DESCRIPTION
Adds "Get flat pricing" upsell banners on three surfaces per PLA-1699, gated on billing visibility (GTF_PLANS || GTF) for non-subscribers:
- Home: dismissible sidebar card (localStorage), "Compare plans"
- Tx history: banner atop the list, "Explore plans"
- Tx-executed modal: banner in the success screen, "Compare plans"

Shared presentational UpsellBanner in components/common; CTAs route to /spaces/billing. MVP ships static copy with placeholder figures behind TODOs (real data pending PLA-1681/PLA-1690); non-subscriber hide deferred.

## What it solves

Resolves: https://linear.app/safe-global/issue/PLA-1699/wallet-plans-upsell-cta-banners-home-tx-history-tx-executed-modal

## How this PR fixes it

## How to test it

## Affected flows

<!-- The primary user journey(s) this PR intentionally changes. One bullet per flow. Example: "Owner adds a new signer from Settings > Signers". -->

## Blast radius

<!--
List the surfaces touched by this change and who else depends on them. Think in dependency terms, not files.
Include where relevant:
- Shared hooks / components / selectors / slices touched and their known consumers
- RTK Query endpoints / API contracts
- Feature flags / chain configs
- Persistence / cache / migration implications
- Routes or layouts affected indirectly
- Mobile impact (shared packages)
-->

## Risks / not checked

<!--
Be explicit about what you did NOT verify. This exposes false confidence and helps reviewers target their attention.
Example:
- Did not verify behavior with feature flag X disabled
- Did not test on mobile
- Did not exercise the retry / error path manually
-->

## Visual summary

<!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
