### PR TITLE
perf(web): open manage-account-list modal instantly for large lists

### DIFF
--- a/apps/web/src/components/common/TrustedSafesModal/ManageTrustedSafesContent.tsx
+++ b/apps/web/src/components/common/TrustedSafesModal/ManageTrustedSafesContent.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { ChevronLeft, Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -71,6 +71,20 @@ const ManageTrustedSafesContent = ({ modal, secondaryLabel, onSecondary, onSaved
   const isDarkMode = useDarkMode()
   const dispatch = useAppDispatch()
   const { orderBy } = useAppSelector(selectOrderByPreference)
+
+  // Rendering hundreds of account rows takes ~1s and blocks the dialog's first paint. Defer the table
+  // past one painted frame (double rAF) so the shell + spinner show immediately, then the rows fill in.
+  const [showTable, setShowTable] = useState(false)
+  useEffect(() => {
+    let inner = 0
+    const outer = requestAnimationFrame(() => {
+      inner = requestAnimationFrame(() => setShowTable(true))
+    })
+    return () => {
+      cancelAnimationFrame(outer)
+      cancelAnimationFrame(inner)
+    }
+  }, [])
 
   // Reordering shares the trusted list's Manual order (same scope as the workspace accounts list).
   // Suppressed while searching: a drop then would persist only the filtered subset, dropping the
@@ -155,7 +169,7 @@ const ManageTrustedSafesContent = ({ modal, secondaryLabel, onSecondary, onSaved
           </div>
         </div>
 
-        {isLoading ? (
+        {isLoading || !showTable ? (
           <div className="flex justify-center py-8">
             <Spinner />
           </div>

--- a/apps/web/src/components/common/TrustedSafesModal/TrustedSafesModal.test.tsx
+++ b/apps/web/src/components/common/TrustedSafesModal/TrustedSafesModal.test.tsx
@@ -116,6 +116,13 @@ describe('TrustedSafesModal', () => {
     ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
     mockUseIsQualifiedSafe.mockReturnValue(false)
     mockWalletValue = null
+    // The content defers its table mount past two animation frames; run them synchronously so the
+    // table renders in the same tick and the assertions below don't need to await frames.
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+      cb(0)
+      return 0
+    })
+    jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
   })
 
   it('should render modal when open', () => {
@@ -152,6 +159,17 @@ describe('TrustedSafesModal', () => {
   it('should render the search bar', () => {
     render(<TrustedSafesModal modal={mockModal} />)
     expect(screen.getByPlaceholderText('by name, address or network')).toBeInTheDocument()
+  })
+
+  it('renders the dialog shell before the accounts table (deferred mount)', () => {
+    // Use real rAF (won't fire during the synchronous render) so the table stays deferred.
+    jest.restoreAllMocks()
+    ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+    render(<TrustedSafesModal modal={mockModal} />)
+    // Shell is present immediately…
+    expect(screen.getByText('Manage my account list')).toBeInTheDocument()
+    // …but the heavy table is not mounted yet.
+    expect(screen.queryByTestId('safe-accounts-table')).not.toBeInTheDocument()
   })
 
   it('should call close when cancel clicked', () => {

--- a/apps/web/src/features/myAccounts/components/MyAccountsV2/components/AccountsList/index.tsx
+++ b/apps/web/src/features/myAccounts/components/MyAccountsV2/components/AccountsList/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { memo, useEffect, useMemo } from 'react'
 import { type AllSafeItems, type AllSafeItemsGrouped, useSafeOrderComparator, useSafesSearch } from '@/hooks/safes'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import useSafeInfo from '@/hooks/useSafeInfo'
@@ -112,4 +112,6 @@ const AccountsList = ({ searchQuery, safes, onLinkClick }: AccountsListProps) =>
   )
 }
 
-export default AccountsList
+// Memoised so opening the "Manage my account list" modal (state lives in the parent) doesn't
+// re-render the full pinned-accounts table — a costly synchronous pass with hundreds of rows.
+export default memo(AccountsList)


### PR DESCRIPTION
## What it solves

Opening "Manage my account list" froze for 1–5s before the modal appeared for users
with hundreds of accounts — clicking blocked on rendering the whole accounts table
synchronously.

Resolves: N/A

## How this PR fixes it

Profiled with a ~300-pinned / ~344-owned wallet. Two independent costs were blocking
the dialog's first paint:

1. **Dominant:** the modal's table (hundreds of rows) rendered synchronously in the
   same commit that opens the dialog. It now mounts one painted frame later (double
   `requestAnimationFrame`), so the shell + spinner appear immediately and the rows
   fill in. Dialog appearance: ~5s → ~440ms.
2. **Secondary:** the modal's open-state lives in the parent, so opening re-rendered
   the welcome page's own pinned-accounts table. Memoising that list removes the
   remaining page re-render. ~440ms → ~110ms.

Net: dialog paints at ~110ms instead of 1–5s. The table *content* still takes ~1.5s
to render at 344 rows (now behind the spinner instead of a blank screen) —
virtualising the table is the follow-up that removes that.

## How to test it

1. Use a wallet with a few hundred accounts, or pin ~300 safes.
2. Go to `/welcome/accounts` and click "Manage list".
3. The modal appears immediately with a spinner, then the list fills in — no
   multi-second freeze before the modal shows.

## Screenshots

N/A — perf/behavior change (modal now shows a spinner first).

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
