### PR TITLE
fix(mobile): WC dApp UX fixes

### DIFF
--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappRow.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappRow.tsx
@@ -14,10 +14,12 @@ interface Props {
   variant?: VerifyVariant
   /** Asks the screen to open the disconnect confirmation for this session. */
   onRequestDisconnect: (session: SessionTypes.Struct) => void
+  /** Notifies the screen that this row starts to swipe open, so it can close the previous one. */
+  onSwipeOpenStart?: (methods: SwipeableMethods) => void
 }
 
 /** A connected-dApp card; the overflow menu and a left-swipe both route to a disconnect confirmation. */
-export const ConnectedDappRow: React.FC<Props> = ({ session, variant, onRequestDisconnect }) => {
+export const ConnectedDappRow: React.FC<Props> = ({ session, variant, onRequestDisconnect, onSwipeOpenStart }) => {
   const meta = session.peer.metadata
   const swipeRef = useRef<SwipeableMethods>(null)
 
@@ -25,6 +27,12 @@ export const ConnectedDappRow: React.FC<Props> = ({ session, variant, onRequestD
     swipeRef.current?.close()
     onRequestDisconnect(session)
   }, [onRequestDisconnect, session])
+
+  const handleOpenStartDrag = useCallback(() => {
+    if (swipeRef.current) {
+      onSwipeOpenStart?.(swipeRef.current)
+    }
+  }, [onSwipeOpenStart])
 
   const renderTrash = useCallback(
     () => (
@@ -51,7 +59,12 @@ export const ConnectedDappRow: React.FC<Props> = ({ session, variant, onRequestD
   )
 
   return (
-    <ReanimatedSwipeable ref={swipeRef} renderRightActions={renderTrash} overshootRight={false}>
+    <ReanimatedSwipeable
+      ref={swipeRef}
+      renderRightActions={renderTrash}
+      overshootRight={false}
+      onSwipeableOpenStartDrag={handleOpenStartDrag}
+    >
       <XStack
         backgroundColor="$backgroundPaper"
         borderRadius="$2"

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappRow.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappRow.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import { Pressable } from 'react-native'
 import ReanimatedSwipeable, {
   SwipeDirection,
@@ -19,12 +19,32 @@ interface Props {
   onRequestDisconnect: (session: SessionTypes.Struct) => void
   /** Notifies the screen that this row starts to swipe open, so it can close the previous one. */
   onSwipeOpenStart?: (methods: SwipeableMethods) => void
+  /** Notifies the screen that this row unmounts, so it can drop a reference to its swipeable. */
+  onSwipeCleanup?: (methods: SwipeableMethods) => void
 }
 
 /** A connected-dApp card; the overflow menu and a left-swipe both route to a disconnect confirmation. */
-export const ConnectedDappRow: React.FC<Props> = ({ session, variant, onRequestDisconnect, onSwipeOpenStart }) => {
+export const ConnectedDappRow: React.FC<Props> = ({
+  session,
+  variant,
+  onRequestDisconnect,
+  onSwipeOpenStart,
+  onSwipeCleanup,
+}) => {
   const meta = session.peer.metadata
   const swipeRef = useRef<SwipeableMethods>(null)
+
+  // Capture the handle at mount: the swipeable's ref is already detached when the cleanup runs.
+  const onSwipeCleanupRef = useRef(onSwipeCleanup)
+  onSwipeCleanupRef.current = onSwipeCleanup
+  useEffect(() => {
+    const methods = swipeRef.current
+    return () => {
+      if (methods) {
+        onSwipeCleanupRef.current?.(methods)
+      }
+    }
+  }, [])
 
   const requestDisconnect = useCallback(() => {
     swipeRef.current?.close()

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappRow.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappRow.tsx
@@ -1,6 +1,9 @@
 import React, { useCallback, useRef } from 'react'
 import { Pressable } from 'react-native'
-import ReanimatedSwipeable, { type SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable'
+import ReanimatedSwipeable, {
+  SwipeDirection,
+  type SwipeableMethods,
+} from 'react-native-gesture-handler/ReanimatedSwipeable'
 import { Text, View, XStack } from 'tamagui'
 import type { SessionTypes } from '@walletconnect/types'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
@@ -28,11 +31,16 @@ export const ConnectedDappRow: React.FC<Props> = ({ session, variant, onRequestD
     onRequestDisconnect(session)
   }, [onRequestDisconnect, session])
 
-  const handleOpenStartDrag = useCallback(() => {
-    if (swipeRef.current) {
-      onSwipeOpenStart?.(swipeRef.current)
-    }
-  }, [onSwipeOpenStart])
+  const handleOpenStartDrag = useCallback(
+    (direction: SwipeDirection) => {
+      // Only a left drag reveals the trash (the sole, right-side action); the ref is always set
+      // once the swipeable has mounted — the guard just narrows the type.
+      if (direction === SwipeDirection.LEFT && swipeRef.current) {
+        onSwipeOpenStart?.(swipeRef.current)
+      }
+    },
+    [onSwipeOpenStart],
+  )
 
   const renderTrash = useCallback(
     () => (

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen.tsx
@@ -28,6 +28,13 @@ export const ConnectedDappsScreen: React.FC = () => {
     openSwipeRef.current = methods
   }, [])
 
+  // Drop the tracked swipeable when its row unmounts (e.g. the session got disconnected).
+  const handleSwipeCleanup = useCallback((methods: SwipeableMethods) => {
+    if (openSwipeRef.current === methods) {
+      openSwipeRef.current = null
+    }
+  }, [])
+
   const handleConfirm = useCallback(async () => {
     if (!selected) {
       return
@@ -46,9 +53,10 @@ export const ConnectedDappsScreen: React.FC = () => {
         variant={verifyByTopic[item.topic]}
         onRequestDisconnect={setSelected}
         onSwipeOpenStart={handleSwipeOpenStart}
+        onSwipeCleanup={handleSwipeCleanup}
       />
     ),
-    [verifyByTopic, handleSwipeOpenStart],
+    [verifyByTopic, handleSwipeOpenStart, handleSwipeCleanup],
   )
 
   return (

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen.tsx
@@ -1,5 +1,6 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { FlatList } from 'react-native'
+import type { SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable'
 import { H2, Text, YStack } from 'tamagui'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import type { SessionTypes } from '@walletconnect/types'
@@ -17,6 +18,16 @@ export const ConnectedDappsScreen: React.FC = () => {
   const insets = useSafeAreaInsets()
   const [selected, setSelected] = useState<SessionTypes.Struct | null>(null)
 
+  // The row currently swiped open
+  const openSwipeRef = useRef<SwipeableMethods | null>(null)
+
+  const handleSwipeOpenStart = useCallback((methods: SwipeableMethods) => {
+    if (openSwipeRef.current && openSwipeRef.current !== methods) {
+      openSwipeRef.current.close()
+    }
+    openSwipeRef.current = methods
+  }, [])
+
   const handleConfirm = useCallback(async () => {
     if (!selected) {
       return
@@ -30,9 +41,14 @@ export const ConnectedDappsScreen: React.FC = () => {
 
   const renderItem = useCallback(
     ({ item }: { item: SessionTypes.Struct }) => (
-      <ConnectedDappRow session={item} variant={verifyByTopic[item.topic]} onRequestDisconnect={setSelected} />
+      <ConnectedDappRow
+        session={item}
+        variant={verifyByTopic[item.topic]}
+        onRequestDisconnect={setSelected}
+        onSwipeOpenStart={handleSwipeOpenStart}
+      />
     ),
-    [verifyByTopic],
+    [verifyByTopic, handleSwipeOpenStart],
   )
 
   return (

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectionPermissionsPanel.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectionPermissionsPanel.tsx
@@ -39,12 +39,12 @@ export const ConnectionPermissionsPanel: React.FC<Props> = ({ variant }) => {
   const isVerified = variant === 'verified'
 
   return (
-    <YStack paddingHorizontal="$4" paddingTop="$2">
+    <YStack>
       <Text fontSize={20} fontWeight="600" letterSpacing={-0.2} marginBottom="$6" textAlign="center">
         Connection request
       </Text>
 
-      <YStack gap="$6" marginBottom="$6">
+      <YStack gap="$6">
         <XStack
           gap="$3"
           paddingHorizontal="$3"

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectionPermissionsPanel.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectionPermissionsPanel.tsx
@@ -44,7 +44,7 @@ export const ConnectionPermissionsPanel: React.FC<Props> = ({ variant }) => {
         Connection request
       </Text>
 
-      <YStack gap="$6">
+      <YStack gap="$6" marginBottom="$6">
         <XStack
           gap="$3"
           paddingHorizontal="$3"

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/DappIdentity.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/DappIdentity.tsx
@@ -45,7 +45,7 @@ export const DappIdentity: React.FC<Props> = ({
   }, [url])
 
   return (
-    <YStack gap="$5" padding="$4">
+    <YStack gap="$5">
       <Text fontSize={20} fontWeight="600" letterSpacing={-0.2} textAlign="center">
         {title}
       </Text>

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/RequestSheetHost.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/RequestSheetHost.tsx
@@ -7,7 +7,7 @@ import {
 } from '@gorhom/bottom-sheet'
 import type { IWalletKit } from '@reown/walletkit'
 import { useStore } from 'react-redux'
-import { getVariable, useTheme, YStack, XStack } from 'tamagui'
+import { getVariable, useTheme, YStack, XStack, View } from 'tamagui'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { BackdropComponent, BackgroundComponent } from '@/src/components/Dropdown/sheetComponents'
 import { SafeButton } from '@/src/components/SafeButton'
@@ -175,19 +175,20 @@ export const RequestSheetHost: React.FC<Props> = ({ walletKit }) => {
       footerComponent={renderFooter}
       handleIndicatorStyle={{ backgroundColor: getVariable(theme.borderMain) }}
     >
-      {/* Dynamic sizing fits the sheet to its content, so this never scrolls in practice — it only
-          kicks in when the content is clamped at max height (e.g. large accessibility font scales),
-          where it prevents clipping. */}
       <BottomSheetScrollView
         bounces={false}
         overScrollMode="never"
         contentContainerStyle={{ paddingBottom: insets.bottom + FOOTER_CLEARANCE }}
       >
-        {proposal && !permissionsOpen && (
-          <SessionProposalSheet pending={proposal} onOpenPermissions={openPermissions} />
-        )}
-        {request && !permissionsOpen && <SendTransactionSheet pending={request} onOpenPermissions={openPermissions} />}
-        {(proposal || request) && permissionsOpen && <ConnectionPermissionsPanel variant={variant} />}
+        <View padding="$4">
+          {proposal && !permissionsOpen && (
+            <SessionProposalSheet pending={proposal} onOpenPermissions={openPermissions} />
+          )}
+          {request && !permissionsOpen && (
+            <SendTransactionSheet pending={request} onOpenPermissions={openPermissions} />
+          )}
+          {(proposal || request) && permissionsOpen && <ConnectionPermissionsPanel variant={variant} />}
+        </View>
       </BottomSheetScrollView>
     </BottomSheetModal>
   )

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/RequestSheetHost.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/RequestSheetHost.tsx
@@ -1,10 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import {
-  BottomSheetModal,
-  BottomSheetScrollView,
-  BottomSheetFooter,
-  type BottomSheetFooterProps,
-} from '@gorhom/bottom-sheet'
+import { BottomSheetModal, BottomSheetView, BottomSheetFooter, type BottomSheetFooterProps } from '@gorhom/bottom-sheet'
 import type { IWalletKit } from '@reown/walletkit'
 import { useStore } from 'react-redux'
 import { getVariable, useTheme, YStack, XStack } from 'tamagui'
@@ -175,14 +170,13 @@ export const RequestSheetHost: React.FC<Props> = ({ walletKit }) => {
       footerComponent={renderFooter}
       handleIndicatorStyle={{ backgroundColor: getVariable(theme.borderMain) }}
     >
-      {/* Scrollable so content can't clip under large font scaling; the footer is pinned. */}
-      <BottomSheetScrollView contentContainerStyle={{ paddingBottom: insets.bottom + FOOTER_CLEARANCE }}>
+      <BottomSheetView style={{ paddingBottom: insets.bottom + FOOTER_CLEARANCE }}>
         {proposal && !permissionsOpen && (
           <SessionProposalSheet pending={proposal} onOpenPermissions={openPermissions} />
         )}
         {request && !permissionsOpen && <SendTransactionSheet pending={request} onOpenPermissions={openPermissions} />}
         {(proposal || request) && permissionsOpen && <ConnectionPermissionsPanel variant={variant} />}
-      </BottomSheetScrollView>
+      </BottomSheetView>
     </BottomSheetModal>
   )
 }

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/RequestSheetHost.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/RequestSheetHost.tsx
@@ -1,5 +1,10 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { BottomSheetModal, BottomSheetView, BottomSheetFooter, type BottomSheetFooterProps } from '@gorhom/bottom-sheet'
+import {
+  BottomSheetModal,
+  BottomSheetScrollView,
+  BottomSheetFooter,
+  type BottomSheetFooterProps,
+} from '@gorhom/bottom-sheet'
 import type { IWalletKit } from '@reown/walletkit'
 import { useStore } from 'react-redux'
 import { getVariable, useTheme, YStack, XStack } from 'tamagui'
@@ -170,13 +175,20 @@ export const RequestSheetHost: React.FC<Props> = ({ walletKit }) => {
       footerComponent={renderFooter}
       handleIndicatorStyle={{ backgroundColor: getVariable(theme.borderMain) }}
     >
-      <BottomSheetView style={{ paddingBottom: insets.bottom + FOOTER_CLEARANCE }}>
+      {/* Dynamic sizing fits the sheet to its content, so this never scrolls in practice — it only
+          kicks in when the content is clamped at max height (e.g. large accessibility font scales),
+          where it prevents clipping. */}
+      <BottomSheetScrollView
+        bounces={false}
+        overScrollMode="never"
+        contentContainerStyle={{ paddingBottom: insets.bottom + FOOTER_CLEARANCE }}
+      >
         {proposal && !permissionsOpen && (
           <SessionProposalSheet pending={proposal} onOpenPermissions={openPermissions} />
         )}
         {request && !permissionsOpen && <SendTransactionSheet pending={request} onOpenPermissions={openPermissions} />}
         {(proposal || request) && permissionsOpen && <ConnectionPermissionsPanel variant={variant} />}
-      </BottomSheetView>
+      </BottomSheetScrollView>
     </BottomSheetModal>
   )
 }

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/RequestSheetHost.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/RequestSheetHost.tsx
@@ -23,10 +23,6 @@ import { ConnectionPermissionsPanel } from './ConnectionPermissionsPanel'
 
 type Props = { walletKit: IWalletKit | null }
 
-// Sheet snap indices: 0 = compact (proposal), 1 = taller (permissions panel).
-const SNAP_COMPACT = 0
-const SNAP_EXPANDED = 1
-
 // Scroll-content clearance so it never sits under the pinned footer CTA (on top of the inset).
 const FOOTER_CLEARANCE = 72
 
@@ -61,15 +57,8 @@ export const RequestSheetHost: React.FC<Props> = ({ walletKit }) => {
     setPermissionsOpen(false)
   }, [current?.id, current?.kind])
 
-  // The permissions panel is taller, so grow the sheet while it's open and shrink back after.
-  const openPermissions = useCallback(() => {
-    setPermissionsOpen(true)
-    ref.current?.snapToIndex(SNAP_EXPANDED)
-  }, [])
-  const closePermissions = useCallback(() => {
-    setPermissionsOpen(false)
-    ref.current?.snapToIndex(SNAP_COMPACT)
-  }, [])
+  const openPermissions = useCallback(() => setPermissionsOpen(true), [])
+  const closePermissions = useCallback(() => setPermissionsOpen(false), [])
 
   useEffect(() => {
     if (!current || !walletKit) {
@@ -178,8 +167,8 @@ export const RequestSheetHost: React.FC<Props> = ({ walletKit }) => {
   return (
     <BottomSheetModal
       ref={ref}
-      snapPoints={['40%', '60%']}
-      enableDynamicSizing={false}
+      enableDynamicSizing
+      topInset={insets.top}
       onDismiss={onSheetDismiss}
       backgroundComponent={BackgroundComponent}
       backdropComponent={renderBackdrop}

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappRow.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappRow.test.tsx
@@ -117,4 +117,19 @@ describe('ConnectedDappRow', () => {
     fireEvent.press(getByTestId('swipe-open-drag-right'))
     expect(onSwipeOpenStart).not.toHaveBeenCalled()
   })
+
+  it('notifies onSwipeCleanup with its swipeable handle when the row unmounts', () => {
+    const onSwipeCleanup = jest.fn()
+    const { unmount } = render(
+      <ConnectedDappRow
+        session={session('t4', 'Balancer')}
+        onRequestDisconnect={jest.fn()}
+        onSwipeCleanup={onSwipeCleanup}
+      />,
+    )
+
+    expect(onSwipeCleanup).not.toHaveBeenCalled()
+    unmount()
+    expect(onSwipeCleanup).toHaveBeenCalledWith(expect.objectContaining({ close: expect.any(Function) }))
+  })
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappRow.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappRow.test.tsx
@@ -4,13 +4,22 @@ import { render, fireEvent } from '@/src/tests/test-utils'
 import { ConnectedDappRow } from '../ConnectedDappRow'
 
 // ReanimatedSwipeable renders its primary child inline and exposes renderRightActions; render
-// both so the trash action is queryable without driving a real gesture.
+// both so the trash action is queryable without driving a real gesture. A pressable stands in
+// for the open-drag gesture so the swipe-open notification is testable.
 jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
   const react = jest.requireActual('react')
-  const { View } = jest.requireActual('react-native')
+  const { View, Pressable } = jest.requireActual('react-native')
   return react.forwardRef(
     (
-      { children, renderRightActions }: { children: React.ReactNode; renderRightActions?: () => React.ReactNode },
+      {
+        children,
+        renderRightActions,
+        onSwipeableOpenStartDrag,
+      }: {
+        children: React.ReactNode
+        renderRightActions?: () => React.ReactNode
+        onSwipeableOpenStartDrag?: (direction: 'left' | 'right') => void
+      },
       ref: React.Ref<unknown>,
     ) => {
       react.useImperativeHandle(ref, () => ({ close: jest.fn() }))
@@ -18,6 +27,7 @@ jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
         <View>
           {children}
           {renderRightActions ? renderRightActions() : null}
+          <Pressable testID="swipe-open-drag" onPress={() => onSwipeableOpenStartDrag?.('right')} />
         </View>
       )
     },
@@ -78,5 +88,18 @@ describe('ConnectedDappRow', () => {
     const { getByTestId } = render(<ConnectedDappRow session={session('t2', 'Aave')} onRequestDisconnect={onRequest} />)
     fireEvent.press(getByTestId('connected-dapp-trash-t2'))
     expect(onRequest).toHaveBeenCalledWith(expect.objectContaining({ topic: 't2' }))
+  })
+
+  it('notifies onSwipeOpenStart with its swipeable handle when a swipe-open drag starts', () => {
+    const onSwipeOpenStart = jest.fn()
+    const { getByTestId } = render(
+      <ConnectedDappRow
+        session={session('t3', 'Curve')}
+        onRequestDisconnect={jest.fn()}
+        onSwipeOpenStart={onSwipeOpenStart}
+      />,
+    )
+    fireEvent.press(getByTestId('swipe-open-drag'))
+    expect(onSwipeOpenStart).toHaveBeenCalledWith(expect.objectContaining({ close: expect.any(Function) }))
   })
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappRow.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappRow.test.tsx
@@ -4,12 +4,12 @@ import { render, fireEvent } from '@/src/tests/test-utils'
 import { ConnectedDappRow } from '../ConnectedDappRow'
 
 // ReanimatedSwipeable renders its primary child inline and exposes renderRightActions; render
-// both so the trash action is queryable without driving a real gesture. A pressable stands in
-// for the open-drag gesture so the swipe-open notification is testable.
+// both so the trash action is queryable without driving a real gesture. Pressables stand in for
+// the open-drag gesture (a 'left' drag reveals the right-side actions; 'right' reveals nothing).
 jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
   const react = jest.requireActual('react')
   const { View, Pressable } = jest.requireActual('react-native')
-  return react.forwardRef(
+  const Swipeable = react.forwardRef(
     (
       {
         children,
@@ -27,11 +27,13 @@ jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
         <View>
           {children}
           {renderRightActions ? renderRightActions() : null}
-          <Pressable testID="swipe-open-drag" onPress={() => onSwipeableOpenStartDrag?.('right')} />
+          <Pressable testID="swipe-open-drag-left" onPress={() => onSwipeableOpenStartDrag?.('left')} />
+          <Pressable testID="swipe-open-drag-right" onPress={() => onSwipeableOpenStartDrag?.('right')} />
         </View>
       )
     },
   )
+  return { __esModule: true, default: Swipeable, SwipeDirection: { LEFT: 'left', RIGHT: 'right' } }
 })
 
 // Stub the native menu: render the trigger plus a pressable per action so the disconnect action
@@ -90,7 +92,7 @@ describe('ConnectedDappRow', () => {
     expect(onRequest).toHaveBeenCalledWith(expect.objectContaining({ topic: 't2' }))
   })
 
-  it('notifies onSwipeOpenStart with its swipeable handle when a swipe-open drag starts', () => {
+  it('notifies onSwipeOpenStart with its swipeable handle when a left drag starts to reveal the trash', () => {
     const onSwipeOpenStart = jest.fn()
     const { getByTestId } = render(
       <ConnectedDappRow
@@ -99,7 +101,20 @@ describe('ConnectedDappRow', () => {
         onSwipeOpenStart={onSwipeOpenStart}
       />,
     )
-    fireEvent.press(getByTestId('swipe-open-drag'))
+    fireEvent.press(getByTestId('swipe-open-drag-left'))
     expect(onSwipeOpenStart).toHaveBeenCalledWith(expect.objectContaining({ close: expect.any(Function) }))
+  })
+
+  it('ignores a right drag — there are no left-side actions to reveal', () => {
+    const onSwipeOpenStart = jest.fn()
+    const { getByTestId } = render(
+      <ConnectedDappRow
+        session={session('t3', 'Curve')}
+        onRequestDisconnect={jest.fn()}
+        onSwipeOpenStart={onSwipeOpenStart}
+      />,
+    )
+    fireEvent.press(getByTestId('swipe-open-drag-right'))
+    expect(onSwipeOpenStart).not.toHaveBeenCalled()
   })
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappsScreen.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappsScreen.test.tsx
@@ -9,18 +9,24 @@ jest.mock('../../hooks/useDisconnectSession', () => ({
   useDisconnectSession: () => ({ disconnect: mockDisconnect, busyTopic: mockBusyTopic }),
 }))
 
-// Stub the row: expose a menu-disconnect trigger and a swipe trigger, so the screen's selection
-// wiring is observable without the native menu / swipe gesture internals. Both route through
-// onRequestDisconnect, mirroring the real row.
+// One fake swipeable handle per row (keyed by topic) so tests can assert which row got closed
+// when another one swipes open.
+const mockSwipeHandles: Record<string, { close: jest.Mock }> = {}
+
+// Stub the row: expose a menu-disconnect trigger, a swipe trigger, and a swipe-open-drag trigger,
+// so the screen's selection + single-open-swipe wiring is observable without the native menu /
+// swipe gesture internals. The first two route through onRequestDisconnect, mirroring the real row.
 jest.mock('../ConnectedDappRow', () => {
   const { Text } = jest.requireActual('react-native')
   return {
     ConnectedDappRow: ({
       session,
       onRequestDisconnect,
+      onSwipeOpenStart,
     }: {
       session: { topic: string; peer: { metadata: { name: string } } }
       onRequestDisconnect: (s: unknown) => void
+      onSwipeOpenStart?: (methods: { close: () => void }) => void
     }) => (
       <>
         <Text testID={`row-menu-${session.topic}`} onPress={() => onRequestDisconnect(session)}>
@@ -28,6 +34,15 @@ jest.mock('../ConnectedDappRow', () => {
         </Text>
         <Text testID={`row-swipe-${session.topic}`} onPress={() => onRequestDisconnect(session)}>
           swipe
+        </Text>
+        <Text
+          testID={`row-open-${session.topic}`}
+          onPress={() => {
+            mockSwipeHandles[session.topic] ??= { close: jest.fn() }
+            onSwipeOpenStart?.(mockSwipeHandles[session.topic])
+          }}
+        >
+          open
         </Text>
       </>
     ),
@@ -67,6 +82,7 @@ describe('ConnectedDappsScreen', () => {
   beforeEach(() => {
     mockDisconnect.mockReset().mockResolvedValue(true)
     mockBusyTopic = null
+    Object.values(mockSwipeHandles).forEach((handle) => handle.close.mockClear())
   })
 
   it('renders the title and the empty state when there are no sessions', () => {
@@ -123,5 +139,24 @@ describe('ConnectedDappsScreen', () => {
 
     fireEvent.press(getByTestId('row-swipe-t1'))
     expect(getByText('confirm:Uniswap')).toBeTruthy()
+  })
+
+  it('closes the previously swiped row when another row starts to swipe open', () => {
+    const { getByTestId } = renderWithStore(
+      <ConnectedDappsScreen />,
+      storeWith([session('t1', 'Uniswap'), session('t2', 'Aave')]),
+    )
+
+    fireEvent.press(getByTestId('row-open-t1'))
+    expect(mockSwipeHandles['t1'].close).not.toHaveBeenCalled()
+
+    // A second drag on the same row must not close it.
+    fireEvent.press(getByTestId('row-open-t1'))
+    expect(mockSwipeHandles['t1'].close).not.toHaveBeenCalled()
+
+    // Swiping another row closes the first, leaving a single open row.
+    fireEvent.press(getByTestId('row-open-t2'))
+    expect(mockSwipeHandles['t1'].close).toHaveBeenCalledTimes(1)
+    expect(mockSwipeHandles['t2'].close).not.toHaveBeenCalled()
   })
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappsScreen.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappsScreen.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import type { SessionTypes } from '@walletconnect/types'
 import { renderWithStore, createTestStore, fireEvent, act } from '@/src/tests/test-utils'
+import { removeSession } from '../../store/walletKitSlice'
 import { ConnectedDappsScreen } from '../ConnectedDappsScreen'
 
 const mockDisconnect = jest.fn()
@@ -15,37 +16,40 @@ const mockSwipeHandles: Record<string, { close: jest.Mock }> = {}
 
 // Stub the row: expose a menu-disconnect trigger, a swipe trigger, and a swipe-open-drag trigger,
 // so the screen's selection + single-open-swipe wiring is observable without the native menu /
-// swipe gesture internals. The first two route through onRequestDisconnect, mirroring the real row.
+// swipe gesture internals. The first two route through onRequestDisconnect, mirroring the real
+// row; onSwipeCleanup fires on unmount with the row's handle, also mirroring the real row.
 jest.mock('../ConnectedDappRow', () => {
+  const react = jest.requireActual('react')
   const { Text } = jest.requireActual('react-native')
   return {
     ConnectedDappRow: ({
       session,
       onRequestDisconnect,
       onSwipeOpenStart,
+      onSwipeCleanup,
     }: {
       session: { topic: string; peer: { metadata: { name: string } } }
       onRequestDisconnect: (s: unknown) => void
       onSwipeOpenStart?: (methods: { close: () => void }) => void
-    }) => (
-      <>
-        <Text testID={`row-menu-${session.topic}`} onPress={() => onRequestDisconnect(session)}>
-          {session.peer.metadata.name}
-        </Text>
-        <Text testID={`row-swipe-${session.topic}`} onPress={() => onRequestDisconnect(session)}>
-          swipe
-        </Text>
-        <Text
-          testID={`row-open-${session.topic}`}
-          onPress={() => {
-            mockSwipeHandles[session.topic] ??= { close: jest.fn() }
-            onSwipeOpenStart?.(mockSwipeHandles[session.topic])
-          }}
-        >
-          open
-        </Text>
-      </>
-    ),
+      onSwipeCleanup?: (methods: { close: () => void }) => void
+    }) => {
+      mockSwipeHandles[session.topic] ??= { close: jest.fn() }
+      const handle = mockSwipeHandles[session.topic]
+      react.useEffect(() => () => onSwipeCleanup?.(handle), [onSwipeCleanup, handle])
+      return (
+        <>
+          <Text testID={`row-menu-${session.topic}`} onPress={() => onRequestDisconnect(session)}>
+            {session.peer.metadata.name}
+          </Text>
+          <Text testID={`row-swipe-${session.topic}`} onPress={() => onRequestDisconnect(session)}>
+            swipe
+          </Text>
+          <Text testID={`row-open-${session.topic}`} onPress={() => onSwipeOpenStart?.(handle)}>
+            open
+          </Text>
+        </>
+      )
+    },
   }
 })
 
@@ -158,5 +162,20 @@ describe('ConnectedDappsScreen', () => {
     fireEvent.press(getByTestId('row-open-t2'))
     expect(mockSwipeHandles['t1'].close).toHaveBeenCalledTimes(1)
     expect(mockSwipeHandles['t2'].close).not.toHaveBeenCalled()
+  })
+
+  it('drops the tracked swipeable when its row unmounts, so a stale handle is never closed', () => {
+    const store = storeWith([session('t1', 'Uniswap'), session('t2', 'Aave')])
+    const { getByTestId } = renderWithStore(<ConnectedDappsScreen />, store)
+
+    // Swipe t1 open, then remove its session (e.g. the dApp disconnected) so the row unmounts.
+    fireEvent.press(getByTestId('row-open-t1'))
+    act(() => {
+      store.dispatch(removeSession('t1'))
+    })
+
+    // Swiping t2 open must not close the unmounted t1 swipeable.
+    fireEvent.press(getByTestId('row-open-t2'))
+    expect(mockSwipeHandles['t1'].close).not.toHaveBeenCalled()
   })
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/RequestSheetHost.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/RequestSheetHost.test.tsx
@@ -14,6 +14,8 @@ const mockDismiss = jest.fn()
 let mockOnDismiss: (() => void | Promise<void>) | undefined
 // Captures the latest modal props so tests can assert sizing configuration.
 let mockModalProps: Record<string, unknown> | undefined
+// Captures the latest scroll-container props so tests can assert the clipping fallback.
+let mockScrollProps: Record<string, unknown> | undefined
 
 // Local mock to capture imperative present/dismiss + render the footer (overrides the global mock).
 jest.mock('@gorhom/bottom-sheet', () => {
@@ -39,13 +41,17 @@ jest.mock('@gorhom/bottom-sheet', () => {
       )
     },
   )
+  const BottomSheetScrollView = ({ children, ...props }: { children?: React.ReactNode }) => {
+    mockScrollProps = props
+    return <View>{children}</View>
+  }
   return {
     __esModule: true,
     default: View,
     BottomSheetModal,
     BottomSheetModalProvider: View,
     BottomSheetView: View,
-    BottomSheetScrollView: View,
+    BottomSheetScrollView,
     BottomSheetFooter: View,
   }
 })
@@ -90,6 +96,7 @@ describe('RequestSheetHost', () => {
     mockDismiss.mockClear()
     mockOnDismiss = undefined
     mockModalProps = undefined
+    mockScrollProps = undefined
   })
 
   it('sizes the sheet dynamically to its content instead of fixed snap points', () => {
@@ -98,6 +105,14 @@ describe('RequestSheetHost', () => {
 
     expect(mockModalProps?.enableDynamicSizing).toBe(true)
     expect(mockModalProps?.snapPoints).toBeUndefined()
+  })
+
+  it('keeps a bounce-free scroll fallback so clamped content (large font scales) cannot clip', () => {
+    const store = proposalStore(9)
+    renderWithStore(<RequestSheetHost walletKit={fakeWalletKit} />, store)
+
+    expect(mockScrollProps?.bounces).toBe(false)
+    expect(mockScrollProps?.overScrollMode).toBe('never')
   })
 
   it('never presents while pending is empty', () => {

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/RequestSheetHost.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/RequestSheetHost.test.tsx
@@ -12,6 +12,8 @@ const mockPresent = jest.fn()
 const mockDismiss = jest.fn()
 // Captures the latest onDismiss prop so tests can simulate a swipe-down / backdrop dismissal.
 let mockOnDismiss: (() => void | Promise<void>) | undefined
+// Captures the latest modal props so tests can assert sizing configuration.
+let mockModalProps: Record<string, unknown> | undefined
 
 // Local mock to capture imperative present/dismiss + render the footer (overrides the global mock).
 jest.mock('@gorhom/bottom-sheet', () => {
@@ -26,8 +28,9 @@ jest.mock('@gorhom/bottom-sheet', () => {
       },
       ref: React.Ref<unknown>,
     ) => {
-      react.useImperativeHandle(ref, () => ({ present: mockPresent, dismiss: mockDismiss, snapToIndex: jest.fn() }))
+      react.useImperativeHandle(ref, () => ({ present: mockPresent, dismiss: mockDismiss }))
       mockOnDismiss = props.onDismiss
+      mockModalProps = props
       return (
         <View>
           {props.children}
@@ -86,6 +89,15 @@ describe('RequestSheetHost', () => {
     mockPresent.mockClear()
     mockDismiss.mockClear()
     mockOnDismiss = undefined
+    mockModalProps = undefined
+  })
+
+  it('sizes the sheet dynamically to its content instead of fixed snap points', () => {
+    const store = proposalStore(9)
+    renderWithStore(<RequestSheetHost walletKit={fakeWalletKit} />, store)
+
+    expect(mockModalProps?.enableDynamicSizing).toBe(true)
+    expect(mockModalProps?.snapPoints).toBeUndefined()
   })
 
   it('never presents while pending is empty', () => {


### PR DESCRIPTION
## What it solves

Resolves: WC UX issues:
1. the request sheet opened at a fixed, too-tall height with a needlessly scrollable body
2. multiple Connected-apps rows could be swiped open at once.

## How this PR fixes it

- `RequestSheetHost`: fixed 40%/60% snap points → `enableDynamicSizing`; scroll view → static `BottomSheetView`.
- `ConnectedDappsScreen`: closes the previously swiped row when another starts to open.

## How to test it

1. Trigger a WC proposal / signing request → sheet fits its content, doesn't scroll, grows/shrinks for the permissions panel.
3. Swipe two Connected-apps rows → only one stays open.

## Video

https://github.com/user-attachments/assets/d594d6cc-8cf4-4010-a430-87d8e940c136

## Affected flows

- WC session proposal / signing request sheets
- dApp disconnect via left-swipe

## Blast radius

Mobile-only, WC-feature-only. No shared packages, slices, or API contracts touched; `ConnectedDappRow`'s new prop is optional.

## Risks / not checked

- Animations/gesture feel not verified on a physical device.
- Content taller than the sheet max (huge font scaling) now clips instead of scrolling.

## Visual summary

```mermaid
flowchart LR
  A[WC request] --> B[RequestSheetHost]
  B -->|enableDynamicSizing| C[Sheet sized to content]
  D[Row swipe] --> E[Previous row closes]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).