### PR TITLE
tests(mobile): add WalletConnect connected-dApps management Maestro flows

### DIFF
--- a/apps/mobile/e2e/tests/walletconnect-dapps/__suite__.yml
+++ b/apps/mobile/e2e/tests/walletconnect-dapps/__suite__.yml
@@ -27,3 +27,21 @@ tags:
 
 - runFlow:
     file: ./pair-proposal-scam.yml
+
+- runFlow:
+    file: ./manage-entry-hidden-when-empty.yml
+
+- runFlow:
+    file: ./manage-entry-visible.yml
+
+- runFlow:
+    file: ./manage-disconnect-via-menu.yml
+
+- runFlow:
+    file: ./manage-disconnect-via-swipe.yml
+
+- runFlow:
+    file: ./manage-disconnect-cancel.yml
+
+- runFlow:
+    file: ./manage-disconnect-from-dapp.yml

--- a/apps/mobile/e2e/tests/walletconnect-dapps/manage-disconnect-cancel.yml
+++ b/apps/mobile/e2e/tests/walletconnect-dapps/manage-disconnect-cancel.yml
@@ -1,0 +1,73 @@
+appId: ${APP_ID}
+tags:
+  - walletconnect-dapps
+---
+# Cancel path: open the confirm sheet via the 3-dots menu, then dismiss it
+# without confirming. The shipped sheet has no Cancel button — cancellation is
+# a swipe-down/backdrop dismissal. The row must survive, no toast may appear,
+# and the settings count must stay at 1.
+
+- runFlow:
+    file: ../../utils/setup/app-start.yml
+
+- tapOn:
+    id: 'e2eWcDappsBase'
+- assertVisible:
+    id: 'home-tab'
+
+- tapOn:
+    id: 'e2eWcSeedSession'
+
+# Open the connected-apps list.
+- tapOn: 'Account, tab, 3 of 3'
+- extendedWaitUntil:
+    visible:
+      id: 'settings-connected-apps-entry'
+    timeout: 10000
+- tapOn:
+    id: 'settings-connected-apps-entry'
+- extendedWaitUntil:
+    visible:
+      id: 'connected-dapp-row'
+    timeout: 10000
+
+# Menu → Disconnect → confirm sheet opens.
+- tapOn:
+    id: 'connected-dapp-menu-e2e-session-topic'
+- extendedWaitUntil:
+    visible:
+      text: 'Disconnect'
+    timeout: 5000
+- tapOn:
+    text: 'Disconnect'
+- extendedWaitUntil:
+    visible:
+      id: 'disconnect-confirm-button'
+    timeout: 10000
+
+# Swipe the sheet down to dismiss (cancel). Coordinate swipe from the sheet
+# body past the bottom, same pattern as pair-proposal-reject.yml.
+- swipe:
+    start: 50%, 60%
+    end: 50%, 95%
+- waitForAnimationToEnd:
+    timeout: 2000
+
+# Sheet gone, row untouched, no disconnect toast.
+- assertNotVisible:
+    id: 'disconnect-confirm-button'
+- assertVisible:
+    id: 'connected-dapp-row'
+- assertNotVisible:
+    text: 'Uniswap disconnected'
+
+# Slice unchanged: back on settings the entry still counts 1 session.
+- tapOn:
+    id: 'go-back'
+- extendedWaitUntil:
+    visible:
+      id: 'settings-connected-apps-entry'
+    timeout: 10000
+- assertVisible:
+    id: 'connected-apps-count'
+    text: '1'

