### PR TITLE
fix: hide full list of chains in the Safe apps drawer in favor of a shorter list + tooltip

### DIFF
--- a/apps/web/src/components/safe-apps/SafeAppPreviewDrawer/index.test.tsx
+++ b/apps/web/src/components/safe-apps/SafeAppPreviewDrawer/index.test.tsx
@@ -1,0 +1,113 @@
+import { SafeAppFeatures, SafeAppAccessPolicyTypes } from '@safe-global/store/gateway/types'
+import { type SafeApp as SafeAppData } from '@safe-global/store/gateway/AUTO_GENERATED/safe-apps'
+
+import SafeAppPreviewDrawer from '@/components/safe-apps/SafeAppPreviewDrawer'
+import { render, renderWithUserEvent, screen, waitFor } from '@/tests/test-utils'
+
+jest.mock('@/features/multichain', () => ({
+  NetworkLogosList: ({ networks, maxVisible, showHasMore }: any) => (
+    <div
+      data-testid="network-logos-list"
+      data-networks={networks.map((n: { chainId: string }) => n.chainId).join(',')}
+      data-max-visible={maxVisible}
+      data-show-has-more={String(showHasMore)}
+    />
+  ),
+}))
+
+jest.mock('@/components/common/ChainIndicator', () => ({
+  __esModule: true,
+  default: ({ chainId }: { chainId: string }) => <div data-testid="chain-indicator">{chainId}</div>,
+}))
+
+const mockUseChains = jest.fn()
+jest.mock('@/hooks/useChains', () => ({
+  __esModule: true,
+  default: () => mockUseChains(),
+  useChain: () => undefined,
+  useCurrentChain: () => undefined,
+  useHasFeature: () => undefined,
+}))
+
+const KNOWN_CHAIN_IDS = ['1', '10', '56', '100', '137']
+
+beforeEach(() => {
+  mockUseChains.mockReturnValue({ configs: KNOWN_CHAIN_IDS.map((chainId) => ({ chainId })) })
+})
+
+const safeAppMock: SafeAppData = {
+  id: 24,
+  url: 'https://safe-apps.dev.5afe.dev/tx-builder',
+  name: 'Transaction Builder',
+  iconUrl: 'https://safe-apps.dev.5afe.dev/tx-builder/tx-builder.png',
+  description: 'A Safe app to compose custom transactions',
+  chainIds: ['1', '10', '56', '100', '137'],
+  provider: undefined,
+  accessControl: {
+    type: SafeAppAccessPolicyTypes.DomainAllowlist,
+    value: ['https://safe.global'],
+  },
+  tags: ['transaction-builder'],
+  features: [SafeAppFeatures.BATCHED_TRANSACTIONS],
+  socialProfiles: [],
+  developerWebsite: '',
+  featured: false,
+}
+
+describe('SafeAppPreviewDrawer', () => {
+  it('renders the available networks section as a collapsed logo cluster', async () => {
+    render(<SafeAppPreviewDrawer isOpen safeApp={safeAppMock} onClose={jest.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Available networks')).toBeInTheDocument()
+    })
+
+    const logos = screen.getByTestId('network-logos-list')
+    expect(logos).toHaveAttribute('data-networks', safeAppMock.chainIds.join(','))
+    expect(logos).toHaveAttribute('data-max-visible', '3')
+    expect(logos).toHaveAttribute('data-show-has-more', 'true')
+  })
+
+  it('passes every chain to the cluster so overflow collapses beyond the visible limit', async () => {
+    render(<SafeAppPreviewDrawer isOpen safeApp={safeAppMock} onClose={jest.fn()} />)
+
+    const logos = await screen.findByTestId('network-logos-list')
+    expect(logos.getAttribute('data-networks')?.split(',')).toHaveLength(safeAppMock.chainIds.length)
+  })
+
+  it('lists all chains in the hover tooltip content', async () => {
+    const { user } = renderWithUserEvent(<SafeAppPreviewDrawer isOpen safeApp={safeAppMock} onClose={jest.fn()} />)
+
+    const trigger = await screen.findByTestId('network-logos-list')
+    await user.hover(trigger)
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('chain-indicator')).toHaveLength(safeAppMock.chainIds.length)
+    })
+    expect(screen.getAllByTestId('chain-indicator').map((el) => el.textContent)).toEqual(safeAppMock.chainIds)
+  })
+
+  it('renders an empty cluster when the app has no networks', async () => {
+    render(<SafeAppPreviewDrawer isOpen safeApp={{ ...safeAppMock, chainIds: [] }} onClose={jest.fn()} />)
+
+    const logos = await screen.findByTestId('network-logos-list')
+    expect(logos).toHaveAttribute('data-networks', '')
+  })
+
+  it('hides chains not recognized by the current environment', async () => {
+    render(
+      <SafeAppPreviewDrawer isOpen safeApp={{ ...safeAppMock, chainIds: ['1', '999999', '10'] }} onClose={jest.fn()} />,
+    )
+
+    const logos = await screen.findByTestId('network-logos-list')
+    expect(logos).toHaveAttribute('data-networks', '1,10')
+  })
+
+  it('renders an empty cluster when none of the app chains are recognized', async () => {
+    mockUseChains.mockReturnValue({ configs: [] })
+    render(<SafeAppPreviewDrawer isOpen safeApp={safeAppMock} onClose={jest.fn()} />)
+
+    const logos = await screen.findByTestId('network-logos-list')
+    expect(logos).toHaveAttribute('data-networks', '')
+  })
+})

