### PR TITLE
refactor: e2e tests on port 4003; fix: multichain tests hardening

### DIFF
--- a/.github/actions/cypress/action.yml
+++ b/.github/actions/cypress/action.yml
@@ -71,14 +71,18 @@ runs:
         browser: ${{ steps.setup-chrome.outputs.chrome-path }}
         record: ${{ inputs.record == 'true' }}
         tag: ${{ inputs.record == 'true' && inputs.tag || '' }}
-        config: baseUrl=http://localhost:8080
+        # Serve Cypress on 4003 (not the shared 8080 default): the CoW swap
+        # widget iframe only fully loads when the parent app's origin is on its
+        # allowlist, which includes localhost:4003. Playwright keeps 8080.
+        config: baseUrl=http://localhost:4003
         install: false
         start: yarn workspace @safe-global/web serve
-        wait-on: 'http://localhost:8080'
+        wait-on: 'http://localhost:4003'
         wait-on-timeout: 120
         working-directory: apps/web
       env:
         NODE_ENV: cypress
+        REVERSE_PROXY_UI_PORT: '4003'
         CYPRESS_RECORD_KEY: ${{ inputs.record_key || fromJSON(inputs.secrets).CYPRESS_RECORD_KEY }}
         GITHUB_TOKEN: ${{ fromJSON(inputs.secrets).GITHUB_TOKEN }}
         CYPRESS_PROJECT_ID: ${{ inputs.project_id }}

--- a/apps/web/cypress/e2e/pages/dashboard.pages.js
+++ b/apps/web/cypress/e2e/pages/dashboard.pages.js
@@ -242,3 +242,12 @@ const differentSignersAcrossChainsMsg = 'different signers across different netw
 export function checkInconsistentSignersMsgDisplayed() {
   cy.contains(differentSignersAcrossChainsMsg, { timeout: 30000 }).should('be.visible')
 }
+
+/**
+ * Verifies the Safe is present in the current URL, i.e. the router query has hydrated.
+ * Use as a precondition before clicking actions that navigate using the `safe` query param.
+ * @param {string} safe - Prefixed safe address expected in the URL
+ */
+export function verifySafeInUrl(safe) {
+  cy.url().should('include', safe)
+}

--- a/apps/web/cypress/e2e/pages/network.pages.js
+++ b/apps/web/cypress/e2e/pages/network.pages.js
@@ -5,6 +5,7 @@ const addChainDialog = '[data-testid="add-chain-dialog"]'
 const addedNetwork = '[data-testid="added-network"]'
 const modalAddNetworkBtn = '[data-testid="modal-add-network-btn"]'
 const allNetworksAccordion = '[data-testid="all-networks-accordion"]'
+const allNetworksAccordionTrigger = '[data-testid="all-networks-accordion-trigger"]'
 const chainNavigationButton = '[data-testid="space-chain-navigation-button"]'
 const chainSelectorLoading = '[data-testid="chain-selector-loading"]'
 
@@ -17,8 +18,9 @@ export function clickChainNavigationButton() {
 }
 
 export function clickAllNetworksAccordion() {
-  cy.get(allNetworksAccordion).should('be.visible').click()
+  cy.get(allNetworksAccordion).should('be.visible')
   cy.get(chainSelectorLoading).should('not.exist')
+  cy.get(allNetworksAccordionTrigger).should('be.visible').click()
   cy.get(addNetworkBtn).should('be.visible')
 }
 

--- a/apps/web/cypress/e2e/regression/multichain_setup_new.cy.js
+++ b/apps/web/cypress/e2e/regression/multichain_setup_new.cy.js
@@ -76,6 +76,7 @@ describe('Multichain setup tests', { defaultCommandTimeout: 60000 }, () => {
     cy.visit(constants.homeUrl + staticSafes.MATIC_STATIC_SAFE_28)
     dashboard.expandActionRequiredPanel()
     dashboard.checkInconsistentSignersMsgDisplayed()
+    dashboard.verifySafeInUrl(staticSafes.MATIC_STATIC_SAFE_28)
     dashboard.clickActionInPanel(dashboard.reviewSignersTestId)
     cy.url().should('include', '/settings/setup').and('include', staticSafes.MATIC_STATIC_SAFE_28)
   })

