### PR TITLE
feat: add a tracking event for using the old UI

### DIFF
--- a/apps/web/src/features/spaces/components/ClassicViewLink/index.test.tsx
+++ b/apps/web/src/features/spaces/components/ClassicViewLink/index.test.tsx
@@ -2,10 +2,17 @@ import { render, screen, fireEvent } from '@/tests/test-utils'
 import ClassicViewLink from './'
 import { disableClassicView, useIsClassicViewOptedIn } from '@/hooks/useClassicView'
 import { AppRoutes } from '@/config/routes'
+import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { renderHook } from '@testing-library/react'
+
+const mockTrackEvent = jest.fn()
+jest.mock('@/services/analytics', () => ({
+  trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}))
 
 describe('ClassicViewLink', () => {
   beforeEach(() => {
+    jest.clearAllMocks()
     sessionStorage.clear()
     localStorage.clear()
   })
@@ -30,6 +37,14 @@ describe('ClassicViewLink', () => {
 
     expect(replace).toHaveBeenCalledWith({ pathname: AppRoutes.welcome.accounts })
     expect(renderHook(() => useIsClassicViewOptedIn()).result.current).toBe(true)
+  })
+
+  it('tracks the USE_OLD_UI event when clicked', () => {
+    render(<ClassicViewLink />, { routerProps: { replace: jest.fn(), query: {} } })
+
+    fireEvent.click(screen.getByTestId('classic-view-link'))
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(SPACE_EVENTS.USE_OLD_UI)
   })
 
   it('honours a sanitised ?next= URL when present', () => {

--- a/apps/web/src/features/spaces/components/ClassicViewLink/index.tsx
+++ b/apps/web/src/features/spaces/components/ClassicViewLink/index.tsx
@@ -4,6 +4,8 @@ import { History } from 'lucide-react'
 import { enableClassicView } from '@/hooks/useClassicView'
 import { AppRoutes } from '@/config/routes'
 import { parseNextUrlForRouter } from '@/utils/nextUrl'
+import { trackEvent } from '@/services/analytics'
+import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 
 /**
  * Escape-hatch link shown under the sign-in card on /welcome/spaces.
@@ -18,6 +20,7 @@ const ClassicViewLink = () => {
   const router = useRouter()
 
   const onClick = useCallback(() => {
+    trackEvent(SPACE_EVENTS.USE_OLD_UI)
     const next = parseNextUrlForRouter(router.query.next) ?? { pathname: AppRoutes.welcome.accounts }
     enableClassicView()
     router.replace(next)

--- a/apps/web/src/services/analytics/events/spaces.ts
+++ b/apps/web/src/services/analytics/events/spaces.ts
@@ -265,6 +265,10 @@ export const SPACE_EVENTS = {
     action: 'Wallet disconnected in space',
     category: SPACE_CATEGORY,
   },
+  USE_OLD_UI: {
+    action: 'Use the old UI',
+    category: SPACE_CATEGORY,
+  },
 }
 
 export enum SPACE_LABELS {

--- a/apps/web/src/services/analytics/ga-mixpanel-mapping.ts
+++ b/apps/web/src/services/analytics/ga-mixpanel-mapping.ts
@@ -95,6 +95,7 @@ export const GA_TO_MIXPANEL_MAPPING: Record<string, string> = {
   [SPACE_EVENTS.ADDRESS_BOOK_ENTRY_CREATED.action]: MixpanelEvent.ADDRESS_BOOK_ENTRY_CREATED,
   [SPACE_EVENTS.TRANSACTION_INITIATED.action]: MixpanelEvent.WORKSPACE_TRANSACTION_INITIATED,
   [SPACE_EVENTS.ONBOARDING_WIZARD.action]: MixpanelEvent.ONBOARDING_WIZARD,
+  [SPACE_EVENTS.USE_OLD_UI.action]: MixpanelEvent.USE_OLD_UI,
 }
 
 // Maps GA labels (lowercase) to Mixpanel properties (Title Case)

--- a/apps/web/src/services/analytics/mixpanel-events.ts
+++ b/apps/web/src/services/analytics/mixpanel-events.ts
@@ -64,6 +64,7 @@ export enum MixpanelEvent {
   ADDRESS_BOOK_ENTRY_CREATED = 'Address Book Entry Created',
   WORKSPACE_TRANSACTION_INITIATED = 'Workspace Transaction Initiated',
   ONBOARDING_WIZARD = 'Onboarding Wizard',
+  USE_OLD_UI = 'Use Old UI',
 }
 
 export enum WorkspaceCreateEntryPoint {


### PR DESCRIPTION
## What it solves

Resolves: [WA-2714](https://linear.app/safe-global/issue/WA-2714/add-mixpanel-tracking-to-the-use-the-old-ui-button)

Adds analytics tracking to the "Use the old UI"  button

## How this PR fixes it

Adds a `USE_OLD_UI` event to `SPACE_EVENTS`, maps it to a new `USE_OLD_UI` Mixpanel event, and fires it from `ClassicViewLink`'s `onClick` (GA + Mixpanel).

## How to test it

1. Go to `/welcome/spaces` while signed out.
2. Click "Use the old UI".
3. Confirm a `Use the old UI` (GA) / `Use Old UI` (Mixpanel) event fires, and you're still redirected into classic view as before.

## Affected flows

- Signed-out user opting out of the new Spaces UI via the "Use the old UI" button.

## Blast radius

- `SPACE_EVENTS`, `MixpanelEvent` enum, `GA_TO_MIXPANEL_MAPPING` — append-only, no existing entries changed.
- `ClassicViewLink` — one added `trackEvent` call; opt-out/redirect logic unchanged.

## Risks / not checked

- Did not verify end-to-end delivery to GA/Mixpanel backends (asserted at unit level via the mapping + fired event).

## Visual summary

```mermaid
flowchart LR
  A["Click 'Use the old UI'"] --> B[trackEvent USE_OLD_UI]
  B --> C[GA event]
  B --> D[Mixpanel: Use Old UI]
  A --> E[enableClassicView + redirect]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
