### PR TITLE
chore(mobile): bump version to 1.0.15

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -31,7 +31,7 @@ const config: ExpoConfig = {
   name: name,
   slug: 'safe-mobileapp',
   owner: 'safeglobal',
-  version: '1.0.14',
+  version: '1.0.15',
   extra: {
     storybookEnabled: process.env.STORYBOOK_ENABLED,
     eas: {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@safe-global/mobile",
   "main": "index.js",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "doctor": {
     "reactNativeDirectoryCheck": {
       "enabled": true


### PR DESCRIPTION
## What it solves

Resolves: mobile release v1.0.15 preparation.

## How this PR fixes it

Bumps the mobile app version from `1.0.14` to `1.0.15` in `apps/mobile/package.json` and `apps/mobile/app.config.ts`. The Expo production build is triggered from this branch (`mobile-release/v1.0.15`).

## How to test it

Verify both files show `1.0.15` and the Expo build from this branch reports the same version.

## Affected flows

- None at runtime — version metadata only.

## Blast radius

- App version shown in stores, TestFlight, and the in-app settings/about screen.
- No shared code, hooks, or endpoints touched.

## Risks / not checked

- Store builds and submission are verified via the Expo/TestFlight/Play Console release flow, not in this PR.

## Visual summary

```mermaid
flowchart LR
  A[dev] --> B[mobile-release/v1.0.15]
  B --> C[Bump version in package.json + app.config.ts]
  C --> D[Expo production build → App Store & Play Store]
  D --> E[Merge back to dev with --no-ff]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics changes
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — version bump only, not applicable
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