--- a/apps/web/src/components/safe-apps/SafeAppPreviewDrawer/index.tsx
+++ b/apps/web/src/components/safe-apps/SafeAppPreviewDrawer/index.tsx
@@ -9,6 +9,12 @@ import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
 import type { SafeApp as SafeAppData } from '@safe-global/store/gateway/AUTO_GENERATED/safe-apps'
 
+import {
+  Tooltip as NetworksTooltip,
+  TooltipTrigger as NetworksTooltipTrigger,
+  TooltipContent as NetworksTooltipContent,
+} from '@/components/ui/tooltip'
+import { NetworkLogosList } from '@/features/multichain'
 import { getSafeAppUrl } from '@/components/safe-apps/SafeAppCard'
 import ChainIndicator from '@/components/common/ChainIndicator'
 import SafeAppIconCard from '@/components/safe-apps/SafeAppIconCard'
@@ -16,6 +22,7 @@ import SafeAppActionButtons from '@/components/safe-apps/SafeAppActionButtons'
 import SafeAppTags from '@/components/safe-apps/SafeAppTags'
 import SafeAppSocialLinksCard from '@/components/safe-apps/SafeAppSocialLinksCard'
 import CloseIcon from '@/public/images/common/close.svg'
+import useChains from '@/hooks/useChains'
 import { useOpenedSafeApps } from '@/hooks/safe-apps/useOpenedSafeApps'
 import css from './styles.module.css'
 import { SAFE_APPS_EVENTS, SAFE_APPS_LABELS, trackSafeAppEvent, SafeAppLaunchLocation } from '@/services/analytics'
