### PR TITLE
feat(web): hide transaction notes for non-signers

### DIFF
--- a/apps/web/src/components/transactions/TxSummary/index.test.tsx
+++ b/apps/web/src/components/transactions/TxSummary/index.test.tsx
@@ -12,6 +12,7 @@ import {
 
 import TxSummary from '@/components/transactions/TxSummary/index'
 import * as pending from '@/hooks/useIsPending'
+import * as useIsSafeOwnerHook from '@/hooks/useIsSafeOwner'
 import { render } from '@/tests/test-utils'
 
 const mockTransaction: MultisigTransaction = {
@@ -50,6 +51,11 @@ const mockTransactionInHistory = {
   ...mockTransaction,
   transaction: { ...mockTransaction.transaction, txStatus: TransactionStatus.SUCCESS },
 }
+
+const mockTransactionWithNote = {
+  ...mockTransaction,
+  transaction: { ...mockTransaction.transaction, note: 'Monthly payroll' },
+} as unknown as MultisigTransaction
 
 describe('TxSummary', () => {
   it('should display a nonce if transaction is not grouped', () => {
@@ -121,5 +127,19 @@ describe('TxSummary', () => {
     const { queryByTestId } = render(<TxSummary item={mockTransaction} isConflictGroup={false} />)
 
     expect(queryByTestId('tx-status-label')).not.toBeInTheDocument()
+  })
+
+  it('should display the note preview for a signer of the Safe', () => {
+    jest.spyOn(useIsSafeOwnerHook, 'default').mockReturnValue(true)
+    const { getByText } = render(<TxSummary item={mockTransactionWithNote} isConflictGroup={false} />)
+
+    expect(getByText('Monthly payroll')).toBeInTheDocument()
+  })
+
+  it('should hide the note preview for a non-signer', () => {
+    jest.spyOn(useIsSafeOwnerHook, 'default').mockReturnValue(false)
+    const { queryByText } = render(<TxSummary item={mockTransactionWithNote} isConflictGroup={false} />)
+
+    expect(queryByText('Monthly payroll')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/transactions/TxSummary/index.tsx
+++ b/apps/web/src/components/transactions/TxSummary/index.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/features/hypernative'
 import { getSafeTxHashFromTxId } from '@/utils/transactions'
 import { useLoadFeature } from '@/features/__core__/useLoadFeature'
+import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 
 type TxSummaryProps = {
   isConflictGroup?: boolean
@@ -45,6 +46,7 @@ const TxSummary = ({ item, isConflictGroup, isBulkGroup }: TxSummaryProps): Reac
   const isTrusted = !hasDefaultTokenlist || isTrustedTx(tx)
   const isImitationTransaction = isImitation(tx)
   const isPending = useIsPending(tx.id)
+  const isSafeOwner = useIsSafeOwner()
   const executionInfo = isMultisigExecutionInfo(tx.executionInfo) ? tx.executionInfo : undefined
   const expiredSwap = useIsExpiredSwap(tx.txInfo)
 
@@ -81,7 +83,7 @@ const TxSummary = ({ item, isConflictGroup, isBulkGroup }: TxSummaryProps): Reac
       <Box data-testid="tx-type" gridArea="type">
         <TxType tx={tx} />
 
-        {tx.note && (
+        {tx.note && isSafeOwner && (
           <Typography variant="body2" component="span" color="text.secondary" title={tx.note}>
             {ellipsis(tx.note, 25)}
           </Typography>

--- a/apps/web/src/components/tx-flow/features/TxNote.tsx
+++ b/apps/web/src/components/tx-flow/features/TxNote.tsx
@@ -4,6 +4,7 @@ import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { TxFlowContext } from '@/components/tx-flow/TxFlowProvider'
 import { TxNotesFeature } from '@/features/tx-notes'
 import { useLoadFeature } from '@/features/__core__'
+import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import { SlotName, withSlot } from '../slots'
 
 const TxNote = (): ReactElement => {
@@ -22,10 +23,12 @@ const TxNote = (): ReactElement => {
   return <TxNoteForm isCreation={isCreation} onChange={onNoteChange} txDetails={txDetails} />
 }
 
-const useShouldRegisterSlot = () => {
+export const useShouldRegisterSlot = () => {
   const { txDetails, isCreation } = useContext(TxFlowContext)
+  const isSafeOwner = useIsSafeOwner()
 
-  return isCreation || !!txDetails?.note
+  // Existing notes are only shown to signers; creation input stays available to proposers
+  return isCreation || (!!txDetails?.note && isSafeOwner)
 }
 
 const TxNoteSlot = withSlot({

--- a/apps/web/src/components/tx-flow/features/__tests__/TxNote.test.tsx
+++ b/apps/web/src/components/tx-flow/features/__tests__/TxNote.test.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from 'react'
+import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { renderHook } from '@/tests/test-utils'
+import { TxFlowContext, type TxFlowContextType } from '@/components/tx-flow/TxFlowProvider'
+import useIsSafeOwner from '@/hooks/useIsSafeOwner'
+import { useShouldRegisterSlot } from '../TxNote'
+
+jest.mock('@/hooks/useIsSafeOwner')
+
+const mockUseIsSafeOwner = useIsSafeOwner as jest.MockedFunction<typeof useIsSafeOwner>
+
+const renderCondition = (ctx: Partial<TxFlowContextType>) => {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <TxFlowContext.Provider value={ctx as TxFlowContextType}>{children}</TxFlowContext.Provider>
+  )
+  return renderHook(() => useShouldRegisterSlot(), { wrapper })
+}
+
+const txDetailsWithNote = { note: 'Monthly payroll' } as unknown as TransactionDetails
+
+describe('tx-flow TxNote useShouldRegisterSlot', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('registers the slot during creation regardless of ownership', () => {
+    mockUseIsSafeOwner.mockReturnValue(false)
+
+    const { result } = renderCondition({ isCreation: true, txDetails: undefined })
+
+    expect(result.current).toBe(true)
+  })
+
+  it('registers the slot for a signer viewing a transaction with a note', () => {
+    mockUseIsSafeOwner.mockReturnValue(true)
+
+    const { result } = renderCondition({ isCreation: false, txDetails: txDetailsWithNote })
+
+    expect(result.current).toBe(true)
+  })
+
+  it('does not register the slot for a non-signer viewing a transaction with a note', () => {
+    mockUseIsSafeOwner.mockReturnValue(false)
+
+    const { result } = renderCondition({ isCreation: false, txDetails: txDetailsWithNote })
+
+    expect(result.current).toBe(false)
+  })
+
+  it('does not register the slot when there is no note', () => {
+    mockUseIsSafeOwner.mockReturnValue(true)
+
+    const { result } = renderCondition({ isCreation: false, txDetails: undefined })
+
+    expect(result.current).toBe(false)
+  })
+})

--- a/apps/web/src/features/tx-notes/components/TxNote/__tests__/index.test.tsx
+++ b/apps/web/src/features/tx-notes/components/TxNote/__tests__/index.test.tsx
@@ -1,0 +1,43 @@
+import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { render, screen } from '@/tests/test-utils'
+import TxNote from '..'
+import useIsSafeOwner from '@/hooks/useIsSafeOwner'
+
+jest.mock('@/hooks/useIsSafeOwner')
+
+const mockUseIsSafeOwner = useIsSafeOwner as jest.MockedFunction<typeof useIsSafeOwner>
+
+const txDetailsWithNote = {
+  note: 'Monthly payroll',
+  detailedExecutionInfo: undefined,
+} as unknown as TransactionDetails
+
+describe('TxNote', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders the note for a signer of the Safe', () => {
+    mockUseIsSafeOwner.mockReturnValue(true)
+
+    render(<TxNote txDetails={txDetailsWithNote} />)
+
+    expect(screen.getByTestId('tx-note')).toHaveTextContent('Monthly payroll')
+  })
+
+  it('hides the note for a non-signer', () => {
+    mockUseIsSafeOwner.mockReturnValue(false)
+
+    render(<TxNote txDetails={txDetailsWithNote} />)
+
+    expect(screen.queryByTestId('tx-note')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when there is no note, even for a signer', () => {
+    mockUseIsSafeOwner.mockReturnValue(true)
+
+    const { container } = render(<TxNote txDetails={{ note: null } as unknown as TransactionDetails} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/apps/web/src/features/tx-notes/components/TxNote/index.tsx
+++ b/apps/web/src/features/tx-notes/components/TxNote/index.tsx
@@ -3,10 +3,14 @@ import { Tooltip, Typography, Stack } from '@mui/material'
 import InfoIcon from '@/public/images/notifications/info.svg'
 import { isMultisigDetailedExecutionInfo } from '@/utils/transaction-guards'
 import EthHashInfo from '@/components/common/EthHashInfo'
+import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 
 export default function TxNote({ txDetails }: { txDetails: TransactionDetails | undefined }) {
+  const isSafeOwner = useIsSafeOwner()
   const note = txDetails?.note
-  if (!note) return null
+
+  // Transaction notes are only visible to signers of the Safe
+  if (!note || !isSafeOwner) return null
 
   const creator =
     isMultisigDetailedExecutionInfo(txDetails?.detailedExecutionInfo) && txDetails?.detailedExecutionInfo.proposer


### PR DESCRIPTION
## What it solves

Resolves [WA-1899](https://linear.app/safe-global/issue/WA-1899/hide-transaction-notes-for-non-signers).

Transaction notes are a Wallet-app feature: the note text is embedded in a transaction's `origin` and returned publicly by the CGW. Anyone viewing a Safe — including non-signers — could read note data that authors likely assumed was private. This PR hides note data in the web app from anyone who is not a signer of the Safe.

This is the frontend half. Removing notes from public CGW API responses is tracked separately in PLA-1211 (Platform, currently Blocked).

## How this PR fixes it

Note display is gated behind `useIsSafeOwner()` (returns `false` when no wallet is connected) across the three surfaces that render the CGW `note` field:

- **`TxNote` details block** (`features/tx-notes/components/TxNote`) — authoritative gate: `if (!note || !isSafeOwner) return null`. Covers both the transaction details view and the tx-flow review step. The `.txNote:empty { display:none }` rule already collapses the empty wrapper.
- **`TxSummary` list-row preview** — the ellipsized note preview only renders when `isSafeOwner`.
- **tx-flow note slot** — `useShouldRegisterSlot` becomes `isCreation || (!!txDetails?.note && isSafeOwner)`, so a non-owner viewing a noted transaction in the flow no longer registers an empty slot.

Note **creation** is intentionally untouched — a proposer writing their own note still works; only *viewing* is gated.

## How to test it

1. As an owner, create a transaction with a note (the "Optional" note field in the review step) and propose/execute it.
2. With the owner wallet connected, open the Safe's queue/history — the note preview shows in the list row and the full "Note" block shows in the expanded transaction.
3. Disconnect the wallet (or connect a non-owner wallet) — the note disappears from both the list row and the expanded details.

Automated:

```bash
yarn workspace @safe-global/web test \
  src/features/tx-notes/components/TxNote/__tests__/index.test.tsx \
  src/components/transactions/TxSummary/index.test.tsx \
  src/components/tx-flow/features/__tests__/TxNote.test.tsx
```

## Affected flows

- Viewing a transaction's note in **transaction details** (queue + history) — now signer-only.
- Viewing the note **preview in transaction list rows** — now signer-only.
- Viewing an existing note inside the **tx-flow review step** — now signer-only.
- Creating a note during a transaction flow — **unchanged** (proposers included).

## Blast radius

- **Shared hook consumed:** `useIsSafeOwner` (read-only; no change to the hook itself).
- **Components touched:** `TxNote` (tx-notes feature, consumed by `TxDetails` and the tx-flow note slot), `TxSummary` (transaction list row), tx-flow `TxNote` slot wrapper.
- **API contract:** none changed. CGW still returns `note`; this is a display-only gate. Backend removal is PLA-1211.
- **Feature flags:** none. `tx-notes` feature flag behaviour is unchanged.
- **Persistence / routes / migrations:** none.
- **Mobile:** not touched — no shared package changed; mobile is out of scope for this ticket.

## Risks / not checked

- Not tested on mobile (out of scope; the mobile hide-notes work is separate).
- Did not verify behaviour once CGW stops returning `note` (PLA-1211 is Blocked); this PR is resilient either way since it only hides an already-present field.
- Definition of "signer" is **direct owners only** — nested-Safe owners and proposers/delegates who authored a note will not see it back. This was an explicit product decision for this ticket.

## Visual summary

```mermaid
flowchart TD
    A[Transaction with note<br/>from CGW] --> B{useIsSafeOwner?}
    B -->|Yes signer| C[Render note]
    B -->|No / no wallet| D[Render nothing]

    subgraph Gated surfaces
      C1[TxNote details block]
      C2[TxSummary list-row preview]
      C3[tx-flow note slot]
    end

    C --> C1
    C --> C2
    C --> C3

    E[Note creation input] -.->|not gated<br/>proposers included| F[Always available]
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (N/A — web-only change)
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics change)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
