### PR TITLE
fix(web): filter trusted safes by network in manage account list

### DIFF
--- a/apps/web/src/components/common/TrustedSafesModal/useTrustedSafesModal.test.ts
+++ b/apps/web/src/components/common/TrustedSafesModal/useTrustedSafesModal.test.ts
@@ -16,6 +16,18 @@ jest.mock('@/hooks/safes/useAllSafes', () => ({
   default: jest.fn(),
 }))
 
+// Stub the Fuse search (covered by its own suite) with a deterministic substring filter.
+jest.mock('@/hooks/safes/useSafesSearch', () => ({
+  useSafesSearch: (items: Array<{ address: string; name?: string }>, query: string) =>
+    query
+      ? items.filter(
+          (item) =>
+            item.address.toLowerCase().includes(query.toLowerCase()) ||
+            (item.name ? item.name.toLowerCase().includes(query.toLowerCase()) : false),
+        )
+      : [],
+}))
+
 jest.mock('@safe-global/utils/utils/addressSimilarity', () => ({
   detectSimilarAddresses: jest.fn(),
 }))

--- a/apps/web/src/components/common/TrustedSafesModal/useTrustedSafesModal.ts
+++ b/apps/web/src/components/common/TrustedSafesModal/useTrustedSafesModal.ts
@@ -6,6 +6,7 @@ import { defaultSafeInfo } from '@safe-global/store/slices/SafeInfo/utils'
 import { OVERVIEW_EVENTS, PIN_SAFE_LABELS, trackEvent } from '@/services/analytics'
 import { useAllSafesGrouped } from '@/hooks/safes/useAllSafesGrouped'
 import useAllSafes from '@/hooks/safes/useAllSafes'
+import { useSafesSearch } from '@/hooks/safes/useSafesSearch'
 import { useSafeOrderComparator } from '@/hooks/safes'
 import { TRUSTED_ORDER_SCOPE } from '@/store/orderByPreferenceSlice'
 import { detectSimilarAddresses } from '@safe-global/utils/utils/addressSimilarity'