@@ -32,6 +39,8 @@ const SafeAppPreviewDrawer = ({ isOpen, safeApp, isBookmarked, onClose, onBookma
   const { markSafeAppOpened } = useOpenedSafeApps()
   const router = useRouter()
   const safeAppUrl = getSafeAppUrl(router, safeApp?.url || '')
+  const { configs } = useChains()
+  const knownChainIds = safeApp?.chainIds.filter((chainId) => configs.some((chain) => chain.chainId === chainId)) ?? []
 
   const onOpenSafe = () => {
     if (safeApp) {
@@ -86,10 +95,21 @@ const SafeAppPreviewDrawer = ({ isOpen, safeApp, isBookmarked, onClose, onBookma
           Available networks
         </Typography>
 
-        <Box sx={{ display: 'flex', gap: 2, mt: 2, flexWrap: 'wrap' }}>
-          {safeApp?.chainIds.map((chainId) => (
-            <ChainIndicator key={chainId} chainId={chainId} inline showUnknown={false} />
-          ))}
+        <Box sx={{ display: 'flex', mt: 2 }}>
+          <NetworksTooltip>
+            <NetworksTooltipTrigger>
+              <span className="inline-flex origin-left scale-85">
+                <NetworkLogosList networks={knownChainIds.map((chainId) => ({ chainId }))} showHasMore maxVisible={3} />
+              </span>
+            </NetworksTooltipTrigger>
+            <NetworksTooltipContent>
+              <div className="flex flex-col gap-1">
+                {knownChainIds.map((chainId) => (
+                  <ChainIndicator key={chainId} chainId={chainId} />
+                ))}
+              </div>
+            </NetworksTooltipContent>
+          </NetworksTooltip>
         </Box>
 
         {/* Open Safe App button */}

--- a/apps/web/src/components/safe-apps/SafeAppPreviewDrawer/index.tsx
+++ b/apps/web/src/components/safe-apps/SafeAppPreviewDrawer/index.tsx
@@ -97,10 +97,8 @@ const SafeAppPreviewDrawer = ({ isOpen, safeApp, isBookmarked, onClose, onBookma
 
         <Box sx={{ display: 'flex', mt: 2 }}>
           <NetworksTooltip>
-            <NetworksTooltipTrigger>
-              <span className="inline-flex origin-left scale-85">
-                <NetworkLogosList networks={knownChainIds.map((chainId) => ({ chainId }))} showHasMore maxVisible={3} />
-              </span>
+            <NetworksTooltipTrigger render={<span className="inline-flex origin-left scale-85" />}>
+              <NetworkLogosList networks={knownChainIds.map((chainId) => ({ chainId }))} showHasMore maxVisible={3} />
             </NetworksTooltipTrigger>
             <NetworksTooltipContent>
               <div className="flex flex-col gap-1">


### PR DESCRIPTION
## What it solves

Resolves: [WA-2793](https://linear.app/safe-global/issue/WA-2793/tx-builder-network-list-too-big)
The Transaction Builder (and every Safe App) preview drawer listed all "Available networks" as a flat, wrapped row of chain icons — long for multi-chain apps.

## How this PR fixes it

Renders the networks as the same collapsed logo cluster used in the Space address book: overlapping logos with a `+N` overflow badge (`maxVisible={3}`) and a hover tooltip listing every chain. Chains not recognized by the current environment's config service are filtered out first, preserving the prior `showUnknown={false}` behavior.

## How to test it

1. Go to `/apps`, search "Transaction Builder", click the card to open the preview drawer.
2. Under "Available networks", confirm 3 logos + a `+N` circle.
3. Hover the cluster → tooltip lists all supported chains.

## Affected flows

- Safe App preview drawer (opened from `/apps`) — "Available networks" display.

## Blast radius

- `SafeAppPreviewDrawer` only (leaf presentational component).
- Reuses shared `NetworkLogosList`, `ui/tooltip`, `useChains` — none modified.

## Risks / not checked

- Did not add a mobile-specific variant (drawer is desktop-oriented).
- Unit tests mock `NetworkLogosList`/`ChainIndicator`/`useChains`, so they assert wiring + unknown-chain filtering, not the real `+N` rendering (owned by `NetworkLogosList`).

## Visual summary

### Before
Before: the chains list was too long, users had to scroll down to see the CTA button, and it was not obvious that they have to scroll:
<img width="638" height="791" alt="image" src="https://github.com/user-attachments/assets/69a8b6ec-5563-418a-9860-392bb0f6b796" />

### After
After: chains are in a small list with a tooltip. The CTA button is in the viewport.
<img width="554" height="793" alt="image" src="https://github.com/user-attachments/assets/0634d6cb-7e7b-48a1-abe0-a91afb478878" />


```mermaid
flowchart LR
  A[safeApp.chainIds] --> B[filter by useChains configs]
  B --> C[NetworkLogosList: 3 logos + N]
  B --> D[Tooltip: full chain list on hover]
```

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
