### PR TITLE
fix(web/AB): AB table on medium and small screens

### DIFF
--- a/apps/web/src/features/spaces/components/PaginatedDataTable/index.test.tsx
+++ b/apps/web/src/features/spaces/components/PaginatedDataTable/index.test.tsx
@@ -133,18 +133,6 @@ describe('PaginatedDataTable', () => {
       expect(screen.getByText('a@example.io').closest('td')).toHaveClass('max-[767px]:hidden')
     })
 
-    it('applies sticky classes and minWidth to both the header and body cells of a sticky column', () => {
-      renderResponsive()
-
-      const nameHeader = screen.getByText('Name').closest('th')
-      const nameCell = screen.getByText('Alice').closest('td')
-
-      expect(nameHeader).toHaveClass('max-[767px]:sticky', 'max-[767px]:left-0')
-      expect(nameHeader).toHaveStyle({ minWidth: '200px' })
-      expect(nameCell).toHaveClass('max-[767px]:sticky', 'max-[767px]:left-0')
-      expect(nameCell).toHaveStyle({ minWidth: '200px' })
-    })
-
     it('adds no separate mobile sort control and keeps sorting on the visible headers', () => {
       mockUseIsMobile.mockReturnValue(true)
       renderResponsive()

--- a/apps/web/src/features/spaces/components/PaginatedDataTable/index.tsx
+++ b/apps/web/src/features/spaces/components/PaginatedDataTable/index.tsx
@@ -55,7 +55,7 @@ export type DataTableColumn<T> = {
   priority?: 'essential' | 'secondary'
   /** Pins the column to the left while horizontally scrolling on mobile */
   sticky?: boolean
-  /** Minimum column width in px — a floor for the content-based auto layout */
+  /** Minimum column width in px, applied on desktop (md+) only; mobile auto-sizes to content */
   minWidth?: number
   /** When provided, the column header becomes sortable using this comparable value */
   sortValue?: (row: T) => string | number | null | undefined
@@ -83,6 +83,12 @@ const hideClass = <T,>(column: DataTableColumn<T>) =>
 // Sticky only kicks in on mobile, where the table can scroll horizontally
 const stickyClass = <T,>(column: DataTableColumn<T>) =>
   column.sticky ? 'max-[767px]:bg-card max-[767px]:sticky max-[767px]:left-0 max-[767px]:z-10' : ''
+
+// minWidth is a desktop-only floor; mobile auto-sizes to content
+const minWidthClass = <T,>(column: DataTableColumn<T>) => (column.minWidth ? 'md:min-w-[var(--col-min-w)]' : '')
+
+const minWidthStyle = <T,>(column: DataTableColumn<T>): Record<string, string> | undefined =>
+  column.minWidth ? { '--col-min-w': `${column.minWidth}px` } : undefined
 
 const compareNullable = (
   a: string | number | null | undefined,
@@ -176,11 +182,12 @@ function PaginatedDataTable<T>({
                 <TableHead
                   key={column.id}
                   aria-sort={column.sortValue ? ariaSortValue(direction) : undefined}
-                  style={column.minWidth ? { minWidth: column.minWidth } : undefined}
+                  style={minWidthStyle(column)}
                   className={cn(
                     tableHeadVariants({ align: column.align }),
                     hideClass(column),
                     stickyClass(column),
+                    minWidthClass(column),
                     column.width && COLUMN_WIDTHS[column.width],
                   )}
                 >
@@ -216,11 +223,12 @@ function PaginatedDataTable<T>({
                     <TableCell
                       key={column.id}
                       data-testid={column.cellTestId}
-                      style={column.minWidth ? { minWidth: column.minWidth } : undefined}
+                      style={minWidthStyle(column)}
                       className={cn(
                         tableCellVariants({ align: column.align, emphasis: column.emphasis }),
                         hideClass(column),
                         stickyClass(column),
+                        minWidthClass(column),
                       )}
                     >
                       {column.cell(row)}

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
@@ -47,12 +47,19 @@ function RequestedBy({ requestedBy }: { requestedBy: string }) {
   }
 
   return (
-    <span className="inline-flex min-w-0 items-center gap-2">
-      <span className="shrink-0">
-        <Identicon address={requestedBy} size={20} />
-      </span>
-      <span className="min-w-0 truncate text-left">{requestedBy}</span>
-    </span>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span className="inline-flex min-w-0 items-center gap-2">
+            <span className="shrink-0">
+              <Identicon address={requestedBy} size={20} />
+            </span>
+            <span className="min-w-0 truncate text-left">{requestedBy}</span>
+          </span>
+        }
+      />
+      <TooltipContent side="bottom">{requestedBy}</TooltipContent>
+    </Tooltip>
   )
 }
 

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
@@ -1,7 +1,4 @@
-import { useState } from 'react'
-import { useMediaQuery } from '@mui/material'
-import { useTheme } from '@mui/material/styles'
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { useState, useMemo } from 'react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -21,7 +18,7 @@ import { showNotification } from '@/store/notificationsSlice'
 import { useAppDispatch } from '@/store'
 import useChains from '@/hooks/useChains'
 import { Check, X } from 'lucide-react'
-import { useMemo } from 'react'
+import PaginatedDataTable, { type DataTableColumn } from '../PaginatedDataTable'
 
 type PendingRequestsTableProps = {
   requests: AddressBookRequestItemDto[]
@@ -32,14 +29,39 @@ const getApproveErrorMessage = (error: unknown): string => {
   return typeof err?.data?.message === 'string' ? err.data.message : 'Failed to approve request'
 }
 
+function RequestedBy({ requestedBy }: { requestedBy: string }) {
+  if (isAddress(requestedBy)) {
+    return (
+      <div className="text-[0.8em] font-mono">
+        <EthHashInfo
+          address={requestedBy}
+          shortAddress={false}
+          showPrefix={false}
+          showName={false}
+          highlight4bytes
+          showCopyButton={false}
+          avatarSize={20}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <span className="inline-flex min-w-0 items-center gap-2">
+      <span className="shrink-0">
+        <Identicon address={requestedBy} size={20} />
+      </span>
+      <span className="min-w-0 truncate text-left">{requestedBy}</span>
+    </span>
+  )
+}
+
 function PendingRequestsTable({ requests }: PendingRequestsTableProps) {
   const chains = useChains()
   const isAdmin = useIsAdmin()
   const spaceId = useCurrentSpaceId()
   const dispatch = useAppDispatch()
   const spaceAddressBook = useGetSpaceAddressBook()
-  const theme = useTheme()
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down('lg'))
   const [approveRequest] = useAddressBookRequestsApproveRequestV1Mutation()
   const [rejectRequest] = useAddressBookRequestsRejectRequestV1Mutation()
   const [loadingId, setLoadingId] = useState<number | null>(null)
@@ -97,141 +119,151 @@ function PendingRequestsTable({ requests }: PendingRequestsTableProps) {
     }
   }
 
+  const renderChains = (req: AddressBookRequestItemDto) => (
+    <Tooltip>
+      <TooltipTrigger>
+        <span className="inline-flex origin-left scale-85">
+          {chains.configs.length === req.chainIds.length ? (
+            <Badge variant="secondary">All</Badge>
+          ) : (
+            <NetworkLogosList networks={req.chainIds.map((chainId) => ({ chainId }))} showHasMore maxVisible={3} />
+          )}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="flex flex-col gap-1">
+          {req.chainIds.map((chainId) => (
+            <ChainIndicator key={chainId} chainId={chainId} />
+          ))}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+
+  const columns: DataTableColumn<AddressBookRequestItemDto>[] = [
+    {
+      id: 'name',
+      header: 'Name',
+      width: '20%',
+      sticky: true,
+      minWidth: 140,
+      emphasis: 'strong',
+      cell: (req) => (
+        <span className="inline-flex min-w-0 items-center gap-2 overflow-hidden">
+          <span className="min-w-0 truncate">{req.name}</span>
+          {spaceAddresses.has(req.address.toLowerCase()) && (
+            <Tooltip>
+              <TooltipTrigger render={<Badge variant="outline">Already in workspace</Badge>} />
+              <TooltipContent>Approving replaces the existing workspace entry for this address.</TooltipContent>
+            </Tooltip>
+          )}
+        </span>
+      ),
+    },
+    {
+      id: 'address',
+      header: 'Address',
+      width: '40%',
+      minWidth: 360,
+      cell: (req) => (
+        <div className="text-[0.8em] font-mono">
+          <EthHashInfo
+            address={req.address}
+            shortAddress={false}
+            showPrefix={false}
+            showName={false}
+            highlight4bytes
+            hasExplorer
+            showCopyButton
+            avatarSize={24}
+          />
+        </div>
+      ),
+    },
+    {
+      id: 'chains',
+      header: 'Chains',
+      width: '15%',
+      priority: 'secondary',
+      minWidth: 100,
+      cell: renderChains,
+    },
+    {
+      id: 'requestedBy',
+      header: 'Requested by',
+      width: '20%',
+      priority: 'secondary',
+      minWidth: 140,
+      cell: (req) => (req.requestedBy ? <RequestedBy requestedBy={req.requestedBy} /> : null),
+    },
+    {
+      id: 'actions',
+      width: '15%',
+      align: 'end',
+      minWidth: 80,
+      cell: (req) =>
+        isAdmin ? (
+          <span className="inline-flex items-center justify-end gap-1">
+            {loadingId === req.id ? (
+              <Spinner className="size-5" />
+            ) : (
+              <>
+                <Tooltip>
+                  <TooltipTrigger render={<span className="inline-flex" />}>
+                    <Button variant="outline" size="icon-sm" onClick={() => handleApprove(req.id)}>
+                      <Check className="size-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Accept</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger render={<span className="inline-flex" />}>
+                    <Button variant="outline" size="icon-sm" onClick={() => handleReject(req.id)}>
+                      <X className="size-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Decline</TooltipContent>
+                </Tooltip>
+              </>
+            )}
+          </span>
+        ) : (
+          <Badge variant="secondary">Pending</Badge>
+        ),
+    },
+  ]
+
+  // Surfaces the columns hidden on mobile (chains, requested-by)
+  const renderRowDetail = (req: AddressBookRequestItemDto) => (
+    <div className="flex flex-col gap-2 text-sm">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-muted-foreground w-24 shrink-0">Chains</span>
+        <div className="flex flex-wrap gap-1">
+          {req.chainIds.map((chainId) => (
+            <ChainIndicator key={chainId} chainId={chainId} />
+          ))}
+        </div>
+      </div>
+      {req.requestedBy && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-muted-foreground w-24 shrink-0">Requested by</span>
+          <RequestedBy requestedBy={req.requestedBy} />
+        </div>
+      )}
+    </div>
+  )
+
   if (requests.length === 0) {
     return <p className="text-muted-foreground text-sm">No pending requests.</p>
   }
 
   return (
-    <Table className="table-fixed min-w-[720px]">
-      <TableHeader>
-        <TableRow>
-          <TableHead className={isSmallScreen ? 'w-[15%]' : 'w-[20%]'}>Name</TableHead>
-          <TableHead className={isSmallScreen ? 'w-[40%]' : 'w-[32%]'}>Address</TableHead>
-          <TableHead className={isSmallScreen ? 'w-[15%]' : 'w-[13%]'}>Chains</TableHead>
-          <TableHead className={isSmallScreen ? 'w-[20%]' : 'w-[25%]'}>Requested by</TableHead>
-          <TableHead className="w-[10%]" />
-        </TableRow>
-      </TableHeader>
-
-      <TableBody>
-        {requests.map((req) => (
-          <TableRow key={req.id}>
-            <TableCell className="font-bold">
-              <span className="inline-flex items-center gap-2">
-                <span className="min-w-0 truncate">{req.name}</span>
-                {spaceAddresses.has(req.address.toLowerCase()) && (
-                  <Tooltip>
-                    <TooltipTrigger render={<Badge variant="outline">Already in workspace</Badge>} />
-                    <TooltipContent>Approving replaces the existing workspace entry for this address.</TooltipContent>
-                  </Tooltip>
-                )}
-              </span>
-            </TableCell>
-
-            <TableCell>
-              <div className="text-[0.8em] font-mono">
-                <EthHashInfo
-                  address={req.address}
-                  shortAddress={false}
-                  showPrefix={false}
-                  showName={false}
-                  highlight4bytes
-                  hasExplorer
-                  showCopyButton
-                  avatarSize={24}
-                />
-              </div>
-            </TableCell>
-
-            <TableCell>
-              <Tooltip>
-                <TooltipTrigger>
-                  <span className="inline-flex origin-left scale-85">
-                    {chains.configs.length === req.chainIds.length ? (
-                      <Badge variant="secondary">All</Badge>
-                    ) : (
-                      <NetworkLogosList
-                        networks={req.chainIds.map((chainId) => ({ chainId }))}
-                        showHasMore
-                        maxVisible={3}
-                      />
-                    )}
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <div className="flex flex-col gap-1">
-                    {req.chainIds.map((chainId) => (
-                      <ChainIndicator key={chainId} chainId={chainId} />
-                    ))}
-                  </div>
-                </TooltipContent>
-              </Tooltip>
-            </TableCell>
-
-            <TableCell>
-              {req.requestedBy && (
-                <Tooltip>
-                  <TooltipTrigger render={<span className="inline-flex min-w-0" />}>
-                    {isAddress(req.requestedBy) ? (
-                      <div className="text-[0.8em] font-mono">
-                        <EthHashInfo
-                          address={req.requestedBy}
-                          shortAddress={false}
-                          showPrefix={false}
-                          showName={false}
-                          highlight4bytes
-                          showCopyButton={false}
-                          avatarSize={20}
-                        />
-                      </div>
-                    ) : (
-                      <span className="inline-flex min-w-0 items-center gap-2">
-                        <span className="shrink-0">
-                          <Identicon address={req.requestedBy} size={20} />
-                        </span>
-                        <span className="min-w-0 break-all text-left">{req.requestedBy}</span>
-                      </span>
-                    )}
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">{req.requestedBy}</TooltipContent>
-                </Tooltip>
-              )}
-            </TableCell>
-
-            <TableCell className="text-right">
-              {isAdmin ? (
-                <span className="inline-flex gap-1">
-                  {loadingId === req.id ? (
-                    <Spinner className="size-5" />
-                  ) : (
-                    <>
-                      <Tooltip>
-                        <TooltipTrigger render={<span className="inline-flex" />}>
-                          <Button variant="outline" size="icon-sm" onClick={() => handleApprove(req.id)}>
-                            <Check className="size-4" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>Accept</TooltipContent>
-                      </Tooltip>
-                      <Tooltip>
-                        <TooltipTrigger render={<span className="inline-flex" />}>
-                          <Button variant="outline" size="icon-sm" onClick={() => handleReject(req.id)}>
-                            <X className="size-4" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>Decline</TooltipContent>
-                      </Tooltip>
-                    </>
-                  )}
-                </span>
-              ) : (
-                <Badge variant="secondary">Pending</Badge>
-              )}
-            </TableCell>
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+    <PaginatedDataTable
+      columns={columns}
+      rows={requests}
+      getRowKey={(req) => String(req.id)}
+      renderRowDetail={renderRowDetail}
+    />
   )
 }
 

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
@@ -170,7 +170,7 @@ function PendingRequestsTable({ requests }: PendingRequestsTableProps) {
     {
       id: 'address',
       header: 'Address',
-      width: '40%',
+      width: '30%',
       minWidth: 360,
       cell: (req) => (
         <div className="text-[0.8em] font-mono">
@@ -198,9 +198,9 @@ function PendingRequestsTable({ requests }: PendingRequestsTableProps) {
     {
       id: 'requestedBy',
       header: 'Requested by',
-      width: '20%',
+      width: '30%',
       priority: 'secondary',
-      minWidth: 140,
+      minWidth: 300,
       cell: (req) => (req.requestedBy ? <RequestedBy requestedBy={req.requestedBy} /> : null),
     },
     {

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/PendingRequestsTable.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/PendingRequestsTable.test.tsx
@@ -4,6 +4,7 @@ import PendingRequestsTable from '../PendingRequestsTable'
 import type { AddressBookRequestItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { Builder } from '@/tests/Builder'
 
+jest.mock('@/hooks/use-mobile', () => ({ useIsMobile: () => false }))
 jest.mock('@/hooks/useChains', () => () => ({ configs: [] }))
 jest.mock('@/features/spaces', () => ({
   useCurrentSpaceId: () => '1',


### PR DESCRIPTION
## What it solves

Resolves: [WA-2975](https://linear.app/safe-global/issue/WA-2795/fix-pending-requests-in-ab-on-medium-and-small-screen-sizes)
The Pending requests table in the Space Address Book had a bespoke layout that didn't match the Contacts tabs and handled small screens with an ad-hoc `useMediaQuery` breakpoint. It also lost long "Requested by" values (emails/display names) to truncation with no way to read them.

## How this PR fixes it

- Refactors `PendingRequestsTable` onto the shared `PaginatedDataTable`, aligning it with the Contacts tabs (columns, sticky name, mobile row-detail, sort/pagination).
- Moves the mobile-hidden columns (Chains, Requested by) into the collapsible per-row detail, revealed via the row chevron.
- Restores a tooltip on the non-address "Requested by" branch so truncated emails/names stay readable on hover.

## How to test it

1. Open a Space → Address Book → Pending tab (as an admin, with pending requests).
2. Verify Name / Address / Chains / Requested by / actions render correctly on desktop.
3. Hover a long non-address "Requested by" value → full value shows in a tooltip.
4. Narrow the viewport below 768px → Chains and Requested by collapse; tap the ⌄ chevron at the right of a row to reveal them in the detail area.

## Affected flows

- Space Address Book → Pending requests: view / approve / reject pending contact requests (desktop + mobile).

## Blast radius

- `PendingRequestsTable` (only consumer changed in this PR).
- Reuses shared `PaginatedDataTable` — no changes to it, so no impact on its other consumers (`MembersList`, `SpaceAddressBookTable`).
- No API, slice, selector, feature-flag, route, or shared-package changes. No mobile-app (Expo) impact.

## Risks / not checked

- Did not manually verify the read-only (non-admin) "Pending" badge path.
- Did not exercise the approve/reject error paths manually (unit tests cover the happy path).
- Breakpoint intentionally changed from MUI `lg` (~1200px) to the shared 768px — tablets in 768–1024px now get the desktop layout (confirmed intended).

## Visual summary

### Before
Elements in the "Pending" tab were overlapping: 
<img width="718" height="249" alt="image" src="https://github.com/user-attachments/assets/842fa8be-6bba-4917-94b2-3fd1f21c6b4e" />

### After

The "Pending" table reuses the same table as other AB tab and therefore is responsive and has a working detailed dropdown:


https://github.com/user-attachments/assets/0d75b414-64e8-4b40-a45d-2f17927eba02



```mermaid
flowchart TB
  subgraph Before
    A1[PendingRequestsTable] --> B1[Bespoke Table + useMediaQuery]
    B1 --> C1[Truncated Requested by, no tooltip]
  end
  subgraph After
    A2[PendingRequestsTable] --> H[PaginatedDataTable]
    H --> D2[Mobile row-detail: Chains + Requested by]
    A2 --> E2[Tooltip on non-address Requested by]
  end
```

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
