### PR TITLE
fix(web): lazy-load safe overview balances in the accounts table

### DIFF
--- a/apps/web/src/features/myAccounts/components/SafeAccountsTable/ReorderableBody.tsx
+++ b/apps/web/src/features/myAccounts/components/SafeAccountsTable/ReorderableBody.tsx
@@ -27,7 +27,7 @@ type ReorderableBodyProps = {
   /** Fired on drop with the reordered top-level account addresses, in display order. */
   onReorder: (orderedAddresses: string[]) => void
   /** Reports a row's lazily-fetched Safe overviews up to the table. */
-  onOverviewsLoaded?: (overviews: SafeOverview[]) => void
+  onOverviewsLoaded: (overviews: SafeOverview[]) => void
 }
 
 /** Toggles a group's expanded state, returning a new set (parent keys are stable across reorders). */
@@ -156,6 +156,7 @@ const ReorderableBody = ({
                         checkbox={getCheckbox?.(group, child)}
                         onSelectToggle={onSelectToggle ? (next) => onSelectToggle(child, next) : undefined}
                         showDivider={groupHasDivider && childIndex === group.children.length - 1}
+                        onOverviewsLoaded={onOverviewsLoaded}
                       />
                     ))}
                 </Fragment>

--- a/apps/web/src/features/myAccounts/components/SafeAccountsTable/ReorderableBody.tsx
+++ b/apps/web/src/features/myAccounts/components/SafeAccountsTable/ReorderableBody.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { DragDropContext, Draggable, Droppable, type DropResult } from '@hello-pangea/dnd'
 import Table from '@mui/material/Table'
 import TableBody from '@mui/material/TableBody'
+import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import { reorderByKey } from '@/utils/reorder'
 import type { SafeAccountColumn } from './columns'
 import type { AccountGroup, AccountLine } from './useSafeAccountRows'
@@ -25,6 +26,8 @@ type ReorderableBodyProps = {
   onSelectToggle?: (line: AccountLine, nextChecked: boolean) => void
   /** Fired on drop with the reordered top-level account addresses, in display order. */
   onReorder: (orderedAddresses: string[]) => void
+  /** Reports a row's lazily-fetched Safe overviews up to the table. */
+  onOverviewsLoaded?: (overviews: SafeOverview[]) => void
 }
 
 /** Toggles a group's expanded state, returning a new set (parent keys are stable across reorders). */
