### PR TITLE
fix(web): update staking promo banner copy

### DIFF
--- a/apps/web/src/features/stake/components/StakingPromoBanner/index.test.tsx
+++ b/apps/web/src/features/stake/components/StakingPromoBanner/index.test.tsx
@@ -21,8 +21,8 @@ describe('StakingPromoBanner', () => {
   it('renders the title, description, learn more link and CTA', () => {
     render(<StakingPromoBanner onDismiss={jest.fn()} />, { routerProps: { query: { safe: SAFE } } })
 
-    expect(screen.getByText('SAFE staking is now live')).toBeInTheDocument()
-    expect(screen.getByText(/Stake SAFE tokens now and get rewards on deposit/i)).toBeInTheDocument()
+    expect(screen.getByText('Stake SAFE tokens and earn up to ~15% APR')).toBeInTheDocument()
+    expect(screen.getByText(/Earn by staking your SAFE tokens, currently rewarded up to 15%/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Stake now' })).toBeInTheDocument()
 
     const learnMore = screen.getByRole('link', { name: 'Learn more' })

--- a/apps/web/src/features/stake/components/StakingPromoBanner/index.tsx
+++ b/apps/web/src/features/stake/components/StakingPromoBanner/index.tsx
@@ -28,10 +28,10 @@ const StakingPromoBanner = ({ onDismiss }: { onDismiss: () => void }) => {
   return (
     <div className={css.stakingPromoBanner}>
       <PromoBanner
-        title="SAFE staking is now live"
+        title="Stake SAFE tokens and earn up to ~15% APR"
         description={
           <>
-            Stake SAFE tokens now and get rewards on deposit.{' '}
+            Earn by staking your SAFE tokens, currently rewarded up to 15%.{' '}
             <Link
               href={LEARN_MORE_LINK}
               target="_blank"


### PR DESCRIPTION
## What it solves

Updates the copy on the SAFE staking promo banner to highlight the APR and rewards more directly.

## How this PR fixes it

Changes the `StakingPromoBanner` title and description:

- **Title:** `SAFE staking is now live` → `Stake SAFE tokens and earn up to ~15% APR`
- **Description:** `Stake SAFE tokens now and get rewards on deposit.` → `Earn by staking your SAFE tokens, currently rewarded up to 15%.`

Copy follows the repo's sentence-case UI convention (kept `SAFE` and `APR` capitalized). The "Learn more" link and CTA are unchanged. Colocated test assertions updated to match.

## How to test it

1. Trigger the staking promo banner (dashboard / balances view for an eligible Safe).
2. Confirm the new title and description render.
3. Confirm the "Learn more" link and "Stake now" CTA still work.

## Affected flows

- Staking promo banner display (dashboard / balances overview)

## Blast radius

- `StakingPromoBanner` component copy only — no logic, props, hooks, selectors, or tracking events changed.
- No shared hooks / RTK Query endpoints / feature flags / routes touched.
- No mobile / shared-package impact.

## Risks / not checked

- Text-only change; did not exercise the banner visibility logic (`useIsStakingPromoBannerVisible`) as it is untouched.
- Did not test on mobile (web-only component).

## Visual summary

```mermaid
flowchart LR
  A[StakingPromoBanner] --> B["Title: Stake SAFE tokens and earn up to ~15% APR"]
  A --> C["Description: Earn by staking your SAFE tokens, currently rewarded up to 15%"]
  A --> D[Learn more link + Stake now CTA — unchanged]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics change
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — updated colocated test assertions
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

🤖 Generated with [Claude Code](https://claude.com/claude-code)
