### PR TITLE
fix(e2e): make multichain tests more robust

### DIFF
--- a/apps/web/cypress/e2e/pages/dashboard.pages.js
+++ b/apps/web/cypress/e2e/pages/dashboard.pages.js
@@ -242,3 +242,12 @@ const differentSignersAcrossChainsMsg = 'different signers across different netw
 export function checkInconsistentSignersMsgDisplayed() {
   cy.contains(differentSignersAcrossChainsMsg, { timeout: 30000 }).should('be.visible')
 }
+
+/**
+ * Verifies the Safe is present in the current URL, i.e. the router query has hydrated.
+ * Use as a precondition before clicking actions that navigate using the `safe` query param.
+ * @param {string} safe - Prefixed safe address expected in the URL
+ */
+export function verifySafeInUrl(safe) {
+  cy.url().should('include', safe)
+}

--- a/apps/web/cypress/e2e/pages/network.pages.js
+++ b/apps/web/cypress/e2e/pages/network.pages.js
@@ -5,6 +5,7 @@ const addChainDialog = '[data-testid="add-chain-dialog"]'
 const addedNetwork = '[data-testid="added-network"]'
 const modalAddNetworkBtn = '[data-testid="modal-add-network-btn"]'
 const allNetworksAccordion = '[data-testid="all-networks-accordion"]'
+const allNetworksAccordionTrigger = '[data-testid="all-networks-accordion-trigger"]'
 const chainNavigationButton = '[data-testid="space-chain-navigation-button"]'
 const chainSelectorLoading = '[data-testid="chain-selector-loading"]'
 
@@ -17,8 +18,9 @@ export function clickChainNavigationButton() {
 }
 
 export function clickAllNetworksAccordion() {
-  cy.get(allNetworksAccordion).should('be.visible').click()
+  cy.get(allNetworksAccordion).should('be.visible')
   cy.get(chainSelectorLoading).should('not.exist')
+  cy.get(allNetworksAccordionTrigger).should('be.visible').click()
   cy.get(addNetworkBtn).should('be.visible')
 }
 

--- a/apps/web/cypress/e2e/regression/multichain_setup_new.cy.js
+++ b/apps/web/cypress/e2e/regression/multichain_setup_new.cy.js
@@ -76,6 +76,7 @@ describe('Multichain setup tests', { defaultCommandTimeout: 60000 }, () => {
     cy.visit(constants.homeUrl + staticSafes.MATIC_STATIC_SAFE_28)
     dashboard.expandActionRequiredPanel()
     dashboard.checkInconsistentSignersMsgDisplayed()
+    dashboard.verifySafeInUrl(staticSafes.MATIC_STATIC_SAFE_28)
     dashboard.clickActionInPanel(dashboard.reviewSignersTestId)
     cy.url().should('include', '/settings/setup').and('include', staticSafes.MATIC_STATIC_SAFE_28)
   })

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/AllNetworksSection.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/AllNetworksSection.tsx
@@ -84,7 +84,10 @@ function AllNetworksSection({ safeAddress, deployedChainIds, onAddNetwork }: All
   return (
     <Accordion defaultValue={[]} onValueChange={handleAccordionChange} data-testid="all-networks-accordion">
       <AccordionItem value="all-networks" className="border-0">
-        <AccordionTrigger className="rounded-lg pl-4 pr-2 py-2 hover:no-underline hover:bg-muted/30 text-muted-foreground cursor-pointer">
+        <AccordionTrigger
+          data-testid="all-networks-accordion-trigger"
+          className="rounded-lg pl-4 pr-2 py-2 hover:no-underline hover:bg-muted/30 text-muted-foreground cursor-pointer"
+        >
           <Typography variant="paragraph-small-medium" className="text-muted-foreground">
             All networks
           </Typography>


### PR DESCRIPTION
## What it solves

Hardening for multichain network tests:
- **"Add another network" flow** — `add-network-btn` never appeared because the page object clicked the Accordion root wrapper instead of the clickable trigger, so the accordion never expanded.
- **"Notification if the owner set up was changed"** — intermittent redirect to `/welcome/accounts`: the test clicked "Review signers" before the router query had hydrated, navigating with an empty `safe` param.

## How this PR fixes it

- Added `data-testid="all-networks-accordion-trigger"` on the `AccordionTrigger` and updated `clickAllNetworksAccordion()` to click the trigger (moving the loading check before the click).
- Added `dashboard.verifySafeInUrl()` as a precondition so the test waits until the `safe` param is in the URL (hydration done) before clicking "Review signers".

## How to test it

- Affected specs: `multichain_networkswitch.cy.js`, `multichain_network.cy.js` (accordion); `multichain_setup_new.cy.js` → Verify all these tests pass with `yarn cypress:open`

## Affected flows

- Multichain header network selector → "All networks" → add another network.
- Dashboard action-required panel → "Review signers" → Settings > Setup.

## Blast radius

- `AllNetworksSection.tsx`: added a `data-testid` only — no behavior change. Consumed via `ChainSelectorBlock`.
- `network.pages.js` `clickAllNetworksAccordion()`: shared by 3 specs, all covered.
- `dashboard.pages.js` `verifySafeInUrl()`: new helper, used by one test.


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
