### PR TITLE
fix: adjust smoke test so ci/cd pipeline does not fail

### DIFF
--- a/apps/web/cypress/e2e/pages/create_tx.pages.js
+++ b/apps/web/cypress/e2e/pages/create_tx.pages.js
@@ -676,7 +676,12 @@ export function verifySummaryByName(name, token, data, alt, altToken) {
 
     // Verify token symbol (altToken parameter)
     if (altToken) {
-      verifyTokenSymbol($element, altToken)
+      cy.wait(3000)
+      cy.get(selector)
+        .first()
+        .then(($freshElement) => {
+          verifyTokenSymbol($freshElement, altToken)
+        })
     }
   })
 }


### PR DESCRIPTION
## What it solves

Adds a `.wait()` to the test page for tx assertions so smoke tests in CI/CD pipeline and regression tests for txs do not fail due to delayed loading.


---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
