### PR TITLE
fix: Execute Free row hidden if GTF is not enabled

### DIFF
--- a/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/ReviewAndExecuteContainer.tsx
+++ b/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/ReviewAndExecuteContainer.tsx
@@ -15,6 +15,7 @@ import { useAppSelector } from '@/src/store/hooks'
 import { selectEstimatedFee } from '@/src/store/estimatedFeeSlice'
 import { selectExecutionMethod } from '@/src/store/executionMethodSlice'
 import { selectActiveChain } from '@/src/store/chains'
+import { FEATURES, hasFeature } from '@safe-global/utils/utils/chains'
 import { ExecutionMethod } from '@/src/features/HowToExecuteSheet/types'
 import { getExecutionMethod } from './helpers'
 import { isMultisigDetailedExecutionInfo } from '@/src/utils/transaction-guards'
@@ -36,6 +37,7 @@ export function ReviewAndExecuteContainer() {
   const { isBiometricsEnabled } = useBiometrics()
 
   const { requiresRelay, isRelayEnabled, isRelayAvailable, isLoadingRelays } = useRequiresRelay(txDetails)
+  const isGtfEnabled = chain ? hasFeature(chain, FEATURES.GTF) : false
   // Clear estimated fee values when screen is mounted
   useClearEstimatedFeeOnMount()
 
@@ -141,6 +143,7 @@ export function ReviewAndExecuteContainer() {
           activeSigner={activeSigner}
           executionMethod={executionMethod}
           isPaidFromSafe={requiresRelay}
+          isGtfEnabled={isGtfEnabled}
           detailedExecutionInfo={
             isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)
               ? txDetails.detailedExecutionInfo

--- a/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/ReviewExecuteFooter.test.tsx
+++ b/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/ReviewExecuteFooter.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react-native'
+import { TamaguiProvider } from 'tamagui'
+import config from '@/src/theme/tamagui.config'
+import { ReviewExecuteFooter } from './ReviewExecuteFooter'
+import { ExecutionMethod } from '@/src/features/HowToExecuteSheet/types'
+
+// Stub the child fee/executor components — they carry their own store/relay hooks and are not part
+// of the GTF gate under test.
+jest.mock('@/src/components/SelectExecutor', () => ({ SelectExecutor: () => null }))
+jest.mock('../EstimatedNetworkFee', () => {
+  const { Text: T } = jest.requireActual('tamagui')
+  return { EstimatedNetworkFee: () => <T>Est. network fee</T> }
+})
+jest.mock('@/src/features/WalletConnect/Signer/components/WalletConnectGate', () => ({
+  WalletConnectGate: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+jest.mock('@/src/store/hooks', () => ({
+  useAppSelector: () => 'usd',
+}))
+
+jest.mock('@/src/features/ConfirmTx/components/TransactionInfo/useFeesBreakdown', () => ({
+  useFeesBreakdown: () => undefined,
+}))
+
+const baseProps = {
+  txId: 'tx123',
+  activeSigner: undefined,
+  executionMethod: ExecutionMethod.WITH_PK,
+  isPaidFromSafe: false,
+  detailedExecutionInfo: undefined,
+  totalFee: '0.01',
+  isLoadingFees: false,
+  willFail: false,
+  hasSufficientFunds: true,
+  isCheckingFunds: false,
+  isExecuting: false,
+  onConfirmPress: jest.fn(),
+}
+
+const renderFooter = (isGtfEnabled: boolean) =>
+  render(
+    <TamaguiProvider config={config} defaultTheme="light">
+      <ReviewExecuteFooter {...baseProps} isGtfEnabled={isGtfEnabled} />
+    </TamaguiProvider>,
+  )
+
+describe('ReviewExecuteFooter', () => {
+  it('hides the "Execution Fee" row on networks without GTF', () => {
+    renderFooter(false)
+    expect(screen.queryByText('Execution Fee')).toBeNull()
+    // The pre-GTF estimated network fee row is still shown.
+    expect(screen.getByText('Est. network fee')).toBeTruthy()
+  })
+
+  it('shows the "Execution Fee" row on GTF-enabled networks', () => {
+    renderFooter(true)
+    expect(screen.getByText('Execution Fee')).toBeTruthy()
+  })
+})

--- a/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/ReviewExecuteFooter.tsx
+++ b/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/ReviewExecuteFooter.tsx
@@ -26,6 +26,7 @@ interface ReviewExecuteFooterProps {
   activeSigner: Signer | undefined
   executionMethod: ExecutionMethod
   isPaidFromSafe: boolean
+  isGtfEnabled: boolean
   detailedExecutionInfo?: MultisigExecutionDetails
   totalFee: string
   isLoadingFees: boolean
@@ -45,6 +46,7 @@ export function ReviewExecuteFooter({
   activeSigner,
   executionMethod,
   isPaidFromSafe,
+  isGtfEnabled,
   detailedExecutionInfo,
   totalFee,
   isLoadingFees,
@@ -84,15 +86,17 @@ export function ReviewExecuteFooter({
           isPaidFromSafe={isPaidFromSafe}
         />
 
-        <FeeRow
-          label={
-            <Text color="$textSecondaryLight" fontSize="$4">
-              Execution Fee
-            </Text>
-          }
-        >
-          <FeeFreeValue />
-        </FeeRow>
+        {isGtfEnabled && (
+          <FeeRow
+            label={
+              <Text color="$textSecondaryLight" fontSize="$4">
+                Execution Fee
+              </Text>
+            }
+          >
+            <FeeFreeValue />
+          </FeeRow>
+        )}
 
         {paidFromSafeGasFee ? (
           <FeeRow


### PR DESCRIPTION
## What it solves

The main changes include adding a new `isGtfEnabled` prop throughout the review and execution components, conditionally displaying the "Execution Fee" row based on GTF support, and adding tests to verify the correct UI behavior.