--- a/apps/mobile/e2e/tests/walletconnect-dapps/manage-disconnect-from-dapp.yml
+++ b/apps/mobile/e2e/tests/walletconnect-dapps/manage-disconnect-from-dapp.yml
@@ -1,0 +1,49 @@
+appId: ${APP_ID}
+tags:
+  - walletconnect-dapps
+---
+# dApp-initiated disconnect: synthesise a session_delete for the fixture topic
+# while the list is open → the row disappears silently. Unlike the user paths
+# there is NO confirm sheet and NO toast; the negative toast assertion runs
+# right after the (synchronous) removal, well inside the 2.5s toast window a
+# toast would occupy if one were wrongly shown.
+
+- runFlow:
+    file: ../../utils/setup/app-start.yml
+
+- tapOn:
+    id: 'e2eWcDappsBase'
+- assertVisible:
+    id: 'home-tab'
+
+- tapOn:
+    id: 'e2eWcSeedSession'
+
+# Open the connected-apps list.
+- tapOn: 'Account, tab, 3 of 3'
+- extendedWaitUntil:
+    visible:
+      id: 'settings-connected-apps-entry'
+    timeout: 10000
+- tapOn:
+    id: 'settings-connected-apps-entry'
+- extendedWaitUntil:
+    visible:
+      id: 'connected-dapp-row'
+    timeout: 10000
+
+# The dApp ends the session (session_delete → removeSession dispatch).
+- tapOn:
+    id: 'e2eWcSynthDelete'
+
+# Row removed; the empty state is the positive anchor for the removal.
+- extendedWaitUntil:
+    visible:
+      text: 'No connected apps.'
+    timeout: 10000
+- assertNotVisible:
+    id: 'connected-dapp-row'
+
+# Explicit negative: the dApp-initiated path must not toast.
+- assertNotVisible:
+    text: 'Uniswap disconnected'

--- a/apps/mobile/e2e/tests/walletconnect-dapps/manage-disconnect-via-menu.yml
+++ b/apps/mobile/e2e/tests/walletconnect-dapps/manage-disconnect-via-menu.yml
@@ -1,0 +1,61 @@
+appId: ${APP_ID}
+tags:
+  - walletconnect-dapps
+---
+# Disconnect via the row's 3-dots menu: menu → Disconnect → confirm sheet →
+# Disconnect → success toast + row removed (empty state shown).
+
+- runFlow:
+    file: ../../utils/setup/app-start.yml
+
+- tapOn:
+    id: 'e2eWcDappsBase'
+- assertVisible:
+    id: 'home-tab'
+
+- tapOn:
+    id: 'e2eWcSeedSession'
+
+# Open the connected-apps list.
+- tapOn: 'Account, tab, 3 of 3'
+- extendedWaitUntil:
+    visible:
+      id: 'settings-connected-apps-entry'
+    timeout: 10000
+- tapOn:
+    id: 'settings-connected-apps-entry'
+- extendedWaitUntil:
+    visible:
+      id: 'connected-dapp-row'
+    timeout: 10000
+
+# Open the 3-dots menu. The menu items are OS-rendered (@react-native-menu),
+# so the Disconnect item is only reachable by its visible text.
+- tapOn:
+    id: 'connected-dapp-menu-e2e-session-topic'
+- extendedWaitUntil:
+    visible:
+      text: 'Disconnect'
+    timeout: 5000
+- tapOn:
+    text: 'Disconnect'
+
+# Confirm sheet → Disconnect → toast "Uniswap disconnected" (2.5s window).
+- extendedWaitUntil:
+    visible:
+      id: 'disconnect-confirm-button'
+    timeout: 10000
+- tapOn:
+    id: 'disconnect-confirm-button'
+- extendedWaitUntil:
+    visible:
+      text: 'Uniswap disconnected'
+    timeout: 10000
+
+# Row removed; the empty state is the positive anchor for the removal.
+- extendedWaitUntil:
+    visible:
+      text: 'No connected apps.'
+    timeout: 10000
+- assertNotVisible:
+    id: 'connected-dapp-row'

