### PR TITLE
[internal] verified squash source for Linear release integration

### DIFF
--- a/.github/workflows/mobile-linear-release.yml
+++ b/.github/workflows/mobile-linear-release.yml
@@ -1,0 +1,79 @@
+name: Linear Release (Mobile)
+
+# Syncs mobile releases to the "Mobile" scheduled release pipeline in Linear.
+# Mobile has no automated production release/tag flow in this repo yet, so this
+# is driven manually to match the EAS release cadence: run `sync` when cutting a
+# release, `update` to move it between stages, and `complete` once it ships.
+#
+# Setup: add the Mobile pipeline access key as the `LINEAR_ACCESS_KEY_MOBILE`
+# repository secret (Settings -> Secrets and variables -> Actions). This must be
+# a pipeline access key generated from the pipeline settings in Linear, not a
+# personal API key.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. 1.0.14) - defaults to apps/mobile/package.json'
+        required: false
+        type: string
+      command:
+        description: 'Linear release command'
+        required: true
+        type: choice
+        default: sync
+        options:
+          - sync
+          - update
+          - complete
+      stage:
+        description: 'Deployment stage (required for the "update" command, e.g. In Progress)'
+        required: false
+        type: string
+      dry_run:
+        description: 'Preview the action without modifying Linear'
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+concurrency:
+  group: linear-release-mobile-${{ inputs.version || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  linear-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.0.0
+        with:
+          fetch-depth: 0 # Full history required to scan commits for Linear issue IDs
+
+      - name: Resolve release version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION=$(node -p "require('./apps/mobile/package.json').version")
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Linear release version: $VERSION"
+
+      - name: Run Linear release (${{ inputs.command }})
+        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f # v0.14.5
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_MOBILE }}
+          command: ${{ inputs.command }}
+          version: ${{ steps.version.outputs.version }}
+          stage: ${{ inputs.stage }}
+          # include_paths is only valid for `sync`; omit it for update/complete
+          include_paths: ${{ inputs.command == 'sync' && 'apps/mobile/**,packages/**,expo-plugins/**' || '' }}
+          dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/web-linear-release.yml
+++ b/.github/workflows/web-linear-release.yml
@@ -1,0 +1,80 @@
+name: Linear Release (Web)
+
+# Manual backfill / repair tool for the "Wallet" scheduled release pipeline in
+# Linear. The normal flow is automated inside the release workflows:
+#   - web-release-start.yml -> `sync` + stage "Code Freeze" when a release is cut
+#   - web-tag-release.yml    -> `complete` when the release is published
+# Use this workflow to re-sync a release, fix a stage, or preview with dry_run.
+#
+# Setup: add the Wallet pipeline access key as the `LINEAR_ACCESS_KEY_WEB`
+# repository secret (Settings -> Secrets and variables -> Actions). This must be
+# a pipeline access key generated from the pipeline settings in Linear, not a
+# personal API key.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. 1.92.0) - defaults to apps/web/package.json'
+        required: false
+        type: string
+      command:
+        description: 'Linear release command'
+        required: true
+        type: choice
+        default: sync
+        options:
+          - sync
+          - update
+          - complete
+      stage:
+        description: 'Deployment stage (required for the "update" command, e.g. Code Freeze)'
+        required: false
+        type: string
+      dry_run:
+        description: 'Preview the action without modifying Linear'
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+concurrency:
+  group: linear-release-web-${{ inputs.version || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  linear-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.0.0
+        with:
+          fetch-depth: 0 # Full history required to scan commits for Linear issue IDs
+
+      - name: Resolve release version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION=$(node -p "require('./apps/web/package.json').version")
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Linear release version: $VERSION"
+
+      - name: Run Linear release (${{ inputs.command }})
+        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f # v0.14.5
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_WEB }}
+          command: ${{ inputs.command }}
+          version: ${{ steps.version.outputs.version }}
+          stage: ${{ inputs.stage }}
+          # include_paths is only valid for `sync`; omit it for update/complete
+          include_paths: ${{ inputs.command == 'sync' && 'apps/web/**,packages/**' || '' }}
+          dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/web-release-start.yml
+++ b/.github/workflows/web-release-start.yml
@@ -251,22 +251,50 @@ jobs:
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
           echo "✅ Pull Request created: $PR_URL"
 
