### PR TITLE
fix: preserve full precision in precise amount formatting (WA-1990)

### DIFF
--- a/apps/web/src/components/common/TokenAmount/index.test.tsx
+++ b/apps/web/src/components/common/TokenAmount/index.test.tsx
@@ -16,4 +16,10 @@ describe('TokenAmount', () => {
     const result = render(<TokenAmount value="10000000" decimals={0} />)
     await expect(result.findByText('10M')).resolves.not.toBeNull()
   })
+
+  it('should render the exact value without float rounding when preciseAmount is set', async () => {
+    // 16000000000020475 wei must not be rounded to ...20474 by a float64 conversion.
+    const result = render(<TokenAmount value="16000000000020475" decimals={18} tokenSymbol="ETH" preciseAmount />)
+    await expect(result.findByText('0.016000000000020475 ETH')).resolves.not.toBeNull()
+  })
 })

--- a/packages/utils/src/utils/__tests__/formatNumber.test.ts
+++ b/packages/utils/src/utils/__tests__/formatNumber.test.ts
@@ -12,6 +12,29 @@ describe('formatNumber', () => {
     it('should format a number with a defined precision', () => {
       expect(formatAmountPrecise(1234.5678, 2)).toBe('1,234.57')
     })
+
+    it('should preserve precision for high-precision decimal strings without float rounding', () => {
+      // 16000000000020475 wei formatted to 18 decimals. Round-tripping through a JS
+      // number (float64) would lose the last digit and yield ...20474.
+      expect(formatAmountPrecise('0.016000000000020475', 20)).toBe('0.016000000000020475')
+    })
+
+    it('should preserve precision for negative high-precision strings', () => {
+      expect(formatAmountPrecise('-0.016000000000020475', 20)).toBe('-0.016000000000020475')
+    })
+
+    it('should still format numeric string input', () => {
+      expect(formatAmountPrecise('1234.5678', 2)).toBe('1,234.57')
+    })
+
+    it('should return "NaN" for a non-numeric string', () => {
+      expect(formatAmountPrecise('not-a-number', 2)).toBe('NaN')
+    })
+
+    it('should return "NaN" for an empty or whitespace-only string', () => {
+      expect(formatAmountPrecise('', 2)).toBe('NaN')
+      expect(formatAmountPrecise('   ', 2)).toBe('NaN')
+    })
   })
 
   describe('formatAmount', () => {

--- a/packages/utils/src/utils/formatNumber.ts
+++ b/packages/utils/src/utils/formatNumber.ts
@@ -63,8 +63,19 @@ export const formatAmount = (number: string | number, precision = 5, maxLength =
  * @param number Number to format
  * @param precision Fraction digits to show
  */
+// A string that `Intl.NumberFormat.format` can consume while preserving full precision.
+const isNumericString = (value: string): value is `${number}` => value.trim() !== '' && !Number.isNaN(Number(value))
+
 export const formatAmountPrecise = (number: string | number, precision?: number): string => {
-  return getNumberFormatter(precision).format(Number(number))
+  const formatter = getNumberFormatter(precision)
+  // Pass the numeric string straight to Intl to keep full precision — converting to a JS
+  // number first (float64) loses digits beyond ~15 significant figures, e.g.
+  // 0.016000000000020475 would render as 0.016000000000020474.
+  if (typeof number === 'number' || isNumericString(number)) {
+    return formatter.format(number)
+  }
+
+  return NaN.toString()
 }
 
 /**


### PR DESCRIPTION
## What it solves

Resolves: [WA-1990](https://linear.app/safe-global/issue/WA-1990/investigate-reported-rounding-issue-in-safe-wallet-ui)

A native transfer of `16000000000020475` wei was displayed in the transaction confirmation view as `0.016000000000020474 ETH` — the last digit was wrong (`…474` vs the true `…475`). The raw value in the Data tab was correct; only the human-readable amount was off, which looked sloppy to users.

## How this PR fixes it

`formatAmountPrecise` converted the value with `Number()` before formatting. `Number('0.016000000000020475')` cannot be represented exactly in float64 (17 significant digits > ~15–16), so it silently became `0.016000000000020474`.

Per ECMA-402, `Intl.NumberFormat.prototype.format` accepts a numeric **string** and preserves its full precision. The fix passes the value straight through — gated by an `isNumericString` **type guard** (narrows `string` → `` `${number}` ``, so no `as` cast is needed). Non-numeric/empty input returns `"NaN"`.

```ts
const isNumericString = (value: string): value is `${number}` =>
  value.trim() !== '' && !Number.isNaN(Number(value))

export const formatAmountPrecise = (number: string | number, precision?: number): string => {
  const formatter = getNumberFormatter(precision)
  if (typeof number === 'number' || isNumericString(number)) {
    return formatter.format(number)
  }
  return NaN.toString()
}
```

## How to test it

1. Open a native-token transfer whose value has >15 significant digits, e.g. `16000000000020475` wei.
2. In the transaction confirmation / details view, the amount now reads `0.016000000000020475 ETH` and matches the raw value in the **Data** tab exactly.
3. Unit tests: `yarn workspace @safe-global/utils test src/utils/__tests__/formatNumber.test.ts` and `yarn workspace @safe-global/web test src/components/common/TokenAmount/index.test.tsx`.

## Affected flows

- Transaction confirmation & details — precise amount for native and ERC-20 transfers (`preciseAmount`), plus the `TokenAmount` tooltip (always precise).
- Approval editor — ERC-20 allowance amounts (`ApprovalItem`).

## Blast radius

- `formatAmountPrecise` (`packages/utils`) — shared by `formatVisualAmount(value, decimals, precision)`, which backs `TokenAmount` (precise path + tooltip) and `ApprovalItem`. Shared package → also imported by mobile.
- Behavioral change limited to the invalid-input path: a non-numeric/empty string now returns `"NaN"` (previously empty → `"0"`). Reached only when `safeFormatUnits` fails (invalid value/decimals); valid data is unaffected.
- `formatAmount` and `formatCurrency*` are untouched (their `Number()` use is correct — they round anyway).

## Risks / not checked

- Did not manually test on mobile (shared package; logic is platform-agnostic).
- Did not add analytics.
- Relies on `Intl.NumberFormat` v3 string-precision support (all evergreen browsers + the Node/jsdom test runtime).
- Did not exercise the `safeFormatUnits` error path in a live browser.

## Visual summary

```mermaid
flowchart LR
  A["raw value<br/>16000000000020475 wei"] --> B["safeFormatUnits<br/>'0.016000000000020475'"]
  B --> C{formatAmountPrecise}
  C -->|"Before: format(Number(str))"| D["0.0160000000000204<b>74</b> ❌"]
  C -->|"After: format(str) via type guard"| E["0.0160000000000204<b>75</b> ✅"]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

🤖 Generated with [Claude Code](https://claude.com/claude-code)
