### PR TITLE
refactor: multichain network tooltip as a separate shared component

### DIFF
--- a/apps/web/src/components/safe-apps/SafeAppPreviewDrawer/index.test.tsx
+++ b/apps/web/src/components/safe-apps/SafeAppPreviewDrawer/index.test.tsx
@@ -2,22 +2,23 @@ import { SafeAppFeatures, SafeAppAccessPolicyTypes } from '@safe-global/store/ga
 import { type SafeApp as SafeAppData } from '@safe-global/store/gateway/AUTO_GENERATED/safe-apps'
 
 import SafeAppPreviewDrawer from '@/components/safe-apps/SafeAppPreviewDrawer'
-import { render, renderWithUserEvent, screen, waitFor } from '@/tests/test-utils'
+import { render, screen, waitFor } from '@/tests/test-utils'
 
 jest.mock('@/features/multichain', () => ({
-  NetworkLogosList: ({ networks, maxVisible, showHasMore }: any) => (
-    <div
-      data-testid="network-logos-list"
-      data-networks={networks.map((n: { chainId: string }) => n.chainId).join(',')}
-      data-max-visible={maxVisible}
-      data-show-has-more={String(showHasMore)}
-    />
+  NetworkLogosTooltip: ({ networks, maxVisible }: { networks: { chainId: string }[]; maxVisible?: number }) => (
+    <div>
+      <div
+        data-testid="network-logos-list"
+        data-networks={networks.map((n) => n.chainId).join(',')}
+        data-max-visible={maxVisible}
+      />
+      {networks.map((n) => (
+        <div key={n.chainId} data-testid="chain-indicator">
+          {n.chainId}
+        </div>
+      ))}
+    </div>
   ),
-}))
-
-jest.mock('@/components/common/ChainIndicator', () => ({
-  __esModule: true,
-  default: ({ chainId }: { chainId: string }) => <div data-testid="chain-indicator">{chainId}</div>,
 }))
 
 const mockUseChains = jest.fn()
@@ -65,7 +66,6 @@ describe('SafeAppPreviewDrawer', () => {
     const logos = screen.getByTestId('network-logos-list')
     expect(logos).toHaveAttribute('data-networks', safeAppMock.chainIds.join(','))
     expect(logos).toHaveAttribute('data-max-visible', '3')
-    expect(logos).toHaveAttribute('data-show-has-more', 'true')
   })
 
   it('passes every chain to the cluster so overflow collapses beyond the visible limit', async () => {
@@ -75,11 +75,8 @@ describe('SafeAppPreviewDrawer', () => {
     expect(logos.getAttribute('data-networks')?.split(',')).toHaveLength(safeAppMock.chainIds.length)
   })
 
-  it('lists all chains in the hover tooltip content', async () => {
-    const { user } = renderWithUserEvent(<SafeAppPreviewDrawer isOpen safeApp={safeAppMock} onClose={jest.fn()} />)
-
-    const trigger = await screen.findByTestId('network-logos-list')
-    await user.hover(trigger)
+  it('lists all chains in the tooltip content', async () => {
+    render(<SafeAppPreviewDrawer isOpen safeApp={safeAppMock} onClose={jest.fn()} />)
 
     await waitFor(() => {
       expect(screen.getAllByTestId('chain-indicator')).toHaveLength(safeAppMock.chainIds.length)

--- a/apps/web/src/components/safe-apps/SafeAppPreviewDrawer/index.tsx
+++ b/apps/web/src/components/safe-apps/SafeAppPreviewDrawer/index.tsx
@@ -9,14 +9,8 @@ import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
 import type { SafeApp as SafeAppData } from '@safe-global/store/gateway/AUTO_GENERATED/safe-apps'
 
-import {
-  Tooltip as NetworksTooltip,
-  TooltipTrigger as NetworksTooltipTrigger,
-  TooltipContent as NetworksTooltipContent,
-} from '@/components/ui/tooltip'
-import { NetworkLogosList } from '@/features/multichain'
+import { NetworkLogosTooltip } from '@/features/multichain'
 import { getSafeAppUrl } from '@/components/safe-apps/SafeAppCard'
-import ChainIndicator from '@/components/common/ChainIndicator'
 import SafeAppIconCard from '@/components/safe-apps/SafeAppIconCard'
 import SafeAppActionButtons from '@/components/safe-apps/SafeAppActionButtons'
 import SafeAppTags from '@/components/safe-apps/SafeAppTags'
@@ -96,18 +90,7 @@ const SafeAppPreviewDrawer = ({ isOpen, safeApp, isBookmarked, onClose, onBookma
         </Typography>
 
         <Box sx={{ display: 'flex', mt: 2 }}>
-          <NetworksTooltip>
-            <NetworksTooltipTrigger render={<span className="inline-flex origin-left scale-85" />}>
-              <NetworkLogosList networks={knownChainIds.map((chainId) => ({ chainId }))} showHasMore maxVisible={3} />
-            </NetworksTooltipTrigger>
-            <NetworksTooltipContent>
-              <div className="flex flex-col gap-1">
-                {knownChainIds.map((chainId) => (
-                  <ChainIndicator key={chainId} chainId={chainId} />
-                ))}
-              </div>
-            </NetworksTooltipContent>
-          </NetworksTooltip>
+          <NetworkLogosTooltip networks={knownChainIds.map((chainId) => ({ chainId }))} maxVisible={3} />
         </Box>
 
         {/* Open Safe App button */}

--- a/apps/web/src/features/multichain/components/NetworkLogosTooltip/NetworkLogosTooltip.test.tsx
+++ b/apps/web/src/features/multichain/components/NetworkLogosTooltip/NetworkLogosTooltip.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import NetworkLogosTooltip from './index'
+
+jest.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <div data-testid="trigger">{children}</div>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+jest.mock('../NetworkLogosList', () => {
+  const NetworkLogosList = ({ maxVisible }: { maxVisible?: number }) => (
+    <span data-testid="network-logos" data-max-visible={maxVisible} />
+  )
+  return NetworkLogosList
+})
+jest.mock('@/components/common/ChainIndicator', () => {
+  const ChainIndicator = ({ chainId }: { chainId: string }) => (
+    <span data-testid="chain-indicator" data-chain-id={chainId} />
+  )
+  return ChainIndicator
+})
+
+const networks = (ids: string[]) => ids.map((chainId) => ({ chainId }))
+
+describe('NetworkLogosTooltip', () => {
+  it('renders NetworkLogosList as the default trigger', () => {
+    render(<NetworkLogosTooltip networks={networks(['1', '137'])} maxVisible={3} />)
+
+    const logos = screen.getByTestId('network-logos')
+    expect(logos).toBeInTheDocument()
+    expect(logos).toHaveAttribute('data-max-visible', '3')
+  })
+
+  it('renders one ChainIndicator per network in the tooltip content', () => {
+    render(<NetworkLogosTooltip networks={networks(['1', '137', '10'])} />)
+
+    const indicators = screen.getAllByTestId('chain-indicator')
+    expect(indicators).toHaveLength(3)
+    expect(indicators.map((el) => el.getAttribute('data-chain-id'))).toEqual(['1', '137', '10'])
+  })
+
+  it('renders a custom trigger instead of the logos list when provided', () => {
+    render(<NetworkLogosTooltip networks={networks(['1'])} trigger={<span data-testid="all-badge">All</span>} />)
+
+    expect(screen.getByTestId('all-badge')).toBeInTheDocument()
+    expect(screen.queryByTestId('network-logos')).not.toBeInTheDocument()
+  })
+
+  it('applies contentTestId to the tooltip content wrapper', () => {
+    render(<NetworkLogosTooltip networks={networks(['1'])} contentTestId="multichain-tooltip" />)
+
+    expect(screen.getByTestId('multichain-tooltip')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/multichain/components/NetworkLogosTooltip/index.tsx
+++ b/apps/web/src/features/multichain/components/NetworkLogosTooltip/index.tsx
@@ -1,0 +1,45 @@
+import type { ReactElement, ReactNode } from 'react'
+import ChainIndicator from '@/components/common/ChainIndicator'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import NetworkLogosList from '../NetworkLogosList'
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+
+export type NetworkLogosTooltipProps = {
+  networks: Pick<Chain, 'chainId'>[]
+  /** Max logos to show before the "+N" indicator */
+  maxVisible?: number
+  /** Logo size in the trigger's NetworkLogosList */
+  imageSize?: number
+  /** Logo size for the ChainIndicator list inside the tooltip */
+  contentImageSize?: number
+  /** Replaces the default NetworkLogosList trigger (e.g. an "All" badge) */
+  trigger?: ReactNode
+  /** Element passed to TooltipTrigger's `render` prop; defaults to a scaled span */
+  triggerRender?: ReactElement
+  contentTestId?: string
+}
+
+const NetworkLogosTooltip = ({
+  networks,
+  maxVisible = 3,
+  imageSize,
+  contentImageSize,
+  trigger,
+  triggerRender = <span className="inline-flex origin-left scale-85" />,
+  contentTestId,
+}: NetworkLogosTooltipProps) => (
+  <Tooltip>
+    <TooltipTrigger render={triggerRender}>
+      {trigger ?? <NetworkLogosList networks={networks} showHasMore maxVisible={maxVisible} imageSize={imageSize} />}
+    </TooltipTrigger>
+    <TooltipContent>
+      <div data-testid={contentTestId} className="flex flex-col gap-1">
+        {networks.map((network) => (
+          <ChainIndicator key={network.chainId} chainId={network.chainId} imageSize={contentImageSize} />
+        ))}
+      </div>
+    </TooltipContent>
+  </Tooltip>
+)
+
+export default NetworkLogosTooltip

--- a/apps/web/src/features/multichain/index.ts
+++ b/apps/web/src/features/multichain/index.ts
@@ -28,6 +28,8 @@ const CreateSafeOnSpecificChain = dynamic(() =>
 
 const NetworkLogosList = dynamic(() => import('./components/NetworkLogosList'))
 
+const NetworkLogosTooltip = dynamic(() => import('./components/NetworkLogosTooltip'))
+
 const SafeCreationNetworkInput = dynamic(() => import('./components/SafeCreationNetworkInput'))
 
 const ChangeSignerSetupWarning = dynamic(() =>
@@ -64,6 +66,7 @@ export {
   CreateSafeOnNewChain,
   CreateSafeOnSpecificChain,
   NetworkLogosList,
+  NetworkLogosTooltip,
   SafeCreationNetworkInput,
   ChangeSignerSetupWarning,
   InconsistentSignerSetupWarning,

--- a/apps/web/src/features/myAccounts/components/AccountItem/AccountItemChainBadge.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItem/AccountItemChainBadge.tsx
@@ -1,6 +1,5 @@
 import ChainIndicator from '@/components/common/ChainIndicator'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { NetworkLogosList } from '@/features/multichain'
+import { NetworkLogosTooltip } from '@/features/multichain'
 import type { SafeItem } from '@/hooks/safes'
 import { cn } from '@/utils/cn'
 
@@ -18,18 +17,13 @@ function AccountItemChainBadge({ chainId, safes, className, imageSize = 24 }: Ac
   if (safes && safes.length > 0) {
     return (
       <div className={cn('flex shrink-0 justify-end', className)}>
-        <Tooltip>
-          <TooltipTrigger render={<span />} tabIndex={0} className="flex items-center">
-            <NetworkLogosList networks={safes} showHasMore />
-          </TooltipTrigger>
-          <TooltipContent>
-            <div data-testid="multichain-tooltip" className="flex flex-col gap-1">
-              {safes.map((safeItem) => (
-                <ChainIndicator key={safeItem.chainId} imageSize={imageSize} chainId={safeItem.chainId} />
-              ))}
-            </div>
-          </TooltipContent>
-        </Tooltip>
+        <NetworkLogosTooltip
+          networks={safes}
+          maxVisible={4}
+          contentImageSize={imageSize}
+          triggerRender={<span tabIndex={0} className="flex items-center" />}
+          contentTestId="multichain-tooltip"
+        />
       </div>
     )
   }

--- a/apps/web/src/features/myAccounts/components/AccountItem/__tests__/AccountItemChainBadge.test.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItem/__tests__/AccountItemChainBadge.test.tsx
@@ -2,13 +2,14 @@ import { render, screen } from '@/tests/test-utils'
 import AccountItemChainBadge from '../AccountItemChainBadge'
 import type { SafeItem } from '@/hooks/safes'
 
-jest.mock('@/components/ui/tooltip', () => ({
-  Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-}))
 jest.mock('@/features/multichain', () => ({
-  NetworkLogosList: () => <span data-testid="network-logos" />,
+  NetworkLogosTooltip: ({ networks, contentTestId }: { networks: { chainId: string }[]; contentTestId?: string }) => (
+    <div data-testid={contentTestId}>
+      {networks.map((network) => (
+        <span key={network.chainId} data-testid="chain-indicator" data-chain-id={network.chainId} />
+      ))}
+    </div>
+  ),
 }))
 jest.mock('@/components/common/ChainIndicator', () => {
   const ChainIndicator = ({ chainId }: { chainId: string }) => (

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
@@ -6,7 +6,7 @@ import { Spinner } from '@/components/ui/spinner'
 import { isAddress } from 'ethers'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import Identicon from '@/components/common/Identicon'
-import { NetworkLogosList } from '@/features/multichain'
+import { NetworkLogosTooltip } from '@/features/multichain'
 import ChainIndicator from '@/components/common/ChainIndicator'
 import type { AddressBookRequestItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import {
@@ -127,24 +127,11 @@ function PendingRequestsTable({ requests }: PendingRequestsTableProps) {
   }
 
   const renderChains = (req: AddressBookRequestItemDto) => (
-    <Tooltip>
-      <TooltipTrigger>
-        <span className="inline-flex origin-left scale-85">
-          {chains.configs.length === req.chainIds.length ? (
-            <Badge variant="secondary">All</Badge>
-          ) : (
-            <NetworkLogosList networks={req.chainIds.map((chainId) => ({ chainId }))} showHasMore maxVisible={3} />
-          )}
-        </span>
-      </TooltipTrigger>
-      <TooltipContent>
-        <div className="flex flex-col gap-1">
-          {req.chainIds.map((chainId) => (
-            <ChainIndicator key={chainId} chainId={chainId} />
-          ))}
-        </div>
-      </TooltipContent>
-    </Tooltip>
+    <NetworkLogosTooltip
+      networks={req.chainIds.map((chainId) => ({ chainId }))}
+      maxVisible={3}
+      trigger={chains.configs.length === req.chainIds.length ? <Badge variant="secondary">All</Badge> : undefined}
+    />
   )
 
   const columns: DataTableColumn<AddressBookRequestItemDto>[] = [

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/RequestToAddButton.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/RequestToAddButton.tsx
@@ -6,7 +6,6 @@ import {
   DialogActions,
   DialogContent,
   Stack,
-  Tooltip,
   Typography,
 } from '@mui/material'
 import { Button } from '@/components/ui/button'
@@ -14,8 +13,7 @@ import InvalidContactNameTooltip from './InvalidContactNameTooltip'
 import { Badge } from '@/components/ui/badge'
 import ModalDialog from '@/components/common/ModalDialog'
 import EthHashInfo from '@/components/common/EthHashInfo'
-import ChainIndicator from '@/components/common/ChainIndicator'
-import { NetworkLogosList } from '@/features/multichain'
+import { NetworkLogosTooltip } from '@/features/multichain'
 import { useAddressBookRequestsCreateRequestV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useCurrentSpaceId } from '@/features/spaces'
 import { showNotification } from '@/store/notificationsSlice'
@@ -143,21 +141,11 @@ const RequestToAddButton = ({ address, name, chainIds, alreadyRequested }: Reque
               {chains.configs.length === chainIds.length ? (
                 <Typography variant="body1">All networks</Typography>
               ) : (
-                <Tooltip
-                  title={
-                    <Stack spacing={0.5}>
-                      {chainIds.map((chainId) => (
-                        <ChainIndicator key={chainId} chainId={chainId} />
-                      ))}
-                    </Stack>
-                  }
-                  placement="top"
-                  arrow
-                >
-                  <Box display="inline-flex">
-                    <NetworkLogosList networks={chainIds.map((chainId) => ({ chainId }))} showHasMore maxVisible={6} />
-                  </Box>
-                </Tooltip>
+                <NetworkLogosTooltip
+                  networks={chainIds.map((chainId) => ({ chainId }))}
+                  maxVisible={6}
+                  triggerRender={<span className="inline-flex" />}
+                />
               )}
             </Box>
           </Stack>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -2,7 +2,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip
 import { isAddress } from 'ethers'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import EmailInfo from '@/components/common/EmailInfo'
-import { NetworkLogosList } from '@/features/multichain'
+import { NetworkLogosTooltip } from '@/features/multichain'
 import ChainIndicator from '@/components/common/ChainIndicator'
 import { HardDrive } from 'lucide-react'
 import type { SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
@@ -59,20 +59,7 @@ function SpaceAddressBookTable({
 
   // Chain logo cluster — used in the desktop "Chains" cell
   const renderChains = (entry: AddressBookEntry) => (
-    <Tooltip>
-      <TooltipTrigger>
-        <span className="inline-flex origin-left scale-85">
-          <NetworkLogosList networks={entry.chainIds.map((chainId) => ({ chainId }))} showHasMore maxVisible={3} />
-        </span>
-      </TooltipTrigger>
-      <TooltipContent>
-        <div className="flex flex-col gap-1">
-          {entry.chainIds.map((chainId) => (
-            <ChainIndicator key={chainId} chainId={chainId} />
-          ))}
-        </div>
-      </TooltipContent>
-    </Tooltip>
+    <NetworkLogosTooltip networks={entry.chainIds.map((chainId) => ({ chainId }))} maxVisible={3} />
   )
 
   // Added-by / Last-updated content — used in the desktop column and the mobile detail row.

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/PendingRequestsTable.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/PendingRequestsTable.test.tsx
@@ -43,8 +43,10 @@ jest.mock('@/components/common/Identicon', () => {
   return Identicon
 })
 jest.mock('@/features/multichain', () => ({
-  NetworkLogosList: ({ networks }: { networks: { chainId: string }[] }) => (
-    <span data-testid="network-logos" data-count={networks.length} />
+  NetworkLogosTooltip: ({ networks, trigger }: { networks: { chainId: string }[]; trigger?: React.ReactNode }) => (
+    <span data-testid="network-logos" data-count={networks.length}>
+      {trigger}
+    </span>
   ),
 }))
 jest.mock('@/components/common/ChainIndicator', () => {

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/SpaceAddressBookTable.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/SpaceAddressBookTable.test.tsx
@@ -25,21 +25,8 @@ jest.mock('@/components/common/Identicon', () => {
   return Identicon
 })
 jest.mock('@/features/multichain', () => ({
-  NetworkLogosList: ({
-    networks,
-    showHasMore,
-    maxVisible,
-  }: {
-    networks: { chainId: string }[]
-    showHasMore?: boolean
-    maxVisible?: number
-  }) => (
-    <span
-      data-testid="network-logos"
-      data-show-has-more={showHasMore}
-      data-max-visible={maxVisible}
-      data-count={networks.length}
-    />
+  NetworkLogosTooltip: ({ networks, maxVisible }: { networks: { chainId: string }[]; maxVisible?: number }) => (
+    <span data-testid="network-logos" data-max-visible={maxVisible} data-count={networks.length} />
   ),
 }))
 jest.mock('@/components/common/ChainIndicator', () => {
@@ -105,17 +92,16 @@ describe('SpaceAddressBookTable', () => {
     expect(screen.getByTestId('local-actions')).toBeInTheDocument()
   })
 
-  it('renders NetworkLogosList with showHasMore and maxVisible=3 for chain logos', () => {
+  it('renders the network logos tooltip with maxVisible=3 for chain logos', () => {
     const chainIds = ['1', '137', '10', '42161', '8453']
     render(<SpaceAddressBookTable entries={[entryBuilder().with({ chainIds }).build()]} />)
 
     const logosList = screen.getByTestId('network-logos')
-    expect(logosList).toHaveAttribute('data-show-has-more', 'true')
     expect(logosList).toHaveAttribute('data-max-visible', '3')
     expect(logosList).toHaveAttribute('data-count', '5')
   })
 
-  it('renders NetworkLogosList even when entry covers all chains', () => {
+  it('renders the network logos tooltip even when entry covers all chains', () => {
     render(
       <SpaceAddressBookTable
         entries={[


### PR DESCRIPTION
## What it solves

Resolves: [WA-2817](https://linear.app/safe-global/issue/WA-2817/refactoring-network-tooltip)
The network-logos-with-tooltip pattern (a `NetworkLogosList` trigger + a per-chain `ChainIndicator` list in the tooltip) was duplicated across 5 places, with one of them using MUI's `Tooltip` and the rest using the shadcn tooltip.

## How this PR fixes it

Extracts a single reusable `NetworkLogosTooltip` component (`@/features/multichain`) built on the shadcn tooltip and migrates all 5 call sites to it, converting the last MUI tooltip to shadcn so the whole pattern is unified.

## How to test it

Hover the chain-logo cluster in each spot; the tooltip should list every chain:
1. Safe Apps → app preview drawer → "Available networks"
2. My Accounts → a multichain Safe entry (chain cluster on the right)
3. Workspace → Address book → contacts table "Chains" column
4. Workspace → Address book → Pending requests table "Chains" column (incl. the "All" badge)
5. Workspace → Address book → "Request to add" dialog → "Networks" row

## Affected flows

- Safe Apps preview drawer — networks listing
- My Accounts multichain badge
- Space address book table + pending requests table — chain columns
- Request-to-add dialog — networks row (MUI → shadcn conversion)

## Blast radius

- New shared component `NetworkLogosTooltip` in `@/features/multichain` (exported from the feature barrel, dynamic import like `NetworkLogosList`)
- Consumers migrated: `SafeAppPreviewDrawer`, `AccountItemChainBadge`, `SpaceAddressBookTable`, `PendingRequestsTable`, `RequestToAddButton`
- No API/flag/route/persistence changes; no shared `ui/` primitive changed

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1[SafeAppPreviewDrawer] --> D1[inline shadcn tooltip]
    A2[AccountItemChainBadge] --> D2[inline shadcn tooltip]
    A3[SpaceAddressBookTable] --> D3[inline shadcn tooltip]
    A4[PendingRequestsTable] --> D4[inline shadcn tooltip]
    A5[RequestToAddButton] --> D5[MUI Tooltip]
  end
  subgraph After
    B1[SafeAppPreviewDrawer] --> N[NetworkLogosTooltip]
    B2[AccountItemChainBadge] --> N
    B3[SpaceAddressBookTable] --> N
    B4[PendingRequestsTable] --> N
    B5[RequestToAddButton] --> N
    N --> S[shadcn tooltip + NetworkLogosList + ChainIndicator list]
  end
```
## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
