### PR TITLE
feat(mobile): nonce editor for draft transactions + spender explorer link

### DIFF
--- a/apps/mobile/src/features/ConfirmTx/ConfirmTx.container.tsx
+++ b/apps/mobile/src/features/ConfirmTx/ConfirmTx.container.tsx
@@ -7,6 +7,7 @@ import { TransactionInfo } from './components/TransactionInfo'
 import { RouteProp, useRoute } from '@react-navigation/native'
 import { ConfirmationView } from './components/ConfirmationView'
 import { ApprovalEditor } from './components/ApprovalEditor'
+import { NonceEditor } from './components/NonceEditor'
 import { Loader } from '@/src/components/Loader'
 import { Alert } from '@/src/components/Alert'
 import { ConfirmTxForm } from './components/ConfirmTxForm'
@@ -107,6 +108,7 @@ function ConfirmTxContainer() {
               <>
                 <View paddingHorizontal="$4">
                   <ConfirmationView txDetails={txDetails} />
+                  <NonceEditor txId={txId} />
                   <ApprovalEditor txId={txId} />
                 </View>
 

--- a/apps/mobile/src/features/ConfirmTx/components/ApprovalEditor/ApprovalsList.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ApprovalEditor/ApprovalsList.tsx
@@ -53,7 +53,7 @@ const ApprovalItem = ({
         <Text color="$color" fontSize="$4">
           Spender
         </Text>
-        <HashDisplay value={approval.spender} textProps={{ color: '$textSecondaryLight' }} />
+        <HashDisplay value={approval.spender} showExternalLink textProps={{ color: '$textSecondaryLight' }} />
       </XStack>
 
       {onEdit && (

--- a/apps/mobile/src/features/ConfirmTx/components/ApprovalEditor/ApprovalsList.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ApprovalEditor/ApprovalsList.tsx
@@ -53,7 +53,7 @@ const ApprovalItem = ({
         <Text color="$color" fontSize="$4">
           Spender
         </Text>
-        <HashDisplay value={approval.spender} showExternalLink={false} textProps={{ color: '$textSecondaryLight' }} />
+        <HashDisplay value={approval.spender} textProps={{ color: '$textSecondaryLight' }} />
       </XStack>
 
       {onEdit && (

--- a/apps/mobile/src/features/ConfirmTx/components/NonceEditor/NonceEditor.test.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/NonceEditor/NonceEditor.test.tsx
@@ -39,14 +39,14 @@ const mockRebuildDraftWithNonce = rebuildDraftWithNonce as jest.MockedFunction<t
 const DRAFT_HASH = '0xdrafthash'
 const owners = [{ value: faker.finance.ethereumAddress(), name: null, logoUri: null }]
 
-const buildDraft = (): DraftTx => ({
+const buildDraft = (executionInfo?: object): DraftTx => ({
   chainId: '1',
   safeAddress: faker.finance.ethereumAddress(),
   buildParams: { to: faker.finance.ethereumAddress(), value: '0', data: '0x', nonce: 7 },
   safeTxHash: DRAFT_HASH,
   txDetails: {
     txId: DRAFT_HASH,
-    detailedExecutionInfo: { type: 'MULTISIG', signers: owners, confirmationsRequired: 1 },
+    detailedExecutionInfo: executionInfo ?? { type: 'MULTISIG', nonce: 7, signers: owners, confirmationsRequired: 1 },
   } as TransactionDetails,
 })
 
@@ -64,6 +64,16 @@ describe('NonceEditor', () => {
 
   it('renders nothing for a transaction without a draft', () => {
     const store = createTestStore({ draftTx: { drafts: {}, redirects: {} } })
+
+    const { queryByTestId } = renderWithStore(<NonceEditor txId={DRAFT_HASH} />, store)
+
+    expect(queryByTestId('nonce-row')).toBeNull()
+  })
+
+  it('renders nothing for a draft without multisig execution info', () => {
+    const store = createTestStore({
+      draftTx: { drafts: { [DRAFT_HASH]: buildDraft({ type: 'MODULE' }) }, redirects: {} },
+    })
 
     const { queryByTestId } = renderWithStore(<NonceEditor txId={DRAFT_HASH} />, store)
 
@@ -113,7 +123,15 @@ describe('NonceEditor', () => {
     fireEvent.press(getByTestId('nonce-row'))
     fireEvent.press(getByTestId('nonce-recommended'))
 
-    await waitFor(() => expect(queryByTestId('nonce-row-value')).toBeNull())
+    // Selecting dismisses the sheet, and the loader replaces the value while rebuilding
+    await waitFor(() => {
+      expect(queryByTestId('nonce-recommended')).toBeNull()
+      expect(queryByTestId('nonce-row-value')).toBeNull()
+    })
+
+    // The row is not pressable mid-rebuild — the sheet must not reopen
+    fireEvent.press(getByTestId('nonce-row'))
+    expect(queryByTestId('nonce-recommended')).toBeNull()
 
     await act(async () => resolveRebuild('0xnewhash'))
     await waitFor(() => expect(selectDraftRedirect(store.getState(), DRAFT_HASH)).toEqual('0xnewhash'))

--- a/apps/mobile/src/features/ConfirmTx/components/NonceEditor/NonceEditor.test.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/NonceEditor/NonceEditor.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react'
+import { faker } from '@faker-js/faker'
+import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { createTestStore, fireEvent, renderWithStore, waitFor } from '@/src/tests/test-utils'
+import { selectDraftByHash, selectDraftRedirect, type DraftTx } from '@/src/store/draftTxSlice'
+import { rebuildDraftWithNonce } from '@/src/services/tx/rebuildDraftWithNonce'
+import { NonceEditor } from './NonceEditor'
+
+jest.mock('@/src/services/tx/rebuildDraftWithNonce', () => ({
+  rebuildDraftWithNonce: jest.fn(),
+}))
+
+// The global @gorhom/bottom-sheet mock lacks useBottomSheet, which the shared backdrop needs
+jest.mock('@/src/components/Dropdown/sheetComponents', () => ({
+  BackdropComponent: () => null,
+  BackgroundComponent: () => null,
+}))
+
+jest.mock('@/src/features/Send/hooks/useNonce', () => ({
+  useNonce: jest.fn(() => ({
+    recommendedNonce: 10,
+    currentNonce: 5,
+    queuedNonces: [{ nonce: 7, label: 'Send transaction' }],
+    fetchMore: jest.fn(),
+    isFetchingMore: false,
+    isLoading: false,
+    hasMore: false,
+  })),
+}))
+
+const mockRebuildDraftWithNonce = rebuildDraftWithNonce as jest.MockedFunction<typeof rebuildDraftWithNonce>
+
+const DRAFT_HASH = '0xdrafthash'
+const owners = [{ value: faker.finance.ethereumAddress(), name: null, logoUri: null }]
+
+const buildDraft = (): DraftTx => ({
+  chainId: '1',
+  safeAddress: faker.finance.ethereumAddress(),
+  buildParams: { to: faker.finance.ethereumAddress(), value: '0', data: '0x', nonce: 7 },
+  safeTxHash: DRAFT_HASH,
+  txDetails: {
+    txId: DRAFT_HASH,
+    detailedExecutionInfo: { type: 'MULTISIG', signers: owners, confirmationsRequired: 1 },
+  } as TransactionDetails,
+})
+
+const createStoreWithDraft = () =>
+  createTestStore({
+    draftTx: { drafts: { [DRAFT_HASH]: buildDraft() }, redirects: {} },
+  })
+
+describe('NonceEditor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRebuildDraftWithNonce.mockResolvedValue('0xnewhash')
+  })
+
+  it('renders nothing for a transaction without a draft', () => {
+    const store = createTestStore({ draftTx: { drafts: {}, redirects: {} } })
+
+    const { queryByTestId } = renderWithStore(<NonceEditor txId={DRAFT_HASH} />, store)
+
+    expect(queryByTestId('nonce-row')).toBeNull()
+  })
+
+  it('shows the draft nonce', () => {
+    const { getByTestId } = renderWithStore(<NonceEditor txId={DRAFT_HASH} />, createStoreWithDraft())
+
+    expect(getByTestId('nonce-row-value')).toHaveTextContent('7')
+  })
+
+  it('rebuilds the draft and redirects to the new hash when another nonce is picked', async () => {
+    const store = createStoreWithDraft()
+    const { getByTestId } = renderWithStore(<NonceEditor txId={DRAFT_HASH} />, store)
+
+    fireEvent.press(getByTestId('nonce-row'))
+    fireEvent.press(getByTestId('nonce-recommended'))
+
+    await waitFor(() => {
+      expect(mockRebuildDraftWithNonce).toHaveBeenCalledWith(
+        expect.objectContaining({ newNonce: 10, safe: { owners, threshold: 1 } }),
+      )
+      expect(selectDraftRedirect(store.getState(), DRAFT_HASH)).toEqual('0xnewhash')
+      expect(selectDraftByHash(store.getState(), DRAFT_HASH)).toBeUndefined()
+    })
+  })
+
+  it('does not rebuild when the already selected nonce is picked again', async () => {
+    const store = createStoreWithDraft()
+    const { getByTestId } = renderWithStore(<NonceEditor txId={DRAFT_HASH} />, store)
+
+    fireEvent.press(getByTestId('nonce-row'))
+    fireEvent.press(getByTestId('nonce-queued-7'))
+
+    await waitFor(() => {
+      expect(mockRebuildDraftWithNonce).not.toHaveBeenCalled()
+      expect(selectDraftByHash(store.getState(), DRAFT_HASH)).toBeDefined()
+    })
+  })
+})

--- a/apps/mobile/src/features/ConfirmTx/components/NonceEditor/NonceEditor.test.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/NonceEditor/NonceEditor.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { faker } from '@faker-js/faker'
 import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
-import { createTestStore, fireEvent, renderWithStore, waitFor } from '@/src/tests/test-utils'
+import { act, createTestStore, fireEvent, renderWithStore, waitFor } from '@/src/tests/test-utils'
 import { selectDraftByHash, selectDraftRedirect, type DraftTx } from '@/src/store/draftTxSlice'
 import { rebuildDraftWithNonce } from '@/src/services/tx/rebuildDraftWithNonce'
 import { NonceEditor } from './NonceEditor'
@@ -16,17 +16,23 @@ jest.mock('@/src/components/Dropdown/sheetComponents', () => ({
   BackgroundComponent: () => null,
 }))
 
+const mockUseNonce = jest.fn()
 jest.mock('@/src/features/Send/hooks/useNonce', () => ({
-  useNonce: jest.fn(() => ({
-    recommendedNonce: 10,
-    currentNonce: 5,
-    queuedNonces: [{ nonce: 7, label: 'Send transaction' }],
-    fetchMore: jest.fn(),
-    isFetchingMore: false,
-    isLoading: false,
-    hasMore: false,
-  })),
+  useNonce: () => mockUseNonce(),
 }))
+
+const nonceQueryResult = {
+  recommendedNonce: 10,
+  currentNonce: 5,
+  queuedNonces: [
+    { nonce: 7, label: 'Send transaction' },
+    { nonce: 8, label: 'Swap transaction' },
+  ],
+  fetchMore: jest.fn(),
+  isFetchingMore: false,
+  isLoading: false,
+  hasMore: false,
+}
 
 const mockRebuildDraftWithNonce = rebuildDraftWithNonce as jest.MockedFunction<typeof rebuildDraftWithNonce>
 
@@ -52,6 +58,7 @@ const createStoreWithDraft = () =>
 describe('NonceEditor', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockUseNonce.mockReturnValue(nonceQueryResult)
     mockRebuildDraftWithNonce.mockResolvedValue('0xnewhash')
   })
 
@@ -83,6 +90,43 @@ describe('NonceEditor', () => {
       expect(selectDraftRedirect(store.getState(), DRAFT_HASH)).toEqual('0xnewhash')
       expect(selectDraftByHash(store.getState(), DRAFT_HASH)).toBeUndefined()
     })
+  })
+
+  it('rebuilds the draft when a queued nonce is picked', async () => {
+    const store = createStoreWithDraft()
+    const { getByTestId } = renderWithStore(<NonceEditor txId={DRAFT_HASH} />, store)
+
+    fireEvent.press(getByTestId('nonce-row'))
+    fireEvent.press(getByTestId('nonce-queued-8'))
+
+    await waitFor(() => {
+      expect(mockRebuildDraftWithNonce).toHaveBeenCalledWith(expect.objectContaining({ newNonce: 8 }))
+    })
+  })
+
+  it('hides the nonce value behind a loader while the rebuild is in flight', async () => {
+    let resolveRebuild: (hash: string) => void = () => undefined
+    mockRebuildDraftWithNonce.mockImplementation(() => new Promise((resolve) => (resolveRebuild = resolve)))
+    const store = createStoreWithDraft()
+    const { getByTestId, queryByTestId } = renderWithStore(<NonceEditor txId={DRAFT_HASH} />, store)
+
+    fireEvent.press(getByTestId('nonce-row'))
+    fireEvent.press(getByTestId('nonce-recommended'))
+
+    await waitFor(() => expect(queryByTestId('nonce-row-value')).toBeNull())
+
+    await act(async () => resolveRebuild('0xnewhash'))
+    await waitFor(() => expect(selectDraftRedirect(store.getState(), DRAFT_HASH)).toEqual('0xnewhash'))
+  })
+
+  it('does not open the sheet before the current nonce has loaded', () => {
+    mockUseNonce.mockReturnValue({ ...nonceQueryResult, currentNonce: undefined })
+    const { getByTestId, queryByTestId } = renderWithStore(<NonceEditor txId={DRAFT_HASH} />, createStoreWithDraft())
+
+    fireEvent.press(getByTestId('nonce-row'))
+
+    expect(queryByTestId('nonce-recommended')).toBeNull()
+    expect(mockRebuildDraftWithNonce).not.toHaveBeenCalled()
   })
 
   it('does not rebuild when the already selected nonce is picked again', async () => {

--- a/apps/mobile/src/features/ConfirmTx/components/NonceEditor/NonceEditor.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/NonceEditor/NonceEditor.tsx
@@ -22,6 +22,8 @@ export const NonceEditor = ({ txId }: { txId: string }) => {
 
 const DraftNonceRow = ({ draft }: { draft: DraftTx }) => {
   const nonce = useDraftNonceEdit(draft)
+  // Without currentNonce the custom-nonce modal cannot validate its lower bound
+  const canEdit = !nonce.isRebuilding && nonce.currentNonce !== undefined
 
   return (
     <>
@@ -42,7 +44,7 @@ const DraftNonceRow = ({ draft }: { draft: DraftTx }) => {
               )}
             </View>
           }
-          onPress={nonce.isRebuilding ? undefined : nonce.handleOpenNonceSheet}
+          onPress={canEdit ? nonce.handleOpenNonceSheet : undefined}
           testID="nonce-row"
         />
       </View>

--- a/apps/mobile/src/features/ConfirmTx/components/NonceEditor/NonceEditor.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/NonceEditor/NonceEditor.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { View } from 'tamagui'
+import { Text, View } from 'tamagui'
 import { SafeListItem } from '@/src/components/SafeListItem'
-import { Badge } from '@/src/components/Badge'
 import { Loader } from '@/src/components/Loader'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { useAppSelector } from '@/src/store/hooks'
@@ -30,18 +29,14 @@ const DraftNonceRow = ({ draft }: { draft: DraftTx }) => {
         <SafeListItem
           label="Nonce"
           rightNode={
-            <View flexDirection="row" alignItems="center" gap="$2">
+            <View flexDirection="row" alignItems="center" gap="$4">
               {nonce.isRebuilding ? (
                 <Loader size={16} color="$color" />
               ) : (
                 <>
-                  <Badge
-                    themeName="badge_background_inverted"
-                    content={String(nonce.draftNonce)}
-                    circleSize="$6"
-                    circular={false}
-                    testID="nonce-row-value"
-                  />
+                  <Text fontSize="$4" lineHeight={20} color="$color" testID="nonce-row-value">
+                    {nonce.draftNonce}
+                  </Text>
                   <SafeFontIcon name="chevron-right" />
                 </>
               )}

--- a/apps/mobile/src/features/ConfirmTx/components/NonceEditor/NonceEditor.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/NonceEditor/NonceEditor.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import { Text, View } from 'tamagui'
+import type { MultisigExecutionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { SafeListItem } from '@/src/components/SafeListItem'
 import { Loader } from '@/src/components/Loader'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { useAppSelector } from '@/src/store/hooks'
 import { selectDraftByHash, type DraftTx } from '@/src/store/draftTxSlice'
+import { isMultisigDetailedExecutionInfo } from '@/src/utils/transaction-guards'
 import { NonceBottomSheet } from '@/src/features/Send/components/NonceBottomSheet'
 import { CustomNonceModal } from '@/src/features/Send/components/CustomNonceModal'
 import { useDraftNonceEdit } from './useDraftNonceEdit'
@@ -12,16 +14,17 @@ import { useDraftNonceEdit } from './useDraftNonceEdit'
 /** Editable nonce row for draft transactions; proposed txs have a fixed nonce and render nothing */
 export const NonceEditor = ({ txId }: { txId: string }) => {
   const draft = useAppSelector((state) => selectDraftByHash(state, txId))
+  const executionInfo = draft?.txDetails.detailedExecutionInfo
 
-  if (!draft) {
+  if (!draft || !isMultisigDetailedExecutionInfo(executionInfo)) {
     return null
   }
 
-  return <DraftNonceRow draft={draft} />
+  return <DraftNonceRow draft={draft} executionInfo={executionInfo} />
 }
 
-const DraftNonceRow = ({ draft }: { draft: DraftTx }) => {
-  const nonce = useDraftNonceEdit(draft)
+const DraftNonceRow = ({ draft, executionInfo }: { draft: DraftTx; executionInfo: MultisigExecutionDetails }) => {
+  const nonce = useDraftNonceEdit(draft, executionInfo)
   // Without currentNonce the custom-nonce modal cannot validate its lower bound
   const canEdit = !nonce.isRebuilding && nonce.currentNonce !== undefined
 
@@ -60,13 +63,15 @@ const DraftNonceRow = ({ draft }: { draft: DraftTx }) => {
         isFetchingMore={nonce.isFetchingMore}
       />
 
-      <CustomNonceModal
-        visible={nonce.showCustomNonceModal}
-        defaultNonce={String(nonce.draftNonce)}
-        currentNonce={nonce.currentNonce ?? 0}
-        onSave={nonce.handleSaveCustomNonce}
-        onCancel={nonce.handleCancelCustomNonce}
-      />
+      {nonce.currentNonce !== undefined && (
+        <CustomNonceModal
+          visible={nonce.showCustomNonceModal}
+          defaultNonce={String(nonce.draftNonce)}
+          currentNonce={nonce.currentNonce}
+          onSave={nonce.handleSaveCustomNonce}
+          onCancel={nonce.handleCancelCustomNonce}
+        />
+      )}
     </>
   )
 }

--- a/apps/mobile/src/features/ConfirmTx/components/NonceEditor/NonceEditor.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/NonceEditor/NonceEditor.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { View } from 'tamagui'
+import { SafeListItem } from '@/src/components/SafeListItem'
+import { Badge } from '@/src/components/Badge'
+import { Loader } from '@/src/components/Loader'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+import { useAppSelector } from '@/src/store/hooks'
+import { selectDraftByHash, type DraftTx } from '@/src/store/draftTxSlice'
+import { NonceBottomSheet } from '@/src/features/Send/components/NonceBottomSheet'
+import { CustomNonceModal } from '@/src/features/Send/components/CustomNonceModal'
+import { useDraftNonceEdit } from './useDraftNonceEdit'
+
+/** Editable nonce row for draft transactions; proposed txs have a fixed nonce and render nothing */
+export const NonceEditor = ({ txId }: { txId: string }) => {
+  const draft = useAppSelector((state) => selectDraftByHash(state, txId))
+
+  if (!draft) {
+    return null
+  }
+
+  return <DraftNonceRow draft={draft} />
+}
+
+const DraftNonceRow = ({ draft }: { draft: DraftTx }) => {
+  const nonce = useDraftNonceEdit(draft)
+
+  return (
+    <>
+      <View marginTop="$4">
+        <SafeListItem
+          label="Nonce"
+          rightNode={
+            <View flexDirection="row" alignItems="center" gap="$2">
+              {nonce.isRebuilding ? (
+                <Loader size={16} color="$color" />
+              ) : (
+                <>
+                  <Badge
+                    themeName="badge_background_inverted"
+                    content={String(nonce.draftNonce)}
+                    circleSize="$6"
+                    circular={false}
+                    testID="nonce-row-value"
+                  />
+                  <SafeFontIcon name="chevron-right" />
+                </>
+              )}
+            </View>
+          }
+          onPress={nonce.isRebuilding ? undefined : nonce.handleOpenNonceSheet}
+          testID="nonce-row"
+        />
+      </View>
+
+      <NonceBottomSheet
+        ref={nonce.nonceSheetRef}
+        recommendedNonce={nonce.recommendedNonce}
+        queuedNonces={nonce.queuedNonces}
+        selectedNonce={nonce.draftNonce}
+        onSelectNonce={nonce.handleSelectNonce}
+        onAddCustomNonce={nonce.handleAddCustomNonce}
+        onEndReached={nonce.fetchMore}
+        isFetchingMore={nonce.isFetchingMore}
+      />
+
+      <CustomNonceModal
+        visible={nonce.showCustomNonceModal}
+        defaultNonce={String(nonce.draftNonce)}
+        currentNonce={nonce.currentNonce ?? 0}
+        onSave={nonce.handleSaveCustomNonce}
+        onCancel={nonce.handleCancelCustomNonce}
+      />
+    </>
+  )
+}

--- a/apps/mobile/src/features/ConfirmTx/components/NonceEditor/index.ts
+++ b/apps/mobile/src/features/ConfirmTx/components/NonceEditor/index.ts
@@ -1,0 +1,1 @@
+export { NonceEditor } from './NonceEditor'

--- a/apps/mobile/src/features/ConfirmTx/components/NonceEditor/useDraftNonceEdit.test.ts
+++ b/apps/mobile/src/features/ConfirmTx/components/NonceEditor/useDraftNonceEdit.test.ts
@@ -66,6 +66,22 @@ describe('useDraftNonceEdit', () => {
     })
   })
 
+  it('opens the custom nonce modal after the sheet dismiss delay, collapsing rapid taps', () => {
+    jest.useFakeTimers()
+    try {
+      const { result } = renderDraftNonceEdit()
+
+      act(() => result.current.handleAddCustomNonce())
+      act(() => result.current.handleAddCustomNonce())
+      expect(result.current.showCustomNonceModal).toBe(false)
+
+      act(() => jest.advanceTimersByTime(300))
+      expect(result.current.showCustomNonceModal).toBe(true)
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
   it('shows an error toast and keeps the draft when the rebuild fails', async () => {
     mockRebuildDraftWithNonce.mockRejectedValue(new Error('preview failed'))
     const { result, store } = renderDraftNonceEdit()

--- a/apps/mobile/src/features/ConfirmTx/components/NonceEditor/useDraftNonceEdit.test.ts
+++ b/apps/mobile/src/features/ConfirmTx/components/NonceEditor/useDraftNonceEdit.test.ts
@@ -1,5 +1,8 @@
 import { faker } from '@faker-js/faker'
-import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import type {
+  MultisigExecutionDetails,
+  TransactionDetails,
+} from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { act, createTestStore, renderHookWithStore, waitFor } from '@/src/tests/test-utils'
 import { selectDraftByHash, selectDraftRedirect, type DraftTx } from '@/src/store/draftTxSlice'
 import { selectToastQueue } from '@/src/store/toastSlice'
@@ -26,23 +29,26 @@ const mockRebuildDraftWithNonce = rebuildDraftWithNonce as jest.MockedFunction<t
 
 const DRAFT_HASH = '0xdrafthash'
 const owners = [{ value: faker.finance.ethereumAddress(), name: null, logoUri: null }]
+const executionInfo = {
+  type: 'MULTISIG',
+  nonce: 7,
+  signers: owners,
+  confirmationsRequired: 1,
+} as unknown as MultisigExecutionDetails
 
 const buildDraft = (): DraftTx => ({
   chainId: '1',
   safeAddress: faker.finance.ethereumAddress(),
   buildParams: { to: faker.finance.ethereumAddress(), value: '0', data: '0x', nonce: 7 },
   safeTxHash: DRAFT_HASH,
-  txDetails: {
-    txId: DRAFT_HASH,
-    detailedExecutionInfo: { type: 'MULTISIG', signers: owners, confirmationsRequired: 1 },
-  } as TransactionDetails,
+  txDetails: { txId: DRAFT_HASH, detailedExecutionInfo: executionInfo } as TransactionDetails,
 })
 
 const renderDraftNonceEdit = () => {
   const store = createTestStore({
     draftTx: { drafts: { [DRAFT_HASH]: buildDraft() }, redirects: {} },
   })
-  return renderHookWithStore(() => useDraftNonceEdit(buildDraft()), store)
+  return renderHookWithStore(() => useDraftNonceEdit(buildDraft(), executionInfo), store)
 }
 
 describe('useDraftNonceEdit', () => {

--- a/apps/mobile/src/features/ConfirmTx/components/NonceEditor/useDraftNonceEdit.test.ts
+++ b/apps/mobile/src/features/ConfirmTx/components/NonceEditor/useDraftNonceEdit.test.ts
@@ -1,4 +1,5 @@
 import { faker } from '@faker-js/faker'
+import type { BottomSheetModal } from '@gorhom/bottom-sheet'
 import type {
   MultisigExecutionDetails,
   TransactionDetails,
@@ -72,13 +73,16 @@ describe('useDraftNonceEdit', () => {
     })
   })
 
-  it('opens the custom nonce modal after the sheet dismiss delay, collapsing rapid taps', () => {
+  it('dismisses the sheet before opening the custom nonce modal, collapsing rapid taps', () => {
     jest.useFakeTimers()
     try {
       const { result } = renderDraftNonceEdit()
+      const dismiss = jest.fn()
+      result.current.nonceSheetRef.current = { dismiss } as unknown as BottomSheetModal
 
       act(() => result.current.handleAddCustomNonce())
       act(() => result.current.handleAddCustomNonce())
+      expect(dismiss).toHaveBeenCalledTimes(2)
       expect(result.current.showCustomNonceModal).toBe(false)
 
       act(() => jest.advanceTimersByTime(300))

--- a/apps/mobile/src/features/ConfirmTx/components/NonceEditor/useDraftNonceEdit.test.ts
+++ b/apps/mobile/src/features/ConfirmTx/components/NonceEditor/useDraftNonceEdit.test.ts
@@ -1,0 +1,84 @@
+import { faker } from '@faker-js/faker'
+import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { act, createTestStore, renderHookWithStore, waitFor } from '@/src/tests/test-utils'
+import { selectDraftByHash, selectDraftRedirect, type DraftTx } from '@/src/store/draftTxSlice'
+import { selectToastQueue } from '@/src/store/toastSlice'
+import { rebuildDraftWithNonce } from '@/src/services/tx/rebuildDraftWithNonce'
+import { useDraftNonceEdit } from './useDraftNonceEdit'
+
+jest.mock('@/src/services/tx/rebuildDraftWithNonce', () => ({
+  rebuildDraftWithNonce: jest.fn(),
+}))
+
+jest.mock('@/src/features/Send/hooks/useNonce', () => ({
+  useNonce: jest.fn(() => ({
+    recommendedNonce: 10,
+    currentNonce: 5,
+    queuedNonces: [],
+    fetchMore: jest.fn(),
+    isFetchingMore: false,
+    isLoading: false,
+    hasMore: false,
+  })),
+}))
+
+const mockRebuildDraftWithNonce = rebuildDraftWithNonce as jest.MockedFunction<typeof rebuildDraftWithNonce>
+
+const DRAFT_HASH = '0xdrafthash'
+const owners = [{ value: faker.finance.ethereumAddress(), name: null, logoUri: null }]
+
+const buildDraft = (): DraftTx => ({
+  chainId: '1',
+  safeAddress: faker.finance.ethereumAddress(),
+  buildParams: { to: faker.finance.ethereumAddress(), value: '0', data: '0x', nonce: 7 },
+  safeTxHash: DRAFT_HASH,
+  txDetails: {
+    txId: DRAFT_HASH,
+    detailedExecutionInfo: { type: 'MULTISIG', signers: owners, confirmationsRequired: 1 },
+  } as TransactionDetails,
+})
+
+const renderDraftNonceEdit = () => {
+  const store = createTestStore({
+    draftTx: { drafts: { [DRAFT_HASH]: buildDraft() }, redirects: {} },
+  })
+  return renderHookWithStore(() => useDraftNonceEdit(buildDraft()), store)
+}
+
+describe('useDraftNonceEdit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRebuildDraftWithNonce.mockResolvedValue('0xnewhash')
+  })
+
+  it('rebuilds the draft when a custom nonce is saved and closes the modal', async () => {
+    const { result, store } = renderDraftNonceEdit()
+
+    act(() => result.current.handleSaveCustomNonce(42))
+
+    expect(result.current.showCustomNonceModal).toBe(false)
+    await waitFor(() => {
+      expect(mockRebuildDraftWithNonce).toHaveBeenCalledWith(
+        expect.objectContaining({ newNonce: 42, safe: { owners, threshold: 1 } }),
+      )
+      expect(selectDraftRedirect(store.getState(), DRAFT_HASH)).toEqual('0xnewhash')
+      expect(result.current.isRebuilding).toBe(false)
+    })
+  })
+
+  it('shows an error toast and keeps the draft when the rebuild fails', async () => {
+    mockRebuildDraftWithNonce.mockRejectedValue(new Error('preview failed'))
+    const { result, store } = renderDraftNonceEdit()
+
+    act(() => result.current.handleSelectNonce(10))
+
+    await waitFor(() => {
+      expect(selectToastQueue(store.getState())).toEqual([
+        expect.objectContaining({ message: 'Failed to update the nonce', variant: 'error' }),
+      ])
+      expect(result.current.isRebuilding).toBe(false)
+    })
+    expect(selectDraftByHash(store.getState(), DRAFT_HASH)).toBeDefined()
+    expect(selectDraftRedirect(store.getState(), DRAFT_HASH)).toBeUndefined()
+  })
+})

--- a/apps/mobile/src/features/ConfirmTx/components/NonceEditor/useDraftNonceEdit.ts
+++ b/apps/mobile/src/features/ConfirmTx/components/NonceEditor/useDraftNonceEdit.ts
@@ -1,16 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { BottomSheetModal } from '@gorhom/bottom-sheet'
+import type { MultisigExecutionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { useAppDispatch } from '@/src/store/hooks'
 import { showToast } from '@/src/store/toastSlice'
 import type { DraftTx } from '@/src/store/draftTxSlice'
 import { redirectDraft } from '@/src/services/tx/draft'
 import { rebuildDraftWithNonce } from '@/src/services/tx/rebuildDraftWithNonce'
 import { useNonce } from '@/src/features/Send/hooks/useNonce'
-import { isMultisigDetailedExecutionInfo } from '@/src/utils/transaction-guards'
 import Logger from '@/src/utils/logger'
 
 /** Picking a different nonce rebuilds the draft under its new safeTxHash; the screen follows the redirect */
-export function useDraftNonceEdit(draft: DraftTx) {
+export function useDraftNonceEdit(draft: DraftTx, executionInfo: MultisigExecutionDetails) {
   const dispatch = useAppDispatch()
   const nonceSheetRef = useRef<BottomSheetModal>(null)
   const [showCustomNonceModal, setShowCustomNonceModal] = useState(false)
@@ -21,7 +21,7 @@ export function useDraftNonceEdit(draft: DraftTx) {
     draft.safeAddress,
   )
 
-  const draftNonce = Number(draft.buildParams.nonce ?? 0)
+  const draftNonce = executionInfo.nonce
 
   const applyNonce = useCallback(
     async (nonce: number) => {
@@ -30,10 +30,6 @@ export function useDraftNonceEdit(draft: DraftTx) {
       }
       setIsRebuilding(true)
       try {
-        const executionInfo = draft.txDetails.detailedExecutionInfo
-        if (!isMultisigDetailedExecutionInfo(executionInfo)) {
-          throw new Error('Draft transaction has no multisig execution info')
-        }
         const safe = { owners: executionInfo.signers, threshold: executionInfo.confirmationsRequired }
         const newSafeTxHash = await rebuildDraftWithNonce({ draft, newNonce: nonce, safe, dispatch })
         redirectDraft(dispatch, draft.safeTxHash, newSafeTxHash)
@@ -44,7 +40,7 @@ export function useDraftNonceEdit(draft: DraftTx) {
         setIsRebuilding(false)
       }
     },
-    [draft, draftNonce, dispatch],
+    [draft, draftNonce, executionInfo, dispatch],
   )
 
   const handleOpenNonceSheet = useCallback(() => {

--- a/apps/mobile/src/features/ConfirmTx/components/NonceEditor/useDraftNonceEdit.ts
+++ b/apps/mobile/src/features/ConfirmTx/components/NonceEditor/useDraftNonceEdit.ts
@@ -23,6 +23,7 @@ export function useDraftNonceEdit(draft: DraftTx, executionInfo: MultisigExecuti
 
   const draftNonce = executionInfo.nonce
 
+  // Intentionally closes over the pre-rebuild draft: its safeTxHash is the redirect source key
   const applyNonce = useCallback(
     async (nonce: number) => {
       if (nonce === draftNonce) {

--- a/apps/mobile/src/features/ConfirmTx/components/NonceEditor/useDraftNonceEdit.ts
+++ b/apps/mobile/src/features/ConfirmTx/components/NonceEditor/useDraftNonceEdit.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { BottomSheetModal } from '@gorhom/bottom-sheet'
 import { useAppDispatch } from '@/src/store/hooks'
 import { showToast } from '@/src/store/toastSlice'
@@ -21,8 +21,7 @@ export function useDraftNonceEdit(draft: DraftTx) {
     draft.safeAddress,
   )
 
-  const draftNonce =
-    typeof draft.buildParams.nonce === 'number' ? draft.buildParams.nonce : Number(draft.buildParams.nonce ?? 0)
+  const draftNonce = Number(draft.buildParams.nonce ?? 0)
 
   const applyNonce = useCallback(
     async (nonce: number) => {
@@ -60,10 +59,14 @@ export function useDraftNonceEdit(draft: DraftTx) {
     [applyNonce],
   )
 
+  const customNonceTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  useEffect(() => () => clearTimeout(customNonceTimer.current), [])
+
   const handleAddCustomNonce = useCallback(() => {
     nonceSheetRef.current?.dismiss()
     // Let the sheet's dismiss animation finish before the modal takes over
-    setTimeout(() => setShowCustomNonceModal(true), 300)
+    clearTimeout(customNonceTimer.current)
+    customNonceTimer.current = setTimeout(() => setShowCustomNonceModal(true), 300)
   }, [])
 
   const handleSaveCustomNonce = useCallback(

--- a/apps/mobile/src/features/ConfirmTx/components/NonceEditor/useDraftNonceEdit.ts
+++ b/apps/mobile/src/features/ConfirmTx/components/NonceEditor/useDraftNonceEdit.ts
@@ -1,0 +1,95 @@
+import { useCallback, useRef, useState } from 'react'
+import { BottomSheetModal } from '@gorhom/bottom-sheet'
+import { useAppDispatch } from '@/src/store/hooks'
+import { showToast } from '@/src/store/toastSlice'
+import type { DraftTx } from '@/src/store/draftTxSlice'
+import { redirectDraft } from '@/src/services/tx/draft'
+import { rebuildDraftWithNonce } from '@/src/services/tx/rebuildDraftWithNonce'
+import { useNonce } from '@/src/features/Send/hooks/useNonce'
+import { isMultisigDetailedExecutionInfo } from '@/src/utils/transaction-guards'
+import Logger from '@/src/utils/logger'
+
+/** Picking a different nonce rebuilds the draft under its new safeTxHash; the screen follows the redirect */
+export function useDraftNonceEdit(draft: DraftTx) {
+  const dispatch = useAppDispatch()
+  const nonceSheetRef = useRef<BottomSheetModal>(null)
+  const [showCustomNonceModal, setShowCustomNonceModal] = useState(false)
+  const [isRebuilding, setIsRebuilding] = useState(false)
+
+  const { recommendedNonce, currentNonce, queuedNonces, fetchMore, isFetchingMore } = useNonce(
+    draft.chainId,
+    draft.safeAddress,
+  )
+
+  const draftNonce =
+    typeof draft.buildParams.nonce === 'number' ? draft.buildParams.nonce : Number(draft.buildParams.nonce ?? 0)
+
+  const applyNonce = useCallback(
+    async (nonce: number) => {
+      if (nonce === draftNonce) {
+        return
+      }
+      setIsRebuilding(true)
+      try {
+        const executionInfo = draft.txDetails.detailedExecutionInfo
+        if (!isMultisigDetailedExecutionInfo(executionInfo)) {
+          throw new Error('Draft transaction has no multisig execution info')
+        }
+        const safe = { owners: executionInfo.signers, threshold: executionInfo.confirmationsRequired }
+        const newSafeTxHash = await rebuildDraftWithNonce({ draft, newNonce: nonce, safe, dispatch })
+        redirectDraft(dispatch, draft.safeTxHash, newSafeTxHash)
+      } catch (error) {
+        Logger.error('rebuildDraftWithNonce failed', error)
+        dispatch(showToast({ message: 'Failed to update the nonce', duration: 3000, variant: 'error' }))
+      } finally {
+        setIsRebuilding(false)
+      }
+    },
+    [draft, draftNonce, dispatch],
+  )
+
+  const handleOpenNonceSheet = useCallback(() => {
+    nonceSheetRef.current?.present()
+  }, [])
+
+  const handleSelectNonce = useCallback(
+    (nonce: number) => {
+      nonceSheetRef.current?.dismiss()
+      void applyNonce(nonce)
+    },
+    [applyNonce],
+  )
+
+  const handleAddCustomNonce = useCallback(() => {
+    nonceSheetRef.current?.dismiss()
+    // Let the sheet's dismiss animation finish before the modal takes over
+    setTimeout(() => setShowCustomNonceModal(true), 300)
+  }, [])
+
+  const handleSaveCustomNonce = useCallback(
+    (nonce: number) => {
+      setShowCustomNonceModal(false)
+      void applyNonce(nonce)
+    },
+    [applyNonce],
+  )
+
+  const handleCancelCustomNonce = useCallback(() => setShowCustomNonceModal(false), [])
+
+  return {
+    nonceSheetRef,
+    draftNonce,
+    recommendedNonce,
+    currentNonce,
+    queuedNonces,
+    fetchMore,
+    isFetchingMore,
+    isRebuilding,
+    showCustomNonceModal,
+    handleOpenNonceSheet,
+    handleSelectNonce,
+    handleAddCustomNonce,
+    handleSaveCustomNonce,
+    handleCancelCustomNonce,
+  }
+}

--- a/apps/mobile/src/features/EditApprovalSheet/components/EditApprovalForm.tsx
+++ b/apps/mobile/src/features/EditApprovalSheet/components/EditApprovalForm.tsx
@@ -221,7 +221,7 @@ export const EditApprovalFields = ({ approval }: { approval: ApprovalInfo & { ba
           <Text fontSize="$4" fontWeight={500} color="$color">
             Spender
           </Text>
-          <HashDisplay value={approval.spender} textProps={{ color: '$color' }} />
+          <HashDisplay value={approval.spender} showExternalLink textProps={{ color: '$color' }} />
         </XStack>
       </YStack>
     </View>

--- a/apps/mobile/src/features/EditApprovalSheet/components/EditApprovalForm.tsx
+++ b/apps/mobile/src/features/EditApprovalSheet/components/EditApprovalForm.tsx
@@ -226,7 +226,7 @@ export const EditApprovalFields = ({ approval }: { approval: ApprovalInfo & { ba
           <Text fontSize="$4" fontWeight={500} color="$color">
             Spender
           </Text>
-          <HashDisplay value={approval.spender} showExternalLink={false} textProps={{ color: '$color' }} />
+          <HashDisplay value={approval.spender} textProps={{ color: '$color' }} />
         </XStack>
       </YStack>
     </View>

--- a/apps/mobile/src/features/EditApprovalSheet/components/EditApprovalForm.tsx
+++ b/apps/mobile/src/features/EditApprovalSheet/components/EditApprovalForm.tsx
@@ -12,9 +12,9 @@ import { validateAmount, validateDecimalLength } from '@safe-global/utils/utils/
 import { formatVisualAmount } from '@safe-global/utils/utils/formatters'
 import { useAppDispatch } from '@/src/store/hooks'
 import { showToast } from '@/src/store/toastSlice'
-import { clearDraft, setDraftRedirect, type DraftTx } from '@/src/store/draftTxSlice'
-import { rekeyOutstandingRequest } from '@/src/features/WalletConnect/Wallet/store/walletKitSlice'
+import { type DraftTx } from '@/src/store/draftTxSlice'
 import { rebuildDraftWithApproval } from '@/src/services/tx/rebuildDraftWithApproval'
+import { redirectDraft } from '@/src/services/tx/draft'
 import { SafeInput } from '@/src/components/SafeInput'
 import { TokenIcon } from '@/src/components/TokenIcon/TokenIcon'
 import { SafeButton } from '@/src/components/SafeButton'
@@ -71,12 +71,7 @@ export const useEditApprovalForm = ({ draft, approval, safe }: EditApprovalFormA
       const newValue = unlimited ? PSEUDO_APPROVAL_VALUES.UNLIMITED : amount
       const newSafeTxHash = await rebuildDraftWithApproval({ draft, approval, newValue, safe, dispatch })
 
-      if (newSafeTxHash !== draft.safeTxHash) {
-        // Hand everything keyed by the old hash over to the new draft before dropping it
-        dispatch(rekeyOutstandingRequest({ fromSafeTxHash: draft.safeTxHash, toSafeTxHash: newSafeTxHash }))
-        dispatch(setDraftRedirect({ fromSafeTxHash: draft.safeTxHash, toSafeTxHash: newSafeTxHash }))
-        dispatch(clearDraft(draft.safeTxHash))
-      }
+      redirectDraft(dispatch, draft.safeTxHash, newSafeTxHash)
       // If the sheet was dismissed mid-rebuild, a second back() would pop the confirm screen
       if (navigation.isFocused()) {
         router.back()

--- a/apps/mobile/src/services/tx/draft.test.ts
+++ b/apps/mobile/src/services/tx/draft.test.ts
@@ -1,0 +1,61 @@
+import { faker } from '@faker-js/faker'
+import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { createTestStore } from '@/src/tests/test-utils'
+import { selectDraftByHash, selectDraftRedirect, type DraftTx } from '@/src/store/draftTxSlice'
+import { selectOutstandingRequestByHash } from '@/src/features/WalletConnect/Wallet/store/walletKitSlice'
+import { redirectDraft } from './draft'
+
+const buildDraft = (safeTxHash: string): DraftTx => ({
+  chainId: '1',
+  safeAddress: faker.finance.ethereumAddress(),
+  buildParams: { to: faker.finance.ethereumAddress(), value: '0', data: '0x', nonce: 7 },
+  safeTxHash,
+  txDetails: { txId: safeTxHash } as TransactionDetails,
+})
+
+const outstandingRequest = {
+  topic: 'topic',
+  id: 1,
+  method: 'eth_sendTransaction' as const,
+  chainId: '1',
+  safeAddress: faker.finance.ethereumAddress(),
+}
+
+const walletKitState = (outstandingRequests: Record<string, typeof outstandingRequest>) => ({
+  sessions: {},
+  verifyByTopic: {},
+  pending: [],
+  outstandingRequests,
+  _persist: { version: -1, rehydrated: true },
+})
+
+describe('redirectDraft', () => {
+  it('rekeys the WC request, records the redirect and drops the old draft', () => {
+    const store = createTestStore({
+      draftTx: { drafts: { '0xold': buildDraft('0xold'), '0xnew': buildDraft('0xnew') }, redirects: {} },
+      walletKit: walletKitState({ '0xold': outstandingRequest }),
+    })
+
+    redirectDraft(store.dispatch, '0xold', '0xnew')
+
+    const state = store.getState()
+    expect(selectDraftByHash(state, '0xold')).toBeUndefined()
+    expect(selectDraftRedirect(state, '0xold')).toEqual('0xnew')
+    expect(selectOutstandingRequestByHash(state, '0xold')).toBeUndefined()
+    expect(selectOutstandingRequestByHash(state, '0xnew')).toEqual(outstandingRequest)
+  })
+
+  it('is a no-op when the rebuild produced the same hash', () => {
+    const store = createTestStore({
+      draftTx: { drafts: { '0xsame': buildDraft('0xsame') }, redirects: {} },
+      walletKit: walletKitState({ '0xsame': outstandingRequest }),
+    })
+
+    redirectDraft(store.dispatch, '0xsame', '0xsame')
+
+    const state = store.getState()
+    expect(selectDraftByHash(state, '0xsame')).toBeDefined()
+    expect(selectDraftRedirect(state, '0xsame')).toBeUndefined()
+    expect(selectOutstandingRequestByHash(state, '0xsame')).toEqual(outstandingRequest)
+  })
+})

--- a/apps/mobile/src/services/tx/draft.ts
+++ b/apps/mobile/src/services/tx/draft.ts
@@ -2,7 +2,8 @@ import { cgwApi, type Operation } from '@safe-global/store/gateway/AUTO_GENERATE
 import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import type { SafeTransaction } from '@safe-global/types-kit'
 import { getSafeSDK } from '@/src/hooks/coreSDK/safeCoreSDK'
-import { setDraft, type DraftTx } from '@/src/store/draftTxSlice'
+import { clearDraft, setDraft, setDraftRedirect, type DraftTx } from '@/src/store/draftTxSlice'
+import { rekeyOutstandingRequest } from '@/src/features/WalletConnect/Wallet/store/walletKitSlice'
 import { synthesizeDraftTxDetails } from '@/src/features/ConfirmTx/utils/synthesizeDraftTxDetails'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
 import type { AppDispatch } from '@/src/store'
@@ -95,4 +96,14 @@ export const previewAndStashDraft = async ({
   dispatch(setDraft(draft))
 
   return safeTxHash
+}
+
+/** After a rebuild: hands everything keyed by the old hash over to the new draft and drops the old entry */
+export const redirectDraft = (dispatch: AppDispatch, fromSafeTxHash: string, toSafeTxHash: string): void => {
+  if (fromSafeTxHash === toSafeTxHash) {
+    return
+  }
+  dispatch(rekeyOutstandingRequest({ fromSafeTxHash, toSafeTxHash }))
+  dispatch(setDraftRedirect({ fromSafeTxHash, toSafeTxHash }))
+  dispatch(clearDraft(fromSafeTxHash))
 }

--- a/apps/mobile/src/services/tx/draft.ts
+++ b/apps/mobile/src/services/tx/draft.ts
@@ -82,6 +82,7 @@ export const previewAndStashDraft = async ({
       preview: previewResult.data,
     })
   } finally {
+    // Safe to release the cache subscription immediately: the result was consumed above
     previewPromise.reset()
   }
 

--- a/apps/mobile/src/services/tx/rebuildDraftWithNonce.test.ts
+++ b/apps/mobile/src/services/tx/rebuildDraftWithNonce.test.ts
@@ -1,0 +1,88 @@
+import { faker } from '@faker-js/faker'
+import { OperationType } from '@safe-global/types-kit'
+import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import type { DraftTx } from '@/src/store/draftTxSlice'
+import type { AppDispatch } from '@/src/store'
+import { getVerifiedSafeSDK, previewAndStashDraft } from './draft'
+import { rebuildDraftWithNonce } from './rebuildDraftWithNonce'
+
+jest.mock('./draft', () => ({
+  getVerifiedSafeSDK: jest.fn(),
+  previewAndStashDraft: jest.fn(),
+}))
+
+const mockGetVerifiedSafeSDK = getVerifiedSafeSDK as jest.MockedFunction<typeof getVerifiedSafeSDK>
+const mockPreviewAndStashDraft = previewAndStashDraft as jest.MockedFunction<typeof previewAndStashDraft>
+
+const safe = { owners: [], threshold: 1 }
+const dispatch = jest.fn() as unknown as AppDispatch
+
+const buildDraft = (buildParams: Partial<DraftTx['buildParams']>): DraftTx => ({
+  chainId: '1',
+  safeAddress: faker.finance.ethereumAddress(),
+  buildParams: { to: faker.finance.ethereumAddress(), value: '0', data: '0x', nonce: 7, ...buildParams },
+  safeTxHash: '0xoldhash',
+  txDetails: { txId: '0xoldhash' } as TransactionDetails,
+})
+
+describe('rebuildDraftWithNonce', () => {
+  const createTransaction = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    createTransaction.mockResolvedValue({ data: {} })
+    mockGetVerifiedSafeSDK.mockResolvedValue({ createTransaction } as unknown as Awaited<
+      ReturnType<typeof getVerifiedSafeSDK>
+    >)
+    mockPreviewAndStashDraft.mockResolvedValue('0xnewhash')
+  })
+
+  it('recreates the transaction with the new nonce and untouched calldata', async () => {
+    const draft = buildDraft({ data: '0xdeadbeef', value: '123' })
+
+    const result = await rebuildDraftWithNonce({ draft, newNonce: 42, safe, dispatch })
+
+    expect(result).toEqual('0xnewhash')
+    expect(createTransaction).toHaveBeenCalledWith({
+      transactions: [
+        {
+          to: draft.buildParams.to,
+          value: '123',
+          data: '0xdeadbeef',
+          operation: OperationType.Call,
+        },
+      ],
+      options: { nonce: 42 },
+    })
+    expect(mockPreviewAndStashDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ chainId: draft.chainId, safeAddress: draft.safeAddress, safe, dispatch }),
+    )
+  })
+
+  it('preserves a delegate call operation of an encoded multiSend', async () => {
+    const draft = buildDraft({ operation: OperationType.DelegateCall })
+
+    await rebuildDraftWithNonce({ draft, newNonce: 8, safe, dispatch })
+
+    const { transactions } = createTransaction.mock.calls[0][0]
+    expect(transactions[0].operation).toEqual(OperationType.DelegateCall)
+  })
+
+  it('defaults missing value and data', async () => {
+    const draft = buildDraft({ value: undefined, data: undefined })
+
+    await rebuildDraftWithNonce({ draft, newNonce: 8, safe, dispatch })
+
+    const { transactions } = createTransaction.mock.calls[0][0]
+    expect(transactions[0]).toEqual(expect.objectContaining({ value: '0', data: '0x' }))
+  })
+
+  it('throws when the draft has no target', async () => {
+    const draft = buildDraft({ to: undefined })
+
+    await expect(rebuildDraftWithNonce({ draft, newNonce: 8, safe, dispatch })).rejects.toThrow(
+      'Draft transaction has no target to rebuild',
+    )
+    expect(mockPreviewAndStashDraft).not.toHaveBeenCalled()
+  })
+})

--- a/apps/mobile/src/services/tx/rebuildDraftWithNonce.ts
+++ b/apps/mobile/src/services/tx/rebuildDraftWithNonce.ts
@@ -1,0 +1,51 @@
+import { OperationType, type MetaTransactionData } from '@safe-global/types-kit'
+import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import type { DraftTx } from '@/src/store/draftTxSlice'
+import type { AppDispatch } from '@/src/store'
+import { getVerifiedSafeSDK, previewAndStashDraft } from './draft'
+
+export type RebuildDraftWithNonceArgs = {
+  draft: DraftTx
+  newNonce: number
+  safe: Pick<SafeState, 'owners' | 'threshold'>
+  dispatch: AppDispatch
+}
+
+/**
+ * Re-hashes the draft SafeTransaction under a new nonce and re-runs the draft pipeline,
+ * returning the new safeTxHash. A single MetaTransactionData passes through
+ * createTransaction as-is, so an encoded multiSend keeps its delegate call operation.
+ */
+export const rebuildDraftWithNonce = async ({
+  draft,
+  newNonce,
+  safe,
+  dispatch,
+}: RebuildDraftWithNonceArgs): Promise<string> => {
+  const { to, value, data, operation } = draft.buildParams
+  if (!to) {
+    throw new Error('Draft transaction has no target to rebuild')
+  }
+
+  const transaction: MetaTransactionData = {
+    to,
+    value: value ?? '0',
+    data: data ?? '0x',
+    operation: operation ?? OperationType.Call,
+  }
+
+  const safeSDK = await getVerifiedSafeSDK(draft.chainId)
+  const safeTx = await safeSDK.createTransaction({
+    transactions: [transaction],
+    options: { nonce: newNonce },
+  })
+
+  return previewAndStashDraft({
+    safeSDK,
+    safeTx,
+    chainId: draft.chainId,
+    safeAddress: draft.safeAddress,
+    safe,
+    dispatch,
+  })
+}


### PR DESCRIPTION
## What it solves

Resolves: [WA-2858](https://linear.app/safe-global/issue/WA-2858/tx-triggered-by-dapps-dont-have-the-option-to-change-the-nonce)

Draft transactions (Send / WalletConnect) could not have their nonce changed on the confirmation screen. Also enables opening the approval spender on the block explorer.

## How this PR fixes it

- Adds a tappable **Nonce row** (styled like `ActionsRow`) to the confirm screen, shown only for drafts. It opens the Send flow's existing `NonceBottomSheet` / `CustomNonceModal`.
- Picking a different nonce runs the new `rebuildDraftWithNonce` service: same calldata, new nonce → new safeTxHash via the shared `previewAndStashDraft` pipeline. The screen follows the draft redirect and updates automatically.
- Extracts the post-rebuild rekey sequence (WC request, redirect, clear old draft) from `EditApprovalForm` into a shared `redirectDraft` helper, now used by both edit flows.
- Enables `HashDisplay`'s external-link button on the spender address in the approval card and edit sheet.

## How to test it

1. Trigger a dApp transaction via WalletConnect (or start a Send) to land on the confirm screen with a draft.
2. Tap the Nonce row → pick a queued/recommended nonce, or "Add new nonce" for a custom one.
3. The row and tx details update under the new nonce; signing proposes with it.
4. Re-picking the current nonce is a no-op; proposed (non-draft) txs show no nonce row.

## Video

https://github.com/user-attachments/assets/96a05fa6-1df8-4ea6-b375-904dd933a0e0

https://github.com/user-attachments/assets/7db59220-8179-419c-8f8a-61ab6ec62a3f

## Affected flows

- Reviewing a draft transaction on the confirm screen (nonce now editable)
- Edit approval amount (refactored to `redirectDraft`, behavior unchanged)
- Approval editor: spender address now links to the block explorer

## Blast radius

- `services/tx/draft.ts` — shared draft pipeline; `redirectDraft` consumed by approval + nonce edit flows
- Reused Send components (`NonceBottomSheet`, `CustomNonceModal`, `useNonce`) — imported only, unmodified
- WC outstanding requests are rekeyed on nonce change so dApps still get their response
- Draft confirm screens now fetch nonces + queue up front (two extra CGW requests)

## Risks / not checked

- Sheet present/dismiss animation timing not verified on device (gorhom + `FullWindowOverlay`)
- Ledger/hardware signing after a nonce edit not exercised (same path as approval edit)

## Visual summary

```mermaid
flowchart LR
  A[Nonce row on confirm screen] -->|tap| B[NonceBottomSheet / CustomNonceModal]
  B -->|pick nonce| C[rebuildDraftWithNonce]
  C -->|same calldata, new nonce| D[previewAndStashDraft → new safeTxHash]
  D --> E[redirectDraft: rekey WC request, redirect, drop old draft]
  E --> F[Confirm screen follows redirect & re-renders]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics changes
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
