### PR TITLE
chore: integrate GitHub with Linear Releases (web + mobile)

### DIFF
--- a/.github/workflows/mobile-linear-release.yml
+++ b/.github/workflows/mobile-linear-release.yml
@@ -1,0 +1,79 @@
+name: Linear Release (Mobile)
+
+# Syncs mobile releases to the "Mobile" scheduled release pipeline in Linear.
+# Mobile has no automated production release/tag flow in this repo yet, so this
+# is driven manually to match the EAS release cadence: run `sync` when cutting a
+# release, `update` to move it between stages, and `complete` once it ships.
+#
+# Setup: add the Mobile pipeline access key as the `LINEAR_ACCESS_KEY_MOBILE`
+# repository secret (Settings -> Secrets and variables -> Actions). This must be
+# a pipeline access key generated from the pipeline settings in Linear, not a
+# personal API key.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. 1.0.14) - defaults to apps/mobile/package.json'
+        required: false
+        type: string
+      command:
+        description: 'Linear release command'
+        required: true
+        type: choice
+        default: sync
+        options:
+          - sync
+          - update
+          - complete
+      stage:
+        description: 'Deployment stage (required for the "update" command, e.g. In Progress)'
+        required: false
+        type: string
+      dry_run:
+        description: 'Preview the action without modifying Linear'
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+concurrency:
+  group: linear-release-mobile-${{ inputs.version || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  linear-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.0.0
+        with:
+          fetch-depth: 0 # Full history required to scan commits for Linear issue IDs
+
+      - name: Resolve release version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION=$(node -p "require('./apps/mobile/package.json').version")
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Linear release version: $VERSION"
+
+      - name: Run Linear release (${{ inputs.command }})
+        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f # v0.14.5
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_MOBILE }}
+          command: ${{ inputs.command }}
+          version: ${{ steps.version.outputs.version }}
+          stage: ${{ inputs.stage }}
+          # include_paths is only valid for `sync`; omit it for update/complete
+          include_paths: ${{ inputs.command == 'sync' && 'apps/mobile/**,packages/**,expo-plugins/**' || '' }}
+          dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/web-linear-release.yml
+++ b/.github/workflows/web-linear-release.yml
@@ -1,0 +1,80 @@
+name: Linear Release (Web)
+
+# Manual backfill / repair tool for the "Wallet" scheduled release pipeline in
+# Linear. The normal flow is automated inside the release workflows:
+#   - web-release-start.yml -> `sync` + stage "Code Freeze" when a release is cut
+#   - web-tag-release.yml    -> `complete` when the release is published
+# Use this workflow to re-sync a release, fix a stage, or preview with dry_run.
+#
+# Setup: add the Wallet pipeline access key as the `LINEAR_ACCESS_KEY_WEB`
+# repository secret (Settings -> Secrets and variables -> Actions). This must be
+# a pipeline access key generated from the pipeline settings in Linear, not a
+# personal API key.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. 1.92.0) - defaults to apps/web/package.json'
+        required: false
+        type: string
+      command:
+        description: 'Linear release command'
+        required: true
+        type: choice
+        default: sync
+        options:
+          - sync
+          - update
+          - complete
+      stage:
+        description: 'Deployment stage (required for the "update" command, e.g. Code Freeze)'
+        required: false
+        type: string
+      dry_run:
+        description: 'Preview the action without modifying Linear'
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+concurrency:
+  group: linear-release-web-${{ inputs.version || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  linear-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.0.0
+        with:
+          fetch-depth: 0 # Full history required to scan commits for Linear issue IDs
+
+      - name: Resolve release version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION=$(node -p "require('./apps/web/package.json').version")
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Linear release version: $VERSION"
+
+      - name: Run Linear release (${{ inputs.command }})
+        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f # v0.14.5
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_WEB }}
+          command: ${{ inputs.command }}
+          version: ${{ steps.version.outputs.version }}
+          stage: ${{ inputs.stage }}
+          # include_paths is only valid for `sync`; omit it for update/complete
+          include_paths: ${{ inputs.command == 'sync' && 'apps/web/**,packages/**' || '' }}
+          dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/web-release-start.yml
+++ b/.github/workflows/web-release-start.yml
@@ -251,22 +251,50 @@ jobs:
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
           echo "✅ Pull Request created: $PR_URL"
 
