### PR TITLE
fix: reconnect signing wallet on refresh via EIP-6963 provider lookup

### DIFF
--- a/apps/web/src/definitions.d.ts
+++ b/apps/web/src/definitions.d.ts
@@ -4,14 +4,6 @@ import type { BeamerConfig, BeamerMethods } from '@services/beamer/types'
 declare global {
   interface Window {
     isDesktop?: boolean
-    ethereum?: {
-      autoRefreshOnNetworkChange: boolean
-      isMetaMask: boolean
-      _metamask: {
-        isUnlocked: () => Promise<boolean>
-      }
-      isConnected?: () => boolean
-    }
     beamer_config?: BeamerConfig
     Beamer?: BeamerMethods
     dataLayer?: any[]

--- a/apps/web/src/hooks/wallets/useOnboard.ts
+++ b/apps/web/src/hooks/wallets/useOnboard.ts
@@ -151,14 +151,12 @@ const lastWalletStorage = localItem<string>('lastWallet')
 
 const connectLastWallet = async (onboard: OnboardAPI) => {
   const lastWalletLabel = lastWalletStorage.get()
-  if (lastWalletLabel) {
-    const isUnlocked = await isWalletUnlocked(lastWalletLabel)
+  if (!lastWalletLabel) return
 
-    if (isUnlocked === true || isUnlocked === undefined) {
-      await connectWallet(onboard, {
-        autoSelect: { label: lastWalletLabel, disableModals: isUnlocked || false },
-      })
-    }
+  if (await isWalletUnlocked(lastWalletLabel)) {
+    await connectWallet(onboard, {
+      autoSelect: { label: lastWalletLabel, disableModals: true },
+    })
   }
 }
 

--- a/apps/web/src/utils/__tests__/wallets.test.ts
+++ b/apps/web/src/utils/__tests__/wallets.test.ts
@@ -7,7 +7,9 @@ import {
   isSmartContract,
   isEIP7702DelegatedAccount,
   EIP_7702_DELEGATED_ACCOUNT_PREFIX,
+  isWalletUnlocked,
 } from '@/utils/wallets'
+import { PRIVATE_KEY_MODULE_LABEL } from '@/services/private-key-module/constants'
 
 describe('wallets', () => {
   const getCodeMock = jest.fn()
@@ -21,6 +23,69 @@ describe('wallets', () => {
       return {
         getCode: getCodeMock,
       } as unknown as JsonRpcProvider
+    })
+  })
+
+  describe('isWalletUnlocked', () => {
+    const announceListeners: Array<() => void> = []
+
+    // Simulates a wallet extension answering the EIP-6963 roll call
+    const announceWallet = (name: string, request: jest.Mock) => {
+      const onRequest = () => {
+        window.dispatchEvent(
+          new CustomEvent('eip6963:announceProvider', {
+            detail: { info: { name }, provider: { request } },
+          }),
+        )
+      }
+      window.addEventListener('eip6963:requestProvider', onRequest)
+      announceListeners.push(() => window.removeEventListener('eip6963:requestProvider', onRequest))
+    }
+
+    afterEach(() => {
+      announceListeners.forEach((removeListener) => removeListener())
+      announceListeners.length = 0
+    })
+
+    it('should return true for WalletConnect and the private key module without probing providers', async () => {
+      expect(await isWalletUnlocked('WalletConnect')).toBe(true)
+      expect(await isWalletUnlocked(PRIVATE_KEY_MODULE_LABEL)).toBe(true)
+    })
+
+    it('should return true when the announced provider reports authorized accounts', async () => {
+      const request = jest.fn().mockResolvedValue(['0x1234'])
+      announceWallet('MetaMask', request)
+
+      expect(await isWalletUnlocked('MetaMask')).toBe(true)
+      expect(request).toHaveBeenCalledWith({ method: 'eth_accounts' })
+    })
+
+    it('should return false when the announced provider reports no accounts (locked or unauthorized)', async () => {
+      const request = jest.fn().mockResolvedValue([])
+      announceWallet('MetaMask', request)
+
+      expect(await isWalletUnlocked('MetaMask')).toBe(false)
+    })
+
+    it('should return false when the provider request throws', async () => {
+      const request = jest.fn().mockRejectedValue(new Error('Provider error'))
+      announceWallet('MetaMask', request)
+
+      expect(await isWalletUnlocked('MetaMask')).toBe(false)
+    })
+
+    it('should return false when no provider announces itself', async () => {
+      expect(await isWalletUnlocked('MetaMask')).toBe(false)
+    })
+
+    it('should only probe the provider matching the saved label', async () => {
+      const braveRequest = jest.fn().mockResolvedValue(['0x1234'])
+      const metaMaskRequest = jest.fn().mockResolvedValue([])
+      announceWallet('Brave Wallet', braveRequest)
+      announceWallet('MetaMask', metaMaskRequest)
+
+      expect(await isWalletUnlocked('MetaMask')).toBe(false)
+      expect(braveRequest).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/web/src/utils/wallets.ts
+++ b/apps/web/src/utils/wallets.ts
@@ -6,7 +6,7 @@ import { WALLET_KEYS } from '@/hooks/wallets/consts'
 const EMPTY_DATA = '0x'
 import memoize from 'lodash/memoize'
 import { PRIVATE_KEY_MODULE_LABEL } from '@/services/private-key-module/constants'
-import { type JsonRpcProvider } from 'ethers'
+import { type Eip1193Provider, type JsonRpcProvider } from 'ethers'
 
 const WALLETCONNECT = 'WalletConnect'
 const WC_LEDGER = 'Ledger Wallet'
@@ -79,21 +79,43 @@ export const isSmartContractWallet = memoize(
   (chainId, address) => chainId + address,
 )
 
-/* Check if the wallet is unlocked. */
-export const isWalletUnlocked = async (walletName: string): Promise<boolean | undefined> => {
-  if ([PRIVATE_KEY_MODULE_LABEL, WALLETCONNECT].includes(walletName)) return true
+type Eip6963AnnounceProviderEvent = CustomEvent<{
+  info: { name: string }
+  provider: Eip1193Provider
+}>
 
-  const METAMASK_LIKE = ['MetaMask', 'Rabby Wallet', 'Zerion', 'Ambire']
+// With several wallet extensions installed, window.ethereum is owned by an arbitrary one,
+// so the saved wallet must be looked up by its EIP-6963 announced name
+const getInjectedProviderByLabel = (label: string): Eip1193Provider | undefined => {
+  const announced: Eip6963AnnounceProviderEvent['detail'][] = []
 
-  // Only MetaMask exposes a method to check if the wallet is unlocked
-  if (METAMASK_LIKE.includes(walletName)) {
-    if (typeof window === 'undefined' || !window.ethereum?._metamask) return false
-    try {
-      return await window.ethereum?._metamask.isUnlocked()
-    } catch {
-      return false
-    }
+  const onAnnounce = (event: Event) => {
+    announced.push((event as Eip6963AnnounceProviderEvent).detail)
   }
 
-  return false
+  // Announcements are dispatched synchronously in response to the request event
+  window.addEventListener('eip6963:announceProvider', onAnnounce)
+  window.dispatchEvent(new Event('eip6963:requestProvider'))
+  window.removeEventListener('eip6963:announceProvider', onAnnounce)
+
+  // No fallback to window.ethereum: it may be a different wallet than the saved one
+  return announced.find(({ info }) => info.name === label)?.provider
+}
+
+/* Check if the last-used wallet can be reconnected without prompting the user. */
+export const isWalletUnlocked = async (walletName: string): Promise<boolean> => {
+  if ([PRIVATE_KEY_MODULE_LABEL, WALLETCONNECT].includes(walletName)) return true
+
+  if (typeof window === 'undefined') return false
+
+  const provider = getInjectedProviderByLabel(walletName)
+  if (!provider) return false
+
+  try {
+    // eth_accounts never prompts; empty means locked or not authorized for this site
+    const accounts = await provider.request({ method: 'eth_accounts' })
+    return Array.isArray(accounts) && accounts.length > 0
+  } catch {
+    return false
+  }
 }


### PR DESCRIPTION
## What it solves
Refreshing the app disconnects the connected signing wallet instead of keeping it connected.

Resolves: (https://linear.app/safe-global/issue/WA-2790/signing-wallet-disconnects-on-page-refresh)

## How this PR fixes it
  - `isWalletUnlocked` stops reading `window.ethereum`. It now asks all installed wallets to identify via [EIP-6963](https://eips.ethereum.org/EIPS/eip-1193) and picks the one matching the saved wallet label, e.g., Metamask.
  - If no installed wallet matches the saved wallet label, there is no guess, so no fallback to `window.ethereum`, so we can never connect to the wrong wallet.
  - Hardware wallets never match the new lookup, so they keep requiring a manual connect, same as today.
  - Removed the `window.ethereum` type declaration: nothing uses it anymore

## How to test it
1. Chrome/Brave with 2+ wallet extensions (e.g. MetaMask + Rabby): connect MetaMask, refresh → stays connected, no modal.
2.  Lock the wallet, refresh → stays disconnected
3. Ledger: connect, navigate welcome → no reconnect prompts 
4. WalletConnect: connect, refresh → session persists.

## Affected flows
- Signer wallet auto-reconnect on page load / chain change. Manual connect, switch wallet, and logout are untouched.

<!-- The primary user journey(s) this PR intentionally changes. One bullet per flow. Example: "Owner adds a new signer from Settings > Signers". -->

## Blast radius

- `isWalletUnlocked` (`utils/wallets.ts`) is a single consumer: `connectLastWallet` in `useOnboard.ts`.
- `connectLastWallet`, called only from the `useInitOnboard` effect (runs on every chain change, hence the no-modals invariant).
-  `window.ethereum` global type deleted.
-  No shared packages touched; no mobile impact.


## Risks / not checked

- Real multi-extension browser matrix not yet run
- Injected wallets without EIP-6963 support won't auto-reconnect
- Locked wallet still requires one manual connect after unlocking

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [X] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [X] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