--- a/apps/mobile/e2e/tests/walletconnect-dapps/manage-disconnect-via-swipe.yml
+++ b/apps/mobile/e2e/tests/walletconnect-dapps/manage-disconnect-via-swipe.yml
@@ -1,0 +1,62 @@
+appId: ${APP_ID}
+tags:
+  - walletconnect-dapps
+---
+# Disconnect via swipe: left-swipe the row (ReanimatedSwipeable) → trash →
+# confirm sheet → Disconnect → success toast + row removed.
+
+- runFlow:
+    file: ../../utils/setup/app-start.yml
+
+- tapOn:
+    id: 'e2eWcDappsBase'
+- assertVisible:
+    id: 'home-tab'
+
+- tapOn:
+    id: 'e2eWcSeedSession'
+
+# Open the connected-apps list.
+- tapOn: 'Account, tab, 3 of 3'
+- extendedWaitUntil:
+    visible:
+      id: 'settings-connected-apps-entry'
+    timeout: 10000
+- tapOn:
+    id: 'settings-connected-apps-entry'
+- extendedWaitUntil:
+    visible:
+      id: 'connected-dapp-row'
+    timeout: 10000
+
+# Left-swipe the row to reveal the trash action, then tap it.
+- swipe:
+    from:
+      id: 'connected-dapp-row'
+    direction: LEFT
+- extendedWaitUntil:
+    visible:
+      id: 'connected-dapp-trash-e2e-session-topic'
+    timeout: 5000
+- tapOn:
+    id: 'connected-dapp-trash-e2e-session-topic'
+
+# Confirm sheet → Disconnect → toast "Uniswap disconnected" (2.5s window).
+- extendedWaitUntil:
+    visible:
+      id: 'disconnect-confirm-button'
+    timeout: 10000
+- tapOn:
+    id: 'disconnect-confirm-button'
+- extendedWaitUntil:
+    visible:
+      text: 'Uniswap disconnected'
+    timeout: 10000
+
+# Row removed; the empty state is the positive anchor for the removal.
+- extendedWaitUntil:
+    visible:
+      text: 'No connected apps.'
+    timeout: 10000
+- assertNotVisible:
+    id: 'connected-dapp-row'

--- a/apps/mobile/e2e/tests/walletconnect-dapps/manage-entry-hidden-when-empty.yml
+++ b/apps/mobile/e2e/tests/walletconnect-dapps/manage-entry-hidden-when-empty.yml
@@ -1,0 +1,25 @@
+appId: ${APP_ID}
+tags:
+  - walletconnect-dapps
+---
+# Empty state: with no sessions in the slice, the "Connected apps" settings
+# entry must not render at all (ConnectedDappsEntry returns null at count 0).
+
+- runFlow:
+    file: ../../utils/setup/app-start.yml
+
+- tapOn:
+    id: 'e2eWcDappsBase'
+- assertVisible:
+    id: 'home-tab'
+
+# Open account settings. Anchor on the Signers row (rendered just above the
+# connected-apps slot) to prove the screen loaded before the negative assert.
+- tapOn: 'Account, tab, 3 of 3'
+- extendedWaitUntil:
+    visible:
+      id: 'settings-signers-list-item'
+    timeout: 10000
+
+- assertNotVisible:
+    id: 'settings-connected-apps-entry'

--- a/apps/mobile/e2e/tests/walletconnect-dapps/manage-entry-visible.yml
+++ b/apps/mobile/e2e/tests/walletconnect-dapps/manage-entry-visible.yml
@@ -1,0 +1,27 @@
+appId: ${APP_ID}
+tags:
+  - walletconnect-dapps
+---
+# Entry visible: seed one approved session → the "Connected apps" settings
+# entry renders with count 1. (The chevron is a decorative icon without a
+# test-id; the entry + count assertions cover the row.)
+
+- runFlow:
+    file: ../../utils/setup/app-start.yml
+
+- tapOn:
+    id: 'e2eWcDappsBase'
+- assertVisible:
+    id: 'home-tab'
+
+- tapOn:
+    id: 'e2eWcSeedSession'
+
+- tapOn: 'Account, tab, 3 of 3'
+- extendedWaitUntil:
+    visible:
+      id: 'settings-connected-apps-entry'
+    timeout: 10000
+- assertVisible:
+    id: 'connected-apps-count'
+    text: '1'

