### PR TITLE
fix(web): only show awaiting-confirmation for actual owners (WA-2889)

### DIFF
--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceSafeSelectorItems.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceSafeSelectorItems.ts
@@ -15,6 +15,7 @@ import { PendingSafeStatus } from '@/features/counterfactual/types'
 import type { UndeployedSafesState } from '@/features/counterfactual/types'
 import useWallet from '@/hooks/wallets/useWallet'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
+import { getOwnerAwaitingConfirmations } from '@/utils/transaction-guards'
 import { skipToken } from '@reduxjs/toolkit/query'
 import { AppRoutes } from '@/config/routes'
 import { trackEvent } from '@/services/analytics'
@@ -57,6 +58,7 @@ const mapMultiChainItemChains = (
   overviews: SafeOverview[] | undefined,
   overviewsLoading: boolean,
   undeployedSafes: UndeployedSafesState,
+  walletAddress: string | undefined,
 ): SafeItemDataChain[] =>
   chainIds.map((id) => {
     const overview = overviews?.find((o) => sameAddress(o.address.value, item.address) && o.chainId === id)
@@ -72,7 +74,7 @@ const mapMultiChainItemChains = (
       balance: overview?.fiatTotal,
       isLoading: overviewsLoading && !overview,
       queued: overview?.queued,
-      awaitingConfirmation: overview?.awaitingConfirmation ?? undefined,
+      awaitingConfirmation: getOwnerAwaitingConfirmations(overview, walletAddress) || undefined,
       isReadOnly: perChainSafe?.isReadOnly ?? false,
       isUndeployed: Boolean(undeployed),
       isActivating: Boolean(undeployed && undeployed.status.status !== PendingSafeStatus.AWAITING_EXECUTION),
@@ -88,6 +90,7 @@ function buildMultiChainItem(
   safe: { threshold: number; owners?: { value: string }[] },
   chainConfigs: Chain[],
   undeployedSafes: UndeployedSafesState,
+  walletAddress: string | undefined,
 ): SafeItemData {
   const chainIds = item.safes.map((s) => s.chainId)
   const orderedChainIds = isCurrentSafe ? [currentChainId, ...chainIds.filter((id) => id !== currentChainId)] : chainIds
@@ -103,7 +106,15 @@ function buildMultiChainItem(
     ...resolveThresholdAndOwners(isCurrentSafe, safe, currentChainOverview),
     balance: currentChainOverview?.fiatTotal ?? '0',
     isLoading: overviewsLoading && !currentChainOverview,
-    chains: mapMultiChainItemChains(chainConfigs, orderedChainIds, item, overviews, overviewsLoading, undeployedSafes),
+    chains: mapMultiChainItemChains(
+      chainConfigs,
+      orderedChainIds,
+      item,
+      overviews,
+      overviewsLoading,
+      undeployedSafes,
+      walletAddress,
+    ),
   }
 }
 
@@ -115,6 +126,7 @@ function buildSingleChainItem(
   safe: { threshold: number; owners?: { value: string }[] },
   chainConfigs: Chain[],
   undeployedSafes: UndeployedSafesState,
+  walletAddress: string | undefined,
 ): SafeItemData {
   const overview = overviews?.find((o) => sameAddress(o.address.value, item.address) && o.chainId === item.chainId)
   const undeployed = undeployedSafes[item.chainId]?.[item.address]
@@ -129,7 +141,7 @@ function buildSingleChainItem(
     chains: mapChainIds(chainConfigs, [item.chainId]).map((chain) => ({
       ...chain,
       queued: overview?.queued,
-      awaitingConfirmation: overview?.awaitingConfirmation ?? undefined,
+      awaitingConfirmation: getOwnerAwaitingConfirmations(overview, walletAddress) || undefined,
       isReadOnly: item.isReadOnly ?? false,
       isUndeployed: Boolean(undeployed),
       isActivating: Boolean(undeployed && undeployed.status.status !== PendingSafeStatus.AWAITING_EXECUTION),
@@ -176,6 +188,7 @@ export function useSpaceSafeSelectorItems() {
             safe,
             chainConfigs,
             undeployedSafes,
+            walletAddress,
           )
         }
 
@@ -187,9 +200,19 @@ export function useSpaceSafeSelectorItems() {
           safe,
           chainConfigs,
           undeployedSafes,
+          walletAddress,
         )
       }),
-    [effectiveSafeAddress, currentChainId, safe, overviews, overviewsLoading, chainConfigs, undeployedSafes],
+    [
+      effectiveSafeAddress,
+      currentChainId,
+      safe,
+      overviews,
+      overviewsLoading,
+      chainConfigs,
+      undeployedSafes,
+      walletAddress,
+    ],
   )
 
   const workspaceItems = useMemo(() => buildItems(workspaceSafes), [buildItems, workspaceSafes])

--- a/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
@@ -15,6 +15,7 @@ import { type MultiChainSafeItem, type SafeItem } from '@/hooks/safes'
 import { AddNetworkButton } from '../AddNetworkButton'
 import MultiAccountContextMenu from '@/components/common/SafeListContextMenu/MultiAccountContextMenu'
 import { ContactSource } from '@/hooks/useAllAddressBooks'
+import { getOwnerAwaitingConfirmations } from '@/utils/transaction-guards'
 
 function MultiChainSubItem({
   safeItem,
@@ -25,15 +26,25 @@ function MultiChainSubItem({
   safeOverview?: SafeOverview
   onLinkClick?: () => void
 }) {
-  const { chain, href, threshold, owners, elementRef, trackingLabel, isCurrentSafe, undeployedSafe, isActivating } =
-    useSafeItemData(safeItem, {
-      safeOverview,
-    })
+  const {
+    chain,
+    href,
+    threshold,
+    owners,
+    elementRef,
+    trackingLabel,
+    isCurrentSafe,
+    undeployedSafe,
+    isActivating,
+    walletAddress,
+  } = useSafeItemData(safeItem, {
+    safeOverview,
+  })
+
+  const awaitingConfirmation = getOwnerAwaitingConfirmations(safeOverview, walletAddress)
 
   const hasQueuedItems =
-    !safeItem.isReadOnly &&
-    safeOverview &&
-    ((safeOverview.queued ?? 0) > 0 || (safeOverview.awaitingConfirmation ?? 0) > 0)
+    !safeItem.isReadOnly && safeOverview && ((safeOverview.queued ?? 0) > 0 || awaitingConfirmation > 0)
 
   return (
     <AccountItem.Link
@@ -61,7 +72,7 @@ function MultiChainSubItem({
             safeAddress={safeOverview.address.value}
             chainShortName={chain?.shortName || ''}
             queued={safeOverview.queued ?? 0}
-            awaitingConfirmation={safeOverview.awaitingConfirmation ?? 0}
+            awaitingConfirmation={awaitingConfirmation}
           />
         )}
       </AccountItem.Info>

--- a/apps/web/src/features/myAccounts/components/SafeAccountsTable/useSafeAccountRows.ts
+++ b/apps/web/src/features/myAccounts/components/SafeAccountsTable/useSafeAccountRows.ts
@@ -19,6 +19,8 @@ import { getSafeSetups, getSharedSetup, hasMultiChainAddNetworkFeature } from '@
 import { useSafeSpaces, type SafeSpacesMap } from '@/hooks/useSafeSpaces'
 import { useAppSelector } from '@/store'
 import useChains from '@/hooks/useChains'
+import useWallet from '@/hooks/wallets/useWallet'
+import { getOwnerAwaitingConfirmations } from '@/utils/transaction-guards'
 
 export type SafeSortColumn = 'name' | 'threshold' | 'networks' | 'workspaces'
 
@@ -76,6 +78,8 @@ type BuildDeps = {
   undeployedSafes: UndeployedSafesState
   chainMap: Record<string, Chain>
   getHref: (chain: Chain, address: string) => LinkProps['href']
+  /** Connected wallet — `awaitingConfirmation` is only surfaced when it's an owner of the Safe. */
+  walletAddress?: string
 }
 
 export const overviewKey = (chainId: string, address: string) => `${chainId}:${address.toLowerCase()}`
@@ -125,7 +129,7 @@ const buildSafeLine = (safe: SafeItem, deps: BuildDeps, variant: 'single' | 'chi
     thresholdMixed: false,
     workspaces: variant === 'child' ? [] : (deps.safeSpaces[overviewKey(chainId, address)] ?? []),
     pending: overview?.queued ?? 0,
-    awaitingConfirmation: overview?.awaitingConfirmation ?? 0,
+    awaitingConfirmation: getOwnerAwaitingConfirmations(overview, deps.walletAddress),
     balance: overview?.fiatTotal,
     href: chain ? deps.getHref(chain, address) : undefined,
     contextMenu: {
@@ -165,7 +169,10 @@ const buildMultiGroup = (item: MultiChainSafeItem, deps: BuildDeps): AccountGrou
   const children = safes.map((s) => buildSafeLine(s, deps, 'child'))
 
   const pending = overviewsForItem.reduce((sum, o) => sum + (o?.queued ?? 0), 0)
-  const awaitingConfirmation = overviewsForItem.reduce((sum, o) => sum + (o?.awaitingConfirmation ?? 0), 0)
+  const awaitingConfirmation = overviewsForItem.reduce(
+    (sum, o) => sum + getOwnerAwaitingConfirmations(o, deps.walletAddress),
+    0,
+  )
   const fiatValues = overviewsForItem.filter((o): o is SafeOverview => Boolean(o)).map((o) => Number(o.fiatTotal))
   const hasReplayableSafe = safes.some((s) => {
     const undeployed = deps.undeployedSafes[s.chainId]?.[s.address]
@@ -243,6 +250,7 @@ export function useSafeAccountRows(
   const undeployedSafes = useAppSelector(selectUndeployedSafes)
   const { configs } = useChains()
   const { safeSpaces } = useSafeSpaces()
+  const { address: walletAddress } = useWallet() ?? {}
 
   const chainMap = useMemo(
     () => Object.fromEntries(configs.map((c) => [c.chainId, c])) as Record<string, Chain>,
@@ -258,11 +266,12 @@ export function useSafeAccountRows(
       undeployedSafes,
       chainMap,
       getHref,
+      walletAddress,
     }
     return items.map((item) =>
       isMultiChainSafeItem(item) ? buildMultiGroup(item, deps) : buildSingleGroup(item, deps),
     )
-  }, [items, overviewsByKey, safeSpaces, undeployedSafes, chainMap, getHref])
+  }, [items, overviewsByKey, safeSpaces, undeployedSafes, chainMap, getHref, walletAddress])
 
   return { groups }
 }

--- a/apps/web/src/features/myAccounts/components/SafesList/SafeListItem.tsx
+++ b/apps/web/src/features/myAccounts/components/SafesList/SafeListItem.tsx
@@ -5,6 +5,7 @@ import css from '../AccountItems/styles.module.css'
 import type { SafeItem } from '@/hooks/safes'
 import { SpacesFeature } from '@/features/spaces'
 import { useLoadFeature } from '@/features/__core__'
+import { getOwnerAwaitingConfirmations } from '@/utils/transaction-guards'
 
 export interface SafeListItemProps {
   safeItem: SafeItem
@@ -30,12 +31,13 @@ export const SafeListItem = ({ safeItem, onLinkClick, isSpaceSafe = false }: Saf
     undeployedSafe,
     elementRef,
     trackingLabel,
+    walletAddress,
   } = useSafeItemData(safeItem, { isSpaceSafe })
 
+  const awaitingConfirmation = getOwnerAwaitingConfirmations(safeOverview, walletAddress)
+
   const hasQueuedItems =
-    !safeItem.isReadOnly &&
-    safeOverview &&
-    ((safeOverview.queued ?? 0) > 0 || (safeOverview.awaitingConfirmation ?? 0) > 0)
+    !safeItem.isReadOnly && safeOverview && ((safeOverview.queued ?? 0) > 0 || awaitingConfirmation > 0)
 
   const statusChips = (
     <>
@@ -49,7 +51,7 @@ export const SafeListItem = ({ safeItem, onLinkClick, isSpaceSafe = false }: Saf
           safeAddress={safeOverview.address.value}
           chainShortName={chain?.shortName || ''}
           queued={safeOverview.queued ?? 0}
-          awaitingConfirmation={safeOverview.awaitingConfirmation ?? 0}
+          awaitingConfirmation={awaitingConfirmation}
         />
       )}
     </>

--- a/apps/web/src/features/myAccounts/hooks/useSafeItemData.ts
+++ b/apps/web/src/features/myAccounts/hooks/useSafeItemData.ts
@@ -87,6 +87,7 @@ export function useSafeItemData(safeItem: SafeItem, options?: UseSafeItemDataOpt
     name,
     href,
     safeOverview,
+    walletAddress,
 
     // Derived state
     isCurrentSafe,

--- a/apps/web/src/utils/__tests__/transaction-guards.test.ts
+++ b/apps/web/src/utils/__tests__/transaction-guards.test.ts
@@ -1,5 +1,6 @@
 import { TransactionInfoType } from '@safe-global/store/gateway/types'
 import {
+  getOwnerAwaitingConfirmations,
   isExecTxData,
   isExecTxInfo,
   isOnChainConfirmationTxData,
@@ -7,6 +8,7 @@ import {
   isOnChainSignMessageTxData,
   isSafeUpdateTxData,
 } from '../transaction-guards'
+import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import { faker } from '@faker-js/faker'
 import { Safe__factory, Sign_message_lib__factory } from '@safe-global/utils/types/contracts'
 import { TransactionTokenType, TransferDirection } from '@safe-global/store/gateway/types'
@@ -345,6 +347,47 @@ describe('transaction-guards', () => {
         .build()
 
       expect(isOnChainSignMessageTxData(mockTxData, '1')).toBeFalsy()
+    })
+  })
+
+  describe('getOwnerAwaitingConfirmations', () => {
+    const walletAddress = faker.finance.ethereumAddress()
+
+    const overviewWith = (
+      awaitingConfirmation: number | null,
+      owners: string[],
+    ): Pick<SafeOverview, 'owners' | 'awaitingConfirmation'> => ({
+      awaitingConfirmation,
+      owners: owners.map((value) => ({ value })),
+    })
+
+    it('returns the count when the wallet is an owner', () => {
+      const overview = overviewWith(3, [faker.finance.ethereumAddress(), walletAddress])
+      expect(getOwnerAwaitingConfirmations(overview, walletAddress)).toBe(3)
+    })
+
+    it('matches owners case-insensitively', () => {
+      const overview = overviewWith(2, [walletAddress.toUpperCase()])
+      expect(getOwnerAwaitingConfirmations(overview, walletAddress.toLowerCase())).toBe(2)
+    })
+
+    it('returns 0 when the wallet is not an owner', () => {
+      const overview = overviewWith(3, [faker.finance.ethereumAddress()])
+      expect(getOwnerAwaitingConfirmations(overview, walletAddress)).toBe(0)
+    })
+
+    it('returns 0 when no wallet is connected', () => {
+      const overview = overviewWith(3, [walletAddress])
+      expect(getOwnerAwaitingConfirmations(overview, undefined)).toBe(0)
+    })
+
+    it('returns 0 when nothing is awaiting confirmation', () => {
+      expect(getOwnerAwaitingConfirmations(overviewWith(0, [walletAddress]), walletAddress)).toBe(0)
+      expect(getOwnerAwaitingConfirmations(overviewWith(null, [walletAddress]), walletAddress)).toBe(0)
+    })
+
+    it('returns 0 when there is no overview', () => {
+      expect(getOwnerAwaitingConfirmations(undefined, walletAddress)).toBe(0)
     })
   })
 })

--- a/apps/web/src/utils/transaction-guards.ts
+++ b/apps/web/src/utils/transaction-guards.ts
@@ -16,7 +16,7 @@ import {
   ConflictType,
   TransactionTokenType,
 } from '@safe-global/store/gateway/types'
-import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import type { SafeOverview, SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 
 import type {
   ConflictHeaderQueuedItem,
@@ -100,6 +100,21 @@ export const isOwner = (safeOwners: AddressInfo[] | NamedAddress[] = [], walletA
   }
 
   return safeOwners.some((owner) => sameAddress(owner.address, walletAddress))
+}
+
+/**
+ * The CGW `awaitingConfirmation` count is keyed off the connected wallet regardless of whether that
+ * wallet is an owner, so gate it on the overview's owner list: a non-owner (or watch-only) wallet
+ * must never be told that transactions await its signature. Returns 0 when there is no wallet, the
+ * wallet is not an owner, or nothing is awaiting confirmation.
+ */
+export const getOwnerAwaitingConfirmations = (
+  overview: Pick<SafeOverview, 'owners' | 'awaitingConfirmation'> | null | undefined,
+  walletAddress: string | undefined,
+): number => {
+  const awaiting = overview?.awaitingConfirmation ?? 0
+  if (awaiting <= 0) return 0
+  return isOwner(overview?.owners, walletAddress) ? awaiting : 0
 }
 
 export const isMultisigDetailedExecutionInfo = (


### PR DESCRIPTION
## What it solves

The "N pending transactions · N awaiting your confirmation" indicator (orange dot, tooltip, and "to confirm" chip) was shown to any connected wallet, even when that wallet is not an owner of the Safe. Non-owners / watch-only wallets were told transactions awaited their signature.

Resolves: https://linear.app/safe-global/issue/WA-2889

## How this PR fixes it

The gateway's `awaitingConfirmation` count is keyed off the connected wallet regardless of ownership, so the fix gates it client-side on the overview's `owners` list via a shared `getOwnerAwaitingConfirmations(overview, walletAddress)` helper.

Gotchas:
- Gating happens **per-chain overview before summing**, so a wallet that owns one chain of a multi-chain Safe but not another is counted correctly.
- Only the *awaiting* part is gated — the plain "N · Pending" queued count still shows regardless of ownership.
- The legacy SafesList already hid the block via its `isReadOnly` flag; it now uses the same authoritative owner-list check so the two data sources can't disagree.

## How to test it

1. Connect a wallet that is **not** an owner of a Safe that has pending transactions (e.g. a watch-only / added account).
2. Open **My accounts** — the row's Pending badge shows the count but **no** orange dot, and the tooltip omits "· N awaiting your confirmation".
3. Open the Safe selector **dropdown** and the spaces accounts list — same: no awaiting indicator for the non-owner.
4. Connect a wallet that **is** an owner with pending txs and confirm the orange dot, tooltip breakdown, and "to confirm" chip all still appear.

## Screenshots

N/A — behavioural fix; existing badge/tooltip UI unchanged.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
