### PR TITLE
fix(UI): Dark mode fixes for the warning banner for Trusted Safes

### DIFF
--- a/apps/web/src/components/common/TrustedSafesModal/SecurityBanner.tsx
+++ b/apps/web/src/components/common/TrustedSafesModal/SecurityBanner.tsx
@@ -17,12 +17,9 @@ const SecurityBanner = ({ title, className }: SecurityBannerProps) => {
   return (
     <Alert
       variant="warning"
-      className={cn(
-        'mb-4 dark:bg-[var(--color-warning-background)] dark:text-[var(--color-warning1-contrast-text)]',
-        className,
-      )}
+      className={cn('mb-4 dark:bg-[var(--color-warning-background)] dark:text-[var(--color-text-primary)]', className)}
     >
-      <TriangleAlert />
+      <TriangleAlert className="dark:text-[var(--color-warning-main)]" />
       {title && <AlertTitle className="font-bold">{title}</AlertTitle>}
       <AlertDescription className="dark:text-current">
         Some Safes linked to your wallet may be malicious or impersonations (address poisoning). Only trust Safes you
@@ -30,7 +27,7 @@ const SecurityBanner = ({ title, className }: SecurityBannerProps) => {
         <ExternalLink
           href={HelpCenterArticle.ADDRESS_POISONING}
           noIcon
-          sx={{ textDecoration: 'underline', '.dark &': { color: 'inherit' } }}
+          sx={{ '& span': { textDecoration: 'underline' }, '.dark &': { color: 'inherit' } }}
         >
           Learn more about address poisoning
         </ExternalLink>


### PR DESCRIPTION
## What it solves

Resolves: [WA-2612](https://linear.app/safe-global/issue/WA-2612/adjust-the-trusted-safes-color-scheme-in-dark-mode)

## How this PR fixes it
Adjusts colors of the new warning banner with the MUI color scheme for warnings.

## How to test it
- Switch the app to the dark mode;
- Open Trusted Safes modal when having several similar safes in the profile;
- The warning about similar addresses should be consistent with MUI warning banners (see color reference below).

## Visual summary

Benchmark: MUI warning banner:
<img width="688" height="114" alt="image" src="https://github.com/user-attachments/assets/5de6994e-4f59-4dab-9d8b-cc44776927fe" />

### Before
Before the fixes the Shadcn warning banner was not consistent with the MUI one:
<img width="704" height="87" alt="image" src="https://github.com/user-attachments/assets/b38a1736-1213-48cd-9255-00501ce97a5f" />

### After
After UI fixes the banner is consistent with existing MUI banners:
<img width="868" height="102" alt="image" src="https://github.com/user-attachments/assets/96c2dc84-ad24-4e06-a18c-97403c7e8bd2" />



## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
