### PR TITLE
fix: Remove pricingContextSnapshot

### DIFF
--- a/apps/web/src/features/gtf/hooks/__tests__/useFeesPreview.test.tsx
+++ b/apps/web/src/features/gtf/hooks/__tests__/useFeesPreview.test.tsx
@@ -107,12 +107,6 @@ const mockSuccessfulPreview = {
       numberSignatures: 2,
     },
     relayCost: { fiatCode: 'USD', fiatValue: '0.12410833692950203' },
-    pricingContextSnapshot: {
-      phase: 2,
-      priceSource: 'COINGECKO',
-      priceTimestamp: 1776428854,
-      gasPriceVolatilityBuffer: 1.3,
-    },
   },
   isLoading: false,
   isFetching: false,

--- a/apps/web/src/features/gtf/services/__tests__/resolveFeeParams.test.ts
+++ b/apps/web/src/features/gtf/services/__tests__/resolveFeeParams.test.ts
@@ -52,7 +52,6 @@ describe('resolveFeeParams', () => {
       numberSignatures: 3,
     },
     relayCost: { fiatCode: 'USD', fiatValue: '38.22' },
-    pricingContextSnapshot: { phase: 1, priceSource: 'coingecko', priceTimestamp: 0, gasPriceVolatilityBuffer: 1.3 },
   }
 
   beforeEach(() => {

--- a/apps/web/src/store/api/gateway/gtfFeePreview.ts
+++ b/apps/web/src/store/api/gateway/gtfFeePreview.ts
@@ -56,12 +56,6 @@ export type FeePreviewRelayCost = {
 export type FeePreviewResponse = {
   txData: FeePreviewTxData
   relayCost: FeePreviewRelayCost
-  pricingContextSnapshot: {
-    phase: number
-    priceSource: string
-    priceTimestamp: number
-    gasPriceVolatilityBuffer: number
-  }
 }
 
 export type FeePreviewArg = {
@@ -71,11 +65,7 @@ export type FeePreviewArg = {
 }
 
 const isFeePreviewResponse = (value: unknown): value is FeePreviewResponse =>
-  typeof value === 'object' &&
-  value !== null &&
-  'txData' in value &&
-  'relayCost' in value &&
-  'pricingContextSnapshot' in value
+  typeof value === 'object' && value !== null && 'txData' in value && 'relayCost' in value
 
 export const gtfFeePreviewEndpoints = (builder: GatewayEndpointBuilder) => ({
   getGtfFeePreview: builder.query<FeePreviewResponse, FeePreviewArg>({


### PR DESCRIPTION
## What it solves

This pull request removes the `pricingContextSnapshot` field from the `FeePreviewResponse` type and all related code and tests. This simplifies the fee preview data model and updates validation logic and test mocks accordingly.

**Type and validation updates:**
* Removed the `pricingContextSnapshot` field from the `FeePreviewResponse` type in `gtfFeePreview.ts`.
* Updated the `isFeePreviewResponse` type guard to no longer require `pricingContextSnapshot`.

**Test updates:**
* Removed `pricingContextSnapshot` from the `mockSuccessfulPreview` test mock in `useFeesPreview.test.tsx`.
* Removed `pricingContextSnapshot` from test data in `resolveFeeParams.test.ts`.