### PR TITLE
fix(mobile): recognise imported signer for WC requests on shared-owner Safes

### DIFF
--- a/apps/mobile/src/features/WalletConnect/Wallet/store/__tests__/walletKitListeners.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/__tests__/walletKitListeners.test.ts
@@ -1,4 +1,5 @@
 import { configureStore, createListenerMiddleware } from '@reduxjs/toolkit'
+import { faker } from '@faker-js/faker'
 import { waitFor } from '@testing-library/react-native'
 import { http, HttpResponse, delay } from 'msw'
 import { formatJsonRpcResult } from '@walletconnect/jsonrpc-utils'
@@ -11,6 +12,9 @@ import { cgwClient } from '@safe-global/store/gateway/cgwClient'
 import { cgwApi, type ProposeTransactionDto } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { setActiveSafe, switchActiveChain, clearActiveSafe } from '@/src/store/activeSafeSlice'
 import { setActiveSigner } from '@/src/store/activeSignerSlice'
+import { addSafe } from '@/src/store/safesSlice'
+import { addSigner } from '@/src/store/signersSlice'
+import { generateSafeOverview, generateSigner } from '@/src/tests/factories/safe'
 import { NO_SIGNER_ERROR_CODE } from '../../services/methodRouter'
 import walletKitListeners from '../walletKitListeners'
 import {
@@ -40,8 +44,8 @@ jest.mock('../../services/methodRouter', () => ({
   routeSessionRequest: (ctx: unknown) => mockRoute(ctx),
 }))
 
-const SAFE = '0x1111111111111111111111111111111111111111'
-const OTHER_SAFE = '0x2222222222222222222222222222222222222222'
+const SAFE = faker.finance.ethereumAddress()
+const OTHER_SAFE = faker.finance.ethereumAddress()
 const HASH = '0xhash'
 const WRONG_CHAIN_CODE = getSdkError('UNSUPPORTED_CHAINS').code
 const DEFERRED = { id: 7, jsonrpc: '2.0', result: '__DEFERRED__' }
@@ -263,7 +267,7 @@ describe('walletKitListeners — safe/chain switch', () => {
 })
 
 describe('walletKitListeners — sessionRequestReceived', () => {
-  it('passes the active Safe/signer context (read from the store) to the router', async () => {
+  it('does not report hasSigner from an activeSigner selection alone', async () => {
     const store = makeStore()
     store.dispatch(setActiveSafe({ address: SAFE as `0x${string}`, chainId: '1' }))
     store.dispatch(setActiveSigner({ safeAddress: SAFE as `0x${string}`, signer: { value: '0xsigner' } as never }))
@@ -272,7 +276,44 @@ describe('walletKitListeners — sessionRequestReceived', () => {
     store.dispatch(sessionRequestReceived(makeRequest('eth_unknownMethod')))
 
     await waitFor(() => expect(mockRoute).toHaveBeenCalled())
+    expect(mockRoute).toHaveBeenCalledWith(expect.objectContaining({ activeSafeAddress: SAFE, hasSigner: false }))
+  })
+
+  it('recognises an imported signer that owns the active Safe without an activeSigner entry', async () => {
+    const OWNER = faker.finance.ethereumAddress()
+    const store = makeStore()
+    store.dispatch(
+      addSafe({
+        address: SAFE as `0x${string}`,
+        info: { '1': generateSafeOverview({ chainId: '1', owners: [OWNER], address: SAFE }) },
+      }),
+    )
+    store.dispatch(addSigner(generateSigner(OWNER)))
+    store.dispatch(setActiveSafe({ address: SAFE as `0x${string}`, chainId: '1' }))
+    mockRoute.mockResolvedValueOnce({ id: 7, jsonrpc: '2.0', error: { code: -32601, message: 'x' } })
+
+    store.dispatch(sessionRequestReceived(makeRequest('eth_sendTransaction', [{ to: '0xabc' }])))
+
+    await waitFor(() => expect(mockRoute).toHaveBeenCalled())
     expect(mockRoute).toHaveBeenCalledWith(expect.objectContaining({ activeSafeAddress: SAFE, hasSigner: true }))
+  })
+
+  it('reports hasSigner false when the imported signer is not an owner of the active Safe', async () => {
+    const store = makeStore()
+    store.dispatch(
+      addSafe({
+        address: SAFE as `0x${string}`,
+        info: { '1': generateSafeOverview({ chainId: '1', owners: [faker.finance.ethereumAddress()], address: SAFE }) },
+      }),
+    )
+    store.dispatch(addSigner(generateSigner()))
+    store.dispatch(setActiveSafe({ address: SAFE as `0x${string}`, chainId: '1' }))
+    mockRoute.mockResolvedValueOnce({ id: 7, jsonrpc: '2.0', error: { code: -32601, message: 'x' } })
+
+    store.dispatch(sessionRequestReceived(makeRequest('eth_sendTransaction', [{ to: '0xabc' }])))
+
+    await waitFor(() => expect(mockRoute).toHaveBeenCalled())
+    expect(mockRoute).toHaveBeenCalledWith(expect.objectContaining({ activeSafeAddress: SAFE, hasSigner: false }))
   })
 
   it('pushes a deferred tx request to pending instead of responding', async () => {

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitListeners.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitListeners.ts
@@ -6,8 +6,8 @@ import { stripEip155Prefix } from '@safe-global/utils/features/walletconnect/uti
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import type { AppDispatch, AppStartListening, RootState } from '@/src/store'
 import { selectActiveSafe, setActiveSafe, switchActiveChain, clearActiveSafe } from '@/src/store/activeSafeSlice'
-import { selectActiveSigner } from '@/src/store/activeSignerSlice'
 import { selectChainById } from '@/src/store/chains'
+import { selectSafeSigners } from '@/src/store/signersSlice'
 import { showToast } from '@/src/store/toastSlice'
 import { getWalletKit } from '../walletKit'
 import { logWalletKitError } from '../utils/errors'
@@ -164,7 +164,7 @@ export const walletKitListeners = (startListening: AppStartListening) => {
       const state = api.getState() as RootState
       const activeSafe = selectActiveSafe(state)
       const activeChain = activeSafe ? (selectChainById(state, activeSafe.chainId) ?? null) : null
-      const hasSigner = activeSafe ? !!selectActiveSigner(state, activeSafe.address) : false
+      const hasSigner = activeSafe ? selectSafeSigners(state, activeSafe).length > 0 : false
       const deployedChainIds = activeSafe ? Object.keys(state.safes[activeSafe.address] ?? {}) : []
 
       const switchActiveChainByCaip2 = makeSwitchActiveChainByCaip2(api.getState as () => RootState, api.dispatch)

--- a/apps/mobile/src/hooks/useHasSigner.test.ts
+++ b/apps/mobile/src/hooks/useHasSigner.test.ts
@@ -8,13 +8,13 @@ const SAFE = faker.finance.ethereumAddress() as Address
 const OWNER_A = faker.finance.ethereumAddress()
 const OWNER_B = faker.finance.ethereumAddress()
 
-const overview = (chainId: string, owners: string[]) => generateSafeOverview({ chainId, owners, address: SAFE })
+const overview = (owners: string[], chainId = '1') => generateSafeOverview({ chainId, owners, address: SAFE })
 
 describe('useHasSigner', () => {
   it('returns the owners of the active Safe that have an imported signer', () => {
     const { result } = renderHook(() => useHasSigner(), {
       activeSafe: { address: SAFE, chainId: '1' },
-      safes: { [SAFE]: { '1': overview('1', [OWNER_A, OWNER_B]) } },
+      safes: { [SAFE]: { '1': overview([OWNER_A, OWNER_B]) } },
       signers: { [OWNER_A]: generateSigner(OWNER_A) },
     })
 
@@ -25,7 +25,7 @@ describe('useHasSigner', () => {
   it('returns all matching owners when several signers are imported', () => {
     const { result } = renderHook(() => useHasSigner(), {
       activeSafe: { address: SAFE, chainId: '1' },
-      safes: { [SAFE]: { '1': overview('1', [OWNER_A, OWNER_B]) } },
+      safes: { [SAFE]: { '1': overview([OWNER_A, OWNER_B]) } },
       signers: { [OWNER_A]: generateSigner(OWNER_A), [OWNER_B]: generateSigner(OWNER_B) },
     })
 
@@ -36,7 +36,7 @@ describe('useHasSigner', () => {
   it('returns hasSigner false when no imported signer is an owner', () => {
     const { result } = renderHook(() => useHasSigner(), {
       activeSafe: { address: SAFE, chainId: '1' },
-      safes: { [SAFE]: { '1': overview('1', [OWNER_A]) } },
+      safes: { [SAFE]: { '1': overview([OWNER_A]) } },
       signers: { [OWNER_B]: generateSigner(OWNER_B) },
     })
 
@@ -47,7 +47,7 @@ describe('useHasSigner', () => {
   it('only considers owners on the active chain', () => {
     const { result } = renderHook(() => useHasSigner(), {
       activeSafe: { address: SAFE, chainId: '137' },
-      safes: { [SAFE]: { '1': overview('1', [OWNER_A]), '137': overview('137', [OWNER_B]) } },
+      safes: { [SAFE]: { '1': overview([OWNER_A]), '137': overview([OWNER_B], '137') } },
       signers: { [OWNER_A]: generateSigner(OWNER_A) },
     })
 
@@ -58,7 +58,7 @@ describe('useHasSigner', () => {
   it('returns hasSigner false when the Safe overview for the active chain is not loaded', () => {
     const { result } = renderHook(() => useHasSigner(), {
       activeSafe: { address: SAFE, chainId: '137' },
-      safes: { [SAFE]: { '1': overview('1', [OWNER_A]) } },
+      safes: { [SAFE]: { '1': overview([OWNER_A]) } },
       signers: { [OWNER_A]: generateSigner(OWNER_A) },
     })
 

--- a/apps/mobile/src/hooks/useHasSigner.test.ts
+++ b/apps/mobile/src/hooks/useHasSigner.test.ts
@@ -1,0 +1,68 @@
+import { faker } from '@faker-js/faker'
+import { renderHook } from '@/src/tests/test-utils'
+import { generateSafeOverview, generateSigner } from '@/src/tests/factories/safe'
+import type { Address } from '@/src/types/address'
+import { useHasSigner } from './useHasSigner'
+
+const SAFE = faker.finance.ethereumAddress() as Address
+const OWNER_A = faker.finance.ethereumAddress()
+const OWNER_B = faker.finance.ethereumAddress()
+
+const overview = (chainId: string, owners: string[]) => generateSafeOverview({ chainId, owners, address: SAFE })
+
+describe('useHasSigner', () => {
+  it('returns the owners of the active Safe that have an imported signer', () => {
+    const { result } = renderHook(() => useHasSigner(), {
+      activeSafe: { address: SAFE, chainId: '1' },
+      safes: { [SAFE]: { '1': overview('1', [OWNER_A, OWNER_B]) } },
+      signers: { [OWNER_A]: generateSigner(OWNER_A) },
+    })
+
+    expect(result.current.hasSigner).toBe(true)
+    expect(result.current.safeSigners).toEqual([OWNER_A])
+  })
+
+  it('returns all matching owners when several signers are imported', () => {
+    const { result } = renderHook(() => useHasSigner(), {
+      activeSafe: { address: SAFE, chainId: '1' },
+      safes: { [SAFE]: { '1': overview('1', [OWNER_A, OWNER_B]) } },
+      signers: { [OWNER_A]: generateSigner(OWNER_A), [OWNER_B]: generateSigner(OWNER_B) },
+    })
+
+    expect(result.current.hasSigner).toBe(true)
+    expect(result.current.safeSigners).toEqual([OWNER_A, OWNER_B])
+  })
+
+  it('returns hasSigner false when no imported signer is an owner', () => {
+    const { result } = renderHook(() => useHasSigner(), {
+      activeSafe: { address: SAFE, chainId: '1' },
+      safes: { [SAFE]: { '1': overview('1', [OWNER_A]) } },
+      signers: { [OWNER_B]: generateSigner(OWNER_B) },
+    })
+
+    expect(result.current.hasSigner).toBe(false)
+    expect(result.current.safeSigners).toEqual([])
+  })
+
+  it('only considers owners on the active chain', () => {
+    const { result } = renderHook(() => useHasSigner(), {
+      activeSafe: { address: SAFE, chainId: '137' },
+      safes: { [SAFE]: { '1': overview('1', [OWNER_A]), '137': overview('137', [OWNER_B]) } },
+      signers: { [OWNER_A]: generateSigner(OWNER_A) },
+    })
+
+    expect(result.current.hasSigner).toBe(false)
+    expect(result.current.safeSigners).toEqual([])
+  })
+
+  it('returns hasSigner false when the Safe overview for the active chain is not loaded', () => {
+    const { result } = renderHook(() => useHasSigner(), {
+      activeSafe: { address: SAFE, chainId: '137' },
+      safes: { [SAFE]: { '1': overview('1', [OWNER_A]) } },
+      signers: { [OWNER_A]: generateSigner(OWNER_A) },
+    })
+
+    expect(result.current.hasSigner).toBe(false)
+    expect(result.current.safeSigners).toEqual([])
+  })
+})

--- a/apps/mobile/src/hooks/useHasSigner.ts
+++ b/apps/mobile/src/hooks/useHasSigner.ts
@@ -1,16 +1,10 @@
 import { useAppSelector } from '@/src/store/hooks'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
-import { selectSafeInfo } from '@/src/store/safesSlice'
-import { selectSigners } from '@/src/store/signersSlice'
-import { getSafeSigners } from '@/src/utils/signer'
-import { RootState } from '@/src/store'
+import { selectSafeSigners } from '@/src/store/signersSlice'
 
 export function useHasSigner() {
   const activeSafe = useDefinedActiveSafe()
-  const safeInfo = useAppSelector((state: RootState) => selectSafeInfo(state, activeSafe.address))
-  const signers = useAppSelector(selectSigners)
-  const chainSafe = safeInfo ? safeInfo[activeSafe.chainId] : undefined
-  const safeSigners = chainSafe ? getSafeSigners(chainSafe, signers) : []
+  const safeSigners = useAppSelector((state) => selectSafeSigners(state, activeSafe))
 
   return { hasSigner: safeSigners.length > 0, safeSigners }
 }

--- a/apps/mobile/src/store/__tests__/signersSlice.test.ts
+++ b/apps/mobile/src/store/__tests__/signersSlice.test.ts
@@ -1,4 +1,5 @@
-import signersReducer, { addSigner, selectSigners, selectTotalSignerCount } from '../signersSlice'
+import signersReducer, { addSigner, selectSafeSigners, selectSigners, selectTotalSignerCount } from '../signersSlice'
+import { addSafe } from '../safesSlice'
 import { addSignerWithEffects, computeSignerChainIds } from '../signerThunks'
 import { selectActiveSigner } from '../activeSignerSlice'
 import { selectAllContacts, selectContactByAddress } from '../addressBookSlice'
@@ -6,11 +7,14 @@ import type { RootState } from '../index'
 import { faker } from '@faker-js/faker'
 import { SignerInfo } from '@/src/types/address'
 import { createTestStore, type TestStoreState } from '@/src/tests/test-utils'
+import { generateSafeOverview } from '@/src/tests/factories/safe'
 
 // Helper function to generate a valid Ethereum address
 const generateEthereumAddress = (): `0x${string}` => {
   return faker.finance.ethereumAddress() as `0x${string}`
 }
+
+const makeOverview = (chainId: string, owners: string[]) => generateSafeOverview({ chainId, owners })
 
 // Helper function to generate private key signer
 const generatePrivateKeySigner = (overrides?: Partial<Omit<SignerInfo, 'type' | 'derivationPath'>>): SignerInfo => ({
@@ -303,15 +307,6 @@ describe('signersSlice', () => {
   describe('computeSignerChainIds', () => {
     const signerAddress = '0xABCDef1234567890abcdef1234567890ABCDEF12'
 
-    const makeOverview = (chainId: string, owners: string[]) => ({
-      address: { value: generateEthereumAddress() },
-      chainId,
-      threshold: 1,
-      owners: owners.map((value) => ({ value })),
-      fiatTotal: '0',
-      queued: 0,
-    })
-
     it('should return all chain IDs where signer is an owner', () => {
       const safeAddress = generateEthereumAddress()
       const initialState: TestStoreState = {
@@ -457,6 +452,89 @@ describe('signersSlice', () => {
       const signer2 = generateSignerInfo()
       state = signersReducer(state, addSigner(signer2))
       expect(selectTotalSignerCount({ signers: state } as RootState)).toBe(2)
+    })
+  })
+
+  describe('selectSafeSigners', () => {
+    it('returns the owners that have an imported signer', () => {
+      const owner = generateEthereumAddress()
+      const otherOwner = generateEthereumAddress()
+      const safeAddress = generateEthereumAddress()
+      const store = createTestStore()
+
+      store.dispatch(addSafe({ address: safeAddress, info: { '1': makeOverview('1', [owner, otherOwner]) } }))
+      store.dispatch(addSigner(generateSignerInfo({ value: owner })))
+
+      expect(selectSafeSigners(store.getState(), { address: safeAddress, chainId: '1' })).toEqual([owner])
+    })
+
+    it('returns empty when the imported signer is not an owner', () => {
+      const safeAddress = generateEthereumAddress()
+      const store = createTestStore()
+
+      store.dispatch(addSafe({ address: safeAddress, info: { '1': makeOverview('1', [generateEthereumAddress()]) } }))
+      store.dispatch(addSigner(generateSignerInfo()))
+
+      expect(selectSafeSigners(store.getState(), { address: safeAddress, chainId: '1' })).toEqual([])
+    })
+
+    it('returns empty when the Safe overview for the chain is not loaded', () => {
+      const owner = generateEthereumAddress()
+      const safeAddress = generateEthereumAddress()
+      const store = createTestStore()
+
+      store.dispatch(addSafe({ address: safeAddress, info: { '1': makeOverview('1', [owner]) } }))
+      store.dispatch(addSigner(generateSignerInfo({ value: owner })))
+
+      expect(selectSafeSigners(store.getState(), { address: safeAddress, chainId: '137' })).toEqual([])
+    })
+
+    it('returns all owners that have an imported signer', () => {
+      const owner1 = generateEthereumAddress()
+      const owner2 = generateEthereumAddress()
+      const ownerWithoutSigner = generateEthereumAddress()
+      const safeAddress = generateEthereumAddress()
+      const store = createTestStore()
+
+      store.dispatch(
+        addSafe({ address: safeAddress, info: { '1': makeOverview('1', [owner1, owner2, ownerWithoutSigner]) } }),
+      )
+      store.dispatch(addSigner(generateSignerInfo({ value: owner1 })))
+      store.dispatch(addSigner(generateSignerInfo({ value: owner2 })))
+
+      expect(selectSafeSigners(store.getState(), { address: safeAddress, chainId: '1' })).toEqual([owner1, owner2])
+    })
+
+    it('is scoped per chain', () => {
+      const owner = generateEthereumAddress()
+      const otherChainOwner = generateEthereumAddress()
+      const safeAddress = generateEthereumAddress()
+      const store = createTestStore()
+
+      store.dispatch(
+        addSafe({
+          address: safeAddress,
+          info: { '1': makeOverview('1', [owner]), '137': makeOverview('137', [otherChainOwner]) },
+        }),
+      )
+      store.dispatch(addSigner(generateSignerInfo({ value: owner })))
+
+      expect(selectSafeSigners(store.getState(), { address: safeAddress, chainId: '1' })).toEqual([owner])
+      expect(selectSafeSigners(store.getState(), { address: safeAddress, chainId: '137' })).toEqual([])
+    })
+
+    it('returns a stable reference for unchanged state', () => {
+      const owner = generateEthereumAddress()
+      const safeAddress = generateEthereumAddress()
+      const store = createTestStore()
+
+      store.dispatch(addSafe({ address: safeAddress, info: { '1': makeOverview('1', [owner]) } }))
+      store.dispatch(addSigner(generateSignerInfo({ value: owner })))
+
+      const first = selectSafeSigners(store.getState(), { address: safeAddress, chainId: '1' })
+      const second = selectSafeSigners(store.getState(), { address: safeAddress, chainId: '1' })
+
+      expect(second).toBe(first)
     })
   })
 })

--- a/apps/mobile/src/store/__tests__/signersSlice.test.ts
+++ b/apps/mobile/src/store/__tests__/signersSlice.test.ts
@@ -5,6 +5,7 @@ import { selectActiveSigner } from '../activeSignerSlice'
 import { selectAllContacts, selectContactByAddress } from '../addressBookSlice'
 import type { RootState } from '../index'
 import { faker } from '@faker-js/faker'
+import { getAddress } from 'ethers'
 import { SignerInfo } from '@/src/types/address'
 import { createTestStore, type TestStoreState } from '@/src/tests/test-utils'
 import { generateSafeOverview } from '@/src/tests/factories/safe'
@@ -521,6 +522,17 @@ describe('signersSlice', () => {
 
       expect(selectSafeSigners(store.getState(), { address: safeAddress, chainId: '1' })).toEqual([owner])
       expect(selectSafeSigners(store.getState(), { address: safeAddress, chainId: '137' })).toEqual([])
+    })
+
+    it('matches owners and signers case-insensitively', () => {
+      const owner = getAddress(generateEthereumAddress()) // EIP-55 checksummed, as returned by CGW
+      const safeAddress = generateEthereumAddress()
+      const store = createTestStore()
+
+      store.dispatch(addSafe({ address: safeAddress, info: { '1': makeOverview('1', [owner]) } }))
+      store.dispatch(addSigner(generateSignerInfo({ value: owner.toLowerCase() as `0x${string}` })))
+
+      expect(selectSafeSigners(store.getState(), { address: safeAddress, chainId: '1' })).toEqual([owner])
     })
 
     it('returns a stable reference for unchanged state', () => {

--- a/apps/mobile/src/store/signersSlice.ts
+++ b/apps/mobile/src/store/signersSlice.ts
@@ -1,7 +1,9 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { AddressInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 
 import { RootState } from '@/src/store'
+import { Address } from '@/src/types/address'
+import { getSafeSigners } from '@/src/utils/signer'
 import logger from '@/src/utils/logger'
 
 export type Signer = AddressInfo &
@@ -53,5 +55,14 @@ export const selectSignerHasPrivateKey = (address: string) => (state: RootState)
 }
 
 export const selectTotalSignerCount = (state: RootState) => Object.keys(state.signers).length
+
+/** Owner addresses of the given Safe (on the given chain) that have an imported signer. */
+export const selectSafeSigners = createSelector(
+  [
+    (state: RootState, safe: { address: Address; chainId: string }) => state.safes[safe.address]?.[safe.chainId],
+    selectSigners,
+  ],
+  (chainSafe, signers): string[] => (chainSafe ? getSafeSigners(chainSafe, signers) : []),
+)
 
 export default signersSlice.reducer

--- a/apps/mobile/src/store/signersSlice.ts
+++ b/apps/mobile/src/store/signersSlice.ts
@@ -46,8 +46,6 @@ export const { addSigner, removeSigner } = signersSlice.actions
 
 export const selectSigners = (state: RootState) => state.signers
 
-export const selectSignersByAddress = (state: RootState) => state.signers
-
 export const selectSignerByAddress = (state: RootState, address: string): Signer | undefined => state.signers[address]
 
 export const selectSignerHasPrivateKey = (address: string) => (state: RootState) => {
@@ -56,13 +54,15 @@ export const selectSignerHasPrivateKey = (address: string) => (state: RootState)
 
 export const selectTotalSignerCount = (state: RootState) => Object.keys(state.signers).length
 
+const EMPTY_SAFE_SIGNERS: string[] = []
+
 /** Owner addresses of the given Safe (on the given chain) that have an imported signer. */
 export const selectSafeSigners = createSelector(
   [
     (state: RootState, safe: { address: Address; chainId: string }) => state.safes[safe.address]?.[safe.chainId],
     selectSigners,
   ],
-  (chainSafe, signers): string[] => (chainSafe ? getSafeSigners(chainSafe, signers) : []),
+  (chainSafe, signers): string[] => (chainSafe ? getSafeSigners(chainSafe, signers) : EMPTY_SAFE_SIGNERS),
 )
 
 export default signersSlice.reducer

--- a/apps/mobile/src/tests/factories/safe.ts
+++ b/apps/mobile/src/tests/factories/safe.ts
@@ -1,0 +1,29 @@
+import { faker } from '@faker-js/faker'
+import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import type { Signer } from '@/src/store/signersSlice'
+
+export function generateSafeOverview({
+  chainId = '1',
+  owners = [],
+  address = faker.finance.ethereumAddress(),
+  threshold = 1,
+}: {
+  chainId?: string
+  owners?: string[]
+  address?: string
+  threshold?: number
+} = {}): SafeOverview {
+  return {
+    address: { value: address, name: null, logoUri: null },
+    chainId,
+    threshold,
+    owners: owners.map((value) => ({ value, name: null, logoUri: null })),
+    fiatTotal: '0',
+    queued: 0,
+    awaitingConfirmation: null,
+  }
+}
+
+export function generateSigner(value: string = faker.finance.ethereumAddress()): Signer {
+  return { value, name: null, logoUri: null, type: 'private-key' }
+}

--- a/apps/mobile/src/utils/signer.ts
+++ b/apps/mobile/src/utils/signer.ts
@@ -1,7 +1,7 @@
 import { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import { AddressInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 
-export const getSafeSigners = (SafeInfo: SafeOverview, signers: Record<string, AddressInfo>) => {
-  const owners = SafeInfo.owners.map((owner) => owner.value)
-  return owners.filter((owner) => signers[owner])
+export const getSafeSigners = (safeInfo: SafeOverview, signers: Record<string, AddressInfo>) => {
+  const signerAddresses = new Set(Object.keys(signers).map((address) => address.toLowerCase()))
+  return safeInfo.owners.map((owner) => owner.value).filter((owner) => signerAddresses.has(owner.toLowerCase()))
 }


### PR DESCRIPTION
## What it solves

Resolves: [WA-2791](https://linear.app/safe-global/issue/WA-2791/mobile-walletconnect-transaction-requests-rejected-with-no-signer)

WC transaction requests to a Safe sharing an owner with another Safe were rejected with 4100 "No signer attached to this Safe". The gate checked the per-Safe `activeSigner` selection map — seeded only by flows already visited on that Safe — instead of actual ownership.

## How this PR fixes it

- New `selectSafeSigners` selector: Safe owners (on the active chain) intersected with imported signers.
- The WC gate and `useHasSigner` both use it now. Deferring without a selection is safe — the confirm flow auto-selects a signer.
- Shared `SafeOverview`/`Signer` test factory in `tests/factories/safe.ts`.

## How to test it

1. Import a signer owning Safe A and Safe B; connect a dApp with Safe A active.
2. Switch to Safe B and send a tx request from a connected dApp.
3. The review sheet opens (previously: "No signer attached" toast).

## Video 

https://github.com/user-attachments/assets/b164d0be-0b39-40bc-bdba-c88cbdf32687

## Affected flows

- WC `eth_sendTransaction` / `wallet_sendCalls` to the active Safe.
- Assets read-only banner / send button (`useHasSigner`).

## Blast radius

- `useHasSigner` consumers (`AssetsHeader`, `ReadOnly`) — return shape unchanged.
- WC `hasSigner` gate; confirm flow unchanged. Mobile only.

## Risks / not checked

- Owner↔signer match stays case-sensitive (as before in `useHasSigner`).
- Not verified on a physical device; covered by unit tests.

## Visual summary

```mermaid
flowchart LR
  R[WC session_request] --> G{owners ∩ imported signers}
  G -->|match| S[Review sheet]
  G -->|none| E[4100 No signer attached]
  X[Before: activeSigner entry per Safe] -.->|missing for Safe B| E
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — none
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
