### PR TITLE
tests: repoint expired ENS test domain to ur.integration-tests.eth

### DIFF
--- a/apps/web/cypress/e2e/pages/address_book.page.js
+++ b/apps/web/cypress/e2e/pages/address_book.page.js
@@ -1,6 +1,5 @@
 import * as constants from '../../support/constants.js'
 import * as main from './main.page.js'
-import staticSafes from '../../fixtures/safes/static.js'
 
 // Re-export common selectors from main.page.js for backward compatibility
 export const tableContainer = main.tableContainer
@@ -118,7 +117,7 @@ export function addEntryByENS(name, ens) {
   typeInName(name)
   typeInAddress(ens)
   clickOnSaveEntryBtn()
-  verifyNewEntryAdded(name, staticSafes.SEP_STATIC_SAFE_6)
+  verifyNewEntryAdded(name, constants.ENS_TEST_SEPOLIA_ADDRESS)
 }
 
 export function verifyModalSummaryMessage(entryCount, chainCount) {

--- a/apps/web/cypress/e2e/smoke/create_tx.cy.js
+++ b/apps/web/cypress/e2e/smoke/create_tx.cy.js
@@ -35,7 +35,7 @@ describe('[SMOKE] Create transactions tests', () => {
 
   it('[SMOKE] Verify address input resolves a valid ENS name', () => {
     createtx.typeRecipientAddress(constants.ENS_TEST_SEPOLIA)
-    createtx.verifyENSResolves(staticSafes.SEP_STATIC_SAFE_6)
+    createtx.verifyENSResolves(constants.ENS_TEST_SEPOLIA_ADDRESS)
   })
 
   it('[SMOKE] Verify error message for invalid amount input', () => {

--- a/apps/web/cypress/e2e/smoke/load_safe.cy.js
+++ b/apps/web/cypress/e2e/smoke/load_safe.cy.js
@@ -38,7 +38,7 @@ describe('[SMOKE] Load Safe tests', { defaultCommandTimeout: 30000 }, () => {
 
   it('[SMOKE] Verify ENS name is translated to a valid address', () => {
     safe.inputAddress(constants.ENS_TEST_SEPOLIA)
-    safe.verifyAddressInputValue(staticSafes.SEP_STATIC_SAFE_6)
+    safe.verifyAddressInputValue(constants.ENS_TEST_SEPOLIA_ADDRESS)
     safe.verifyNextButtonStatus('be.enabled')
   })
 

--- a/apps/web/cypress/e2e/smoke/spending_limits.cy.js
+++ b/apps/web/cypress/e2e/smoke/spending_limits.cy.js
@@ -24,7 +24,7 @@ describe('[SMOKE] Spending limits tests', () => {
 
   it('Verify A valid ENS name is resolved successfully', () => {
     spendinglimit.enterBeneficiaryAddress(constants.ENS_TEST_SEPOLIA)
-    spendinglimit.checkBeneficiaryENS(staticSafes.SEP_STATIC_SAFE_6)
+    spendinglimit.checkBeneficiaryENS(constants.ENS_TEST_SEPOLIA_ADDRESS)
   })
 
   it('Verify writing a valid address shows no errors', () => {

--- a/apps/web/cypress/support/constants.js
+++ b/apps/web/cypress/support/constants.js
@@ -29,8 +29,9 @@ export const SEPOLIA_OWNER_2 = '0x96D4c6fFC338912322813a77655fCC926b9A5aC5'
 export const SEPOLIA_OWNER_2_SHORT = '0x96D4...5aC5'
 export const TEST_SAFE_2 = 'gor:0xE96C43C54B08eC528e9e815fC3D02Ea94A320505'
 export const SIDEBAR_ADDRESS = '0x04f8...1a91'
-//ENS_TEST_SEPOLIA resolves to 0xBf30F749FC027a5d79c4710D988F0D3C8e217A4F
-export const ENS_TEST_SEPOLIA = 'e2etestsafe.eth'
+// ENS_TEST_SEPOLIA resolves to ENS_TEST_SEPOLIA_ADDRESS on Sepolia
+export const ENS_TEST_SEPOLIA = 'ur.integration-tests.eth'
+export const ENS_TEST_SEPOLIA_ADDRESS = 'sep:0x2222222222222222222222222222222222222222'
 export const ENS_TEST_GOERLI = 'goerli-safe-test.eth'
 export const ENS_TEST_SEPOLIA_INVALID = 'ivladitestenssepolia.eth'
 export const ENS_TEST_SEPOLIA_VALID = 'testenssepolia.eth'


### PR DESCRIPTION
## What it solves

The `e2etestsafe.eth` Sepolia domain used by the ENS-resolution E2E tests
expired in November, so it no longer resolves. ethers 6.17.0 (ENSv2) now
honours expiry, surfacing the failure. Affected: create_tx, load_safe,
spending_limits smoke tests + address_book regression.

## How this PR fixes it

Repoints the test domain to `ur.integration-tests.eth` and decouples its
resolution target from `SEP_STATIC_SAFE_6` via a new `ENS_TEST_SEPOLIA_ADDRESS`
constant. The constant keeps the `sep:` prefix so the existing
prefix-stripping assert helpers work unchanged. Requires the domain to be
registered on Sepolia with `addr` → `0x2222…2222` (operational prerequisite).

## How to test it

1. Ensure `ur.integration-tests.eth` resolves to `0x2222…2222` on Sepolia.
2. Run `yarn workspace @safe-global/web cypress:run --spec "cypress/e2e/smoke/create_tx.cy.js"`.
3. Confirm the "resolves a valid ENS name" test passes.

## Screenshots

N/A - test-only change

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