+      # Create/sync the release in the Linear "Wallet" pipeline and move it to
+      # Code Freeze. Guarded so a Linear outage never blocks cutting a release.
+      - name: Sync release to Linear
+        id: linear_sync
+        continue-on-error: true
+        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f # v0.14.5
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_WEB }}
+          command: sync
+          version: ${{ steps.version.outputs.version }}
+          include_paths: apps/web/**,packages/**
+          links: ${{ steps.create_pr.outputs.pr_url }}
+
+      - name: Move Linear release to Code Freeze
+        continue-on-error: true
+        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f # v0.14.5
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_WEB }}
+          command: update
+          version: ${{ steps.version.outputs.version }}
+          stage: Code Freeze
+
       - name: Notify on Slack
         if: vars.SLACK_WEBHOOK_URL
         continue-on-error: true
         env:
           INPUT_RELEASE_TYPE: ${{ inputs.release_type }}
+          LINEAR_URL: ${{ steps.linear_sync.outputs['release-url'] }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           RELEASE_TYPE="$INPUT_RELEASE_TYPE"
           BASE_BRANCH="${{ steps.base.outputs.branch }}"
           PR_URL="${{ steps.create_pr.outputs.pr_url }}"
+          LINEAR_LINK=""
+          if [ -n "$LINEAR_URL" ]; then
+            LINEAR_LINK="<$LINEAR_URL|View release in Linear>"
+          fi
 
           jq -n \
             --arg version "$VERSION" \
             --arg release_type "$RELEASE_TYPE" \
             --arg base "$BASE_BRANCH" \
             --arg pr_url "$PR_URL" \
+            --arg linear "$LINEAR_LINK" \
             '{
               text: ("🚀 *Release web-v" + $version + " Started*"),
               blocks: [
@@ -274,7 +302,7 @@ jobs:
                   type: "section",
                   text: {
                     type: "mrkdwn",
-                    text: ("*Release web-v" + $version + " has been initiated* ✅\n\n*Type:* " + $release_type + "\n*Base:* " + $base + "\n*PR:* " + $pr_url + "\n\n_QA team: Please review and test_ 🧪")
+                    text: ("*Release web-v" + $version + " has been initiated* ✅\n\n*Type:* " + $release_type + "\n*Base:* " + $base + "\n*PR:* " + $pr_url + (if $linear != "" then "\n*Linear:* " + $linear else "" end) + "\n\n_QA team: Please review and test_ 🧪")
                   }
                 }
               ]

--- a/.github/workflows/web-tag-release.yml
+++ b/.github/workflows/web-tag-release.yml
@@ -299,10 +299,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+      # Mark the Linear "Wallet" release as Released (auto-generates release
+      # notes). Guarded so a Linear outage never fails a shipped release.
+      - name: Complete Linear release
+        if: needs.tag.outputs.version && success()
+        id: linear_complete
+        continue-on-error: true
+        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f # v0.14.5
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_WEB }}
+          command: complete
+          version: ${{ needs.tag.outputs.version_number }}
+
       - name: Notify on Slack
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          LINEAR_URL: ${{ steps.linear_complete.outputs['release-url'] }}
         run: |
           if [ -z "$SLACK_WEBHOOK_URL" ]; then
             echo "No Slack webhook configured, skipping notification"
@@ -313,6 +326,10 @@ jobs:
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${{ needs.tag.outputs.version }}"
           BACKMERGE_PR_URL="${{ steps.backmerge.outputs.pr_url }}"
           HAS_CONFLICTS="${{ steps.backmerge.outputs.has_conflicts }}"
+          LINEAR_LINK=""
+          if [ -n "$LINEAR_URL" ]; then
+            LINEAR_LINK="<$LINEAR_URL|View release in Linear>"
+          fi
 
           if [ -n "$BACKMERGE_PR_URL" ]; then
             if [ "$HAS_CONFLICTS" = "true" ]; then
@@ -328,6 +345,7 @@ jobs:
             --arg version "$VERSION" \
             --arg url "$RELEASE_URL" \
             --arg backmerge "$BACKMERGE_MSG" \
+            --arg linear "$LINEAR_LINK" \
             '{
               channel: "#topic-wallet-releases",
               text: ("✅ Safe Wallet " + $version + " ready for going live"),
@@ -336,7 +354,7 @@ jobs:
                   type: "section",
                   text: {
                     type: "mrkdwn",
-                    text: ("*Safe Wallet " + $version + " is ready for going live* ✅\n\n<" + $url + "|View Release on GitHub>\n\n" + $backmerge)
+                    text: ("*Safe Wallet " + $version + " is ready for going live* ✅\n\n<" + $url + "|View Release on GitHub>" + (if $linear != "" then "\n" + $linear else "" end) + "\n\n" + $backmerge)
                   }
                 }
               ]


### PR DESCRIPTION
## What it solves

Resolves [WA-2846](https://linear.app/safe-global/issue/WA-2846/integrate-github-with-linear-releases-web-mobile)

We had no automated link between our GitHub releases and Linear's release pipelines, so shipped issues weren't grouped into Linear releases. This wires the [Linear Release GitHub Action](<https://github.com/marketplace/actions/linear-release>) into the monorepo for both apps, driven from our existing release lifecycle.

## How this PR fixes it

**Web →** `Wallet` **pipeline — two-phase, driven by the existing release workflows:**

* `web-release-start.yml` (Thursday / code freeze): after the release PR is opened, `sync` the Linear release (attach the issues found in commits) and `update` it to the **Code Freeze** stage.
* `web-tag-release.yml` (Tuesday / ship): after the GitHub release is published, `complete` the Linear release → **Released** + auto-generated notes.
* Both Linear steps are `continue-on-error`, so a Linear outage can never block or fail cutting/shipping a release.
* The Linear release URL is posted in the "Release started" and "ready for going live" Slack messages.
* `web-linear-release.yml` is reduced to a **manual-only** backfill/repair tool (re-sync, fix a stage, `dry_run` preview).

**Mobile →** `Mobile` **pipeline:**

* `mobile-linear-release.yml` — manual `workflow_dispatch` (`sync` / `update` / `complete`), scoped to `apps/mobile/**` + `packages/**` + `expo-plugins/**`, matching the EAS release cadence (no automated mobile release/tag flow exists yet).

The action is SHA-pinned (`c0cb835` = `v0.14.5`). Pipelines stay **scheduled** — this fits the code-freeze→release cadence and a future daily cadence with no Linear-side change.

## How to test it

1. Add repo secrets `LINEAR_ACCESS_KEY_WEB` (Wallet pipeline key) and `LINEAR_ACCESS_KEY_MOBILE` (Mobile pipeline key) — each pipeline has its own access key.
2. Merge to `dev` (GitHub only activates `release` / `workflow_dispatch` triggers from the default branch).
3. Preview safely: Actions → **Linear Release (Web)** / **Linear Release (Mobile)** → Run workflow with `dry_run: true`.
4. End-to-end: run **Start Web Release** → confirm the release appears in the Wallet pipeline in **Code Freeze** with its issues; publish the `web-v*` release → confirm it moves to **Released** with auto-generated notes.

## Affected flows

* **Start Web Release** (`web-release-start.yml`) — now also creates/syncs the Linear release and sets **Code Freeze**, and adds the Linear link to Slack. Additive; release-branch/PR creation unchanged.
* **Web Tag, Release & Deploy** (`web-tag-release.yml`) — now also `complete`s the Linear release after publish, and adds the Linear link to Slack. Additive; tag/build/deploy/back-merge unchanged.
* **Mobile release** — new manual workflow to sync the Linear Mobile release.

## Blast radius

* **CI only.** No application code, shared hooks/components/selectors/slices/RTK Query endpoints/routes/persisted state touched.
* Edits two production release workflows **additively**; every new step is `continue-on-error`, so it cannot change the outcome of an actual release.
* New standalone workflow files: `web-linear-release.yml` (manual backfill), `mobile-linear-release.yml` (manual).
* Adds one SHA-pinned third-party action (`linear/linear-release-action`).
* Requires two new repo secrets; if absent, the guarded Linear steps simply skip.

## Risks / not checked

* Not run end-to-end against the live pipelines yet (requires the secrets + merge to `dev`). Recommend a `dry_run: true` dispatch first.
* Moving **issues** to a Done status on release completion is a separate **Linear status automation** (a settings toggle), intentionally **not** part of this PR.
* Assumes `release: [released]` fires when the draft `web-v*` release is published — consistent with the existing `web-deploy-dockerhub.yml` pattern.
* Shared `packages/**` changes appear in both pipelines by design.

## Visual summary

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant Lin as Linear · Wallet pipeline

    Note over GH,Lin: Thursday — web-release-start.yml (code freeze)
    GH->>Lin: sync — create release + attach issues
    GH->>Lin: update — stage "Code Freeze"

    Note over GH,Lin: QA window (Fri–Mon) — stays in Code Freeze

    Note over GH,Lin: Tuesday — web-tag-release.yml (ship)
    GH->>Lin: complete — Released + auto-generated notes
```

Mobile mirrors this via manual `workflow_dispatch` against the `Mobile` pipeline.

## Checklist

- [ ] I've tested the branch on mobile 📱 *(N/A — CI-only change)*
- [X] I've documented how it affects the analytics (if at all) 📊 *(N/A — no analytics)*
- [X] I've written a unit/e2e test for it (if applicable) 🧑‍💻 *(workflow YAML validated with prettier + jq payloads unit-checked; no unit surface)*
- [X] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](<https://safe.global/cla>).