### PR TITLE
fix: make the loader wording more generic (not workspace related)

### DIFF
--- a/apps/web/src/components/common/LaunchScreen/LaunchScreen.test.tsx
+++ b/apps/web/src/components/common/LaunchScreen/LaunchScreen.test.tsx
@@ -18,7 +18,7 @@ describe('LaunchScreen', () => {
     expect(screen.getByRole('status')).toBeInTheDocument()
     expect(screen.getByTestId('launch-screen')).toHaveAttribute('aria-busy', 'true')
     expect(screen.getByAltText('Safe')).toBeInTheDocument()
-    expect(screen.getByText('Loading your workspace…')).toBeInTheDocument()
+    expect(screen.getByText('Loading Safe{Wallet}…')).toBeInTheDocument()
     expect(screen.getByTestId('launch-progress-bar')).toHaveStyle({ width: '30%' })
   })
 

--- a/apps/web/src/components/common/LaunchScreen/index.tsx
+++ b/apps/web/src/components/common/LaunchScreen/index.tsx
@@ -4,7 +4,7 @@ import { useLaunchScreen } from './useLaunchScreen'
 import css from './LaunchScreen.module.css'
 
 const LAUNCH_STEPS = [
-  { progress: 30, caption: 'Loading your workspace…' },
+  { progress: 30, caption: 'Loading Safe{Wallet}…' },
   { progress: 65, caption: 'Fetching your accounts…' },
   { progress: 90, caption: 'Almost there…' },
 ] as const


### PR DESCRIPTION
## What it solves

Resolves: [WA-2759](https://linear.app/safe-global/issue/WA-2759/loading-state-improvement)
The loader always showed "Loading your workspaces..." copy, even when just opening a Safe.

## How this PR fixes it
Makes the copy more generic: "Loading your Safe{Wallet}..."

## How to test it
Open the app, refresh / hard refresh --> the loader should have a new copy.

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
