### PR TITLE
fix(security): render all Safe-level check addresses consistently with copy

### DIFF
--- a/apps/web/src/features/security/data/scanners/__tests__/contractVersion.test.ts
+++ b/apps/web/src/features/security/data/scanners/__tests__/contractVersion.test.ts
@@ -166,6 +166,11 @@ describe('contractVersionScanner', () => {
     expect(result.status).toBe('issue')
     expect(result.severity).toBe('High')
     expect(result.score).toBe(30)
+    // Full address so EvidenceList shortens it and adds a copy button (WA-2371).
+    expect(result.evidence).toContainEqual({
+      label: 'Implementation',
+      value: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF',
+    })
   })
 
   it('returns clear for known L2 singleton address', async () => {
@@ -193,6 +198,10 @@ describe('contractVersionScanner', () => {
     expect(result.status).toBe('partial')
     expect(result.severity).toBe('Medium')
     expect(result.score).toBe(60)
+    expect(result.evidence).toContainEqual({
+      label: 'Original implementation',
+      value: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF',
+    })
   })
 
   it('returns clear when creation master copy is a known deployment', async () => {

--- a/apps/web/src/features/security/data/scanners/__tests__/factoryValidation.test.ts
+++ b/apps/web/src/features/security/data/scanners/__tests__/factoryValidation.test.ts
@@ -36,6 +36,12 @@ describe('factoryValidationScanner', () => {
     )
     expect(result.status).toBe('clear')
     expect(result.score).toBe(100)
+    // The factory evidence carries the full, un-truncated address so the shared
+    // EvidenceList renderer can shorten it and attach a copy button (WA-2371).
+    expect(result.evidence).toContainEqual({
+      label: 'Factory',
+      value: '0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2',
+    })
   })
 
   it('returns partial for an unrecognized factory address', async () => {
@@ -53,6 +59,10 @@ describe('factoryValidationScanner', () => {
     expect(result.status).toBe('partial')
     expect(result.severity).toBe('Medium')
     expect(result.score).toBe(60)
+    expect(result.evidence).toContainEqual({
+      label: 'Factory',
+      value: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF',
+    })
   })
 
   it('includes lastChecked timestamp', async () => {

--- a/apps/web/src/features/security/data/scanners/__tests__/fallbackHandler.test.ts
+++ b/apps/web/src/features/security/data/scanners/__tests__/fallbackHandler.test.ts
@@ -38,6 +38,12 @@ describe('fallbackHandlerScanner', () => {
     expect(result.status).toBe('issue')
     expect(result.severity).toBe('High')
     expect(result.score).toBe(20)
+    // With no CGW name, the handler evidence carries the full address so EvidenceList
+    // shortens it and adds a copy button — consistent with every other check (WA-2371).
+    expect(result.evidence).toContainEqual({
+      label: 'Handler',
+      value: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF',
+    })
   })
 
   it('includes handler name in evidence when available', async () => {

--- a/apps/web/src/features/security/data/scanners/__tests__/guard.test.ts
+++ b/apps/web/src/features/security/data/scanners/__tests__/guard.test.ts
@@ -22,6 +22,11 @@ describe('guardScanner', () => {
       const result = await guardScanner.scan(ctx)
       expect(result.status).toBe('issue')
       expect(result.severity).toBe('High')
+      // No name → full address so EvidenceList shortens it and adds a copy button (WA-2371).
+      expect(result.evidence).toContainEqual({
+        label: 'Guard',
+        value: '0xabcdef1234567890abcdef1234567890abcdef12',
+      })
     })
   })
 

--- a/apps/web/src/features/security/data/scanners/contractVersion.ts
+++ b/apps/web/src/features/security/data/scanners/contractVersion.ts
@@ -63,7 +63,7 @@ export const contractVersionScanner: SecurityScanner = {
         evidence: [
           { label: 'Current version', value: versionLabel },
           { label: 'Status', value: 'Unsupported' },
-          { label: 'Implementation', value: `${implementationAddress.slice(0, 10)}...` },
+          { label: 'Implementation', value: implementationAddress },
         ],
         remediation: canMigrateL2
           ? 'This version may miss security fixes and improvements. You can migrate it to a compatible version.'
@@ -114,7 +114,7 @@ export const contractVersionScanner: SecurityScanner = {
         score,
         evidence: [
           { label: 'Current version', value: versionLabel },
-          { label: 'Implementation', value: `${implementationAddress.slice(0, 10)}...` },
+          { label: 'Implementation', value: implementationAddress },
           { label: 'Status', value: 'Unrecognized implementation' },
         ],
         remediation:
@@ -132,7 +132,7 @@ export const contractVersionScanner: SecurityScanner = {
         score,
         evidence: [
           { label: 'Current version', value: versionLabel },
-          { label: 'Original implementation', value: `${creationInfo.masterCopy.slice(0, 10)}...` },
+          { label: 'Original implementation', value: creationInfo.masterCopy },
           { label: 'Status', value: 'Deployed with unrecognized implementation' },
         ],
         remediation:

--- a/apps/web/src/features/security/data/scanners/factoryValidation.ts
+++ b/apps/web/src/features/security/data/scanners/factoryValidation.ts
@@ -48,7 +48,7 @@ export const factoryValidationScanner: SecurityScanner = {
         severity: getSeverityFromScore(score),
         score,
         evidence: [
-          { label: 'Factory', value: `${creationInfo.factoryAddress.slice(0, 10)}...` },
+          { label: 'Factory', value: creationInfo.factoryAddress },
           { label: 'Status', value: 'Official Safe factory' },
         ],
         remediation: '',
@@ -62,7 +62,7 @@ export const factoryValidationScanner: SecurityScanner = {
       severity: getSeverityFromScore(score),
       score,
       evidence: [
-        { label: 'Factory', value: `${creationInfo.factoryAddress.slice(0, 10)}...` },
+        { label: 'Factory', value: creationInfo.factoryAddress },
         { label: 'Status', value: 'Unrecognized factory' },
       ],
       remediation:

--- a/apps/web/src/features/security/data/scanners/fallbackHandler.ts
+++ b/apps/web/src/features/security/data/scanners/fallbackHandler.ts
@@ -64,7 +64,7 @@ export const fallbackHandlerScanner: SecurityScanner = {
       }
     }
 
-    const handlerLabel = fallbackHandler.name ?? `${fallbackHandler.value.slice(0, 10)}...`
+    const handlerLabel = fallbackHandler.name ?? fallbackHandler.value
     const match = identifyFallbackHandler(fallbackHandler.value, chainId)
 
     if (match) {

--- a/apps/web/src/features/security/data/scanners/guard.ts
+++ b/apps/web/src/features/security/data/scanners/guard.ts
@@ -65,7 +65,7 @@ export const guardScanner: SecurityScanner = {
     // Tier 1: Untrusted guard detected
     if (hasGuard && !isTrustedGuard(guard.name, chainId, guard.value)) {
       const score = 30
-      const guardLabel = guard.name || `${guard.value.slice(0, 10)}...`
+      const guardLabel = guard.name || guard.value
       return {
         status: 'issue',
         severity: getSeverityFromScore(score),

--- a/apps/web/src/features/security/data/scanners/modules.ts
+++ b/apps/web/src/features/security/data/scanners/modules.ts
@@ -105,7 +105,7 @@ export const modulesScanner: SecurityScanner = {
 
     const activeModules = (modules ?? []).filter((m) => m.value !== ZERO_ADDRESS)
 
-    const moduleLabel = (m: { value: string; name?: string | null }) => m.name || `${m.value.slice(0, 10)}...`
+    const moduleLabel = (m: { value: string; name?: string | null }) => m.name || m.value
 
     // Tier 1: No modules — perfectly fine for most Safes
     if (activeModules.length === 0) {

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityChecks/__tests__/primitives.test.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityChecks/__tests__/primitives.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@/tests/test-utils'
+import { EvidenceList } from '../primitives'
+
+const ADDRESS = '0x1234567890AbcdEF1234567890aBcdef12345678'
+
+describe('EvidenceList', () => {
+  it('shortens an address value and renders a copy button', () => {
+    // WA-2371: every address-typed evidence value renders the same way —
+    // shortened (0xabcd…1234) with a copy button next to it.
+    render(<EvidenceList evidence={[{ label: 'Factory', value: ADDRESS }]} />)
+
+    // shortenAddress => first 6 chars + '...' + last 4
+    expect(screen.getByText('0x1234...5678')).toBeInTheDocument()
+    expect(screen.queryByText(ADDRESS)).not.toBeInTheDocument()
+    expect(screen.getByTestId('copy-btn-icon')).toBeInTheDocument()
+  })
+
+  it('renders a non-address value as plain text without a copy button', () => {
+    render(<EvidenceList evidence={[{ label: 'Status', value: 'Official Safe factory' }]} />)
+
+    expect(screen.getByText('Official Safe factory')).toBeInTheDocument()
+    expect(screen.queryByTestId('copy-btn-icon')).not.toBeInTheDocument()
+  })
+
+  it('renders each address field consistently across multiple evidence items', () => {
+    const other = '0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2'
+    render(
+      <EvidenceList
+        evidence={[
+          { label: 'Factory', value: ADDRESS },
+          { label: 'Implementation', value: other },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('0x1234...5678')).toBeInTheDocument()
+    expect(screen.getByText('0xa6B7...6AB2')).toBeInTheDocument()
+    expect(screen.getAllByTestId('copy-btn-icon')).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## What it solves

Resolves: [WA-2371](https://linear.app/safe-global/issue/WA-2371/apply-the-same-rules-for-the-addresses-for-all-checks-on-safe-level) QA follow-up.

QA found that addresses in the Safe-level Security Hub checks were rendered inconsistently:

* Some addresses used the first 8 characters (`0x76E2cFc1...`), others used first-4/last-4 (`0x4861...c0c5`).
* Some addresses had a copy-to-clipboard button, others did not.

All addresses should render the same way — shortened (`0xabcd...1234`) with a copy button next to them.

## How this PR fixes it

The shared `EvidenceList` renderer (`SecurityChecks/primitives.tsx`) is already the single source of truth for address formatting: when an evidence value is a **full valid address** (`isAddress`), it renders `shortenAddress(value)` **plus a** `CopyButton`; otherwise it renders plain text.

The problem was in the **scanners**, which pre-truncated addresses into strings like `` `${addr.slice(0, 10)}...` ``. Those strings failed `isAddress()`, so they fell through to the plain-text branch — wrong format, no copy button.

Fix: scanners now emit the **full raw address**, letting `EvidenceList` format every address identically. Where a CGW-provided **name** exists (guard / fallback handler / module), it still renders as plain text — only the address fallback changed.

Scanners updated: `factoryValidation`, `contractVersion`, `guard`, `fallbackHandler`, `modules`.

## How to test it

1. Open a Safe with, e.g., a recognized factory, an unrecognized module, and a custom fallback handler.
2. Open the Security Hub report drawer → **Checks** tab, expand each check.
3. Every address now renders as `0xabcd...1234` with a copy button; clicking it copies the full address.

## Affected flows

* Security Hub report drawer → Checks tab → expanded evidence rows for: factory validation, contract version (implementation / original implementation), transaction guard, fallback handler, and modules.

## Blast radius

* **Data layer only:** 5 scanner files under `apps/web/src/features/security/data/scanners/`. Web-only — not in a shared package, no mobile impact.
* **Sole render consumer** of `ScanResult.evidence` is `EvidenceList` via `buildExpanded` (`SecurityChecks/primitives.tsx`), which was **not modified** — it already formats addresses correctly.
* Fallback-handler title derivation (`useSecurityChecks.tsx`) reads the `Status` evidence value, not the address, so it is unaffected (covered by existing `SecurityDrawerChecks` test).
* No RTK Query, feature flag, route, or persistence changes.

## Risks / not checked

* Did not capture a live screenshot (app not running) — behavior verified via a new `EvidenceList` render test instead.
* Note: ethers `isAddress()` rejects mixed-case, non-checksummed strings. CGW returns checksummed addresses, so this is fine in practice; an improperly-cased address would silently render as plain text.
* Did not test on mobile (feature is web-only).

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    S1[Scanner] -->|"value: '0x76E2cFc1...'"| E1[EvidenceList]
    E1 --> P1["isAddress() = false<br/>→ plain text, first 8 chars, no copy"]
  end
  subgraph After
    S2[Scanner] -->|"value: full raw address"| E2[EvidenceList]
    E2 --> P2["isAddress() = true<br/>→ shortenAddress 0xabcd...1234 + CopyButton"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (N/A — web-only feature)
- [X] I've documented how it affects the analytics (if at all) 📊 (no analytics impact)
- [X] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [X] I've listed affected flows and blast radius, and named what I did not verify 🎯

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)