### PR TITLE
fix(web): offer in-app L2 migration regardless of nonce (WA-1685)

### DIFF
--- a/apps/web/src/components/tx-flow/flows/MigrateSafeL2/MigrateSafeL2Review.tsx
+++ b/apps/web/src/components/tx-flow/flows/MigrateSafeL2/MigrateSafeL2Review.tsx
@@ -25,10 +25,8 @@ export const MigrateSafeL2Review = ({ children, ...props }: ReviewTransactionPro
       <ReviewTransaction {...props}>
         <ErrorMessage level="warning" title="Migration transaction">
           <Typography>
-            When executing this transaction, it will not get indexed and appear in the history due to the current
-            incompatible base contract. It might also take a few minutes until the new Safe account version and nonce
-            are reflected in the interface. After the migration is complete, future transactions will get processed and
-            indexed as usual, and there will be no further restrictions.
+            The migration may take a few minutes. Transactions made before or during the migration won&apos;t show up in
+            your transaction history, but all future transactions will appear as usual.
           </Typography>
         </ErrorMessage>
 

--- a/apps/web/src/features/security/data/scanners/contractVersion.ts
+++ b/apps/web/src/features/security/data/scanners/contractVersion.ts
@@ -38,7 +38,6 @@ export const contractVersionScanner: SecurityScanner = {
       version,
       latestVersion,
       masterCopyDeployer,
-      nonce,
       chainId,
       creationInfo,
     } = ctx
@@ -47,13 +46,12 @@ export const contractVersionScanner: SecurityScanner = {
 
     // Unsupported mastercopy — same check as UnsupportedMastercopyWarning
     if (!isValidMasterCopy(implementationVersionState)) {
-      // isMigrationToL2Possible only reads nonce, chainId, and implementationVersionState
-      // from SafeState. We cast to satisfy the type, but only these 3 fields are accessed.
+      // isMigrationToL2Possible only reads version and chainId from SafeState.
+      // We cast to satisfy the type, but only these 2 fields are accessed.
       const canMigrateL2 = isMigrationToL2Possible({
-        nonce,
+        version,
         chainId,
-        implementationVersionState,
-      } as Pick<SafeState, 'nonce' | 'chainId' | 'implementationVersionState'> as SafeState)
+      } as Pick<SafeState, 'version' | 'chainId'> as SafeState)
 
       const score = 10
       return {

--- a/apps/web/src/features/security/data/scanners/contractVersion.ts
+++ b/apps/web/src/features/security/data/scanners/contractVersion.ts
@@ -3,7 +3,6 @@ import semverValid from 'semver/functions/valid'
 import { isValidMasterCopy, isMigrationToL2Possible } from '@safe-global/utils/services/contracts/safeContracts'
 import { getSafeSingletonDeployments, getSafeL2SingletonDeployments } from '@safe-global/safe-deployments'
 import { hasMatchingDeployment } from '@safe-global/utils/services/contracts/deployments'
-import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import type { SecurityScanner } from './types'
 import { KNOWN_SAFE_VERSIONS, getSeverityFromScore } from './constants'
 
@@ -46,12 +45,7 @@ export const contractVersionScanner: SecurityScanner = {
 
     // Unsupported mastercopy — same check as UnsupportedMastercopyWarning
     if (!isValidMasterCopy(implementationVersionState)) {
-      // isMigrationToL2Possible only reads version and chainId from SafeState.
-      // We cast to satisfy the type, but only these 2 fields are accessed.
-      const canMigrateL2 = isMigrationToL2Possible({
-        version,
-        chainId,
-      } as Pick<SafeState, 'version' | 'chainId'> as SafeState)
+      const canMigrateL2 = isMigrationToL2Possible({ version, chainId })
 
       const score = 10
       return {

--- a/apps/web/src/services/contracts/__tests__/safeContracts.test.ts
+++ b/apps/web/src/services/contracts/__tests__/safeContracts.test.ts
@@ -1,11 +1,6 @@
 import { ImplementationVersionState } from '@safe-global/store/gateway/types'
 import { _getMinimumMultiSendCallOnlyVersion } from '../safeContracts'
-import {
-  isValidMasterCopy,
-  _getValidatedGetContractProps,
-  isMigrationToL2Possible,
-} from '@safe-global/utils/services/contracts/safeContracts'
-import { safeInfoBuilder } from '@/tests/builders/safe'
+import { isValidMasterCopy, _getValidatedGetContractProps } from '@safe-global/utils/services/contracts/safeContracts'
 
 describe('safeContracts', () => {
   describe('isValidMasterCopy', () => {
@@ -67,20 +62,6 @@ describe('safeContracts', () => {
 
     it('should return the Safe version if the Safe version is higher than the initial version', () => {
       expect(_getMinimumMultiSendCallOnlyVersion('1.4.1')).toBe('1.4.1')
-    })
-  })
-
-  describe('isMigrationToL2Possible', () => {
-    it('should be possible to migrate Safes on unregistered chains (chain-agnostic canonical fallback)', () => {
-      expect(isMigrationToL2Possible(safeInfoBuilder().with({ nonce: 0, chainId: '69420' }).build())).toBeTruthy()
-    })
-
-    it('should not be possible to migrate Safes with nonce > 0', () => {
-      expect(isMigrationToL2Possible(safeInfoBuilder().with({ nonce: 2, chainId: '10' }).build())).toBeFalsy()
-    })
-
-    it('should be possible to migrate Safes with nonce 0 on chains with migration lib', () => {
-      expect(isMigrationToL2Possible(safeInfoBuilder().with({ nonce: 0, chainId: '10' }).build())).toBeTruthy()
     })
   })
 })

--- a/packages/utils/src/services/contracts/__tests__/safeContracts.test.ts
+++ b/packages/utils/src/services/contracts/__tests__/safeContracts.test.ts
@@ -79,22 +79,38 @@ describe('safeContracts', () => {
       ({
         nonce: 0,
         chainId: '1',
+        version: '1.3.0',
         address: { value: '0x123' },
         ...overrides,
       }) as SafeState
 
-    it('should return false when nonce is not 0', () => {
-      const safe = createMockSafe({ nonce: 1 })
+    it('should return true for a 1.3.0 Safe with nonce > 0 (migration does not depend on nonce)', () => {
+      const safe = createMockSafe({ nonce: 5, version: '1.3.0' })
 
-      expect(isMigrationToL2Possible(safe)).toBe(false)
+      expect(isMigrationToL2Possible(safe)).toBe(true)
     })
 
-    it('should check for migration deployment when nonce is 0', () => {
-      const safe = createMockSafe()
+    it('should return true for a 1.4.1 Safe with nonce > 0', () => {
+      const safe = createMockSafe({ nonce: 12, version: '1.4.1' })
 
-      // Result depends on whether migration deployment exists for the chain
-      const result = isMigrationToL2Possible(safe)
-      expect(typeof result).toBe('boolean')
+      expect(isMigrationToL2Possible(safe)).toBe(true)
+    })
+
+    it('should return true for versions with build metadata like 1.3.0+L2', () => {
+      const safe = createMockSafe({ nonce: 3, version: '1.3.0+L2' })
+
+      expect(isMigrationToL2Possible(safe)).toBe(true)
+    })
+
+    it('should return false for versions not supported by the SafeMigration contract', () => {
+      expect(isMigrationToL2Possible(createMockSafe({ version: '1.1.1' }))).toBe(false)
+      expect(isMigrationToL2Possible(createMockSafe({ version: '1.0.0' }))).toBe(false)
+    })
+
+    it('should return false when the Safe version is unknown', () => {
+      const safe = createMockSafe({ version: null })
+
+      expect(isMigrationToL2Possible(safe)).toBe(false)
     })
   })
 })

--- a/packages/utils/src/services/contracts/__tests__/safeContracts.test.ts
+++ b/packages/utils/src/services/contracts/__tests__/safeContracts.test.ts
@@ -112,5 +112,11 @@ describe('safeContracts', () => {
 
       expect(isMigrationToL2Possible(safe)).toBe(false)
     })
+
+    it('should return true on unregistered chains via the chain-agnostic canonical fallback', () => {
+      const safe = createMockSafe({ chainId: '69420' })
+
+      expect(isMigrationToL2Possible(safe)).toBe(true)
+    })
   })
 })

--- a/packages/utils/src/services/contracts/safeContracts.ts
+++ b/packages/utils/src/services/contracts/safeContracts.ts
@@ -58,8 +58,10 @@ export const _getValidatedGetContractProps = (
  * Checks if a Safe can be migrated to the canonical L2 singleton via the
  * SafeMigration contract (`migrateL2Singleton`). The contract supports
  * 1.3.0 and 1.4.1 Safes and does not depend on the Safe's nonce.
+ * Only the base version is matched — build metadata such as `+L2` or
+ * `+Circles` is ignored.
  */
-export const isMigrationToL2Possible = (safe: SafeState): boolean => {
+export const isMigrationToL2Possible = (safe: Pick<SafeState, 'version' | 'chainId'>): boolean => {
   if (!safe.version || !isSupportedL2Version(safe.version)) {
     return false
   }

--- a/packages/utils/src/services/contracts/safeContracts.ts
+++ b/packages/utils/src/services/contracts/safeContracts.ts
@@ -5,7 +5,7 @@ import { assertValidSafeVersion } from '@safe-global/utils/services/contracts/ut
 import { getSafeMigrationDeployments } from '@safe-global/safe-deployments'
 import { SAFE_TO_L2_MIGRATION_VERSION } from '@safe-global/utils/config/constants'
 import { getChainAgnosticAddress } from '@safe-global/utils/services/contracts/deployments'
-import type { BytecodeComparisonResult } from './bytecodeComparison'
+import { isSupportedL2Version, type BytecodeComparisonResult } from './bytecodeComparison'
 
 // `UNKNOWN` is returned if the mastercopy does not match supported ones
 // @see https://github.com/safe-global/safe-client-gateway/blob/main/src/routes/safes/handlers/safes.rs#L28-L31
@@ -54,7 +54,15 @@ export const _getValidatedGetContractProps = (
     safeVersion: noMetadataVersion as SafeVersion,
   }
 }
+/**
+ * Checks if a Safe can be migrated to the canonical L2 singleton via the
+ * SafeMigration contract (`migrateL2Singleton`). The contract supports
+ * 1.3.0 and 1.4.1 Safes and does not depend on the Safe's nonce.
+ */
 export const isMigrationToL2Possible = (safe: SafeState): boolean => {
+  if (!safe.version || !isSupportedL2Version(safe.version)) {
+    return false
+  }
   const deployment = getSafeMigrationDeployments({ version: SAFE_TO_L2_MIGRATION_VERSION })
-  return safe.nonce === 0 && Boolean(getChainAgnosticAddress(deployment, safe.chainId))
+  return Boolean(getChainAgnosticAddress(deployment, safe.chainId))
 }


### PR DESCRIPTION
## What it solves

Resolves: [WA-1685](https://linear.app/safe-global/issue/WA-1685/ui-shows-unsupported-mastercopy-use-cli-instead-of-migrate) (duplicate: WA-2874)

Safes deployed with an **official L1 mastercopy** on an L2 chain (1.3.0 L1 on Katana / Unichain, 1.4.1 L1 on Arbitrum — real customer Safes from HN and Morpho) that had already executed transactions were shown the dead-end **"Unsupported mastercopy → Use CLI"** card instead of the in-app **Migrate** flow.

Root cause: `isMigrationToL2Possible` gated the Migrate CTA on `safe.nonce === 0`. That constraint belongs to the retired **SafeToL2Migration** contract (`0xfF83F6...`, whose `migrateToL2()` requires nonce 0). The current flow (since #5207) executes **SafeMigration** (`0x526643...`) `migrateL2Singleton()`, which has **no nonce requirement** and supports `1.3.0 L1 → 1.4.1 L2` and `1.4.1 L1 → 1.4.1 L2` per the [official migration docs](https://docs.safe.global/advanced/smart-account-migration). The nonce gate was never removed when the contract was swapped.

## How this PR fixes it

`isMigrationToL2Possible` now gates on the **Safe version** instead of the nonce, matching what the SafeMigration contract actually supports:

- version base `1.3.0` / `1.4.1` (build metadata like `+L2` tolerated, via the existing `isSupportedL2Version`) → **Migrate**
- `1.1.1` and older, or unknown version → still **Use CLI** (SafeMigration does not support them; 1.1.1 needs the separate `migrateFromV111` path)
- the existing per-chain SafeMigration deployment check is unchanged

CGW's `implementationVersionState = UNKNOWN` classification is intentionally untouched — the backend is correct; only the frontend's migrate-eligibility decision was wrong.

## How to test it

1. In a dev build, run `localStorage.setItem('debugProdCgw', 'true')` in the console and reload (routes the app to prod CGW, read-only).
2. Open the affected customer Safe from WA-2874: `unichain:0xF057afeEc22E220f47AD4220871364e9E828b2e9` (official 1.3.0 L1 mastercopy, nonce 20, `implementationVersionState: UNKNOWN`).
3. The dashboard banner and Settings → Security now show **Migrate** (previously "Get CLI"); the flow builds a `SafeMigration.migrateL2Singleton` delegatecall.
4. A supported Safe shows no banner; a pre-1.3.0 unsupported Safe still shows the CLI link.
5. Unit specs: `packages/utils` → `yarn jest src/services/contracts/__tests__/safeContracts.test.ts`.

## Affected flows

- Owner of an unsupported-mastercopy Safe (official L1 singleton, any nonce) sees the dashboard attention card and can start the in-app **Migrate** tx flow instead of being sent to the CLI
- Same decision in **Settings → Security** (contract version scanner remediation + CTA)
- Same decision in the **unknown-contract transaction error** shown when composing a tx from such a Safe
- Mobile **Settings** screen uses the same helper for its unsupported-mastercopy alert

## Blast radius

- `packages/utils/src/services/contracts/safeContracts.ts` → `isMigrationToL2Possible` is a **shared helper** with four consumers, all of which now offer migration to more Safes (nonce > 0) and to fewer Safes (pre-1.3.0, previously offered migration at nonce 0 even though SafeMigration doesn't support them):
  - web: `UnsupportedMastercopyWarning` (dashboard banner), `contractVersion` Security Hub scanner, `UnknownContractError`
  - mobile: `Settings.container.tsx` (shared package — behavior change ships to mobile too)
- The scanner call site now reads `safe.version` instead of `safe.nonce` (both already present in `SafeState`; no API/RTK-Query contract changes)
- No feature flags, chain configs, persistence, or routes involved; CGW untouched

## Risks / not checked

- Did not execute an actual migration transaction on-chain; verified up to the tx preview (delegatecall to `SafeMigration.migrateL2Singleton`)
- Did not test the mobile app; its behavior change is inferred from the shared helper (unit-tested only)
- Did not verify a chain where SafeMigration is genuinely undeployed — `getChainAgnosticAddress` deliberately falls back to the canonical deterministic address for unregistered chains (pre-existing semantics, unchanged)
- Behavior for pre-1.3.0 Safes at nonce 0 changes from "Migrate" to "Use CLI" — this is intended (SafeMigration doesn't support them) but was not exercised against a live 1.1.1 Safe
- Ticket Case 3 (add-network flow for Ethereum 1.3.0 Safes) was not separately exercised; it shares this decision path via the banner on the newly added chain

## Visual summary
Before
<img width="1807" height="530" alt="Screenshot 2026-07-20 at 14 28 40" src="https://github.com/user-attachments/assets/32534bbf-bd00-45cc-a7c8-550fc85dd2af" />


After
<img width="1904" height="510" alt="Screenshot 2026-07-20 at 14 29 12" src="https://github.com/user-attachments/assets/e82b0e32-10a4-46f5-b7ba-1968c30b61c8" />


```mermaid
flowchart TD
    A[implementationVersionState = UNKNOWN] --> B{Before:<br/>nonce === 0?}
    B -- yes --> C[Migrate]
    B -- "no (customer Safes)" --> D[Use CLI ❌]

    A2[implementationVersionState = UNKNOWN] --> E{After:<br/>version base is<br/>1.3.0 or 1.4.1?}
    E -- yes --> F{SafeMigration<br/>deployed on chain?}
    F -- yes --> G[Migrate ✅<br/>SafeMigration.migrateL2Singleton<br/>— no nonce requirement]
    F -- no --> H[Use CLI]
    E -- "no (≤1.1.1 / unknown)" --> H
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics changes; existing `MIGRATE_MASTERCOPY` / `GET_CLI_MASTERCOPY` events unchanged, their relative volume will shift toward Migrate
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).