--- a/apps/web/cypress/support/commands.js
+++ b/apps/web/cypress/support/commands.js
@@ -214,7 +214,7 @@ Cypress.Commands.add('enter', (selector, opts) => {
 
 Cypress.Commands.add('setupInterceptors', () => {
   cy.intercept('*', (req) => {
-    req.headers['Origin'] = 'http://localhost:8080'
+    req.headers['Origin'] = 'http://localhost:4003'
     console.log('Intercepted request with headers:', req.headers)
     req.continue()
   }).as('headers')

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,7 +37,7 @@
     "cypress:open": "cross-env TZ=UTC NODE_ENV=cypress cypress open --e2e",
     "cypress:canary": "cross-env TZ=UTC NODE_ENV=cypress cypress open --e2e -b chrome:canary",
     "cypress:run": "cross-env NODE_ENV=cypress cypress run",
-    "cypress:ci": "cross-env NODE_ENV=cypress yarn cypress:run --config baseUrl=http://localhost:8080 --spec cypress/e2e/smoke/*.cy.js",
+    "cypress:ci": "cross-env NODE_ENV=cypress yarn cypress:run --config baseUrl=http://localhost:4003 --spec cypress/e2e/smoke/*.cy.js",
     "serve": "sh -c 'npx -y serve out -p ${REVERSE_PROXY_UI_PORT:=8080}'",
     "static-serve": "yarn build && yarn serve",
     "storybook": "storybook dev -p 6006",

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/AllNetworksSection.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/AllNetworksSection.tsx
@@ -84,7 +84,10 @@ function AllNetworksSection({ safeAddress, deployedChainIds, onAddNetwork }: All
   return (
     <Accordion defaultValue={[]} onValueChange={handleAccordionChange} data-testid="all-networks-accordion">
       <AccordionItem value="all-networks" className="border-0">
-        <AccordionTrigger className="rounded-lg pl-4 pr-2 py-2 hover:no-underline hover:bg-muted/30 text-muted-foreground cursor-pointer">
+        <AccordionTrigger
+          data-testid="all-networks-accordion-trigger"
+          className="rounded-lg pl-4 pr-2 py-2 hover:no-underline hover:bg-muted/30 text-muted-foreground cursor-pointer"
+        >
           <Typography variant="paragraph-small-medium" className="text-muted-foreground">
             All networks
           </Typography>


### PR DESCRIPTION
## What it solves
Resolves: [WA-2806](https://linear.app/safe-global/issue/WA-2806/fix-twap-e2e-test-flows)

Changes to the Cypress E2E setup:

1. **Serve CI Cypress on port 4003 instead of 8080** — fixes swap-widget-dependent tests failing on the shared 8080 default to `localhost:4003`.
2. Fix multichain network tests:
- **"Add another network" flow** — `add-network-btn` never appeared because the page object clicked the Accordion root wrapper instead of the clickable trigger, so the accordion never expanded.
- **"Notification if the owner set up was changed"** — intermittent redirect to `/welcome/accounts`: the test clicked "Review signers" before the router query had hydrated, navigating with an empty `safe` param.

## How this PR fixes it

- Set CI Cypress `baseUrl`/`wait-on` to `http://localhost:4003` (`action.yml`, `package.json`), pass `REVERSE_PROXY_UI_PORT=4003` to the serve step, and update the request-Origin interceptor (`commands.js`). Playwright stays on 8080.
- Added `data-testid="all-networks-accordion-trigger"` on the `AccordionTrigger` and updated `clickAllNetworksAccordion()` to click the trigger (moving the loading check before the click).
- Added `dashboard.verifySafeInUrl()` as a precondition so the test waits until the `safe` param is in the URL (hydration done) before clicking "Review signers".

## How to test it

- CI Cypress smoke run serves on `:4003` and passes.
- Affected specs: `multichain_networkswitch.cy.js`, `multichain_network.cy.js` (accordion); `multichain_setup_new.cy.js` → "Verify notification if the owner set up was changed in original safe".

## Affected flows

- CI test harness: port the app is served on and the request Origin header.
- Multichain header network selector → "All networks" → add another network.
- Dashboard action-required panel → "Review signers" → Settings > Setup.

## Blast radius

- **Port 4003**: touches CI cypress action, `cypress:ci` script, and the Origin interceptor. Affects all Cypress runs. `serve` still defaults to 8080 when `REVERSE_PROXY_UI_PORT` is unset; Playwright unaffected.
- `AllNetworksSection.tsx`: added a `data-testid` only — no behavior change. Consumed via `ChainSelectorBlock`.
- `network.pages.js` `clickAllNetworksAccordion()`: shared by 3 specs, all covered.
- `dashboard.pages.js` `verifySafeInUrl()`: new helper, used by one test.

## Risks / not checked

- Did not run the entire suite locally (app is driven manually).


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