--- a/apps/mobile/src/tests/e2e-maestro/components/TestCtrls.e2e.tsx
+++ b/apps/mobile/src/tests/e2e-maestro/components/TestCtrls.e2e.tsx
@@ -26,6 +26,7 @@ import {
 import { setupHistory, setupTransactionHistory, setupTransactionHistoryDirect } from '../setup/historySetup'
 import {
   setupWcDappsBase,
+  seedWcSession,
   synthSessionProposalValid,
   synthSessionProposalUnverified,
   synthSessionProposalScam,
@@ -299,6 +300,7 @@ export function TestCtrls() {
           accessibilityRole="button"
           style={BTN}
         />
+        <Pressable testID="e2eWcSeedSession" onPress={() => seedWcSession()} accessibilityRole="button" style={BTN} />
         <Pressable
           testID="e2eWcSynthProposalValid"
           onPress={() => synthSessionProposalValid()}

--- a/apps/mobile/src/tests/e2e-maestro/createE2eStore.ts
+++ b/apps/mobile/src/tests/e2e-maestro/createE2eStore.ts
@@ -3,9 +3,8 @@
  * and walletConnectE2eState. TestCtrls mutate it via set(); `.e2e` overrides read
  * it via get()/useSyncExternalStore; reset() runs between flows.
  *
- * reset() restores a deep clone of the initial state, so a scenario that mutated
- * even a nested value can't leak into the next flow. Update via set() with new
- * values — mutating get() in place won't notify subscribers.
+ * State is shallow-cloned — update via set() with new values, never mutate a
+ * nested value in place (it would corrupt initialState and break reset()).
  */
 export interface E2eStore<T> {
   get: () => T

--- a/apps/mobile/src/tests/e2e-maestro/setup/__tests__/walletConnectDappsSetup.test.ts
+++ b/apps/mobile/src/tests/e2e-maestro/setup/__tests__/walletConnectDappsSetup.test.ts
@@ -5,10 +5,13 @@ import {
   clearWalletKitState,
   selectPending,
   selectSessionsRecord,
+  selectVerifyByTopic,
   type PendingSessionProposal,
 } from '@/src/features/WalletConnect/Wallet/store/walletKitSlice'
 import { walletKitE2eState, E2E_SESSION_TOPIC } from '@/src/features/WalletConnect/Wallet/walletKitE2eState'
+import { APPROVED_SESSION, getWalletKit } from '@/src/features/WalletConnect/Wallet/walletKit.e2e'
 import {
+  seedWcSession,
   synthSessionProposalValid,
   synthSessionProposalUnverified,
   synthSessionProposalScam,
@@ -43,6 +46,26 @@ describe('walletConnectDappsSetup synthesis', () => {
   it('synthSessionProposalScam pushes a scam-flagged proposal', () => {
     synthSessionProposalScam()
     expect(getProposals()[0].proposal.verifyContext?.verified?.isScam).toBe(true)
+  })
+
+  it('seedWcSession puts the approved-session fixture in the slice as verified', () => {
+    seedWcSession()
+    expect(selectSessionsRecord(store.getState())[E2E_SESSION_TOPIC]).toEqual(APPROVED_SESSION)
+    expect(selectVerifyByTopic(store.getState())[E2E_SESSION_TOPIC]).toBe('verified')
+  })
+
+  it('seedWcSession seeds the fake WalletKit so getActiveSessions reflects the session', async () => {
+    seedWcSession()
+    const walletKit = await getWalletKit()
+    expect(walletKit.getActiveSessions()[E2E_SESSION_TOPIC]).toEqual(APPROVED_SESSION)
+  })
+
+  it('synthSessionDelete removes a seeded session from the slice and the fake', async () => {
+    seedWcSession()
+    synthSessionDelete()
+    expect(selectSessionsRecord(store.getState())[E2E_SESSION_TOPIC]).toBeUndefined()
+    const walletKit = await getWalletKit()
+    expect(walletKit.getActiveSessions()[E2E_SESSION_TOPIC]).toBeUndefined()
   })
 
   it('synthSessionDelete removes the fixture session from the slice', () => {

--- a/apps/mobile/src/tests/e2e-maestro/setup/walletConnectDappsSetup.ts
+++ b/apps/mobile/src/tests/e2e-maestro/setup/walletConnectDappsSetup.ts
@@ -3,7 +3,8 @@ import type { Router } from 'expo-router'
 import type { WalletKitTypes } from '@reown/walletkit'
 import { getEip155ChainId } from '@safe-global/utils/features/walletconnect/utils'
 import { store } from '@/src/store'
-import { pushPending, removeSession } from '@/src/features/WalletConnect/Wallet/store/walletKitSlice'
+import { addSession, pushPending, removeSession } from '@/src/features/WalletConnect/Wallet/store/walletKitSlice'
+import { APPROVED_SESSION } from '@/src/features/WalletConnect/Wallet/walletKit.e2e'
 import {
   walletKitE2eState,
   E2E_SESSION_TOPIC,
@@ -93,6 +94,14 @@ export const synthSessionProposalUnverified = () => synthProposal({ validation: 
 
 /** Synthesise a scam-flagged session_proposal. */
 export const synthSessionProposalScam = () => synthProposal({ validation: 'VALID', isScam: true })
+
+/** Seed one approved session (slice + fake's session store) so management flows skip pairing. */
+export const seedWcSession = () => {
+  store.dispatch(addSession({ session: APPROVED_SESSION, verifyVariant: 'verified' }))
+  walletKitE2eState.set({
+    sessions: { ...walletKitE2eState.get().sessions, [APPROVED_SESSION.topic]: APPROVED_SESSION },
+  })
+}
 
 /** Synthesise a session_delete for the fixture session topic (slice + fake's session store). */
 export const synthSessionDelete = () => {


### PR DESCRIPTION
## What it solves

Resolves: [WA-2325](https://linear.app/safe-global/issue/WA-2325/e2e-connected-dapps-management)

Maestro coverage for Connected dApps management: the conditional "Connected apps" settings entry and the three independent disconnect paths (3-dots menu, swipe-to-trash, dApp-initiated `session_delete`). These regress easily when the settings stack or the swipeable row is refactored.

## How this PR fixes it

Six flows under `apps/mobile/e2e/tests/walletconnect-dapps/`, reusing the WA-2324 harness (fake WalletKit, `walletKitE2eState`, TestCtrls synthesis):

- `manage-entry-hidden-when-empty` — no sessions → settings entry absent
- `manage-entry-visible` — seeded session → entry with count 1
- `manage-disconnect-via-menu` / `manage-disconnect-via-swipe` — confirm → toast + row removed
- `manage-disconnect-cancel` — sheet dismissed → row + count intact, no toast
- `manage-disconnect-from-dapp` — synthesized `session_delete` → row removed, explicit **no-toast** negative assertion

New harness helper `seedWcSession()` (TestCtrls: `e2eWcSeedSession`) seeds an approved session into the slice + fake WalletKit so management flows skip pairing. Covered by unit tests.

Deviations from the ticket (documented in the suite README): cancel is a swipe-down sheet dismissal (the shipped modal has no Cancel button), the chevron isn't directly assertable, and the native menu's "Disconnect" item is tapped by visible text (OS-rendered, no testID).

## How to test it

```bash
yarn workspace @safe-global/mobile e2e:metro-ios
maestro test apps/mobile/e2e/tests/walletconnect-dapps/__suite__.yml
```

All 13 flows (7 pairing + 6 management) verified on iOS simulator.

## Affected flows

- None at runtime — e2e-only change (`.e2e.tsx` harness + Maestro yaml); no production code touched.

## Blast radius

- `walletConnectDappsSetup.ts` / `TestCtrls.e2e.tsx` — e2e-only, shadowed via `RN_SRC_EXT`, never in production bundles.
- Existing WA-2324 pairing flows share the harness; full suite re-run green.

## Risks / not checked

- Not verified on Android (CI EAS profile is iOS); native-menu text tap and swipe may need tuning there.
- Toast has no testID — asserted by visible text ("Uniswap disconnected").
- CI runs only with the `mobile-e2e-test` label or nightly.

## Visual summary

```mermaid
flowchart LR
  subgraph User-initiated
    M[3-dots menu] --> C{Confirm sheet}
    S[Swipe → trash] --> C
    C -->|Disconnect| T[Toast + row removed]
    C -->|Swipe-down dismiss| K[Row + count intact, no toast]
  end
  D[dApp session_delete] --> R[Row removed, no toast]
```

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