@@ -109,22 +110,13 @@ const useTrustedSafesModal = (): UseTrustedSafesModalReturn => {
 
   const similarityResult = useMemo(() => detectSimilarAddresses(addresses), [addresses])
 
-  // Structural list (no selection state) — rebuilds only when the underlying safes, pins,
-  // similarity, or search change, not on every checkbox click.
+  // Full list without selection state, rebuilt only when the safes, pins, or similarity change.
   const structuralItems = useMemo<SelectableItem[]>(() => {
     if (!allMultiChainSafes || !allSingleSafes) return []
 
     const items: SelectableItem[] = []
 
-    const matchesSearch = (address: string, name?: string): boolean => {
-      if (!searchQuery) return true
-      const query = searchQuery.toLowerCase()
-      return address.toLowerCase().includes(query) || (name ? name.toLowerCase().includes(query) : false)
-    }
-
     for (const multiSafe of allMultiChainSafes) {
-      if (!matchesSearch(multiSafe.address, multiSafe.name)) continue
-
       const group = similarityResult.getGroup(multiSafe.address)
 
       const selectableSafes: SelectableSafe[] = multiSafe.safes.map((safe) => ({
@@ -149,8 +141,6 @@ const useTrustedSafesModal = (): UseTrustedSafesModalReturn => {
     }
 
     for (const safe of allSingleSafes) {
-      if (!matchesSearch(safe.address, safe.name)) continue
-
       const group = similarityResult.getGroup(safe.address)
       const isPinned = Boolean(addedSafes[safe.chainId]?.[safe.address])
 
@@ -163,11 +153,21 @@ const useTrustedSafesModal = (): UseTrustedSafesModalReturn => {
     }
 
     return items.sort(sortComparator)
-  }, [allMultiChainSafes, allSingleSafes, addedSafes, similarityResult, searchQuery, sortComparator])
+  }, [allMultiChainSafes, allSingleSafes, addedSafes, similarityResult, sortComparator])
 
-  // Thin overlay injecting selection state over the structural list
+  // Shared name/address/network search (as on the main list); returns [] for an empty query.
+  const searchResults = useSafesSearch(structuralItems, searchQuery)
+
+  // Filter by the search matches, keeping the structural sort order and SelectableItem typing.
+  const visibleItems = useMemo<SelectableItem[]>(() => {
+    if (!searchQuery) return structuralItems
+    const matched = new Set(searchResults.map((item) => item.address.toLowerCase()))
+    return structuralItems.filter((item) => matched.has(item.address.toLowerCase()))
+  }, [searchQuery, searchResults, structuralItems])
+
+  // Thin overlay injecting selection state over the visible (search-filtered) list
   const availableItems = useMemo<SelectableItem[]>(() => {
-    return structuralItems.map((item) => {
+    return visibleItems.map((item) => {
       const isSelected = selectedAddresses.has(item.address.toLowerCase())
       if (isSelectableMultiChainSafe(item)) {
         return {
@@ -178,7 +178,7 @@ const useTrustedSafesModal = (): UseTrustedSafesModalReturn => {
       }
       return { ...item, isSelected }
     })
-  }, [structuralItems, selectedAddresses])
+  }, [visibleItems, selectedAddresses])
 
   // Check if there are any changes to submit (pins or unpins) across the full list,
   // not just the search-filtered view — selection persists across searches, so Save

--- a/apps/web/src/hooks/safes/useSafesSearch.test.ts
+++ b/apps/web/src/hooks/safes/useSafesSearch.test.ts
@@ -1,0 +1,66 @@
+import { renderHook } from '@testing-library/react'
+import { useSafesSearch } from './useSafesSearch'
+import type { AllSafeItems, MultiChainSafeItem } from './useAllSafesGrouped'
+import type { SafeItem } from './useAllSafes'
+
+jest.mock('@/hooks/useChains', () => ({
+  __esModule: true,
+  default: () => ({
+    configs: [
+      { chainId: '1', chainName: 'Ethereum' },
+      { chainId: '137', chainName: 'Polygon' },
+    ],
+  }),
+}))
+
+const safe = (over: Partial<SafeItem> & Pick<SafeItem, 'address' | 'chainId'>): SafeItem => ({
+  isReadOnly: false,
+  isPinned: false,
+  lastVisited: 0,
+  name: undefined,
+  ...over,
+})
+
+const ETH_SAFE = safe({ chainId: '1', address: '0x1111111111111111111111111111111111111111', name: 'Alpha' })
+const POLYGON_SAFE = safe({ chainId: '137', address: '0x2222222222222222222222222222222222222222', name: 'Beta' })
+
+describe('useSafesSearch', () => {
+  it('returns an empty array for an empty query', () => {
+    const { result } = renderHook(() => useSafesSearch([ETH_SAFE, POLYGON_SAFE], ''))
+    expect(result.current).toEqual([])
+  })
+
+  it('matches by safe name', () => {
+    const { result } = renderHook(() => useSafesSearch([ETH_SAFE, POLYGON_SAFE], 'Alpha'))
+    expect(result.current.map((s) => s.address)).toEqual([ETH_SAFE.address])
+  })
+
+  it('matches by address', () => {
+    const { result } = renderHook(() => useSafesSearch([ETH_SAFE, POLYGON_SAFE], POLYGON_SAFE.address))
+    expect(result.current.map((s) => s.address)).toEqual([POLYGON_SAFE.address])
+  })
+
+  it('matches by network name', () => {
+    const { result } = renderHook(() => useSafesSearch([ETH_SAFE, POLYGON_SAFE], 'Polygon'))
+    expect(result.current.map((s) => s.address)).toEqual([POLYGON_SAFE.address])
+  })
+
+  it('matches a multichain safe by any of its network names', () => {
+    const multiChainAddress = '0x3333333333333333333333333333333333333333'
+    const multiSafe: MultiChainSafeItem = {
+      address: multiChainAddress,
+      name: 'Multi',
+      isPinned: false,
+      lastVisited: 0,
+      safes: [
+        safe({ chainId: '1', address: multiChainAddress, name: 'Multi' }),
+        safe({ chainId: '137', address: multiChainAddress, name: 'Multi' }),
+      ],
+    }
+    const items: AllSafeItems = [multiSafe, ETH_SAFE]
+
+    const { result } = renderHook(() => useSafesSearch(items, 'Polygon'))
+
+    expect(result.current.map((s) => s.address)).toEqual([multiChainAddress])
+  })
+})


### PR DESCRIPTION
## What it solves

The "Manage my account list" modal's search box is labelled "by name, address or
network", but network search never worked — it filtered only on address and name.
Safes coming from the owned-safes endpoint (which usually have no custom name)
couldn't be found by their network at all.

Resolves:

## How this PR fixes it

Replaces the modal's bespoke substring `matchesSearch` (address + name only) with
the shared `useSafesSearch` hook — the same Fuse-based search over name, address
**and** network name that the main accounts list already uses. The structural list
is now built unfiltered, and a new `visibleItems` applies the search results while
preserving the modal's sort order and `SelectableItem` typing. Selection, counts,
and select-all already derive from the filtered `availableItems`, so they scope to
the visible set automatically.

## How to test it

1. Connect a wallet that owns safes on multiple networks.
2. Open Accounts → **Manage my account list**.
3. Type a network name (e.g. `Polygon`, `Ethereum`) → only safes on that network
   are shown, including owned safes with no custom name.
4. Confirm searching by name and by address still work, and that selections
   persist across searches.

## Affected flows

- Manage my account list → search/filter safes (standalone modal, Spaces "Add
  accounts" embed, and SpaceSafeBar all share `ManageTrustedSafesContent`).

## Blast radius

- `useTrustedSafesModal` — filtering now delegates to `useSafesSearch`. Consumers:
  `MyAccountsV2`, `AccountsList`, Spaces `AddAccounts`, `SpaceSafeBar` (all via
  `ManageTrustedSafesContent` / `TrustedSafesModal`).
- Reuses `useSafesSearch` (already shared with the main list's `FilteredSafes`) —
  not modified.
- No RTK Query / API contract, feature-flag, persistence, or route changes.
- Mobile: not affected (web-only modal).

## Risks / not checked

- Modal search now uses Fuse fuzzy matching (was substring) — this makes it
  consistent with the main accounts list, but a very-close name pair can match more
  loosely than before.
- Did not add debounce to the search input (out of scope); Fuse over a few hundred
  items per keystroke is fast enough.
- Did not test on mobile (N/A — web only).
- Did not exercise the Spaces "Add accounts" embed manually in a browser (covered by
  unit tests).

## Visual summary

```mermaid
flowchart LR
  subgraph Before
    A1[Search query] --> B1["matchesSearch()<br/>address + name only"]
    B1 --> C1["Network query →<br/>no matches"]
  end
  subgraph After
    A2[Search query] --> B2["useSafesSearch()<br/>name + address + network"]
    B2 --> C2[Filter structural list<br/>keep sort order]
    C2 --> D2[availableItems]
  end
