### PR TITLE
fix: SpenderField overflow

### DIFF
--- a/apps/web/src/components/tx/ApprovalEditor/SpenderField.tsx
+++ b/apps/web/src/components/tx/ApprovalEditor/SpenderField.tsx
@@ -44,7 +44,7 @@ export const SpenderField = ({ address }: { address: string }) => {
       >
         Spender
       </Typography>
-      <div>
+      <div className="overflow-hidden">
         <EthHashInfo
           avatarSize={24}
           address={address}


### PR DESCRIPTION
## What it solves
In space-constrained windows, the address shown in the Spender field overflows and causes UI glitches.

Resolves: [WA-1493](https://linear.app/safe-global/issue/WA-1493/spender-address-overflows-in-narrow-wallet-ui)

## How this PR fixes it

Truncates the address to stay within the container borders. Switches to short version on mobile (existing logic, not changed)

## How to test it
<img width="958" height="425" alt="Screenshot 2026-07-13 at 11 27 56 AM" src="https://github.com/user-attachments/assets/e8e5c318-1fad-46fd-b655-74c3021db469" />

## Affected flows

<!-- The primary user journey(s) this PR intentionally changes. One bullet per flow. Example: "Owner adds a new signer from Settings > Signers". -->

## Blast radius

<!--
List the surfaces touched by this change and who else depends on them. Think in dependency terms, not files.
Include where relevant:
- Shared hooks / components / selectors / slices touched and their known consumers
- RTK Query endpoints / API contracts
- Feature flags / chain configs
- Persistence / cache / migration implications
- Routes or layouts affected indirectly
- Mobile impact (shared packages)
-->

## Risks / not checked

<!--
Be explicit about what you did NOT verify. This exposes false confidence and helps reviewers target their attention.
Example:
- Did not verify behavior with feature flag X disabled
- Did not test on mobile
- Did not exercise the retry / error path manually
-->

## Visual summary

<!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
