### PR TITLE
fix(web): Apply No-Fee 1M gas cap only on campaign chains

### DIFF
--- a/apps/web/src/features/no-fee-campaign/hooks/__tests__/useGasTooHigh.test.ts
+++ b/apps/web/src/features/no-fee-campaign/hooks/__tests__/useGasTooHigh.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from '@/tests/test-utils'
+import type { SafeTransaction } from '@safe-global/types-kit'
+import { useGasTooHigh } from '../useGasTooHigh'
+import * as useGasLimitModule from '@/hooks/useGasLimit'
+import * as useIsNoFeeCampaignEnabledModule from '../useIsNoFeeCampaignEnabled'
+
+const mockSafeTx = { data: {} } as SafeTransaction
+
+const mockGasLimit = (gasLimit: bigint | undefined) => {
+  jest
+    .spyOn(useGasLimitModule, 'default')
+    .mockReturnValue({ gasLimit, gasLimitError: undefined, gasLimitLoading: false })
+}
+
+const mockCampaignEnabled = (enabled: boolean) => {
+  jest.spyOn(useIsNoFeeCampaignEnabledModule, 'useIsNoFeeCampaignEnabled').mockReturnValue(enabled)
+}
+
+describe('useGasTooHigh', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns false for a >1M-gas tx when the No-Fee campaign is not enabled', () => {
+    mockCampaignEnabled(false)
+    mockGasLimit(BigInt(2_600_000))
+
+    const { result } = renderHook(() => useGasTooHigh(mockSafeTx))
+
+    expect(result.current).toBe(false)
+  })
+
+  it('returns true for a >1M-gas tx when the No-Fee campaign is enabled', () => {
+    mockCampaignEnabled(true)
+    mockGasLimit(BigInt(2_600_000))
+
+    const { result } = renderHook(() => useGasTooHigh(mockSafeTx))
+
+    expect(result.current).toBe(true)
+  })
+
+  it('returns false for a tx within the cap when the campaign is enabled', () => {
+    mockCampaignEnabled(true)
+    mockGasLimit(BigInt(500_000))
+
+    const { result } = renderHook(() => useGasTooHigh(mockSafeTx))
+
+    expect(result.current).toBe(false)
+  })
+
+  it('returns false when the gas limit is unknown', () => {
+    mockCampaignEnabled(true)
+    mockGasLimit(undefined)
+
+    const { result } = renderHook(() => useGasTooHigh(mockSafeTx))
+
+    expect(result.current).toBe(false)
+  })
+})

--- a/apps/web/src/features/no-fee-campaign/hooks/useGasTooHigh.ts
+++ b/apps/web/src/features/no-fee-campaign/hooks/useGasTooHigh.ts
@@ -1,9 +1,16 @@
 import useGasLimit from '@/hooks/useGasLimit'
 import { MAX_GAS_LIMIT_NO_FEE_CAMPAIGN } from '../constants'
+import { useIsNoFeeCampaignEnabled } from './useIsNoFeeCampaignEnabled'
 import type { SafeTransaction } from '@safe-global/types-kit'
 
 export function useGasTooHigh(safeTx?: SafeTransaction): boolean | undefined {
   const { gasLimit } = useGasLimit(safeTx)
+  const isNoFeeCampaignEnabled = useIsNoFeeCampaignEnabled()
+
+  // The 1M gas cap only applies to the No-Fee campaign. On other RELAYING chains it must not gate relay availability
+  if (!isNoFeeCampaignEnabled) {
+    return false
+  }
 
   // Check if gas limit exceeds maximum allowed for No Fee November
   if (gasLimit && BigInt(gasLimit) > MAX_GAS_LIMIT_NO_FEE_CAMPAIGN) {


### PR DESCRIPTION
## What it solves

The main goal is to prevent the gas cap from affecting relay availability when the campaign is not active

**Logic improvements:**
* Updated `useGasTooHigh` to always return `false` when the No-Fee campaign is not enabled, so the 1M gas cap only applies during the campaign and does not restrict other relaying chains.

**Unit testing additions:**
* Added a new test suite for the `useGasTooHigh` hook, covering scenarios with different campaign states and gas limits to ensure correct behavior.