@@ -54,6 +57,7 @@ const ReorderableBody = ({
   getCheckbox,
   onSelectToggle,
   onReorder,
+  onOverviewsLoaded,
 }: ReorderableBodyProps) => {
   // Remembers what was open across a drag: collapsing must happen before dnd measures the rows.
   const expandedBeforeDrag = useRef<Set<string>>(new Set())
@@ -113,6 +117,7 @@ const ReorderableBody = ({
                           rowDraggableProps={dragProvided.draggableProps}
                           dragHandleProps={dragProvided.dragHandleProps}
                           isDragging={snapshot.isDragging}
+                          onOverviewsLoaded={onOverviewsLoaded}
                         />
                       )
 

--- a/apps/web/src/features/myAccounts/components/SafeAccountsTable/SafeAccountTableRow.tsx
+++ b/apps/web/src/features/myAccounts/components/SafeAccountsTable/SafeAccountTableRow.tsx
@@ -60,7 +60,7 @@ type SafeAccountTableRowProps = {
   rowDraggableProps?: DraggableProvidedDraggableProps
   isDragging?: boolean
   /** Reports this row's lazily-fetched Safe overviews up to the table so it can fill balance/threshold. */
-  onOverviewsLoaded?: (overviews: SafeOverview[]) => void
+  onOverviewsLoaded: (overviews: SafeOverview[]) => void
 }
 
 const HighSimilarityBadge = () => (

--- a/apps/web/src/features/myAccounts/components/SafeAccountsTable/SafeAccountTableRow.tsx
+++ b/apps/web/src/features/myAccounts/components/SafeAccountsTable/SafeAccountTableRow.tsx
@@ -1,9 +1,13 @@
-import { type MouseEvent, type ReactNode } from 'react'
+import { useMemo, type MouseEvent, type ReactNode } from 'react'
 import type { DraggableProvidedDraggableProps, DraggableProvidedDragHandleProps } from '@hello-pangea/dnd'
 import NextLink from 'next/link'
 import { useRouter } from 'next/router'
 import TableCell from '@mui/material/TableCell'
 import TableRow from '@mui/material/TableRow'
+import { useForkRef } from '@mui/material/utils'
+import type { SafeItem } from '@/hooks/safes'
+import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { useRowOverviews } from './useRowOverviews'
 import { Badge } from '@/components/ui/badge'
 import { GripVertical, TriangleAlert } from 'lucide-react'
 import Identicon from '@/components/common/Identicon'
@@ -55,6 +59,8 @@ type SafeAccountTableRowProps = {
   rowRef?: (element: HTMLElement | null) => void
   rowDraggableProps?: DraggableProvidedDraggableProps
   isDragging?: boolean
+  /** Reports this row's lazily-fetched Safe overviews up to the table so it can fill balance/threshold. */
+  onOverviewsLoaded?: (overviews: SafeOverview[]) => void
 }
 
 const HighSimilarityBadge = () => (
@@ -346,8 +352,19 @@ const SafeAccountTableRow = ({
   rowRef,
   rowDraggableProps,
   isDragging,
+  onOverviewsLoaded,
 }: SafeAccountTableRowProps) => {
   const router = useRouter()
+
+  // A group parent covers its per-chain safes, a single/child its own. Children don't fetch — the
+  // parent already loaded them (enabled = variant !== 'child').
+  const rowSafes = useMemo<SafeItem[]>(
+    () => (line.variant === 'group' ? (line.networks ?? []) : [line.source as SafeItem]),
+    [line],
+  )
+  const observerRef = useRowOverviews(rowSafes, line.variant !== 'child', onOverviewsLoaded)
+  // Compose the visibility observer ref with the drag-and-drop ref (only set in reorder mode).
+  const setRowRef = useForkRef(observerRef, rowRef)
 
   // In selection mode a leaf row is one big checkbox — clicking anywhere on it toggles selection
   // (except affordances that stop propagation: the checkbox, actions, copy and explorer link).
@@ -387,7 +404,7 @@ const SafeAccountTableRow = ({
 
   const rowEl = (
     <TableRow
-      ref={rowRef}
+      ref={setRowRef}
       {...rowDraggableProps}
       data-testid="account-table-row"
       data-variant={line.variant}

--- a/apps/web/src/features/myAccounts/components/SafeAccountsTable/__tests__/SafeAccountTableRow.test.tsx
+++ b/apps/web/src/features/myAccounts/components/SafeAccountsTable/__tests__/SafeAccountTableRow.test.tsx
@@ -5,6 +5,8 @@ import { SELECT_COLUMN, type SafeAccountColumn } from '../columns'
 import type { AccountLine } from '../useSafeAccountRows'
 
 // Keep the heavy per-cell widgets out of the way; this suite covers row-level link/selection wiring.
+// Stub the lazy overview fetch — its own suite covers it (and it needs an IntersectionObserver).
+jest.mock('../useRowOverviews', () => ({ useRowOverviews: () => ({ current: null }) }))
 jest.mock('@/components/common/Identicon', () => ({ __esModule: true, default: () => <div data-testid="identicon" /> }))
 jest.mock('../../AccountItem', () => ({
   AccountItem: { Icon: () => null, ChainBadge: () => null, ContextMenu: () => null },

--- a/apps/web/src/features/myAccounts/components/SafeAccountsTable/__tests__/SafeAccountTableRow.test.tsx
+++ b/apps/web/src/features/myAccounts/components/SafeAccountsTable/__tests__/SafeAccountTableRow.test.tsx
@@ -5,8 +5,12 @@ import { SELECT_COLUMN, type SafeAccountColumn } from '../columns'
 import type { AccountLine } from '../useSafeAccountRows'
 
 // Keep the heavy per-cell widgets out of the way; this suite covers row-level link/selection wiring.
-// Stub the lazy overview fetch — its own suite covers it (and it needs an IntersectionObserver).
-jest.mock('../useRowOverviews', () => ({ useRowOverviews: () => ({ current: null }) }))
+// Stub the lazy overview fetch — its own suite covers it (and it needs an IntersectionObserver). The
+// spy lets us assert the group-vs-child fetch gating (`enabled`) without a real store/observer.
+const mockUseRowOverviews: jest.Mock = jest.fn(() => ({ current: null }))
+jest.mock('../useRowOverviews', () => ({
+  useRowOverviews: (...args: unknown[]) => mockUseRowOverviews(...args),
+}))
 jest.mock('@/components/common/Identicon', () => ({ __esModule: true, default: () => <div data-testid="identicon" /> }))
 jest.mock('../../AccountItem', () => ({
   AccountItem: { Icon: () => null, ChainBadge: () => null, ContextMenu: () => null },
@@ -63,7 +67,7 @@ const renderRow = (props: Partial<Parameters<typeof SafeAccountTableRow>[0]>) =>
   render(
     <table>
       <tbody>
-        <SafeAccountTableRow line={leaf()} columns={columns} {...props} />
+        <SafeAccountTableRow line={leaf()} columns={columns} onOverviewsLoaded={jest.fn()} {...props} />
       </tbody>
     </table>,
   )
@@ -76,9 +80,25 @@ const checkbox = (over: Partial<RowCheckbox> = {}): RowCheckbox => ({
 })
 
 describe('SafeAccountTableRow', () => {
+  beforeEach(() => {
+    mockUseRowOverviews.mockClear()
+  })
+
   it('renders the name as a navigation link when not in selection mode', () => {
     renderRow({})
     expect(screen.getByTestId('account-row-link')).toHaveAttribute('href', '/home?safe=eth:0xabc')
+  })
+
+  describe('lazy overview fetching', () => {
+    // The parent already loads a group's per-chain overviews, so a child row must not fetch them again.
+    it('enables the fetch for single/parent rows and disables it for child rows', () => {
+      renderRow({ line: leaf({ variant: 'single' }) })
+      expect(mockUseRowOverviews).toHaveBeenLastCalledWith(expect.anything(), true, expect.any(Function))
+
+      mockUseRowOverviews.mockClear()
+      renderRow({ line: leaf({ variant: 'child', showAddress: false, displayName: 'Ethereum' }) })
+      expect(mockUseRowOverviews).toHaveBeenLastCalledWith(expect.anything(), false, expect.any(Function))
+    })
   })
 
   it('does not navigate in selection mode — the whole row toggles the checkbox instead', () => {
@@ -118,7 +138,7 @@ describe('SafeAccountTableRow', () => {
       render(
         <table>
           <tbody>
-            <SafeAccountTableRow line={leaf()} columns={navColumns} {...props} />
+            <SafeAccountTableRow line={leaf()} columns={navColumns} onOverviewsLoaded={jest.fn()} {...props} />
           </tbody>
         </table>,
         { routerProps: { push } },
@@ -156,6 +176,7 @@ describe('SafeAccountTableRow', () => {
               line={leaf({ variant: 'group', expandable: true, href: undefined })}
               columns={navColumns}
               onToggle={onToggle}
+              onOverviewsLoaded={jest.fn()}
             />
           </tbody>
         </table>,
@@ -176,7 +197,7 @@ describe('SafeAccountTableRow', () => {
       render(
         <table>
           <tbody>
-            <SafeAccountTableRow line={leaf(over)} columns={balanceColumns} />
+            <SafeAccountTableRow line={leaf(over)} columns={balanceColumns} onOverviewsLoaded={jest.fn()} />
           </tbody>
         </table>,
       )

--- a/apps/web/src/features/myAccounts/components/SafeAccountsTable/__tests__/useRowOverviews.test.ts
+++ b/apps/web/src/features/myAccounts/components/SafeAccountsTable/__tests__/useRowOverviews.test.ts
@@ -61,10 +61,19 @@ describe('useRowOverviews', () => {
     expect(onLoaded).not.toHaveBeenCalled()
   })
 
-  it('does not fetch when no callback is provided', () => {
-    renderHook(() => useRowOverviews([safeItemBuilder().build()], true))
+  it('reports once while the resolved data keeps a stable reference across re-renders', () => {
+    const data = [overview('1', '0xabc')]
+    querySpy.mockReturnValue({ data } as never)
+    const onLoaded = jest.fn()
+    const safes = [safeItemBuilder().with({ chainId: '1', address: '0xabc' }).build()]
 
-    expect(querySpy).toHaveBeenCalledWith(skipToken)
+    // The table's map merge relies on this: RTK hands back the same `data` ref until a genuine
+    // refetch, so a plain re-render must not re-report already-seen overviews.
+    const { rerender } = renderHook(() => useRowOverviews(safes, true, onLoaded))
+    rerender()
+    rerender()
+
+    expect(onLoaded).toHaveBeenCalledTimes(1)
   })
 
   it('skips counterfactual safes that have no overview', () => {

--- a/apps/web/src/features/myAccounts/components/SafeAccountsTable/__tests__/useRowOverviews.test.ts
+++ b/apps/web/src/features/myAccounts/components/SafeAccountsTable/__tests__/useRowOverviews.test.ts
@@ -1,0 +1,110 @@
+import { skipToken } from '@reduxjs/toolkit/query'
+import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { renderHook } from '@/tests/test-utils'
+import { safeItemBuilder } from '@/tests/builders/safeItem'
+import type { RootState } from '@/store'
+import * as gateway from '@/store/api/gateway'
+import { useRowOverviews } from '../useRowOverviews'
+
+const mockIsVisible = jest.fn(() => true)
+
+jest.mock('@/hooks/useOnceVisible', () => ({
+  __esModule: true,
+  default: () => mockIsVisible(),
+}))
+
+jest.mock('@/hooks/wallets/useWallet', () => ({
+  __esModule: true,
+  default: () => ({ address: '0x1234567890123456789012345678901234567890' }),
+}))
+
+const overview = (chainId: string, address: string): SafeOverview =>
+  ({ chainId, address: { value: address }, fiatTotal: '100' }) as SafeOverview
+
+describe('useRowOverviews', () => {
+  let querySpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsVisible.mockReturnValue(true)
+    querySpy = jest.spyOn(gateway, 'useGetMultipleSafeOverviewsQuery').mockReturnValue({ data: undefined } as never)
+  })
+
+  it('fetches the row overviews once visible and reports them up', () => {
+    const data = [overview('1', '0xabc')]
+    querySpy.mockReturnValue({ data } as never)
+    const onLoaded = jest.fn()
+    const safes = [safeItemBuilder().with({ chainId: '1', address: '0xabc' }).build()]
+
+    renderHook(() => useRowOverviews(safes, true, onLoaded))
+
+    expect(querySpy).toHaveBeenCalledWith(expect.objectContaining({ safes }))
+    expect(onLoaded).toHaveBeenCalledWith(data)
+  })
+
+  it('does not fetch until the row is visible', () => {
+    mockIsVisible.mockReturnValue(false)
+    const onLoaded = jest.fn()
+
+    renderHook(() => useRowOverviews([safeItemBuilder().build()], true, onLoaded))
+
+    expect(querySpy).toHaveBeenCalledWith(skipToken)
+    expect(onLoaded).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch for a disabled (child) row', () => {
+    const onLoaded = jest.fn()
+
+    renderHook(() => useRowOverviews([safeItemBuilder().build()], false, onLoaded))
+
+    expect(querySpy).toHaveBeenCalledWith(skipToken)
+    expect(onLoaded).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch when no callback is provided', () => {
+    renderHook(() => useRowOverviews([safeItemBuilder().build()], true))
+
+    expect(querySpy).toHaveBeenCalledWith(skipToken)
+  })
+
+  it('skips counterfactual safes that have no overview', () => {
+    const safe = safeItemBuilder().with({ chainId: '1', address: '0xabc123' }).build()
+
+    renderHook(() => useRowOverviews([safe], true, jest.fn()), {
+      initialReduxState: {
+        undeployedSafes: {
+          '1': {
+            '0xabc123': {
+              status: { status: 'AWAITING_EXECUTION' },
+              props: { safeAccountConfig: { owners: ['0x111'], threshold: 1 } },
+            },
+          },
+        },
+      } as unknown as Partial<RootState>,
+    })
+
+    // Every safe is undeployed, so there is nothing to fetch.
+    expect(querySpy).toHaveBeenCalledWith(skipToken)
+  })
+
+  it('fetches only the deployed safes of a group row', () => {
+    const deployed = safeItemBuilder().with({ chainId: '1', address: '0xdeployed' }).build()
+    const undeployed = safeItemBuilder().with({ chainId: '10', address: '0xundeployed' }).build()
+    querySpy.mockReturnValue({ data: [overview('1', '0xdeployed')] } as never)
+
+    renderHook(() => useRowOverviews([deployed, undeployed], true, jest.fn()), {
+      initialReduxState: {
+        undeployedSafes: {
+          '10': {
+            '0xundeployed': {
+              status: { status: 'AWAITING_EXECUTION' },
+              props: { safeAccountConfig: { owners: ['0x111'], threshold: 1 } },
+            },
+          },
+        },
+      } as unknown as Partial<RootState>,
+    })
+
+    expect(querySpy).toHaveBeenCalledWith(expect.objectContaining({ safes: [deployed] }))
+  })
+})

--- a/apps/web/src/features/myAccounts/components/SafeAccountsTable/index.tsx
+++ b/apps/web/src/features/myAccounts/components/SafeAccountsTable/index.tsx
@@ -159,8 +159,9 @@ const SafeAccountsTable = ({
 }: SafeAccountsTableProps) => {
   const [overviewsByKey, setOverviewsByKey] = useState<Map<string, SafeOverview>>(new Map())
 
-  // Rows report their lazily-fetched overviews here. Keep the previous map when nothing new arrived,
-  // so a repeated report doesn't churn a re-render.
+  // Rows report their lazily-fetched overviews here. RTK returns a stable object ref per cache entry
+  // (a new ref only on a genuine refetch), so reference equality detects real updates; keep the
+  // previous map when nothing new arrived, so a repeated report doesn't churn a re-render.
   const handleOverviewsLoaded = useCallback((overviews: SafeOverview[]) => {
     setOverviewsByKey((prev) => {
       let changed = false

--- a/apps/web/src/features/myAccounts/components/SafeAccountsTable/index.tsx
+++ b/apps/web/src/features/myAccounts/components/SafeAccountsTable/index.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import Box from '@mui/material/Box'
 import Table from '@mui/material/Table'
 import TableBody from '@mui/material/TableBody'
@@ -12,6 +13,7 @@ import { cn } from '@/utils/cn'
 import { SAFE_ACCOUNT_COLUMNS, SELECT_COLUMN, type SafeAccountColumnId } from './columns'
 import {
   compareGroups,
+  overviewKey,
   useSafeAccountRows,
   type AccountGroup,
   type AccountLine,
@@ -155,7 +157,26 @@ const SafeAccountsTable = ({
   embedded = false,
   'data-testid': testId = 'safe-accounts-table',
 }: SafeAccountsTableProps) => {
-  const { groups } = useSafeAccountRows(items)
+  const [overviewsByKey, setOverviewsByKey] = useState<Map<string, SafeOverview>>(new Map())
+
+  // Rows report their lazily-fetched overviews here. Keep the previous map when nothing new arrived,
+  // so a repeated report doesn't churn a re-render.
+  const handleOverviewsLoaded = useCallback((overviews: SafeOverview[]) => {
+    setOverviewsByKey((prev) => {
+      let changed = false
+      const next = new Map(prev)
+      for (const overview of overviews) {
+        const key = overviewKey(overview.chainId, overview.address.value)
+        if (next.get(key) !== overview) {
+          next.set(key, overview)
+          changed = true
+        }
+      }
+      return changed ? next : prev
+    })
+  }, [])
+
+  const { groups } = useSafeAccountRows(items, overviewsByKey)
   const [sort, setSort] = useState<SortState>({ orderBy: null, order: 'asc' })
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [renameTarget, setRenameTarget] = useState<RenameTarget | null>(null)
@@ -339,6 +360,7 @@ const SafeAccountsTable = ({
               getCheckbox={selection ? (group, line) => getRowCheckbox(group, line, selection) : undefined}
               onSelectToggle={selection ? (line, next) => selection.onToggle(line, next) : undefined}
               onReorder={reorder.onReorder}
+              onOverviewsLoaded={handleOverviewsLoaded}
             />
           ) : (
             <TableBody>
@@ -356,6 +378,7 @@ const SafeAccountsTable = ({
                   onToggle={line.expandable ? () => toggle(groupKey) : undefined}
                   onLinkClick={onLinkClick}
                   showDivider={index < lines.length - 1 && lines[index + 1].groupKey !== groupKey}
+                  onOverviewsLoaded={handleOverviewsLoaded}
                 />
               ))}
             </TableBody>

--- a/apps/web/src/features/myAccounts/components/SafeAccountsTable/useRowOverviews.ts
+++ b/apps/web/src/features/myAccounts/components/SafeAccountsTable/useRowOverviews.ts
@@ -13,7 +13,7 @@ import useOnceVisible from '@/hooks/useOnceVisible'
  * Fetches a row's Safe overview(s) only once the row scrolls into view, reporting the result via
  * `onLoaded`. Undeployed safes are skipped (no overview). Returns the ref to attach to the row.
  */
-export function useRowOverviews(safes: SafeItem[], enabled: boolean, onLoaded?: (overviews: SafeOverview[]) => void) {
+export function useRowOverviews(safes: SafeItem[], enabled: boolean, onLoaded: (overviews: SafeOverview[]) => void) {
   const ref = useRef<HTMLElement | null>(null)
   const isVisible = useOnceVisible(ref)
   const currency = useAppSelector(selectCurrency)
@@ -25,15 +25,19 @@ export function useRowOverviews(safes: SafeItem[], enabled: boolean, onLoaded?: 
     [safes, undeployedSafes],
   )
 
-  const active = enabled && isVisible && Boolean(onLoaded) && deployedSafes.length > 0
+  const active = enabled && isVisible && deployedSafes.length > 0
 
   const { data } = useGetMultipleSafeOverviewsQuery(
     active ? { currency, walletAddress, safes: deployedSafes } : skipToken,
   )
 
+  // Reporting keys off `data` alone (via a ref for the callback), so a genuine load/refetch fires it
+  // exactly once no matter how `onLoaded` is passed — the correctness can't be broken by a caller.
+  const onLoadedRef = useRef(onLoaded)
+  onLoadedRef.current = onLoaded
   useEffect(() => {
-    if (data && data.length > 0) onLoaded?.(data)
-  }, [data, onLoaded])
+    if (data && data.length > 0) onLoadedRef.current(data)
+  }, [data])
 
   return ref
 }

--- a/apps/web/src/features/myAccounts/components/SafeAccountsTable/useRowOverviews.ts
+++ b/apps/web/src/features/myAccounts/components/SafeAccountsTable/useRowOverviews.ts
@@ -1,0 +1,39 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { skipToken } from '@reduxjs/toolkit/query'
+import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import type { SafeItem } from '@/hooks/safes'
+import { useGetMultipleSafeOverviewsQuery } from '@/store/api/gateway'
+import { selectUndeployedSafes } from '@/features/counterfactual/store'
+import { selectCurrency } from '@/store/settingsSlice'
+import { useAppSelector } from '@/store'
+import useWallet from '@/hooks/wallets/useWallet'
+import useOnceVisible from '@/hooks/useOnceVisible'
+
+/**
+ * Fetches a row's Safe overview(s) only once the row scrolls into view, reporting the result via
+ * `onLoaded`. Undeployed safes are skipped (no overview). Returns the ref to attach to the row.
+ */
+export function useRowOverviews(safes: SafeItem[], enabled: boolean, onLoaded?: (overviews: SafeOverview[]) => void) {
+  const ref = useRef<HTMLElement | null>(null)
+  const isVisible = useOnceVisible(ref)
+  const currency = useAppSelector(selectCurrency)
+  const undeployedSafes = useAppSelector(selectUndeployedSafes)
+  const { address: walletAddress } = useWallet() || {}
+
+  const deployedSafes = useMemo(
+    () => safes.filter((safe) => !undeployedSafes[safe.chainId]?.[safe.address]),
+    [safes, undeployedSafes],
+  )
+
+  const active = enabled && isVisible && Boolean(onLoaded) && deployedSafes.length > 0
+
+  const { data } = useGetMultipleSafeOverviewsQuery(
+    active ? { currency, walletAddress, safes: deployedSafes } : skipToken,
+  )
+
+  useEffect(() => {
+    if (data && data.length > 0) onLoaded?.(data)
+  }, [data, onLoaded])
+
+  return ref
+}

--- a/apps/web/src/features/myAccounts/components/SafeAccountsTable/useSafeAccountRows.ts
+++ b/apps/web/src/features/myAccounts/components/SafeAccountsTable/useSafeAccountRows.ts
@@ -10,18 +10,14 @@ import {
   type AllSafeItems,
   type MultiChainSafeItem,
   type SafeItem,
-  flattenSafeItems,
   isMultiChainSafeItem,
   useGetHref,
 } from '@/hooks/safes'
-import { useGetMultipleSafeOverviewsQuery } from '@/store/api/gateway'
 import { selectUndeployedSafes } from '@/features/counterfactual/store'
 import { isPredictedSafeProps } from '@/features/counterfactual/services'
 import { getSafeSetups, getSharedSetup, hasMultiChainAddNetworkFeature } from '@/features/multichain'
 import { useSafeSpaces, type SafeSpacesMap } from '@/hooks/useSafeSpaces'
 import { useAppSelector } from '@/store'
-import { selectCurrency } from '@/store/settingsSlice'
-import useWallet from '@/hooks/wallets/useWallet'
 import useChains from '@/hooks/useChains'
 
 export type SafeSortColumn = 'name' | 'threshold' | 'networks' | 'workspaces'
@@ -82,7 +78,7 @@ type BuildDeps = {
   getHref: (chain: Chain, address: string) => LinkProps['href']
 }
 
-const overviewKey = (chainId: string, address: string) => `${chainId}:${address.toLowerCase()}`
+export const overviewKey = (chainId: string, address: string) => `${chainId}:${address.toLowerCase()}`
 
 /**
  * Network sort key: the chain identity to order the Networks column by (e.g. Ethereum before
@@ -232,31 +228,21 @@ const buildMultiGroup = (item: MultiChainSafeItem, deps: BuildDeps): AccountGrou
 }
 
 /**
- * Enriches grouped Safe items with the data the accounts table sorts and renders by:
- * eagerly fetches Safe overviews for the (small) trusted set and resolves workspace
- * membership, then derives per-account threshold, networks, workspaces, pending and
- * balance. Sort keys are computed at the group level so multi-chain children never
- * detach from their parent when the table re-sorts.
+ * Enriches grouped Safe items with the data the accounts table sorts and renders by: resolves
+ * workspace membership and derives per-account threshold, networks, workspaces, pending and balance
+ * from the `overviewsByKey` map (populated lazily per row by `useRowOverviews`). Sort keys are
+ * computed at the group level so multi-chain children never detach from their parent when the table
+ * re-sorts.
  */
-export function useSafeAccountRows(items: AllSafeItems): { groups: AccountGroup[]; isLoading: boolean } {
+export function useSafeAccountRows(
+  items: AllSafeItems,
+  overviewsByKey: Map<string, SafeOverview>,
+): { groups: AccountGroup[] } {
   const router = useRouter()
   const getHref = useGetHref(router)
-  const currency = useAppSelector(selectCurrency)
-  const { address: walletAddress } = useWallet() || {}
   const undeployedSafes = useAppSelector(selectUndeployedSafes)
   const { configs } = useChains()
   const { safeSpaces } = useSafeSpaces()
-
-  const deployedSafes = useMemo(
-    () => flattenSafeItems(items).filter((s) => !undeployedSafes[s.chainId]?.[s.address]),
-    [items, undeployedSafes],
-  )
-
-  const { data: overviews, isLoading } = useGetMultipleSafeOverviewsQuery({
-    currency,
-    walletAddress,
-    safes: deployedSafes,
-  })
 
   const chainMap = useMemo(
     () => Object.fromEntries(configs.map((c) => [c.chainId, c])) as Record<string, Chain>,
@@ -264,15 +250,21 @@ export function useSafeAccountRows(items: AllSafeItems): { groups: AccountGroup[
   )
 
   const groups = useMemo<AccountGroup[]>(() => {
-    const overviewList = overviews ?? []
-    const overviewByKey = new Map(overviewList.map((o) => [overviewKey(o.chainId, o.address.value), o]))
-    const deps: BuildDeps = { overviews: overviewList, overviewByKey, safeSpaces, undeployedSafes, chainMap, getHref }
+    const overviewList = Array.from(overviewsByKey.values())
+    const deps: BuildDeps = {
+      overviews: overviewList,
+      overviewByKey: overviewsByKey,
+      safeSpaces,
+      undeployedSafes,
+      chainMap,
+      getHref,
+    }
     return items.map((item) =>
       isMultiChainSafeItem(item) ? buildMultiGroup(item, deps) : buildSingleGroup(item, deps),
     )
-  }, [items, overviews, safeSpaces, undeployedSafes, chainMap, getHref])
+  }, [items, overviewsByKey, safeSpaces, undeployedSafes, chainMap, getHref])
 
-  return { groups, isLoading }
+  return { groups }
 }
 
 const compareAddresses = (a: AccountGroup, b: AccountGroup) =>


### PR DESCRIPTION
## What it solves

The unified accounts table introduced in #8271 fetches Safe overviews (balance / threshold / pending) for **every** account up front, so opening a large trusted list fires dozens of `/v2/safes` requests on mount. Before #8271 each row fetched its own overview only once scrolled into view. This restores that lazy loading.

Resolves: [WA-2882](https://linear.app/safe-global/issue/WA-2882)

## How this PR fixes it

Overview fetching moves from one eager whole-list query in `useSafeAccountRows` back down to the row: each row fetches its own overview only once it scrolls into view (`useOnceVisible`), and reports the result up into a map the table shares with `useSafeAccountRows`.

Gotchas worth a look in review:

- **Per-row singular queries, not a growing multi-query.** Feeding a growing "visible safes" array to `getSafeOverviewForMany` would re-fetch the whole visible set on every reveal (it uses `forceRefetch` and isn't per-safe cached) — O(n²) on scroll. Per-row queries are individually RTK-cached and coalesced by the existing 300 ms batcher, matching the pre-#8271 design.
- **Threshold-column sort degrades to "loads as you scroll":** balance / pending / threshold share one overview call, and the sort is computed centrally, so rows whose overview hasn't loaded yet sink to the bottom until visible. Name / Networks / Workspaces sorts are unaffected (no overview needed). Agreed tradeoff.
- **Group rows** fetch their (small, fixed) per-chain set once when revealed; expanded children don't re-fetch (`enabled = variant !== 'child'`) — they read what the parent loaded.
- The accumulation callback returns the previous map when nothing new arrived, to avoid a re-render churn loop.

## How to test it

1. Sign in with a wallet that owns many Safes (ideally 50+) and open the trusted accounts list.
2. In DevTools → Network, filter for `/v2/safes` — on load only the visible rows should trigger requests (a handful), not the whole list.
3. Scroll the list — more `/v2/safes` requests fire as rows come into view; already-loaded rows are not re-fetched.
4. Reorder (drag-and-drop) rows and switch surfaces (welcome ↔ dropdown "Manage" ↔ workspace accounts) — balances still load and rows stay draggable.
5. Sort by Threshold on a large list — loaded rows sort correctly; not-yet-loaded rows settle in as you scroll.

## Affected flows

- Welcome → Trusted accounts list (and its search results)
- Workspace Safe accounts + dashboard accounts widget
- Safe-selector dropdown → "Manage" view / Trusted Safes picker
- Spaces → Add accounts modal, and onboarding "Select Safes"

## Blast radius

- **Shared engine:** `useSafeAccountRows` + `SafeAccountsTable` back all 7 surfaces above, so the fetching change applies everywhere the table renders. Its output (`AccountGroup` / `AccountLine`) and sort logic are unchanged.
- **New hook:** `useRowOverviews` (per-row, visibility-gated) wraps `useGetMultipleSafeOverviewsQuery` — same RTK endpoint and batcher as before, just called per row.
- **RTK Query / API:** no contract change; `/v2/safes` (10-per-chunk batching) is untouched.
- **Space pages:** `useSpaceAccountsData` still eager-loads all overviews for the aggregate total-balance widget (inherently needs them) — left as-is, so space pages are not fully lazy by design.
- **Mobile:** none — web-only (`apps/web`).

## Risks / not checked

- No automated assertion of the request-count win — verified by the unit tests' gating logic; the "~30 → ~2 on load" reduction should be spot-checked manually in DevTools.
- Threshold-sort UX under partial load is an accepted degradation, not a bug.
- Exact IntersectionObserver thresholds across scroll containers (page vs. modal) not exhaustively tuned.
- Not tested on mobile (web-only change).

## Visual summary

```mermaid
flowchart TB
  subgraph Before["Before (#8271) — eager"]
    T1[SafeAccountsTable] --> H1[useSafeAccountRows]
    H1 -->|all safes at once| Q1[getSafeOverviewForMany]
    Q1 --> S1[~30 /v2/safes on mount]
  end
  subgraph After["After — lazy per row"]
    T2[SafeAccountsTable] -->|overviewsByKey map| H2[useSafeAccountRows: structure + sort]
    H2 -->|AccountLine| R2[SafeAccountTableRow]
    R2 -->|useOnceVisible| V{visible?}
    V -->|yes| Q2[fetch this row's safes]
    Q2 -->|onOverviewsLoaded| T2
    V -->|no| SK[skeleton]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
