### PR TITLE
feat(mobile): support WalletConnect dApp deep linking into Safe{Mobile}

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -40,7 +40,8 @@ const config: ExpoConfig = {
   },
   orientation: 'portrait',
   icon: './assets/images/icon.png',
-  scheme: ['wc'],
+  // `safe` matches the WalletConnect registry native link (and SAFE_WALLET_METADATA.redirect); `wc` keeps raw wc: links.
+  scheme: ['safe', 'wc'],
   userInterfaceStyle: 'automatic',
   ios: {
     config: {

--- a/apps/mobile/src/app/+native-intent.tsx
+++ b/apps/mobile/src/app/+native-intent.tsx
@@ -50,7 +50,8 @@ export function redirectSystemPath({ path, initial: _initial }: { path: string; 
     }
     return path
   } catch {
-    console.error('Error in redirectSystemPath:', path)
+    // Only the scheme — a WalletConnect pairing URI carries the session symKey.
+    console.error('Error in redirectSystemPath for scheme:', path.split(':')[0])
     return '/'
   }
 }

--- a/apps/mobile/src/app/+native-intent.tsx
+++ b/apps/mobile/src/app/+native-intent.tsx
@@ -30,7 +30,7 @@ const isNonNavigationalDeepLink = (path: string): boolean => {
   if (schemeEnd === -1) {
     return false
   }
-  // Custom schemes (safe://) carry the route in the authority; https carries it in the first segment.
+  // Custom schemes (safe://) put the route in the authority; https in the first path segment.
   const [authority, firstSegment] = path.slice(schemeEnd + 3).split(/[/?#]/)
   return authority === '' || authority === 'wc' || firstSegment === 'wc'
 }

--- a/apps/mobile/src/app/+native-intent.tsx
+++ b/apps/mobile/src/app/+native-intent.tsx
@@ -1,3 +1,4 @@
+import { isPairingUri } from '@safe-global/utils/features/walletconnect/utils'
 import { trackEvent } from '@/src/services/analytics'
 import { createProtectedRouteAttemptEvent } from '@/src/services/analytics/events/nativeIntent'
 
@@ -16,11 +17,33 @@ const protectedRoutes: string[] = [
   'biometrics-opt-in',
   'confirm-transaction',
 ]
+
+// WalletConnect links (pairing, request foregrounding, raw wc:, universal /wc) and AppKit's bare
+// safe:// return redirect have no route; expo-router would send them to +not-found or the root
+// index, resetting the user's stack. Hand-parsed rather than via `new URL` so it doesn't depend
+// on the url polyfill, which may not be loaded this early on a cold launch.
+const isNonNavigationalDeepLink = (path: string): boolean => {
+  if (isPairingUri(path)) {
+    return true
+  }
+  const schemeEnd = path.indexOf('://')
+  if (schemeEnd === -1) {
+    return false
+  }
+  // Custom schemes (safe://) carry the route in the authority; https carries it in the first segment.
+  const [authority, firstSegment] = path.slice(schemeEnd + 3).split(/[/?#]/)
+  return authority === '' || authority === 'wc' || firstSegment === 'wc'
+}
+
 export function redirectSystemPath({ path, initial: _initial }: { path: string; initial: boolean }) {
   try {
+    if (isNonNavigationalDeepLink(path)) {
+      // '' performs no navigation (expo-router skips routing on a falsy result); '/' would reset
+      // the stack to the root index, breaking a flow that's mid-navigation (e.g. importing a signer).
+      return ''
+    }
     const isProtectedRoute = protectedRoutes.some((route) => path.includes(route))
     if (isProtectedRoute) {
-      console.log('trying to navigate to protected route', path)
       // Log to Firebase Analytics
       trackEvent(createProtectedRouteAttemptEvent(path))
       return '/'

--- a/apps/mobile/src/app/__tests__/native-intent.test.ts
+++ b/apps/mobile/src/app/__tests__/native-intent.test.ts
@@ -51,6 +51,11 @@ describe('redirectSystemPath', () => {
     expect(redirectSystemPath({ path, initial: false })).toBe(path)
   })
 
+  it('still swallows a WC envelope carrying a non-wc uri (no navigation)', () => {
+    // extractWcUri validates the pairing URI downstream; safe://wc?… never routes here.
+    expect(redirectSystemPath({ path: 'safe://wc?uri=https://evil', initial: false })).toBe('')
+  })
+
   it('redirects protected routes to home', () => {
     expect(redirectSystemPath({ path: '/sign-transaction', initial: false })).toBe('/')
   })

--- a/apps/mobile/src/app/__tests__/native-intent.test.ts
+++ b/apps/mobile/src/app/__tests__/native-intent.test.ts
@@ -1,0 +1,61 @@
+import { redirectSystemPath } from '../+native-intent'
+
+jest.mock('@/src/services/analytics', () => ({ trackEvent: jest.fn() }))
+jest.mock('@/src/services/analytics/events/nativeIntent', () => ({
+  createProtectedRouteAttemptEvent: jest.fn(() => ({})),
+}))
+
+describe('redirectSystemPath', () => {
+  const wcUri = 'wc:abc123@2?relay-protocol=irn&symKey=deadbeef'
+
+  it('swallows the wrapped pairing link (safe://wc?uri=…) without navigating', () => {
+    expect(redirectSystemPath({ path: `safe://wc?uri=${encodeURIComponent(wcUri)}`, initial: false })).toBe('')
+  })
+
+  it('swallows a request-foregrounding link (safe://wc?requestId=…&sessionTopic=…) without navigating', () => {
+    const path = 'safe://wc?requestId=1782477540021154&sessionTopic=823422c89de5a6b18'
+    expect(redirectSystemPath({ path, initial: false })).toBe('')
+  })
+
+  it('swallows a bare safe://wc link without navigating', () => {
+    expect(redirectSystemPath({ path: 'safe://wc', initial: false })).toBe('')
+  })
+
+  it('swallows a raw wc: pairing link without navigating', () => {
+    expect(redirectSystemPath({ path: 'wc:abc123@2?relay-protocol=irn', initial: true })).toBe('')
+  })
+
+  it('swallows the universal-link variant (https://app.safe.global/wc?uri=…) without navigating', () => {
+    expect(
+      redirectSystemPath({ path: `https://app.safe.global/wc?uri=${encodeURIComponent(wcUri)}`, initial: false }),
+    ).toBe('')
+  })
+
+  it('swallows a bare scheme foreground redirect (safe://) without navigating', () => {
+    expect(redirectSystemPath({ path: 'safe://', initial: false })).toBe('')
+    expect(redirectSystemPath({ path: 'safe://?foo=1', initial: false })).toBe('')
+  })
+
+  it('does not swallow a real navigation deep link (route lives in the host)', () => {
+    const path = 'safe://address-book'
+    expect(redirectSystemPath({ path, initial: false })).toBe(path)
+  })
+
+  it('does not swallow an unrelated route that merely starts with the letters wc', () => {
+    const path = 'safe://wconnect-settings'
+    expect(redirectSystemPath({ path, initial: false })).toBe(path)
+  })
+
+  it('does not swallow a normal deep link with an unrelated uri param', () => {
+    const path = 'safe://contact?uri=https%3A%2F%2Fexample.com'
+    expect(redirectSystemPath({ path, initial: false })).toBe(path)
+  })
+
+  it('redirects protected routes to home', () => {
+    expect(redirectSystemPath({ path: '/sign-transaction', initial: false })).toBe('/')
+  })
+
+  it('passes through a regular route unchanged', () => {
+    expect(redirectSystemPath({ path: '/address-book', initial: false })).toBe('/address-book')
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/WalletKitController.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/WalletKitController.tsx
@@ -5,7 +5,7 @@ import { getSdkError } from '@walletconnect/utils'
 import { formatJsonRpcError } from '@walletconnect/jsonrpc-utils'
 import { useStore } from 'react-redux'
 import { FEATURES } from '@safe-global/utils/utils/chains'
-import { isPairingUri } from '@safe-global/utils/features/walletconnect/utils'
+import { extractWcUri } from '@safe-global/utils/features/walletconnect/utils'
 import { useHasFeature } from '@/src/hooks/useHasFeature'
 import { useAppDispatch } from '@/src/store/hooks'
 import { type RootState } from '@/src/store'
@@ -123,11 +123,12 @@ export const WalletKitController: React.FC = () => {
     }
     let cancelled = false
     const handleUrl = async (url: string) => {
-      if (!isPairingUri(url)) {
+      const uri = extractWcUri(url)
+      if (!uri) {
         return
       }
       try {
-        await walletKit.pair({ uri: url })
+        await walletKit.pair({ uri })
       } catch (e) {
         logWalletKitError('deep-link pair failed', e)
       }

--- a/apps/mobile/src/features/WalletConnect/Wallet/__tests__/WalletKitController.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/__tests__/WalletKitController.test.tsx
@@ -119,6 +119,14 @@ describe('WalletKitController', () => {
     await waitFor(() => expect(mockWalletKit.pair).toHaveBeenCalledWith({ uri: 'wc:abc123@2?relay-protocol=irn' }))
   })
 
+  it('pairs on a registry-envelope deep link (safe://wc?uri=…)', async () => {
+    renderController()
+    await waitFor(() => expect(mockUrlHandler).toBeDefined())
+    const inner = 'wc:abc123@2?relay-protocol=irn'
+    mockUrlHandler?.({ url: `safe://wc?uri=${encodeURIComponent(inner)}` })
+    await waitFor(() => expect(mockWalletKit.pair).toHaveBeenCalledWith({ uri: inner }))
+  })
+
   it('ignores non-wc deep links', async () => {
     renderController()
     await waitFor(() => expect(mockUrlHandler).toBeDefined())

--- a/apps/mobile/src/features/WalletConnect/shared/metadata.ts
+++ b/apps/mobile/src/features/WalletConnect/shared/metadata.ts
@@ -5,4 +5,9 @@ export const SAFE_WALLET_METADATA: CoreTypes.Metadata = {
   description: 'Safe multi-signature wallet',
   url: 'https://app.safe.global',
   icons: ['https://app.safe.global/favicons/favicon.ico'],
+  // Returns the user to the dApp after approving a deep-linked session; keep `native` in sync with app.config.ts scheme.
+  redirect: {
+    native: 'safe://',
+    universal: 'https://app.safe.global',
+  },
 }

--- a/apps/mobile/src/services/walletconnect/walletconnect-signing.hash.test.ts
+++ b/apps/mobile/src/services/walletconnect/walletconnect-signing.hash.test.ts
@@ -1,0 +1,31 @@
+import { TypedDataEncoder } from 'ethers'
+import { stringifyTypedData } from './walletconnect-signing.service'
+
+// Real ethers (the sibling suite mocks it): the serialized (numeric chainId) typed data must hash
+// to the same digest as the original bigint domain, so the wallet signs the hash we computed.
+describe('stringifyTypedData is hash-preserving', () => {
+  const types = {
+    SafeTx: [
+      { name: 'to', type: 'address' },
+      { name: 'value', type: 'uint256' },
+    ],
+  }
+  const message = { to: '0x0000000000000000000000000000000000000001', value: '123456789012345678901234567890' }
+  const verifyingContract = '0x9a1148b5D6a2D34CA46111379d0FD1352a0ade4a'
+
+  it('serialized (numeric chainId) hashes identically to the original bigint domain', () => {
+    const typedData = {
+      domain: { chainId: BigInt(137), verifyingContract },
+      types: { EIP712Domain: [], ...types },
+      primaryType: 'SafeTx',
+      message,
+    }
+
+    const parsed = JSON.parse(stringifyTypedData(typedData))
+    expect(parsed.domain.chainId).toBe(137)
+
+    const originalHash = TypedDataEncoder.hash(typedData.domain, types, message)
+    const serializedHash = TypedDataEncoder.hash(parsed.domain, types, parsed.message)
+    expect(serializedHash).toBe(originalHash)
+  })
+})

--- a/apps/mobile/src/services/walletconnect/walletconnect-signing.service.test.ts
+++ b/apps/mobile/src/services/walletconnect/walletconnect-signing.service.test.ts
@@ -187,6 +187,29 @@ describe('signWithWalletConnect', () => {
     expect(parsed.message.value).toBe('123456789012345678901234567890')
   })
 
+  it('only coerces domain.chainId to a number — a chainId bigint in the message stays a string', async () => {
+    mockGenerateTypedData.mockReturnValueOnce({
+      ...mockTypedData,
+      domain: { verifyingContract: '0xSafeAddress', chainId: BigInt(1) },
+      message: { to: '0xRecipient', chainId: BigInt(137) },
+    })
+
+    await signWithWalletConnect(defaultParams)
+
+    const parsed = JSON.parse(mockProvider.request.mock.calls[0][0].params[1])
+    expect(parsed.domain.chainId).toBe(1)
+    expect(parsed.message.chainId).toBe('137')
+  })
+
+  it('throws when domain.chainId exceeds Number.MAX_SAFE_INTEGER', async () => {
+    mockGenerateTypedData.mockReturnValueOnce({
+      ...mockTypedData,
+      domain: { verifyingContract: '0xSafeAddress', chainId: BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1) },
+    })
+
+    await expect(signWithWalletConnect(defaultParams)).rejects.toThrow('exceeds Number.MAX_SAFE_INTEGER')
+  })
+
   it('throws when provider returns non-string signature', async () => {
     mockProvider.request.mockResolvedValue(42)
 

--- a/apps/mobile/src/services/walletconnect/walletconnect-signing.service.test.ts
+++ b/apps/mobile/src/services/walletconnect/walletconnect-signing.service.test.ts
@@ -74,7 +74,8 @@ describe('signWithWalletConnect', () => {
   const mockTypedData = {
     domain: {
       verifyingContract: '0xSafeAddress',
-      chainId: 1,
+      // protocol-kit's generateTypedData returns chainId as a bigint.
+      chainId: BigInt(1),
     },
     types: {
       EIP712Domain: [{ name: 'verifyingContract', type: 'address' }],
@@ -159,13 +160,16 @@ describe('signWithWalletConnect', () => {
     expect(types).toHaveProperty('SafeTx')
   })
 
-  it('calls provider.request with eth_signTypedData_v4', async () => {
+  it('calls provider.request with eth_signTypedData_v4 and a bigint-safe typed-data string', async () => {
     await signWithWalletConnect(defaultParams)
 
-    expect(mockProvider.request).toHaveBeenCalledWith({
-      method: SigningMethod.ETH_SIGN_TYPED_DATA_V4,
-      params: ['0xSignerAddress', JSON.stringify(mockTypedData)],
-    })
+    expect(mockProvider.request).toHaveBeenCalledTimes(1)
+    const { method, params } = mockProvider.request.mock.calls[0][0]
+    expect(method).toBe(SigningMethod.ETH_SIGN_TYPED_DATA_V4)
+    expect(params[0]).toBe('0xSignerAddress')
+    // The bigint domain.chainId must serialize (plain JSON.stringify throws) as a decimal string.
+    const parsed = JSON.parse(params[1])
+    expect(parsed.domain.chainId).toBe('1')
   })
 
   it('throws when provider returns non-string signature', async () => {

--- a/apps/mobile/src/services/walletconnect/walletconnect-signing.service.test.ts
+++ b/apps/mobile/src/services/walletconnect/walletconnect-signing.service.test.ts
@@ -167,9 +167,24 @@ describe('signWithWalletConnect', () => {
     const { method, params } = mockProvider.request.mock.calls[0][0]
     expect(method).toBe(SigningMethod.ETH_SIGN_TYPED_DATA_V4)
     expect(params[0]).toBe('0xSignerAddress')
-    // The bigint domain.chainId must serialize (plain JSON.stringify throws) as a decimal string.
+    // bigint chainId serializes as a number (EIP-712 uint256), not a string.
     const parsed = JSON.parse(params[1])
-    expect(parsed.domain.chainId).toBe('1')
+    expect(parsed.domain.chainId).toBe(1)
+  })
+
+  it('serializes a large bigint message field as a string without precision loss', async () => {
+    const bigValue = BigInt('123456789012345678901234567890')
+    mockGenerateTypedData.mockReturnValueOnce({
+      ...mockTypedData,
+      domain: { verifyingContract: '0xSafeAddress', chainId: BigInt(137) },
+      message: { to: '0xRecipient', value: bigValue },
+    })
+
+    await signWithWalletConnect(defaultParams)
+
+    const parsed = JSON.parse(mockProvider.request.mock.calls[0][0].params[1])
+    expect(parsed.domain.chainId).toBe(137)
+    expect(parsed.message.value).toBe('123456789012345678901234567890')
   })
 
   it('throws when provider returns non-string signature', async () => {

--- a/apps/mobile/src/services/walletconnect/walletconnect-signing.service.ts
+++ b/apps/mobile/src/services/walletconnect/walletconnect-signing.service.ts
@@ -30,6 +30,10 @@ export interface SigningResponse {
   safeTransactionHash: string
 }
 
+// domain.chainId is a bigint; JSON.stringify can't serialize it, so emit bigints as strings.
+const stringifyTypedData = (typedData: unknown): string =>
+  JSON.stringify(typedData, (_key, value) => (typeof value === 'bigint' ? value.toString() : value))
+
 export const signWithWalletConnect = async (params: WalletConnectSigningParams): Promise<SigningResponse> => {
   const { chain, activeSafe, txId, signerAddress, safeVersion, provider, prebuiltSafeTx } = params
 
@@ -64,7 +68,7 @@ export const signWithWalletConnect = async (params: WalletConnectSigningParams):
 
   const signature = await provider.request({
     method: SigningMethod.ETH_SIGN_TYPED_DATA_V4,
-    params: [signerAddress, JSON.stringify(typedData)],
+    params: [signerAddress, stringifyTypedData(typedData)],
   })
 
   if (typeof signature !== 'string') {

--- a/apps/mobile/src/services/walletconnect/walletconnect-signing.service.ts
+++ b/apps/mobile/src/services/walletconnect/walletconnect-signing.service.ts
@@ -30,9 +30,12 @@ export interface SigningResponse {
   safeTransactionHash: string
 }
 
-// domain.chainId is a bigint; JSON.stringify can't serialize it, so emit bigints as strings.
-const stringifyTypedData = (typedData: unknown): string =>
-  JSON.stringify(typedData, (_key, value) => (typeof value === 'bigint' ? value.toString() : value))
+// chainId → number (EIP-712 uint256; a string is rejected by strict wallets); other bigints →
+// string to keep uint256 precision. Exported for the hash-preservation test.
+export const stringifyTypedData = (typedData: unknown): string =>
+  JSON.stringify(typedData, (key, value) =>
+    typeof value !== 'bigint' ? value : key === 'chainId' ? Number(value) : value.toString(),
+  )
 
 export const signWithWalletConnect = async (params: WalletConnectSigningParams): Promise<SigningResponse> => {
   const { chain, activeSafe, txId, signerAddress, safeVersion, provider, prebuiltSafeTx } = params

--- a/apps/mobile/src/services/walletconnect/walletconnect-signing.service.ts
+++ b/apps/mobile/src/services/walletconnect/walletconnect-signing.service.ts
@@ -30,12 +30,19 @@ export interface SigningResponse {
   safeTransactionHash: string
 }
 
-// chainId → number (EIP-712 uint256; a string is rejected by strict wallets); other bigints →
-// string to keep uint256 precision. Exported for the hash-preservation test.
-export const stringifyTypedData = (typedData: unknown): string =>
-  JSON.stringify(typedData, (key, value) =>
-    typeof value !== 'bigint' ? value : key === 'chainId' ? Number(value) : value.toString(),
+// domain.chainId → number (EIP-712 uint256; a string is rejected by strict wallets), scoped to
+// the domain so a chainId elsewhere in the message isn't coerced. All other bigints → string to
+// keep uint256 precision. Exported for the hash-preservation test.
+export const stringifyTypedData = (typedData: { domain: { chainId?: bigint | number } }): string => {
+  const { chainId } = typedData.domain
+  if (typeof chainId === 'bigint' && chainId > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(`chainId ${chainId} exceeds Number.MAX_SAFE_INTEGER`)
+  }
+  const domain = typeof chainId === 'bigint' ? { ...typedData.domain, chainId: Number(chainId) } : typedData.domain
+  return JSON.stringify({ ...typedData, domain }, (_key, value) =>
+    typeof value === 'bigint' ? value.toString() : value,
   )
+}
 
 export const signWithWalletConnect = async (params: WalletConnectSigningParams): Promise<SigningResponse> => {
   const { chain, activeSafe, txId, signerAddress, safeVersion, provider, prebuiltSafeTx } = params

--- a/packages/utils/src/features/walletconnect/__tests__/utils.test.ts
+++ b/packages/utils/src/features/walletconnect/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { toHex } from '../utils'
+import { extractWcUri, isPairingUri, toHex } from '../utils'
 
 describe('toHex', () => {
   it('converts numeric chain ids to hex', () => {
@@ -15,5 +15,43 @@ describe('toHex', () => {
   it('preserves precision above 2^53 (BigInt, not Number)', () => {
     // 0x20000000000001 = 2^53 + 1 — Number would round this down to 2^53.
     expect(toHex('0x20000000000001')).toBe('0x20000000000001')
+  })
+})
+
+describe('isPairingUri', () => {
+  it('accepts wc: URIs and rejects everything else', () => {
+    expect(isPairingUri('wc:abc@2?relay-protocol=irn')).toBe(true)
+    expect(isPairingUri('safe://wc?uri=wc%3Aabc')).toBe(false)
+    expect(isPairingUri('https://app.safe.global/foo')).toBe(false)
+  })
+})
+
+describe('extractWcUri', () => {
+  const wcUri = 'wc:abc123@2?relay-protocol=irn&symKey=deadbeef'
+
+  it('returns a bare wc: URI unchanged', () => {
+    expect(extractWcUri(wcUri)).toBe(wcUri)
+  })
+
+  it('unwraps the native registry envelope (safe://wc?uri=…)', () => {
+    expect(extractWcUri(`safe://wc?uri=${encodeURIComponent(wcUri)}`)).toBe(wcUri)
+  })
+
+  it('unwraps the universal-link envelope (https://app.safe.global/wc?uri=…)', () => {
+    expect(extractWcUri(`https://app.safe.global/wc?uri=${encodeURIComponent(wcUri)}`)).toBe(wcUri)
+  })
+
+  it('returns null for a link without a pairing uri', () => {
+    expect(extractWcUri('https://app.safe.global/foo')).toBeNull()
+    expect(extractWcUri('safe://settings')).toBeNull()
+  })
+
+  it('returns null when the wrapped uri is not a wc: URI', () => {
+    expect(extractWcUri(`safe://wc?uri=${encodeURIComponent('https://evil.example')}`)).toBeNull()
+  })
+
+  it('returns null for unparseable input', () => {
+    expect(extractWcUri('not a url')).toBeNull()
+    expect(extractWcUri('')).toBeNull()
   })
 })

--- a/packages/utils/src/features/walletconnect/utils.ts
+++ b/packages/utils/src/features/walletconnect/utils.ts
@@ -4,6 +4,20 @@ export const isPairingUri = (uri: string): boolean => {
   return uri.startsWith('wc:')
 }
 
+// Pull the pairing `wc:` URI out of a deep link: a bare `wc:` URI, or the mobile-linking envelope
+// `safe://wc?uri=<encoded>` / `https://app.safe.global/wc?uri=<encoded>`. Null if there is none.
+export const extractWcUri = (url: string): string | null => {
+  if (isPairingUri(url)) {
+    return url
+  }
+  try {
+    const wrapped = new URL(url).searchParams.get('uri')
+    return wrapped && isPairingUri(wrapped) ? wrapped : null
+  } catch {
+    return null
+  }
+}
+
 // CAIP-2 chain id from a numeric chain id, e.g. '1' -> 'eip155:1'.
 export const getEip155ChainId = (chainId: string): `${typeof EIP155}:${string}` => {
   return `${EIP155}:${chainId}`


### PR DESCRIPTION
## What it solves

Resolves: [WA-2757](https://linear.app/safe-global/issue/WA-2757/allow-dapps-to-deep-link-into-safemobile-walletconnect-mobile-linking)

dApps couldn't deep-link into Safe{Mobile} via WalletConnect mobile linking — the app didn't claim the `safe://` link, had no `redirect` metadata, and WC deep links hit the "This screen doesn't exist" screen or reset the nav stack. Also fixes a BigInt bug that made every WalletConnect signature fail.

## How this PR fixes it

- **`safe://` scheme** (`app.config.ts`) + **`redirect` metadata** so WalletKit returns the user to the dApp after approving.
- **`extractWcUri()`** unwraps the registry envelope (`safe://wc?uri=…`, universal, and raw `wc:`) before pairing.
- **`+native-intent`** swallows non-navigational WC / bare `safe://` links (returns `''`, no navigation) so they don't 404 or reset an in-progress stack. Hand-parsed to avoid a cold-start URL-polyfill dependency.
- **BigInt fix**: `generateTypedData` returns `domain.chainId` as a bigint; serialize bigints as strings so `JSON.stringify` no longer throws (hash unchanged).

## How to test it

1. **Pair** from a mobile dApp → proposal sheet, no "Oops!".
2. **Request a tx** from a connected dApp → signing sheet, then bounced back on approve.
3. **Import a signer via WalletConnect** → returns with working back navigation (no blank "index").
4. Verify **cold** (killed app) and **warm** start, and that a WC signature completes.

> Requires a **native build** for `safe://`; dApp discovery needs the Reown registry repoint (see Risks).

## Video

https://github.com/user-attachments/assets/f6073303-b9e0-4f07-8981-e4c96b2713d1

## Affected flows

- WC pairing, tx-request signing, and import-signer via deep link.
- WalletConnect signing of any Safe transaction (BigInt fix).

## Blast radius

- `SAFE_WALLET_METADATA` is shared by WalletKit **and** AppKit — the new `redirect.native` also drives the signer return hop.
- `+native-intent.redirectSystemPath` governs all incoming deep links; new branch runs before the protected-route logic (unchanged for non-WC links).
- `extractWcUri` added to `@safe-global/utils` (only consumer: `WalletKitController`).
- BigInt fix scoped to `walletconnect-signing.service.ts`.

## Risks / not checked

- Reown **WalletGuide registry** still points `safe://` at the legacy app — must be repointed to `global.safe.mobileapp` / `id6748754793`; `safe://` may collide with the legacy app until it's deprecated.
- **Universal links** (`app.safe.global/wc`) not claimed — needs AASA/assetlinks with the web team.
- Not verified on a real native build; tests cover JS logic only.

## Visual summary

```mermaid
flowchart TD
  A[dApp deep link] --> C[+native-intent redirectSystemPath]
  A --> D[WalletKitController Linking listener]
  C -->|WC / bare safe://| E["return '' — no navigation"]
  C -->|normal route| F[route as usual]
  D --> G[extractWcUri unwraps safe://wc?uri=…]
  G --> H["walletKit.pair()"] --> J[proposal / request sheet]
  J --> K[approve + sign] --> L[redirect.native → back to dApp]
```

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
