### PR TITLE
fix(web): show active chain threshold in multi-chain safe selector trigger

### DIFF
--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeSelectorTriggerContent.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeSelectorTriggerContent.tsx
@@ -23,12 +23,9 @@ import { useLoadFeature } from '@/features/__core__'
 export interface SafeSelectorTriggerContentProps {
   selectedItem: SafeItemData
   selectedChainId: string
-  /** True when the safe exists on more than one chain — the owner computes this across all items,
-   * since the trigger item itself can be a chain-scoped entry for the current safe. */
-  isMultiChain?: boolean
 }
 
-function SafeSelectorTriggerContent({ selectedItem, selectedChainId, isMultiChain }: SafeSelectorTriggerContentProps) {
+function SafeSelectorTriggerContent({ selectedItem, selectedChainId }: SafeSelectorTriggerContentProps) {
   const selectedChain = selectedItem.chains.find((c) => c.chainId === selectedChainId) ?? selectedItem.chains[0]
   const isUndeployed = Boolean(selectedChain?.isUndeployed)
   const isActivating = Boolean(selectedChain?.isActivating)
@@ -83,12 +80,9 @@ function SafeSelectorTriggerContent({ selectedItem, selectedChainId, isMultiChai
         // flex (not inline): the inline-flex badge would otherwise sit on the wrapper's text
         // baseline and render a couple of px above the vertical middle of the chip.
         <span className="flex shrink-0 items-center max-sm:hidden">
-          {/* Multi-chain setups can differ per chain, so the count would be misleading — icon only. */}
-          <ThresholdBadge
-            threshold={selectedItem.threshold}
-            owners={selectedItem.owners}
-            iconOnly={isMultiChain ?? selectedItem.chains.length > 1}
-          />
+          {/* The trigger always reflects the active safe on the active chain, so it shows that chain's
+              threshold — even for a multi-chain safe (the dropdown group summary stays icon-only). */}
+          <ThresholdBadge threshold={selectedItem.threshold} owners={selectedItem.owners} />
         </span>
       )}
       {isUndeployed ? (

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeSelectorTriggerContent.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeSelectorTriggerContent.test.tsx
@@ -144,13 +144,12 @@ describe('SafeSelectorTriggerContent', () => {
     expect(getByTestId('account-threshold')).toHaveTextContent('2/3')
   })
 
-  it('renders an icon-only threshold pill for a multi-chain safe (setup can differ per chain)', () => {
+  it('shows the active chain threshold for a multi-chain safe (the trigger reflects the active chain)', () => {
     const item = createItem({ threshold: 2, owners: 3 })
 
     const { getByTestId } = render(<SafeSelectorTriggerContent selectedItem={item} selectedChainId="1" />)
 
-    expect(getByTestId('account-threshold')).toBeInTheDocument()
-    expect(getByTestId('account-threshold')).not.toHaveTextContent('2/3')
+    expect(getByTestId('account-threshold')).toHaveTextContent('2/3')
   })
 
   it('does not render the threshold pill when the setup is unknown', () => {

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { parsePrefixedAddress, sameAddress } from '@safe-global/utils/utils/addresses'
+import { parsePrefixedAddress } from '@safe-global/utils/utils/addresses'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { Select, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -105,14 +105,6 @@ function SafeSelectorDropdown({
   )
   const triggerItem = selectedItem ?? fallbackSelectedItem
 
-  // The trigger item for the current safe can be a chain-scoped entry while the same safe appears
-  // as a multi-chain group elsewhere in the list — check by address, not just the item's chains.
-  const isTriggerSafeMultiChain = useMemo(() => {
-    if (!triggerItem) return false
-    if (triggerItem.chains.length > 1) return true
-    return items.some((item) => sameAddress(item.address, triggerItem.address) && item.chains.length > 1)
-  }, [items, triggerItem])
-
   // A lifted search query would otherwise persist across open/close (local state resets with the popup).
   const handleOpenChangeWithReset = (open: boolean) => {
     // Ignore close requests while a modal is layered on top (e.g. renaming): base-ui tries to close
@@ -159,11 +151,7 @@ function SafeSelectorDropdown({
         data-testid="open-safes-icon"
       >
         <SelectValue>
-          <SafeSelectorTriggerContent
-            selectedItem={triggerItem}
-            selectedChainId={selectedChainId}
-            isMultiChain={isTriggerSafeMultiChain}
-          />
+          <SafeSelectorTriggerContent selectedItem={triggerItem} selectedChainId={selectedChainId} />
         </SelectValue>
       </SelectTrigger>
 


### PR DESCRIPTION
## What it solves

When a multi-chain Safe is the active account, the safe-selector trigger (the header pill) showed a generic multi-chain icon with no threshold — even though the trigger always represents the active safe on one specific chain, so the threshold is known.

Resolves: N/A — no Linear issue

## How this PR fixes it

The trigger already had the active chain's threshold/owners in hand (sourced from `useSafeInfo` via the item builder); they were just rendered icon-only through the multi-chain branch. Removing that branch makes the trigger always show the active chain's `M/N`.

Deliberately **not** changed: the dropdown list rows. A collapsed multi-chain group can't summarize differing per-chain thresholds into one number, so it stays icon-only and expanding still shows each chain's own. Also removed the now-dead `isMultiChain` / `isTriggerSafeMultiChain` plumbing.

## How to test it

1. Connect a wallet with a multi-chain Safe (same address on 2+ networks, ideally with differing thresholds).
2. Open the Safe on one of those networks.
3. Check the safe-selector pill in the header — it should show the active network's threshold (e.g. `2/2`) next to the people icon, not an icon-only badge.
4. Open the dropdown: the multi-chain group summary row stays icon-only; expand it to confirm each chain still shows its own threshold.

## Screenshots
before
<img width="678" height="80" alt="image" src="https://github.com/user-attachments/assets/31b531a1-1205-42b3-8126-e6c1a830ebbc" />

after
<img width="681" height="84" alt="image" src="https://github.com/user-attachments/assets/7e2f9084-941c-46c8-81cd-58510e068de7" />



## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).