### PR TITLE
fix(web): change staking promo banner key so all users see the new banner

### DIFF
--- a/apps/web/src/features/stake/hooks/useIsStakingPromoBannerVisible.ts
+++ b/apps/web/src/features/stake/hooks/useIsStakingPromoBannerVisible.ts
@@ -3,7 +3,7 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import useBalances from '@/hooks/useBalances'
 import useIsStakingBannerEnabled from './useIsStakingBannerEnabled'
 
-export const STAKING_PROMO_BANNER_HIDE_KEY = 'hideStakingPromoBanner'
+export const STAKING_PROMO_BANNER_HIDE_KEY = 'hideStakingPromoBanner_v2'
 
 /**
  * Visibility for the staking promo banner.

--- a/apps/web/src/tests/pages/balances.test.tsx
+++ b/apps/web/src/tests/pages/balances.test.tsx
@@ -49,7 +49,7 @@ jest.mock('@/features/portfolio', () => ({
 jest.mock('@/features/stake', () => ({
   StakeFeature: {},
   useIsStakingPromoBannerVisible: () => false,
-  STAKING_PROMO_BANNER_HIDE_KEY: 'hideStakingPromoBanner',
+  STAKING_PROMO_BANNER_HIDE_KEY: 'hideStakingPromoBanner_v2',
 }))
 
 jest.mock('@/features/__core__', () => ({


### PR DESCRIPTION
## What it solves

The staking promo banner was updated to a **new** banner, but it reuses the same dismissal localStorage key (`hideStakingPromoBanner`). Any user who dismissed the *previous* banner already has that flag set to `true`, so they will never see the new banner.

## How this PR fixes it

Bumps the dismissal key from `hideStakingPromoBanner` → `hideStakingPromoBanner_v2`. Since the visibility hook now reads a fresh key, the previous "hidden" flag no longer applies and the new banner is shown again to everyone (still gated by the existing feature flag, deployed-Safe, and positive-balance conditions).

## How to test it

1. In a browser with `localStorage.setItem('hideStakingPromoBanner', 'true')` set (simulating a user who dismissed the old banner).
2. Load the balances/home page for an activated Safe with a positive fiat balance and the `STAKING_PROMO` flag enabled.
3. The new staking promo banner should now appear (previously it stayed hidden).
4. Dismiss it → `hideStakingPromoBanner_v2` is written and it stays hidden on reload.

## Affected flows

- Balances / home page — staking promo banner visibility on load and after dismissal.

## Blast radius

- `useIsStakingPromoBannerVisible` hook — reads the new key; consumed by the staking promo banner render path.
- `STAKING_PROMO_BANNER_HIDE_KEY` exported constant — only writer is `PromoButtons.tsx` (dismiss action); no hardcoded string consumers elsewhere.
- Persistence: existing `hideStakingPromoBanner` entries are effectively orphaned (harmless; no migration needed).
- No API, feature flag, route, or shared-package (mobile) changes.

## Risks / not checked

- Did not manually verify with the `STAKING_PROMO` feature flag disabled (unchanged gating logic).
- Did not test on mobile (change is web-only; the constant lives under `apps/web`).
- Orphaned old localStorage key is left in place intentionally — not cleaned up.

## Visual summary

```mermaid
flowchart LR
  A[useIsStakingPromoBannerVisible] --> B{reads localStorage}
  B -->|old key: hideStakingPromoBanner| C[was true for dismissers -> banner hidden]
  B -->|new key: hideStakingPromoBanner_v2| D[undefined -> banner shown again]
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (N/A — web-only)
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics change)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 (existing tests updated for new key)
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
