### PR TITLE
fix: Check Safe creation relay flag from config and exempt GTF/RELAY_FEE chains from limit checks during Safe creation

### DIFF
--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.test.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.test.tsx
@@ -157,6 +157,16 @@ describe('ReviewStep', () => {
     }
     jest.spyOn(useChains, 'useHasFeature').mockReturnValue(true)
     jest.spyOn(relay, 'hasRemainingRelays').mockReturnValue(true)
+    const currentChainSpy = jest.spyOn(useChains, 'useCurrentChain').mockReturnValue({
+      ...mockChain,
+      features: [],
+      relayer: {
+        type: 'RELAY_FEE',
+        safeCreationSponsored: true,
+        safeTransactionSponsored: true,
+        enableTenderlySimulationBeforeRelay: false,
+      },
+    } as Chain)
 
     const { getByText } = render(
       <ReviewStep data={mockData} onSubmit={jest.fn()} onBack={jest.fn()} setStep={jest.fn()} />,
@@ -169,7 +179,83 @@ describe('ReviewStep', () => {
     })
 
     expect(getByText(/Who will pay gas fees:/)).toBeInTheDocument()
+
+    currentChainSpy.mockRestore()
   })
+
+  it('shows sponsored creation on a RELAY_FEE chain', () => {
+    const mockData: NewSafeFormData = {
+      name: 'Test',
+      networks: [mockChain],
+      threshold: 1,
+      owners: [{ name: '', address: '0x1' }],
+      saltNonce: 0,
+      safeVersion: LATEST_SAFE_VERSION as SafeVersion,
+    }
+    jest.spyOn(useChains, 'useHasFeature').mockReturnValue(true)
+    // RELAY_FEE chains report remaining: 0 from the legacy quota endpoint; it must not gate sponsorship.
+    jest.spyOn(relay, 'hasRemainingRelays').mockReturnValue(false)
+    const currentChainSpy = jest.spyOn(useChains, 'useCurrentChain').mockReturnValue({
+      ...mockChain,
+      features: [],
+      relayer: {
+        type: 'RELAY_FEE',
+        safeCreationSponsored: true,
+        safeTransactionSponsored: true,
+        enableTenderlySimulationBeforeRelay: false,
+      },
+    } as Chain)
+
+    const { getByText } = render(
+      <ReviewStep data={mockData} onSubmit={jest.fn()} onBack={jest.fn()} setStep={jest.fn()} />,
+    )
+
+    act(() => {
+      fireEvent.click(getByText('Pay now'))
+    })
+
+    expect(getByText('Sponsored free transaction')).toBeInTheDocument()
+
+    currentChainSpy.mockRestore()
+  })
+
+  it.each(['DAILY_LIMIT', 'NO_FEE_CAMPAIGN'] as const)(
+    'does not show sponsored creation on a %s chain when the quota is exhausted',
+    (relayerType) => {
+      const mockData: NewSafeFormData = {
+        name: 'Test',
+        networks: [mockChain],
+        threshold: 1,
+        owners: [{ name: '', address: '0x1' }],
+        saltNonce: 0,
+        safeVersion: LATEST_SAFE_VERSION as SafeVersion,
+      }
+      jest.spyOn(useChains, 'useHasFeature').mockReturnValue(true)
+      jest.spyOn(relay, 'hasRemainingRelays').mockReturnValue(false)
+      const currentChainSpy = jest.spyOn(useChains, 'useCurrentChain').mockReturnValue({
+        ...mockChain,
+        features: [],
+        relayer: {
+          type: relayerType,
+          safeCreationSponsored: true,
+          safeTransactionSponsored: true,
+          enableTenderlySimulationBeforeRelay: false,
+        },
+      } as Chain)
+
+      const { getByText, queryByText } = render(
+        <ReviewStep data={mockData} onSubmit={jest.fn()} onBack={jest.fn()} setStep={jest.fn()} />,
+      )
+
+      act(() => {
+        fireEvent.click(getByText('Pay now'))
+      })
+
+      expect(queryByText('Sponsored free transaction')).not.toBeInTheDocument()
+
+      currentChainSpy.mockRestore()
+    },
+  )
 
   const authReduxState = {
     auth: {

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -76,6 +76,8 @@ import {
   hasFeature,
   getNativeTokenDisplay,
   NATIVE_TOKEN_DISPLAY_DEFAULT,
+  isSafeCreationSponsored,
+  isDailyRelayQuota,
 } from '@safe-global/utils/utils/chains'
 import { PayMethod } from '@safe-global/utils/features/counterfactual/types'
 import { type TransactionOptions } from '@safe-global/types-kit'
@@ -205,8 +207,8 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
 
   const isMultiChainDeployment = data.networks.length > 1
 
-  // Every owner has remaining relays and relay method is selected
-  const canRelay = hasRemainingRelays(minRelays)
+  // Daily-quota relay models (daily-limit, no-fee-campaign) additionally require every owner to have remaining relays.
+  const canRelay = isSafeCreationSponsored(chain) && (!isDailyRelayQuota(chain) || hasRemainingRelays(minRelays))
   const willRelay = getWillRelay(canRelay, executionMethod)
 
   const newSafeProps = useMemo(

--- a/apps/web/src/features/counterfactual/components/ActivateAccountFlow/index.tsx
+++ b/apps/web/src/features/counterfactual/components/ActivateAccountFlow/index.tsx
@@ -33,7 +33,7 @@ import useIsWrongChain from '@/hooks/useIsWrongChain'
 import NetworkWarning from '@/components/new-safe/create/NetworkWarning'
 import CheckWallet from '@/components/common/CheckWallet'
 import { getSafeToL2SetupDeployment } from '@safe-global/safe-deployments'
-import { FEATURES, hasFeature } from '@safe-global/utils/utils/chains'
+import { FEATURES, hasFeature, isSafeCreationSponsored, isDailyRelayQuota } from '@safe-global/utils/utils/chains'
 import { useNativeTokenDisplay } from '@/hooks/useNativeTokenDisplay'
 import type { UndeployedSafe } from '@safe-global/utils/features/counterfactual/store/types'
 import type { TransactionOptions } from '@safe-global/types-kit'
@@ -95,8 +95,8 @@ const ActivateAccountFlow = () => {
   const ownerAddresses = undeployedSafeSetup?.owners || []
   const [minRelays] = useLeastRemainingRelays(ownerAddresses)
 
-  // Every owner has remaining relays and relay method is selected
-  const canRelay = hasRemainingRelays(minRelays)
+  // Daily-quota relay models (daily-limit, no-fee-campaign) additionally require every owner to have remaining relays.
+  const canRelay = isSafeCreationSponsored(chain) && (!isDailyRelayQuota(chain) || hasRemainingRelays(minRelays))
   const willRelay = canRelay && executionMethod === ExecutionMethod.RELAY
 
   if (!undeployedSafe || !undeployedSafeSetup) return null

--- a/apps/web/src/hooks/__tests__/useRemainingRelays.test.ts
+++ b/apps/web/src/hooks/__tests__/useRemainingRelays.test.ts
@@ -50,6 +50,33 @@ describe('fetch remaining relays hooks', () => {
       expect(result.current[0]).toEqual({ remaining: 5, limit: 5 })
     })
 
+    // The per-address relay quota must still be fetched for tx execution on every
+    // relay model, only creation is exempt from the remaining check.
+    it.each(['GTF', 'RELAY_FEE'] as const)('should fetch relay count on a %s chain', async (relayerType) => {
+      jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(
+        chainBuilder()
+          .with({
+            features: [FEATURES.RELAYING],
+            chainId: '1',
+            relayer: {
+              type: relayerType,
+              safeCreationSponsored: true,
+              safeTransactionSponsored: true,
+              enableTenderlySimulationBeforeRelay: false,
+            },
+          })
+          .build(),
+      )
+
+      const { result } = renderHook(() => useRelaysBySafe())
+
+      await waitFor(() => {
+        expect(result.current[2]).toBe(false) // isLoading should be false
+      })
+
+      expect(result.current[0]).toEqual({ remaining: 5, limit: 5 })
+    })
+
     it('refetch if the txHistoryTag changes', async () => {
       const { result, rerender } = renderHook(() => useRelaysBySafe())
 
@@ -160,6 +187,32 @@ describe('fetch remaining relays hooks', () => {
 
       expect(result.current[0]).toBeUndefined() // data should be undefined
       expect(result.current[1]).toBeUndefined() // error should be undefined
+    })
+
+    it.each(['GTF', 'RELAY_FEE'] as const)('should fetch relay count on a %s chain', async (relayerType) => {
+      jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(
+        chainBuilder()
+          .with({
+            features: [FEATURES.RELAYING],
+            chainId: '1',
+            relayer: {
+              type: relayerType,
+              safeCreationSponsored: true,
+              safeTransactionSponsored: true,
+              enableTenderlySimulationBeforeRelay: false,
+            },
+          })
+          .build(),
+      )
+
+      const { result } = renderHook(() => useLeastRemainingRelays(ownerAddresses))
+
+      await waitFor(() => {
+        expect(result.current[2]).toBe(false) // isLoading should be false
+      })
+
+      // Default MSW handler returns { remaining: 5, limit: 5 } for every owner.
+      expect(result.current[0]).toEqual({ remaining: 5, limit: 5 })
     })
 
     it('refetch if the txHistoryTag changes', async () => {

--- a/packages/utils/src/utils/chains.relayer.test.ts
+++ b/packages/utils/src/utils/chains.relayer.test.ts
@@ -1,0 +1,41 @@
+import type { Chain, Relayer } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import { isSafeCreationSponsored, isDailyRelayQuota } from './chains'
+
+const relayer = (overrides: Partial<Relayer> = {}): Relayer => ({
+  type: 'RELAY_FEE',
+  safeCreationSponsored: true,
+  safeTransactionSponsored: true,
+  enableTenderlySimulationBeforeRelay: true,
+  ...overrides,
+})
+
+const chainWith = (relayerValue: Relayer | null): Pick<Chain, 'relayer'> => ({ relayer: relayerValue })
+
+describe('relayer chain helpers', () => {
+  describe('isSafeCreationSponsored', () => {
+    it('requires a relay model and the creation flag to be set', () => {
+      expect(isSafeCreationSponsored(chainWith(relayer({ safeCreationSponsored: true })))).toBe(true)
+      expect(isSafeCreationSponsored(chainWith(relayer({ safeCreationSponsored: false })))).toBe(false)
+    })
+
+    it('is false when relaying is disabled even if the flag is set', () => {
+      expect(isSafeCreationSponsored(chainWith(relayer({ type: null, safeCreationSponsored: true })))).toBe(false)
+      expect(isSafeCreationSponsored(chainWith(null))).toBe(false)
+      expect(isSafeCreationSponsored(undefined)).toBe(false)
+    })
+  })
+
+  describe('isDailyRelayQuota', () => {
+    it('is true for the quota-gated models (daily-limit, no-fee-campaign)', () => {
+      expect(isDailyRelayQuota(chainWith(relayer({ type: 'DAILY_LIMIT' })))).toBe(true)
+      expect(isDailyRelayQuota(chainWith(relayer({ type: 'NO_FEE_CAMPAIGN' })))).toBe(true)
+    })
+
+    it('is false for the unmetered models (relay-fee, gtf) and when relaying is disabled', () => {
+      expect(isDailyRelayQuota(chainWith(relayer({ type: 'RELAY_FEE' })))).toBe(false)
+      expect(isDailyRelayQuota(chainWith(relayer({ type: 'GTF' })))).toBe(false)
+      expect(isDailyRelayQuota(chainWith(null))).toBe(false)
+      expect(isDailyRelayQuota(undefined)).toBe(false)
+    })
+  })
+})

--- a/packages/utils/src/utils/chains.ts
+++ b/packages/utils/src/utils/chains.ts
@@ -78,6 +78,25 @@ export const hasFeature = (chain: Pick<Chain, 'features'>, feature: FEATURES): b
   return (chain.features as string[]).includes(feature)
 }
 
+type RelayerChain = Pick<Chain, 'relayer'>
+
+/**
+ * Whether Safe creation is sponsored on this chain, derived from the config
+ * service's structured `relayer` object.
+ */
+export const isSafeCreationSponsored = (chain?: RelayerChain): boolean => {
+  return chain?.relayer?.type != null && !!chain.relayer.safeCreationSponsored
+}
+
+/**
+ * Whether the relay model is gated by a per-address daily quota (the
+ * `/relay/{address}` remaining count). DAILY_LIMIT and NO_FEE_CAMPAIGN use it;
+ * RELAY_FEE and GTF do not.
+ */
+export const isDailyRelayQuota = (chain?: RelayerChain): boolean => {
+  return chain?.relayer?.type === 'DAILY_LIMIT' || chain?.relayer?.type === 'NO_FEE_CAMPAIGN'
+}
+
 export type NativeTokenDisplay = {
   showNativeInBalances: boolean
   showGasFeeEstimation: boolean


### PR DESCRIPTION


## What it solves

Resolves: https://linear.app/safe-global/issue/PLA-1736/safe-creation-relay-sponsored-payment-option-cannot-be-enabled-on-gtf

## How this PR fixes it

- Check Safe creation relay flag from chain config
- Exempt GTF/RELAY_FEE chains from limit checks during Safe creation

## How to test it

- Safe creation for chains with `RELAY_FEE` and flag `safeCreationSponsored=true` should be sponsored

## Affected flows

- Safe creation

## Blast radius

- Safe creation
- Safe tx execution

<!--
List the surfaces touched by this change and who else depends on them. Think in dependency terms, not files.
Include where relevant:
- Shared hooks / components / selectors / slices touched and their known consumers
- RTK Query endpoints / API contracts
- Feature flags / chain configs
- Persistence / cache / migration implications
- Routes or layouts affected indirectly
- Mobile impact (shared packages)
-->

## Risks / not checked

- Did not when relayer type= `RELAY_FEE` and `safeCreationSponsored=false` as I don't have write access to config service in staging
<!--
Be explicit about what you did NOT verify. This exposes false confidence and helps reviewers target their attention.
Example:
- Did not verify behavior with feature flag X disabled
- Did not test on mobile
- Did not exercise the retry / error path manually
-->

## Visual summary

<!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