+      # Create/sync the release in the Linear "Wallet" pipeline and move it to
+      # Code Freeze. Guarded so a Linear outage never blocks cutting a release.
+      - name: Sync release to Linear
+        id: linear_sync
+        continue-on-error: true
+        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f # v0.14.5
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_WEB }}
+          command: sync
+          version: ${{ steps.version.outputs.version }}
+          include_paths: apps/web/**,packages/**
+          links: ${{ steps.create_pr.outputs.pr_url }}
+
+      - name: Move Linear release to Code Freeze
+        continue-on-error: true
+        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f # v0.14.5
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_WEB }}
+          command: update
+          version: ${{ steps.version.outputs.version }}
+          stage: Code Freeze
+
       - name: Notify on Slack
         if: vars.SLACK_WEBHOOK_URL
         continue-on-error: true
         env:
           INPUT_RELEASE_TYPE: ${{ inputs.release_type }}
+          LINEAR_URL: ${{ steps.linear_sync.outputs['release-url'] }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           RELEASE_TYPE="$INPUT_RELEASE_TYPE"
           BASE_BRANCH="${{ steps.base.outputs.branch }}"
           PR_URL="${{ steps.create_pr.outputs.pr_url }}"
+          LINEAR_LINK=""
+          if [ -n "$LINEAR_URL" ]; then
+            LINEAR_LINK="<$LINEAR_URL|View release in Linear>"
+          fi
 
           jq -n \
             --arg version "$VERSION" \
             --arg release_type "$RELEASE_TYPE" \
             --arg base "$BASE_BRANCH" \
             --arg pr_url "$PR_URL" \
+            --arg linear "$LINEAR_LINK" \
             '{
               text: ("🚀 *Release web-v" + $version + " Started*"),
               blocks: [
@@ -274,7 +302,7 @@ jobs:
                   type: "section",
                   text: {
                     type: "mrkdwn",
-                    text: ("*Release web-v" + $version + " has been initiated* ✅\n\n*Type:* " + $release_type + "\n*Base:* " + $base + "\n*PR:* " + $pr_url + "\n\n_QA team: Please review and test_ 🧪")
+                    text: ("*Release web-v" + $version + " has been initiated* ✅\n\n*Type:* " + $release_type + "\n*Base:* " + $base + "\n*PR:* " + $pr_url + (if $linear != "" then "\n*Linear:* " + $linear else "" end) + "\n\n_QA team: Please review and test_ 🧪")
                   }
                 }
               ]

--- a/.github/workflows/web-tag-release.yml
+++ b/.github/workflows/web-tag-release.yml
@@ -299,10 +299,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+      # Mark the Linear "Wallet" release as Released (auto-generates release
+      # notes). Guarded so a Linear outage never fails a shipped release.
+      - name: Complete Linear release
+        if: needs.tag.outputs.version && success()
+        id: linear_complete
+        continue-on-error: true
+        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f # v0.14.5
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_WEB }}
+          command: complete
+          version: ${{ needs.tag.outputs.version_number }}
+
       - name: Notify on Slack
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          LINEAR_URL: ${{ steps.linear_complete.outputs['release-url'] }}
         run: |
           if [ -z "$SLACK_WEBHOOK_URL" ]; then
             echo "No Slack webhook configured, skipping notification"
@@ -313,6 +326,10 @@ jobs:
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${{ needs.tag.outputs.version }}"
           BACKMERGE_PR_URL="${{ steps.backmerge.outputs.pr_url }}"
           HAS_CONFLICTS="${{ steps.backmerge.outputs.has_conflicts }}"
+          LINEAR_LINK=""
+          if [ -n "$LINEAR_URL" ]; then
+            LINEAR_LINK="<$LINEAR_URL|View release in Linear>"
+          fi
 
           if [ -n "$BACKMERGE_PR_URL" ]; then
             if [ "$HAS_CONFLICTS" = "true" ]; then
@@ -328,6 +345,7 @@ jobs:
             --arg version "$VERSION" \
             --arg url "$RELEASE_URL" \
             --arg backmerge "$BACKMERGE_MSG" \
+            --arg linear "$LINEAR_LINK" \
             '{
               channel: "#topic-wallet-releases",
               text: ("✅ Safe Wallet " + $version + " ready for going live"),
@@ -336,7 +354,7 @@ jobs:
                   type: "section",
                   text: {
                     type: "mrkdwn",
-                    text: ("*Safe Wallet " + $version + " is ready for going live* ✅\n\n<" + $url + "|View Release on GitHub>\n\n" + $backmerge)
+                    text: ("*Safe Wallet " + $version + " is ready for going live* ✅\n\n<" + $url + "|View Release on GitHub>" + (if $linear != "" then "\n" + $linear else "" end) + "\n\n" + $backmerge)
                   }
                 }
               ]


### PR DESCRIPTION
Throwaway PR used only to produce a single GitHub-signed (verified) squash commit of the whole Linear release integration onto the feature branch. Will be squash-merged and its source branch deleted immediately. Not for review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T2E3CSjKDcr9F7kSzFvSF3)_