### PR TITLE
fix(web): point staking promo banner to native SAFE staking app

### DIFF
--- a/apps/web/src/components/common/Header/Topbar/SafenetStakingButton.tsx
+++ b/apps/web/src/components/common/Header/Topbar/SafenetStakingButton.tsx
@@ -1,24 +1,18 @@
-import { useState } from 'react'
 import { Loader2 } from 'lucide-react'
-import { useRouter, useSearchParams } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
-import { AppRoutes } from '@/config/routes'
-import { SAFE_TOKEN_ADDRESSES, SafeAppsTag } from '@/config/constants'
+import { SAFE_TOKEN_ADDRESSES } from '@/config/constants'
 import useBalances from '@/hooks/useBalances'
 import useChainId from '@/hooks/useChainId'
+import { useOpenSafenetStakingApp } from '@/hooks/useOpenSafenetStakingApp'
 import { formatVisualAmount } from '@safe-global/utils/utils/formatters'
 import SafeTokenIcon from '@/public/images/common/safe-token.svg'
-import { useLazySafeAppsGetSafeAppsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/safe-apps'
 
 const SafenetStakingButton = () => {
-  const query = useSearchParams()
   const chainId = useChainId()
-  const router = useRouter()
   const { balances, loading } = useBalances()
-  const [triggerSafeApps] = useLazySafeAppsGetSafeAppsV1Query()
-  const [navigating, setNavigating] = useState(false)
+  const { openSafenetStakingApp, isNavigating } = useOpenSafenetStakingApp()
 
   const safeTokenAddress = SAFE_TOKEN_ADDRESSES[chainId]
   const safeTokenItem = balances.items.find(
@@ -28,21 +22,6 @@ const SafenetStakingButton = () => {
     ? formatVisualAmount(safeTokenItem.balance, safeTokenItem.tokenInfo.decimals, 0)
     : '0'
 
-  const handleClick = async () => {
-    setNavigating(true)
-    try {
-      const [apps] = await Promise.all([
-        triggerSafeApps({ chainId, clientUrl: window.location.origin }),
-        new Promise((resolve) => setTimeout(resolve, 1000)),
-      ])
-      const safenetApp = apps.data?.find((app) => app.tags.includes(SafeAppsTag.SAFENET))
-      if (!safenetApp) return
-      router.push(`${AppRoutes.apps.open}?safe=${query?.get('safe')}&appUrl=${encodeURIComponent(safenetApp.url)}`)
-    } finally {
-      setNavigating(false)
-    }
-  }
-
   return (
     <Tooltip>
       <div className="flex self-stretch items-stretch rounded-lg bg-card shadow-[0px_4px_20px_0px_rgba(0,0,0,0.03)]">
@@ -51,14 +30,14 @@ const SafenetStakingButton = () => {
             <Button
               variant="ghost"
               size="sm"
-              onClick={handleClick}
-              disabled={navigating}
+              onClick={openSafenetStakingApp}
+              disabled={isNavigating}
               className="cursor-pointer gap-1.5 rounded-lg bg-transparent hover:bg-muted/30 transition-colors m-1"
               aria-label="Safenet staking"
             />
           }
         >
-          {navigating ? <Loader2 className="size-5 animate-spin" /> : <SafeTokenIcon width={20} height={20} />}
+          {isNavigating ? <Loader2 className="size-5 animate-spin" /> : <SafeTokenIcon width={20} height={20} />}
           {loading ? (
             <Skeleton className="h-3 w-6" />
           ) : (

--- a/apps/web/src/components/common/SafenetStakingWidget/index.tsx
+++ b/apps/web/src/components/common/SafenetStakingWidget/index.tsx
@@ -1,23 +1,16 @@
-import { useState } from 'react'
-import { AppRoutes } from '@/config/routes'
-import { SAFE_TOKEN_ADDRESSES, SafeAppsTag } from '@/config/constants'
+import { SAFE_TOKEN_ADDRESSES } from '@/config/constants'
 import useBalances from '@/hooks/useBalances'
 import useChainId from '@/hooks/useChainId'
+import { useOpenSafenetStakingApp } from '@/hooks/useOpenSafenetStakingApp'
 import { formatVisualAmount } from '@safe-global/utils/utils/formatters'
 import { Box, ButtonBase, CircularProgress, Skeleton, Tooltip, Typography } from '@mui/material'
-import { useRouter } from 'next/navigation'
-import { useSearchParams } from 'next/navigation'
 import SafeTokenIcon from '@/public/images/common/safe-token.svg'
 import css from './styles.module.css'
-import { useLazySafeAppsGetSafeAppsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/safe-apps'
 
 const SafenetStakingWidget = () => {
-  const query = useSearchParams()
   const chainId = useChainId()
-  const router = useRouter()
   const { balances, loading } = useBalances()
-  const [triggerSafeApps] = useLazySafeAppsGetSafeAppsV1Query()
-  const [navigating, setNavigating] = useState(false)
+  const { openSafenetStakingApp, isNavigating } = useOpenSafenetStakingApp()
 
   const safeTokenAddress = SAFE_TOKEN_ADDRESSES[chainId]
   const safeTokenItem = balances.items.find(
@@ -27,21 +20,6 @@ const SafenetStakingWidget = () => {
     ? formatVisualAmount(safeTokenItem.balance, safeTokenItem.tokenInfo.decimals, 0)
     : '0'
 
-  const handleClick = async () => {
-    setNavigating(true)
-    try {
-      const [apps] = await Promise.all([
-        triggerSafeApps({ chainId, clientUrl: window.location.origin }),
-        new Promise((resolve) => setTimeout(resolve, 1000)),
-      ])
-      const safenetApp = apps.data?.find((app) => app.tags.includes(SafeAppsTag.SAFENET))
-      if (!safenetApp) return
-      router.push(`${AppRoutes.apps.open}?safe=${query?.get('safe')}&appUrl=${encodeURIComponent(safenetApp.url)}`)
-    } finally {
-      setNavigating(false)
-    }
-  }
-
   return (
     <Box className={css.container}>
       <Tooltip title="Go to Safenet Staking">
@@ -49,10 +27,10 @@ const SafenetStakingWidget = () => {
           <ButtonBase
             aria-label="Safenet Staking"
             className={css.tokenButton}
-            onClick={handleClick}
-            disabled={navigating}
+            onClick={openSafenetStakingApp}
+            disabled={isNavigating}
           >
-            {navigating ? <CircularProgress size={16} color="inherit" /> : <SafeTokenIcon width={24} height={24} />}
+            {isNavigating ? <CircularProgress size={16} color="inherit" /> : <SafeTokenIcon width={24} height={24} />}
             <Typography component="div" variant="body2" lineHeight={1}>
               {loading ? <Skeleton width="16px" animation="wave" /> : safeBalance}
             </Typography>

--- a/apps/web/src/features/stake/components/StakingPromoBanner/index.test.tsx
+++ b/apps/web/src/features/stake/components/StakingPromoBanner/index.test.tsx
@@ -1,13 +1,21 @@
 import { render, screen, fireEvent } from '@/tests/test-utils'
 import StakingPromoBanner from './index'
 import { OVERVIEW_EVENTS } from '@/services/analytics'
-import { AppRoutes } from '@/config/routes'
 
 jest.mock('@/services/analytics', () => ({
   ...jest.requireActual('@/services/analytics'),
   trackEvent: jest.fn(),
 }))
 import { trackEvent } from '@/services/analytics'
+
+const mockOpenSafenetStakingApp = jest.fn()
+let mockIsNavigating = false
+jest.mock('@/hooks/useOpenSafenetStakingApp', () => ({
+  useOpenSafenetStakingApp: () => ({
+    openSafenetStakingApp: mockOpenSafenetStakingApp,
+    isNavigating: mockIsNavigating,
+  }),
+}))
 
 const mockTrackEvent = trackEvent as jest.MockedFunction<typeof trackEvent>
 
@@ -16,6 +24,7 @@ const SAFE = 'eth:0x0000000000000000000000000000000000000001'
 describe('StakingPromoBanner', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockIsNavigating = false
   })
 
   it('renders the title, description, learn more link and CTA', () => {
@@ -39,14 +48,22 @@ describe('StakingPromoBanner', () => {
     expect(mockTrackEvent).toHaveBeenCalledWith(OVERVIEW_EVENTS.SHOW_STAKING_BANNER)
   })
 
-  it('navigates to the staking route and tracks the CTA click', () => {
-    const push = jest.fn(() => Promise.resolve(true))
-    render(<StakingPromoBanner onDismiss={jest.fn()} />, { routerProps: { push, query: { safe: SAFE } } })
+  it('opens the native SAFE staking app and tracks the CTA click', () => {
+    render(<StakingPromoBanner onDismiss={jest.fn()} />, { routerProps: { query: { safe: SAFE } } })
 
     fireEvent.click(screen.getByRole('button', { name: 'Stake now' }))
 
-    expect(push).toHaveBeenCalledWith({ pathname: AppRoutes.stake, query: { safe: SAFE } })
+    expect(mockOpenSafenetStakingApp).toHaveBeenCalled()
     expect(mockTrackEvent.mock.calls.some((call) => call[0] === OVERVIEW_EVENTS.OPEN_STAKING_WIDGET)).toBe(true)
+  })
+
+  it('shows a spinner in the CTA while navigating to the staking app', () => {
+    mockIsNavigating = true
+    render(<StakingPromoBanner onDismiss={jest.fn()} />, { routerProps: { query: { safe: SAFE } } })
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+    // The CTA stays enabled and visible while loading (re-clicks are guarded inside the hook)
+    expect(screen.getByRole('button', { name: 'Stake now' })).toBeEnabled()
   })
 
   it('tracks the learn more click', () => {

--- a/apps/web/src/features/stake/components/StakingPromoBanner/index.tsx
+++ b/apps/web/src/features/stake/components/StakingPromoBanner/index.tsx
@@ -1,9 +1,8 @@
 import { useEffect } from 'react'
-import { useRouter } from 'next/router'
-import { Link } from '@mui/material'
+import { CircularProgress, Link } from '@mui/material'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import PromoBanner from '@/components/common/PromoBanner/PromoBanner'
-import { AppRoutes } from '@/config/routes'
+import { useOpenSafenetStakingApp } from '@/hooks/useOpenSafenetStakingApp'
 import { OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
 import css from './styles.module.css'
 
@@ -11,14 +10,14 @@ const LEARN_MORE_LINK =
   'https://forum.safefoundation.org/t/sep-55-phase-2-fund-safenet-beta-for-safe-token-utility/6967'
 
 const StakingPromoBanner = ({ onDismiss }: { onDismiss: () => void }) => {
-  const router = useRouter()
+  const { openSafenetStakingApp, isNavigating } = useOpenSafenetStakingApp()
 
   useEffect(() => {
     trackEvent(OVERVIEW_EVENTS.SHOW_STAKING_BANNER)
   }, [])
 
   const onStake = () => {
-    router.push({ pathname: AppRoutes.stake, query: { safe: router.query.safe } })
+    openSafenetStakingApp()
   }
 
   const onLearnMore = () => {
@@ -46,7 +45,7 @@ const StakingPromoBanner = ({ onDismiss }: { onDismiss: () => void }) => {
         ctaLabel="Stake now"
         onCtaClick={onStake}
         ctaVariant="text"
-        endIcon={<ArrowForwardIcon fontSize="small" />}
+        endIcon={isNavigating ? <CircularProgress size={16} color="inherit" /> : <ArrowForwardIcon fontSize="small" />}
         imageSrc="/images/common/staking-promo/safe-coin.svg"
         imageAlt="Safe token"
         trackingEvents={OVERVIEW_EVENTS.OPEN_STAKING_WIDGET}

--- a/apps/web/src/hooks/useOpenSafenetStakingApp.test.ts
+++ b/apps/web/src/hooks/useOpenSafenetStakingApp.test.ts
@@ -1,0 +1,86 @@
+import { act } from '@testing-library/react'
+import { renderHook } from '@/tests/test-utils'
+import { useOpenSafenetStakingApp } from './useOpenSafenetStakingApp'
+import { AppRoutes } from '@/config/routes'
+import { SafeAppsTag } from '@/config/constants'
+
+const mockPush = jest.fn()
+const SAFE = 'eth:0x0000000000000000000000000000000000000001'
+const SAFENET_APP_URL = 'https://safenet.staking.example/app'
+
+jest.mock('@/hooks/useChainId', () => ({
+  __esModule: true,
+  default: () => '1',
+}))
+
+const mockTriggerSafeApps = jest.fn()
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/safe-apps', () => ({
+  useLazySafeAppsGetSafeAppsV1Query: () => [mockTriggerSafeApps],
+}))
+
+describe('useOpenSafenetStakingApp', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    jest.spyOn(require('next/navigation'), 'useRouter').mockReturnValue({ push: mockPush })
+    jest.spyOn(require('next/navigation'), 'useSearchParams').mockReturnValue(new URLSearchParams({ safe: SAFE }))
+  })
+
+  it('opens the Safenet-tagged app in the app frame', async () => {
+    mockTriggerSafeApps.mockResolvedValue({
+      data: [
+        { url: 'https://other.example', tags: ['other'] },
+        { url: SAFENET_APP_URL, tags: [SafeAppsTag.SAFENET] },
+      ],
+    })
+
+    const { result } = renderHook(() => useOpenSafenetStakingApp())
+
+    await act(async () => {
+      await result.current.openSafenetStakingApp()
+    })
+
+    expect(mockPush).toHaveBeenCalledWith(
+      `${AppRoutes.apps.open}?safe=${SAFE}&appUrl=${encodeURIComponent(SAFENET_APP_URL)}`,
+    )
+  })
+
+  it('does not navigate when no Safenet app is available', async () => {
+    mockTriggerSafeApps.mockResolvedValue({ data: [{ url: 'https://other.example', tags: ['other'] }] })
+
+    const { result } = renderHook(() => useOpenSafenetStakingApp())
+
+    await act(async () => {
+      await result.current.openSafenetStakingApp()
+    })
+
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+
+  it('ignores concurrent calls while a navigation is already in flight', async () => {
+    mockTriggerSafeApps.mockResolvedValue({ data: [{ url: SAFENET_APP_URL, tags: [SafeAppsTag.SAFENET] }] })
+
+    const { result } = renderHook(() => useOpenSafenetStakingApp())
+
+    await act(async () => {
+      await Promise.all([result.current.openSafenetStakingApp(), result.current.openSafenetStakingApp()])
+    })
+
+    expect(mockTriggerSafeApps).toHaveBeenCalledTimes(1)
+    expect(mockPush).toHaveBeenCalledTimes(1)
+  })
+
+  it('resets the navigating flag after completion', async () => {
+    mockTriggerSafeApps.mockResolvedValue({ data: [{ url: SAFENET_APP_URL, tags: [SafeAppsTag.SAFENET] }] })
+
+    const { result } = renderHook(() => useOpenSafenetStakingApp())
+
+    expect(result.current.isNavigating).toBe(false)
+
+    await act(async () => {
+      await result.current.openSafenetStakingApp()
+    })
+
+    expect(result.current.isNavigating).toBe(false)
+  })
+})

--- a/apps/web/src/hooks/useOpenSafenetStakingApp.test.ts
+++ b/apps/web/src/hooks/useOpenSafenetStakingApp.test.ts
@@ -13,10 +13,23 @@ jest.mock('@/hooks/useChainId', () => ({
   default: () => '1',
 }))
 
+const mockLogError = jest.fn()
+jest.mock('@/services/exceptions', () => ({
+  logError: (...args: unknown[]) => mockLogError(...args),
+}))
+
 const mockTriggerSafeApps = jest.fn()
 jest.mock('@safe-global/store/gateway/AUTO_GENERATED/safe-apps', () => ({
   useLazySafeAppsGetSafeAppsV1Query: () => [mockTriggerSafeApps],
 }))
+
+type SafeApp = { url: string; tags: string[] }
+
+const mockSafeAppsResolve = (apps: SafeApp[]) =>
+  mockTriggerSafeApps.mockReturnValue({ unwrap: () => Promise.resolve(apps) })
+
+const mockSafeAppsReject = (error: Error) =>
+  mockTriggerSafeApps.mockReturnValue({ unwrap: () => Promise.reject(error) })
 
 describe('useOpenSafenetStakingApp', () => {
   beforeEach(() => {
@@ -27,12 +40,10 @@ describe('useOpenSafenetStakingApp', () => {
   })
 
   it('opens the Safenet-tagged app in the app frame', async () => {
-    mockTriggerSafeApps.mockResolvedValue({
-      data: [
-        { url: 'https://other.example', tags: ['other'] },
-        { url: SAFENET_APP_URL, tags: [SafeAppsTag.SAFENET] },
-      ],
-    })
+    mockSafeAppsResolve([
+      { url: 'https://other.example', tags: ['other'] },
+      { url: SAFENET_APP_URL, tags: [SafeAppsTag.SAFENET] },
+    ])
 
     const { result } = renderHook(() => useOpenSafenetStakingApp())
 
@@ -46,7 +57,7 @@ describe('useOpenSafenetStakingApp', () => {
   })
 
   it('does not navigate when no Safenet app is available', async () => {
-    mockTriggerSafeApps.mockResolvedValue({ data: [{ url: 'https://other.example', tags: ['other'] }] })
+    mockSafeAppsResolve([{ url: 'https://other.example', tags: ['other'] }])
 
     const { result } = renderHook(() => useOpenSafenetStakingApp())
 
@@ -57,8 +68,24 @@ describe('useOpenSafenetStakingApp', () => {
     expect(mockPush).not.toHaveBeenCalled()
   })
 
+  it('logs the error and does not navigate when the CGW call fails', async () => {
+    const error = new Error('network error')
+    mockSafeAppsReject(error)
+
+    const { result } = renderHook(() => useOpenSafenetStakingApp())
+
+    await act(async () => {
+      await result.current.openSafenetStakingApp()
+    })
+
+    expect(mockLogError).toHaveBeenCalledWith(expect.anything(), error)
+    expect(mockPush).not.toHaveBeenCalled()
+    // The button recovers so it can be retried
+    expect(result.current.isNavigating).toBe(false)
+  })
+
   it('ignores concurrent calls while a navigation is already in flight', async () => {
-    mockTriggerSafeApps.mockResolvedValue({ data: [{ url: SAFENET_APP_URL, tags: [SafeAppsTag.SAFENET] }] })
+    mockSafeAppsResolve([{ url: SAFENET_APP_URL, tags: [SafeAppsTag.SAFENET] }])
 
     const { result } = renderHook(() => useOpenSafenetStakingApp())
 
@@ -71,7 +98,7 @@ describe('useOpenSafenetStakingApp', () => {
   })
 
   it('resets the navigating flag after completion', async () => {
-    mockTriggerSafeApps.mockResolvedValue({ data: [{ url: SAFENET_APP_URL, tags: [SafeAppsTag.SAFENET] }] })
+    mockSafeAppsResolve([{ url: SAFENET_APP_URL, tags: [SafeAppsTag.SAFENET] }])
 
     const { result } = renderHook(() => useOpenSafenetStakingApp())
 

--- a/apps/web/src/hooks/useOpenSafenetStakingApp.ts
+++ b/apps/web/src/hooks/useOpenSafenetStakingApp.ts
@@ -3,6 +3,8 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { AppRoutes } from '@/config/routes'
 import { SafeAppsTag } from '@/config/constants'
 import useChainId from '@/hooks/useChainId'
+import { logError } from '@/services/exceptions'
+import ErrorCodes from '@safe-global/utils/services/exceptions/ErrorCodes'
 import { useLazySafeAppsGetSafeAppsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/safe-apps'
 
 /**
@@ -26,12 +28,14 @@ export const useOpenSafenetStakingApp = () => {
     setIsNavigating(true)
     try {
       const [apps] = await Promise.all([
-        triggerSafeApps({ chainId, clientUrl: window.location.origin }),
+        triggerSafeApps({ chainId, clientUrl: window.location.origin }).unwrap(),
         new Promise((resolve) => setTimeout(resolve, 1000)),
       ])
-      const safenetApp = apps.data?.find((app) => app.tags.includes(SafeAppsTag.SAFENET))
+      const safenetApp = apps.find((app) => app.tags.includes(SafeAppsTag.SAFENET))
       if (!safenetApp) return
       router.push(`${AppRoutes.apps.open}?safe=${query?.get('safe')}&appUrl=${encodeURIComponent(safenetApp.url)}`)
+    } catch (error) {
+      logError(ErrorCodes._902, error)
     } finally {
       setIsNavigating(false)
       isNavigatingRef.current = false

--- a/apps/web/src/hooks/useOpenSafenetStakingApp.ts
+++ b/apps/web/src/hooks/useOpenSafenetStakingApp.ts
@@ -1,0 +1,42 @@
+import { useRef, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { AppRoutes } from '@/config/routes'
+import { SafeAppsTag } from '@/config/constants'
+import useChainId from '@/hooks/useChainId'
+import { useLazySafeAppsGetSafeAppsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/safe-apps'
+
+/**
+ * Navigates to the native SAFE (Safenet) staking app.
+ *
+ * Resolves the Safe App tagged as `SAFENET` for the current chain and opens it in the
+ * embedded app frame. Shared by the top bar Safe token button and the staking promo banner
+ * so both point to the same destination.
+ */
+export const useOpenSafenetStakingApp = () => {
+  const query = useSearchParams()
+  const chainId = useChainId()
+  const router = useRouter()
+  const [triggerSafeApps] = useLazySafeAppsGetSafeAppsV1Query()
+  const [isNavigating, setIsNavigating] = useState(false)
+  const isNavigatingRef = useRef(false)
+
+  const openSafenetStakingApp = async () => {
+    if (isNavigatingRef.current) return
+    isNavigatingRef.current = true
+    setIsNavigating(true)
+    try {
+      const [apps] = await Promise.all([
+        triggerSafeApps({ chainId, clientUrl: window.location.origin }),
+        new Promise((resolve) => setTimeout(resolve, 1000)),
+      ])
+      const safenetApp = apps.data?.find((app) => app.tags.includes(SafeAppsTag.SAFENET))
+      if (!safenetApp) return
+      router.push(`${AppRoutes.apps.open}?safe=${query?.get('safe')}&appUrl=${encodeURIComponent(safenetApp.url)}`)
+    } finally {
+      setIsNavigating(false)
+      isNavigatingRef.current = false
+    }
+  }
+
+  return { openSafenetStakingApp, isNavigating }
+}


### PR DESCRIPTION
## What it solves

Resolves the incorrect destination of the staking promo banner CTA.

The **"Stake now"** button on the staking promo banner routed to `/stake` (the generic Kiln staking widget). It should open the **native SAFE (Safenet) staking app** — the same destination as the Safe token logo button in the top bar.

As confirmed by Greg, the Safenet app URL **must be read from the config service**: the `eth.limo` URL can't be embedded because eth.limo rejects iframes, so the app is served via its direct IPFS/gateway URL published on the config service.

## How this PR fixes it

- Extracts the config-service-driven navigation (resolve the Safe App tagged `SAFENET` from CGW → open it in the embedded app frame) into a shared `useOpenSafenetStakingApp` hook. Nothing is hardcoded.
- Reuses the hook in the three places that need this destination: the top-bar `SafenetStakingButton`, the `SafenetStakingWidget`, and the promo banner (removing the previously duplicated logic).
- The banner CTA now shows a spinner (`CircularProgress`) while the app URL resolves, and stays fully visible/enabled — re-clicks are guarded inside the hook via a ref, so the button no longer needs the `disabled` state that was painting the label/icon white on the light banner.

## How to test it

1. Open a Safe on a chain that has the SAFE staking promo banner enabled.
2. On the assets/dashboard page, locate the staking promo banner.
3. Click **"Stake now"** → a spinner appears in the button, then you're taken to the native SAFE staking app (same app as clicking the Safe token logo in the top bar), **not** `/stake`.
4. Confirm the top-bar Safe token button and the `SafenetStakingWidget` still open the same app (unchanged behavior).

## Affected flows

- **Staking promo banner → "Stake now"**: now opens the native SAFE (Safenet) staking app instead of `/stake`.
- **Top-bar Safe token button** (`SafenetStakingButton`): unchanged behavior, now backed by the shared hook.
- **`SafenetStakingWidget`**: unchanged behavior, now backed by the shared hook.

## Blast radius

- **New shared hook** `apps/web/src/hooks/useOpenSafenetStakingApp.ts` — consumers: `SafenetStakingButton` (top bar, always-visible), `SafenetStakingWidget`, `StakingPromoBanner`. Pure extraction; navigation behavior identical to before for the two existing consumers.
- **RTK Query**: uses existing `useLazySafeAppsGetSafeAppsV1Query`; no API contract change.
- **Config dependency**: relies on a Safe App tagged `SAFENET` being published in the config service per chain. On chains without one, the CTA is a no-op (same as the existing top-bar button).
- **Routes**: navigates to `AppRoutes.apps.open` (existing).
- **No persisted state / migrations. No feature-flag changes.**

## Risks / not checked

- Did not verify live Safenet Safe App presence per chain (data-driven via CGW; unchanged from existing top-bar button).
- Did not exercise the embedded app frame end-to-end (no E2E added).
- Not tested on mobile (change is web-only; shared `packages/**` untouched).

## Visual summary

```mermaid
flowchart LR
  subgraph Before
    A1[Stake now CTA] --> B1["/stake (Kiln widget)"]
  end
  subgraph After
    A2[Stake now CTA] --> H[useOpenSafenetStakingApp]
    T[Top-bar SAFE token button] --> H
    W[SafenetStakingWidget] --> H
    H --> C{Safe App tagged SAFENET<br/>from config service}
    C -->|found| D[Open in app frame]
    C -->|none| E[No-op]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (web-only change)
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics change — CTA still fires `OPEN_STAKING_WIDGET`)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
