### PR TITLE
feat(web): consolidate mixpanel error tracking with datadog tracking

### DIFF
--- a/apps/web/src/features/nfts/__tests__/NftCollections.test.tsx
+++ b/apps/web/src/features/nfts/__tests__/NftCollections.test.tsx
@@ -12,7 +12,7 @@ jest.mock('@/services/observability', () => ({
     info: jest.fn(),
     warn: jest.fn(),
   },
-  captureException: jest.fn(),
+  captureError: jest.fn(),
 }))
 
 jest.mock('@/services/analytics', () => ({

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -89,9 +89,9 @@ import { useVisitedSafes } from '@/features/myAccounts'
 import { usePortfolioRefetchOnTxHistory } from '@/features/portfolio'
 import useInvalidateOverviewsOnTx from '@/hooks/useInvalidateOverviewsOnTx'
 import { GATEWAY_URL } from '@/config/gateway'
-import { captureException, initObservability } from '@/services/observability'
-import { setErrorSurfacedHandler } from '@/services/exceptions'
-import { trackErrorSurfaced } from '@/services/analytics/error-tracking'
+import { captureError, initObservability } from '@/services/observability'
+import { DatadogProvider } from '@/services/observability/providers/datadog'
+import { MixpanelTracingProvider } from '@/services/analytics/MixpanelTracingProvider'
 import useMixpanel from '@/services/analytics/useMixpanel'
 import { AddressBookSourceProvider } from '@/components/common/AddressBookSourceProvider'
 import { CaptchaProvider } from '@/components/common/Captcha'
@@ -105,9 +105,9 @@ import { ShadcnProvider } from '@/components/ui/ShadcnProvider'
 // Initialize observability before React rendering starts
 // This ensures we capture early page metrics (FCP, LCP, TTI) and errors during hydration
 if (typeof window !== 'undefined') {
-  initObservability()
-  // Wire the coded-error logger to the Mixpanel "Error Surfaced" event (WA-2775)
-  setErrorSurfacedHandler(trackErrorSurfaced)
+  // Datadog RUM + Mixpanel "Error Surfaced" tracking (WA-2775) behind one service.
+  // DatadogProvider self-gates when its RUM tokens are absent.
+  initObservability([new DatadogProvider(), new MixpanelTracingProvider()])
 }
 
 const reduxStore = makeStore()
@@ -163,7 +163,7 @@ export const AppProviders = ({ children }: { children: ReactNode | ReactNode[] }
   const themeMode = isDarkMode ? THEME_DARK : THEME_LIGHT
 
   const handleError = (error: Error, componentStack?: string) => {
-    captureException(error, { componentStack })
+    captureError({ error, isUserFacing: true, tags: { componentStack } })
   }
 
   const content = (

--- a/apps/web/src/services/analytics/MixpanelTracingProvider.ts
+++ b/apps/web/src/services/analytics/MixpanelTracingProvider.ts
@@ -1,0 +1,41 @@
+import type { ILogger, IObservabilityProvider, ObservedError } from '@/services/observability/types'
+import { trackErrorSurfaced } from './error-tracking'
+
+const noopLogger: ILogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+}
+
+/**
+ * Observability provider that forwards surfaced coded errors to Mixpanel as the
+ * `Error Surfaced` analytics event (WA-2775). Registered alongside the Datadog
+ * provider so both error sinks live behind the same observability service.
+ *
+ * `captureError` acts only on coded errors — raw crashes without a `code` (e.g.
+ * a React error boundary) are skipped — and forwards the taxonomy only, never
+ * the `error`/stack/tags, so no message or PII reaches analytics. `init` and
+ * `getLogger` are inert because Mixpanel is not a logging sink.
+ *
+ * Constructed at the composition root (`_app.tsx`) and injected into
+ * `initObservability`, so the observability core never imports the analytics
+ * module graph — keeping `services/exceptions` free of an analytics import cycle.
+ */
+export class MixpanelTracingProvider implements IObservabilityProvider {
+  readonly name = 'MixpanelTracing'
+
+  init(): void {}
+
+  getLogger(): ILogger {
+    return noopLogger
+  }
+
+  captureError({ error, isUserFacing, code, context }: ObservedError): void {
+    if (code == null) {
+      return
+    }
+
+    trackErrorSurfaced({ code, message: error.message, isUserFacing, context })
+  }
+}

--- a/apps/web/src/services/analytics/__tests__/MixpanelTracingProvider.test.ts
+++ b/apps/web/src/services/analytics/__tests__/MixpanelTracingProvider.test.ts
@@ -1,0 +1,49 @@
+import { MixpanelTracingProvider } from '../MixpanelTracingProvider'
+import { trackErrorSurfaced } from '../error-tracking'
+
+jest.mock('../error-tracking', () => ({
+  trackErrorSurfaced: jest.fn(),
+}))
+
+const mockedTrackErrorSurfaced = trackErrorSurfaced as jest.MockedFunction<typeof trackErrorSurfaced>
+
+describe('MixpanelTracingProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('forwards coded errors to the Error Surfaced analytics event (taxonomy only)', () => {
+    const provider = new MixpanelTracingProvider()
+    const error = new Error('Code 804: revert')
+
+    provider.captureError({ error, isUserFacing: true, code: 804, context: { txHash: '0xabc' } })
+
+    expect(mockedTrackErrorSurfaced).toHaveBeenCalledWith({
+      code: 804,
+      message: 'Code 804: revert',
+      isUserFacing: true,
+      context: { txHash: '0xabc' },
+    })
+  })
+
+  it('skips raw crashes that carry no coded taxonomy', () => {
+    const provider = new MixpanelTracingProvider()
+
+    provider.captureError({ error: new Error('render crash'), isUserFacing: true })
+
+    expect(mockedTrackErrorSurfaced).not.toHaveBeenCalled()
+  })
+
+  it('is inert as a logging sink (Mixpanel is not a logger)', () => {
+    const provider = new MixpanelTracingProvider()
+
+    provider.init()
+    const logger = provider.getLogger()
+    logger.info('info')
+    logger.warn('warn')
+    logger.error('error')
+    logger.debug('debug')
+
+    expect(mockedTrackErrorSurfaced).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/services/analytics/error-tracking.ts
+++ b/apps/web/src/services/analytics/error-tracking.ts
@@ -1,18 +1,7 @@
 import { normalizeError } from '@safe-global/utils/services/exceptions/normalizeError'
-import type { ErrorContext } from '@/services/exceptions'
+import type { ErrorContext, SurfacedError } from '@/services/observability/types'
 import { MixpanelEvent, MixpanelEventParams } from './mixpanel-events'
 import { mixpanelTrack } from './mixpanel'
-
-export interface ErrorSurfacedInput {
-  /** Numeric part of the coded error (`CodedException.code`). */
-  code: number
-  /** Full error message; used only for classification — never sent to Mixpanel. */
-  message: string
-  /** Whether the error was shown to the user (true for `trackError`, false for `logError`). */
-  isUserFacing: boolean
-  /** Optional call-site context (e.g. txHash), mapped to Mixpanel properties below. */
-  context?: ErrorContext
-}
 
 /**
  * Maps the analytics-agnostic `ErrorContext` to Mixpanel event properties.
@@ -35,7 +24,7 @@ const mapContext = (context?: ErrorContext): Record<string, string> => {
  * analytics (AC7). Reused properties (Blockchain Network, Safe Address, EOA
  * Wallet Label) are attached automatically as Mixpanel super-properties.
  */
-export const trackErrorSurfaced = ({ code, message, isUserFacing, context }: ErrorSurfacedInput): void => {
+export const trackErrorSurfaced = ({ code, message, isUserFacing, context }: SurfacedError): void => {
   const normalized = normalizeError({ code, message, isUserFacing })
 
   mixpanelTrack(MixpanelEvent.ERROR_SURFACED, {

--- a/apps/web/src/services/exceptions/__tests__/index.test.ts
+++ b/apps/web/src/services/exceptions/__tests__/index.test.ts
@@ -130,30 +130,37 @@ describe('CodedException', () => {
     })
   })
 
+  const mockObservability = (captureError: jest.Mock, logger?: Record<string, jest.Mock>) => {
+    jest.doMock('@/services/observability', () => ({
+      __esModule: true,
+      ...jest.requireActual('@/services/observability'),
+      captureError,
+      logger: logger ?? { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+    }))
+  }
+
   describe('Tracking (error level)', () => {
-    it('logs at error level AND forwards to captureException on production', async () => {
+    it('logs at error level AND reports a user-facing error to observability on production', async () => {
       process.env.NEXT_PUBLIC_IS_PRODUCTION = 'true'
 
-      const mockCaptureException = jest.fn()
+      const mockCaptureError = jest.fn()
       const mockError = jest.fn()
-
-      jest.doMock('@/services/observability', () => ({
-        __esModule: true,
-        ...jest.requireActual('@/services/observability'),
-        captureException: mockCaptureException,
-        logger: { info: jest.fn(), warn: jest.fn(), error: mockError, debug: jest.fn() },
-      }))
+      mockObservability(mockCaptureError, { info: jest.fn(), warn: jest.fn(), error: mockError, debug: jest.fn() })
 
       const { trackError, Errors } = await import('..')
 
       const err = trackError(Errors._100)
-      expect(mockCaptureException).toHaveBeenCalledWith(
-        err,
+      expect(mockCaptureError).toHaveBeenCalledWith(
         expect.objectContaining({
+          error: err,
+          isUserFacing: true,
           code: 100,
-          error_domain: ErrorDomain.TX_CREATION,
-          error_type: ErrorType.ADDRESS_INVALID,
-          error_layer: ErrorLayer.OFF_CHAIN,
+          tags: expect.objectContaining({
+            code: 100,
+            error_domain: ErrorDomain.TX_CREATION,
+            error_type: ErrorType.ADDRESS_INVALID,
+            error_layer: ErrorLayer.OFF_CHAIN,
+          }),
         }),
       )
       expect(mockError).toHaveBeenCalledWith(
@@ -169,89 +176,74 @@ describe('CodedException', () => {
 
     it('tags the Datadog error with the refined domain/type/layer (on-chain revert)', async () => {
       process.env.NEXT_PUBLIC_IS_PRODUCTION = 'true'
-      const mockCaptureException = jest.fn()
-      jest.doMock('@/services/observability', () => ({
-        __esModule: true,
-        ...jest.requireActual('@/services/observability'),
-        captureException: mockCaptureException,
-        logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
-      }))
+      const mockCaptureError = jest.fn()
+      mockObservability(mockCaptureError)
 
       const { trackError, Errors } = await import('..')
 
       trackError(Errors._804, 'execution reverted GS013')
-      expect(mockCaptureException).toHaveBeenCalledWith(
-        expect.anything(),
+      expect(mockCaptureError).toHaveBeenCalledWith(
         expect.objectContaining({
-          error_domain: ErrorDomain.TX_EXECUTION,
-          error_type: ErrorType.ON_CHAIN_REVERT,
-          error_layer: ErrorLayer.ON_CHAIN,
+          tags: expect.objectContaining({
+            error_domain: ErrorDomain.TX_EXECUTION,
+            error_type: ErrorType.ON_CHAIN_REVERT,
+            error_layer: ErrorLayer.ON_CHAIN,
+          }),
         }),
       )
     })
 
     it('does not track in non-production envs', async () => {
-      const mockCaptureException = jest.fn()
-      jest.doMock('@/services/observability', () => ({
-        __esModule: true,
-        ...jest.requireActual('@/services/observability'),
-        captureException: mockCaptureException,
-      }))
+      const mockCaptureError = jest.fn()
+      mockObservability(mockCaptureError)
 
       const { trackError, Errors } = await import('..')
 
       const err = trackError(Errors._100)
-      expect(mockCaptureException).not.toHaveBeenCalled()
+      expect(mockCaptureError).not.toHaveBeenCalled()
       expect(console.error).toHaveBeenCalledWith(err)
     })
   })
 
   describe('Error Surfaced analytics', () => {
-    it('emits a user-facing Error Surfaced event to the registered handler when tracking in production', async () => {
+    it('reports a user-facing error to observability when tracking in production', async () => {
       process.env.NEXT_PUBLIC_IS_PRODUCTION = 'true'
-      const handler = jest.fn()
-      const { trackError, setErrorSurfacedHandler, Errors } = await import('..')
-      setErrorSurfacedHandler(handler)
+      const captureError = jest.fn()
+      mockObservability(captureError)
+      const { trackError, Errors } = await import('..')
 
       trackError(Errors._804, 'rpc down')
-      expect(handler).toHaveBeenCalledWith(expect.objectContaining({ code: 804, isUserFacing: true }))
+      expect(captureError).toHaveBeenCalledWith(expect.objectContaining({ code: 804, isUserFacing: true }))
     })
 
-    it('emits a non-user-facing Error Surfaced event to the registered handler when logging in production', async () => {
+    it('reports a non-user-facing error to observability when logging in production', async () => {
       process.env.NEXT_PUBLIC_IS_PRODUCTION = 'true'
-      const handler = jest.fn()
-      const { logError, setErrorSurfacedHandler, Errors } = await import('..')
-      setErrorSurfacedHandler(handler)
+      const captureError = jest.fn()
+      mockObservability(captureError)
+      const { logError, Errors } = await import('..')
 
       logError(Errors._601)
-      expect(handler).toHaveBeenCalledWith(expect.objectContaining({ code: 601, isUserFacing: false }))
+      expect(captureError).toHaveBeenCalledWith(expect.objectContaining({ code: 601, isUserFacing: false }))
     })
 
-    it('does not emit Error Surfaced in non-production envs', async () => {
-      const handler = jest.fn()
-      const { trackError, logError, setErrorSurfacedHandler, Errors } = await import('..')
-      setErrorSurfacedHandler(handler)
+    it('does not report an error in non-production envs', async () => {
+      const captureError = jest.fn()
+      mockObservability(captureError)
+      const { trackError, logError, Errors } = await import('..')
 
       trackError(Errors._804)
       logError(Errors._601)
-      expect(handler).not.toHaveBeenCalled()
+      expect(captureError).not.toHaveBeenCalled()
     })
 
-    it('forwards call-site context (e.g. txHash) to the handler', async () => {
+    it('forwards call-site context (e.g. txHash) to observability', async () => {
       process.env.NEXT_PUBLIC_IS_PRODUCTION = 'true'
-      const handler = jest.fn()
-      const { trackError, setErrorSurfacedHandler, Errors } = await import('..')
-      setErrorSurfacedHandler(handler)
-
-      trackError(Errors._814, 'speed up failed', { txHash: '0xdeadbeef' })
-      expect(handler).toHaveBeenCalledWith(expect.objectContaining({ context: { txHash: '0xdeadbeef' } }))
-    })
-
-    it('does not throw when no handler is registered', async () => {
-      process.env.NEXT_PUBLIC_IS_PRODUCTION = 'true'
+      const captureError = jest.fn()
+      mockObservability(captureError)
       const { trackError, Errors } = await import('..')
 
-      expect(() => trackError(Errors._804)).not.toThrow()
+      trackError(Errors._814, 'speed up failed', { txHash: '0xdeadbeef' })
+      expect(captureError).toHaveBeenCalledWith(expect.objectContaining({ context: { txHash: '0xdeadbeef' } }))
     })
   })
 })

--- a/apps/web/src/services/exceptions/index.ts
+++ b/apps/web/src/services/exceptions/index.ts
@@ -2,38 +2,17 @@ import { IS_PRODUCTION } from '@/config/constants'
 import ErrorCodes from '@safe-global/utils/services/exceptions/ErrorCodes'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
 import { normalizeError } from '@safe-global/utils/services/exceptions/normalizeError'
-import { logger, captureException } from '../observability'
+import { logger, captureError } from '../observability'
+import type { ErrorContext } from '../observability/types'
 
 /**
- * Sink for surfaced errors, registered by the analytics layer at app startup
- * (see WA-2775). Kept as an injected callback so this low-level logger never
- * imports the analytics/Mixpanel module graph — that coupling would create an
- * import cycle, since the analytics layer is itself a consumer of `logError`.
+ * Re-exported from the observability core so existing call sites can keep
+ * importing `ErrorContext` from `@/services/exceptions`. It lives in the core
+ * (not here) so both the exceptions layer and analytics providers can reference
+ * it without closing an import cycle — the analytics layer is itself a consumer
+ * of `logError` (see WA-2775).
  */
-/**
- * Optional call-site context for a surfaced error. Analytics-agnostic on
- * purpose (no Mixpanel types here) — the analytics layer maps these to event
- * properties. Only populated where the data is genuinely in scope (e.g. a
- * `txHash` exists only once a transaction has been broadcast).
- */
-export interface ErrorContext {
-  txHash?: string
-  targetContractLabel?: string
-  transactionType?: string
-}
-
-export type ErrorSurfacedHandler = (params: {
-  code: number
-  message: string
-  isUserFacing: boolean
-  context?: ErrorContext
-}) => void
-
-let errorSurfacedHandler: ErrorSurfacedHandler | undefined
-
-export const setErrorSurfacedHandler = (handler: ErrorSurfacedHandler | undefined): void => {
-  errorSurfacedHandler = handler
-}
+export type { ErrorContext }
 
 export class CodedException extends Error {
   public readonly code: number
@@ -89,8 +68,9 @@ export class CodedException extends Error {
     console.warn(IS_PRODUCTION ? this.message : this)
 
     if (IS_PRODUCTION) {
-      logger.warn(this.message, this.getObservabilityContext())
-      errorSurfacedHandler?.({ code: this.code, message: this.message, isUserFacing: false, context })
+      const tags = this.getObservabilityContext()
+      logger.warn(this.message, tags)
+      captureError({ error: this, isUserFacing: false, code: this.code, tags, context })
     }
   }
 
@@ -100,8 +80,7 @@ export class CodedException extends Error {
     if (IS_PRODUCTION) {
       const tags = this.getObservabilityContext()
       logger.error(this.message, tags)
-      captureException(this, tags)
-      errorSurfacedHandler?.({ code: this.code, message: this.message, isUserFacing: true, context })
+      captureError({ error: this, isUserFacing: true, code: this.code, tags, context })
     }
   }
 }

--- a/apps/web/src/services/observability/__tests__/composite.test.ts
+++ b/apps/web/src/services/observability/__tests__/composite.test.ts
@@ -1,5 +1,5 @@
 import { CompositeProvider } from '../providers/composite'
-import type { IObservabilityProvider, ILogger } from '../types'
+import type { IObservabilityProvider, ILogger, ObservedError } from '../types'
 
 describe('CompositeProvider', () => {
   const createMockProvider = (name: string): IObservabilityProvider => {
@@ -14,9 +14,11 @@ describe('CompositeProvider', () => {
       name,
       init: jest.fn().mockResolvedValue(undefined),
       getLogger: jest.fn().mockReturnValue(mockLogger),
-      captureException: jest.fn(),
+      captureError: jest.fn(),
     }
   }
+
+  const observedError: ObservedError = { error: new Error('Code 804: revert'), isUserFacing: true, code: 804 }
 
   it('should initialize all providers', async () => {
     const provider1 = createMockProvider('Provider1')
@@ -44,18 +46,15 @@ describe('CompositeProvider', () => {
     expect(logger2.info).toHaveBeenCalledWith('test message', { key: 'value' })
   })
 
-  it('should call captureException on all providers', () => {
+  it('should call captureError on all providers', () => {
     const provider1 = createMockProvider('Provider1')
     const provider2 = createMockProvider('Provider2')
     const composite = new CompositeProvider([provider1, provider2])
 
-    const error = new Error('test error')
-    const context = { componentStack: 'test' }
+    composite.captureError(observedError)
 
-    composite.captureException(error, context)
-
-    expect(provider1.captureException).toHaveBeenCalledWith(error, context)
-    expect(provider2.captureException).toHaveBeenCalledWith(error, context)
+    expect(provider1.captureError).toHaveBeenCalledWith(observedError)
+    expect(provider2.captureError).toHaveBeenCalledWith(observedError)
   })
 
   it('should continue if one provider throws during logger call', () => {
@@ -80,20 +79,19 @@ describe('CompositeProvider', () => {
     consoleErrorSpy.mockRestore()
   })
 
-  it('should continue if one provider throws during captureException', () => {
+  it('should continue if one provider throws during captureError', () => {
     const provider1 = createMockProvider('Provider1')
     const provider2 = createMockProvider('Provider2')
 
-    ;(provider1.captureException as jest.Mock).mockImplementation(() => {
+    ;(provider1.captureError as jest.Mock).mockImplementation(() => {
       throw new Error('Provider1 error')
     })
 
     const composite = new CompositeProvider([provider1, provider2])
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
 
-    const error = new Error('test error')
-    expect(() => composite.captureException(error)).not.toThrow()
-    expect(provider2.captureException).toHaveBeenCalledWith(error, undefined)
+    expect(() => composite.captureError(observedError)).not.toThrow()
+    expect(provider2.captureError).toHaveBeenCalledWith(observedError)
 
     consoleErrorSpy.mockRestore()
   })

--- a/apps/web/src/services/observability/__tests__/index.test.ts
+++ b/apps/web/src/services/observability/__tests__/index.test.ts
@@ -15,7 +15,7 @@ describe('Observability Module', () => {
           error: jest.fn(),
           debug: jest.fn(),
         })),
-        captureException: jest.fn(),
+        captureError: jest.fn(),
       }
 
       jest.isolateModules(() => {
@@ -43,7 +43,7 @@ describe('Observability Module', () => {
           error: jest.fn(),
           debug: jest.fn(),
         })),
-        captureException: jest.fn(),
+        captureError: jest.fn(),
       }
 
       jest.isolateModules(() => {
@@ -74,7 +74,7 @@ describe('Observability Module', () => {
           error: jest.fn(),
           debug: jest.fn(),
         })),
-        captureException: jest.fn(),
+        captureError: jest.fn(),
       }
 
       await jest.isolateModulesAsync(async () => {
@@ -95,7 +95,7 @@ describe('Observability Module', () => {
     })
   })
 
-  describe('captureException', () => {
+  describe('captureError', () => {
     it('should delegate to provider', () => {
       const mockProvider = {
         name: 'Mock',
@@ -106,7 +106,7 @@ describe('Observability Module', () => {
           error: jest.fn(),
           debug: jest.fn(),
         })),
-        captureException: jest.fn(),
+        captureError: jest.fn(),
       }
 
       jest.isolateModules(() => {
@@ -114,40 +114,68 @@ describe('Observability Module', () => {
           createObservabilityProvider: jest.fn(() => mockProvider),
         }))
 
-        const { captureException } = require('../index')
-        const error = new Error('test error')
-        const context = { userId: '123', componentStack: 'Component Stack' }
+        const { captureError } = require('../index')
+        const observed = {
+          error: new Error('test error'),
+          isUserFacing: true,
+          code: 100,
+          tags: { componentStack: 'Component Stack' },
+        }
 
-        captureException(error, context)
+        captureError(observed)
 
-        expect(mockProvider.captureException).toHaveBeenCalledWith(error, context)
+        expect(mockProvider.captureError).toHaveBeenCalledWith(observed)
+      })
+    })
+  })
+
+  describe('provider injection', () => {
+    const makeMockProvider = (name: string) => ({
+      name,
+      init: jest.fn().mockResolvedValue(undefined),
+      getLogger: jest.fn(() => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() })),
+      captureError: jest.fn(),
+    })
+
+    it('fully replaces the default provider with consumer-provided providers', () => {
+      const defaultProvider = makeMockProvider('Default')
+      const injected = makeMockProvider('Injected')
+
+      jest.isolateModules(() => {
+        jest.doMock('../factory', () => ({
+          createObservabilityProvider: jest.fn(() => defaultProvider),
+        }))
+
+        const { initObservability, captureError } = require('../index')
+        initObservability([injected])
+
+        expect(injected.init).toHaveBeenCalledTimes(1)
+        expect(defaultProvider.init).not.toHaveBeenCalled()
+
+        const observed = { error: new Error('boom'), isUserFacing: true }
+        captureError(observed)
+        expect(injected.captureError).toHaveBeenCalledWith(observed)
+        expect(defaultProvider.captureError).not.toHaveBeenCalled()
       })
     })
 
-    it('should work without context', () => {
-      const mockProvider = {
-        name: 'Mock',
-        init: jest.fn(),
-        getLogger: jest.fn(() => ({
-          info: jest.fn(),
-          warn: jest.fn(),
-          error: jest.fn(),
-          debug: jest.fn(),
-        })),
-        captureException: jest.fn(),
-      }
+    it('fans errors out to every injected provider', () => {
+      const provider1 = makeMockProvider('One')
+      const provider2 = makeMockProvider('Two')
 
       jest.isolateModules(() => {
         jest.doMock('../factory', () => ({
-          createObservabilityProvider: jest.fn(() => mockProvider),
+          createObservabilityProvider: jest.fn(() => makeMockProvider('Default')),
         }))
 
-        const { captureException } = require('../index')
-        const error = new Error('test error')
+        const { initObservability, captureError } = require('../index')
+        initObservability([provider1, provider2])
 
-        captureException(error)
+        const observed = { error: new Error('Code 601'), isUserFacing: false, code: 601 }
+        captureError(observed)
 
-        expect(mockProvider.captureException).toHaveBeenCalledWith(error, undefined)
+        expect(provider1.captureError).toHaveBeenCalledWith(observed)
+        expect(provider2.captureError).toHaveBeenCalledWith(observed)
       })
     })
   })
@@ -165,7 +193,7 @@ describe('Observability Module', () => {
         name: 'Mock',
         init: jest.fn(),
         getLogger: jest.fn(() => mockLogger),
-        captureException: jest.fn(),
+        captureError: jest.fn(),
       }
 
       jest.isolateModules(() => {

--- a/apps/web/src/services/observability/__tests__/noop.test.ts
+++ b/apps/web/src/services/observability/__tests__/noop.test.ts
@@ -9,7 +9,9 @@ describe('NoOpProvider', () => {
 
     // Test that all operations are safe no-ops
     expect(() => provider.init()).not.toThrow()
-    expect(() => provider.captureException(new Error('test'), { key: 'value' })).not.toThrow()
+    expect(() =>
+      provider.captureError({ error: new Error('test'), isUserFacing: true, tags: { key: 'value' } }),
+    ).not.toThrow()
     expect(() => logger.info('test', { context: 'data' })).not.toThrow()
     expect(() => logger.warn('test')).not.toThrow()
     expect(() => logger.error('test')).not.toThrow()

--- a/apps/web/src/services/observability/index.ts
+++ b/apps/web/src/services/observability/index.ts
@@ -1,27 +1,46 @@
 import { createObservabilityProvider } from './factory'
-import type { ILogger } from './types'
+import { CompositeProvider } from './providers/composite'
+import type { ILogger, IObservabilityProvider, ObservedError } from './types'
 
-const observabilityProvider = createObservabilityProvider()
+let activeProvider: IObservabilityProvider = createObservabilityProvider()
 
 /**
- * Initialize observability providers (Datadog RUM, etc.)
+ * Initialize observability providers (Datadog RUM, Mixpanel tracing, etc.).
  * Must be called explicitly at app startup to enable error tracking and monitoring.
+ *
+ * When `providers` is supplied it fully replaces the default provider (built
+ * from the Datadog/NoOp factory) and is fanned out through a CompositeProvider,
+ * so the composition root can wire multiple sinks behind this single service.
  *
  * This function should be called once at the application entry point (_app.tsx)
  * before React rendering begins to capture early page metrics and errors.
  */
-export const initObservability = (): void => {
+export const initObservability = (providers?: IObservabilityProvider[]): void => {
   if (typeof window === 'undefined') {
     return
   }
 
-  Promise.resolve(observabilityProvider.init()).catch((error: Error) => {
+  if (providers?.length) {
+    activeProvider = providers.length === 1 ? providers[0] : new CompositeProvider(providers)
+  }
+
+  Promise.resolve(activeProvider.init()).catch((error: Error) => {
     console.error('Failed to initialize observability provider:', error)
   })
 }
 
-export const logger: ILogger = observabilityProvider.getLogger()
+/**
+ * Stable logger that delegates to the active provider at call time. The active
+ * provider is unknown until `initObservability` runs, so this cannot be bound to
+ * a concrete logger at import time.
+ */
+export const logger: ILogger = {
+  info: (...args) => activeProvider.getLogger().info(...args),
+  warn: (...args) => activeProvider.getLogger().warn(...args),
+  error: (...args) => activeProvider.getLogger().error(...args),
+  debug: (...args) => activeProvider.getLogger().debug(...args),
+}
 
-export const captureException = (error: Error, context?: Record<string, unknown>): void => {
-  observabilityProvider.captureException(error, context)
+export const captureError = (error: ObservedError): void => {
+  activeProvider.captureError(error)
 }

--- a/apps/web/src/services/observability/providers/__tests__/datadog.test.ts
+++ b/apps/web/src/services/observability/providers/__tests__/datadog.test.ts
@@ -1,4 +1,5 @@
 import type * as ConstantsModule from '@/config/constants'
+import type { ObservedError } from '../../types'
 
 const mockAddAction = jest.fn()
 const mockAddError = jest.fn()
@@ -23,7 +24,7 @@ interface DatadogProviderInstance {
     error: (message: string, context?: Record<string, unknown>) => void
     debug: (message: string, context?: Record<string, unknown>) => void
   }
-  captureException: (error: Error, context?: Record<string, unknown>) => void
+  captureError: (error: ObservedError) => void
 }
 
 type DatadogProviderConstructor = new () => DatadogProviderInstance
@@ -127,19 +128,19 @@ describe('DatadogProvider', () => {
     logger.warn('test')
     logger.error('test')
     logger.debug('test')
-    provider.captureException(new Error('test'))
+    provider.captureError({ error: new Error('test'), isUserFacing: true })
 
     expect(mockAddAction).not.toHaveBeenCalled()
     expect(mockAddError).not.toHaveBeenCalled()
   })
 
-  it('should not throw when calling captureException before initialization', () => {
+  it('should not throw when calling captureError before initialization', () => {
     mockDisabledDatadogConstants()
     const Provider = require('../datadog').DatadogProvider as DatadogProviderConstructor
     const provider = new Provider()
     const error = new Error('test error')
 
-    expect(() => provider.captureException(error)).not.toThrow()
+    expect(() => provider.captureError({ error, isUserFacing: true })).not.toThrow()
   })
 
   it('should handle logger methods with context', () => {
@@ -155,14 +156,14 @@ describe('DatadogProvider', () => {
     expect(() => logger.debug('test', context)).not.toThrow()
   })
 
-  it('should handle captureException with context', () => {
+  it('should handle captureError with tags', () => {
     mockDisabledDatadogConstants()
     const Provider = require('../datadog').DatadogProvider as DatadogProviderConstructor
     const provider = new Provider()
     const error = new Error('test error')
-    const context = { componentStack: 'test' }
+    const tags = { componentStack: 'test' }
 
-    expect(() => provider.captureException(error, context)).not.toThrow()
+    expect(() => provider.captureError({ error, isUserFacing: true, tags })).not.toThrow()
   })
 
   describe('after initialization', () => {
@@ -204,14 +205,23 @@ describe('DatadogProvider', () => {
       })
     })
 
-    it('should call addError for captureException', async () => {
+    it('should call addError for a user-facing captureError', async () => {
       const provider = await createInitializedProvider()
       const error = new Error('captured error')
-      const context = { componentStack: 'test' }
+      const tags = { componentStack: 'test' }
 
-      provider.captureException(error, context)
+      provider.captureError({ error, isUserFacing: true, tags })
 
-      expect(mockAddError).toHaveBeenCalledWith(error, context)
+      expect(mockAddError).toHaveBeenCalledWith(error, tags)
+    })
+
+    it('does not call addError for a non-user-facing captureError (kept off the SLO)', async () => {
+      const provider = await createInitializedProvider()
+      const error = new Error('background error')
+
+      provider.captureError({ error, isUserFacing: false, tags: { code: 601 } })
+
+      expect(mockAddError).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/web/src/services/observability/providers/composite.ts
+++ b/apps/web/src/services/observability/providers/composite.ts
@@ -1,4 +1,4 @@
-import type { ILogger, IObservabilityProvider } from '../types'
+import type { ILogger, IObservabilityProvider, ObservedError } from '../types'
 
 export class CompositeProvider implements IObservabilityProvider {
   readonly name = 'Composite'
@@ -55,12 +55,12 @@ export class CompositeProvider implements IObservabilityProvider {
     }
   }
 
-  captureException(error: Error, context?: Record<string, unknown>): void {
+  captureError(error: ObservedError): void {
     this.providers.forEach((provider) => {
       try {
-        provider.captureException(error, context)
+        provider.captureError(error)
       } catch (err) {
-        console.error('Error capturing exception in provider:', err)
+        console.error('Error capturing error in provider:', err)
       }
     })
   }

--- a/apps/web/src/services/observability/providers/datadog.ts
+++ b/apps/web/src/services/observability/providers/datadog.ts
@@ -1,4 +1,4 @@
-import type { ILogger, IObservabilityProvider } from '../types'
+import type { ILogger, IObservabilityProvider, ObservedError } from '../types'
 import {
   datadogRum,
   type RumEvent,
@@ -176,9 +176,12 @@ export class DatadogProvider implements IObservabilityProvider {
     }
   }
 
-  captureException(error: Error, context?: Record<string, unknown>): void {
-    if (this.isInitialized) {
-      datadogRum.addError(error, context)
+  captureError({ error, isUserFacing, tags }: ObservedError): void {
+    // Only user-facing failures become RUM errors (addError) so background /
+    // logged errors don't count against the Error-Free Views SLO — those are
+    // already recorded as warn-level actions via getLogger().warn.
+    if (this.isInitialized && isUserFacing) {
+      datadogRum.addError(error, tags)
     }
   }
 }

--- a/apps/web/src/services/observability/providers/noop.ts
+++ b/apps/web/src/services/observability/providers/noop.ts
@@ -1,4 +1,4 @@
-import type { ILogger, IObservabilityProvider } from '../types'
+import type { ILogger, IObservabilityProvider, ObservedError } from '../types'
 
 const noopLogger: ILogger = {
   // eslint-disable-next-line unused-imports/no-unused-vars
@@ -21,5 +21,5 @@ export class NoOpProvider implements IObservabilityProvider {
   }
 
   // eslint-disable-next-line unused-imports/no-unused-vars
-  captureException(_error: Error, _context?: Record<string, unknown>): void {}
+  captureError(_error: ObservedError): void {}
 }

--- a/apps/web/src/services/observability/types.ts
+++ b/apps/web/src/services/observability/types.ts
@@ -5,9 +5,64 @@ export interface ILogger {
   debug: (message: string, context?: Record<string, unknown>) => void
 }
 
+/**
+ * Optional call-site context for a surfaced error. Analytics-agnostic on
+ * purpose (no Mixpanel types here) — providers map these to their own event
+ * properties. Only populated where the data is genuinely in scope (e.g. a
+ * `txHash` exists only once a transaction has been broadcast).
+ *
+ * Lives in the observability core (not `services/exceptions`) so it can be
+ * referenced by both the exceptions layer and analytics providers without
+ * closing an import cycle.
+ */
+export interface ErrorContext {
+  txHash?: string
+  targetContractLabel?: string
+  transactionType?: string
+}
+
+/**
+ * The normalized analytics input for a surfaced coded error. The raw `message`
+ * is used only for classification (taxonomy) and must never be forwarded to a
+ * downstream analytics tool.
+ */
+export interface SurfacedError {
+  code: number
+  message: string
+  isUserFacing: boolean
+  context?: ErrorContext
+}
+
+/**
+ * A single error event reported to observability. Each provider extracts the
+ * pieces it needs:
+ * - Datadog RUM records `error` (with its stack) via `addError`, but only when
+ *   `isUserFacing` — background/logged failures stay off the Error-Free Views SLO.
+ * - Mixpanel emits the `Error Surfaced` taxonomy, but only when a `code` is
+ *   present (raw crashes without a coded taxonomy are skipped); it never
+ *   receives the `error`/`tags`, keeping messages and stacks out of analytics.
+ */
+export interface ObservedError {
+  /** The thrown error, including its stack. */
+  error: Error
+  /** Whether the error was surfaced to the user (drives Datadog addError and the Mixpanel flag). */
+  isUserFacing: boolean
+  /** Coded-error number when the error came from `CodedException`; absent for raw crashes. */
+  code?: number
+  /** Backend tags attached to the Datadog RUM error (error taxonomy, componentStack, …). */
+  tags?: Record<string, unknown>
+  /** Analytics call-site context (txHash, …) mapped to Mixpanel event properties. */
+  context?: ErrorContext
+}
+
 export interface IObservabilityProvider {
   readonly name: string
   init: () => void | Promise<void>
   getLogger: () => ILogger
-  captureException: (error: Error, context?: Record<string, unknown>) => void
+  /**
+   * Report an error event. Providers react to the parts they care about, so a
+   * single call fans out to raw-exception capture (Datadog) and surfaced-error
+   * analytics (Mixpanel) without the caller knowing which sinks are wired.
+   */
+  captureError: (error: ObservedError) => void
 }


### PR DESCRIPTION
## What it solves

Follow-up to WA-2775. Error reporting was split across two APIs and glued together with a runtime DI hook:

- `captureException(error, context)` for Datadog RUM, and
- a `setErrorSurfacedHandler` callback wired in `_app.tsx` so `services/exceptions` could reach the Mixpanel `Error Surfaced` event **without** statically importing analytics (that import would close an `exceptions → analytics → exceptions` cycle).

This works but is awkward: two call shapes for "an error happened", an injected global callback that's easy to forget to register, and error taxonomy types (`ErrorContext`) living in `services/exceptions` where analytics can't import them.

## How this PR fixes it

Collapses everything behind a single, injectable observability service.

- **One entry point** — `captureException(...)` + `captureSurfacedError(...)` become one `captureError(ObservedError)`. Each provider reacts only to the parts it needs, so the caller doesn't know or care which sinks are wired.
- **Injectable providers** — `initObservability(providers?)` accepts a consumer-supplied `IObservabilityProvider[]` that fully replaces the factory default and is fanned out through the existing `CompositeProvider`. `logger`/`captureError` delegate to the active provider at call time.
- **Mixpanel as a provider** — new `MixpanelTracingProvider`, constructed at the `_app.tsx` composition root alongside `DatadogProvider` and injected into `initObservability`. It emits the `Error Surfaced` taxonomy **only** for coded errors and forwards taxonomy only — never the raw `error`/stack/`tags` — so no message or PII reaches analytics.
- **Datadog stays SLO-safe** — `DatadogProvider.captureError` calls `addError` **only** when `isUserFacing`, so background/logged errors don't count against the Error-Free Views SLO (they're still recorded as `warn`-level actions).
- **Import cycle stays broken by construction** — `ErrorContext` (plus new `SurfacedError`/`ObservedError`) move into the observability core, re-exported from `services/exceptions` for existing importers. The core never imports analytics; only `_app.tsx` (which already imports everything) does the wiring. The `setErrorSurfacedHandler` DI hook is removed.

## How to test it

1. Set `NEXT_PUBLIC_IS_PRODUCTION=true` with Datadog RUM + Mixpanel tokens configured.
2. Trigger a user-facing coded error (e.g. a failed tx execution) → a Datadog RUM error **and** a Mixpanel `Error Surfaced` event (user-facing) should fire.
3. Trigger a logged (non-user-facing) coded error → Mixpanel `Error Surfaced` (non-user-facing) fires, but **no** Datadog RUM `addError` (verify it stays off the Error-Free Views SLO).
4. Trigger a raw crash via the React error boundary (no `code`) → Datadog RUM error fires, Mixpanel is skipped.
5. `yarn workspace @safe-global/web test` — all observability/exceptions/analytics suites pass.

## Affected flows

- Frontend error reporting (all `trackError` / `logError` call sites, and the React error boundary) — same behaviour, unified plumbing.
- Mixpanel `Error Surfaced` analytics (WA-2775).
- Datadog RUM error capture and the Error-Free Views SLO.

## Blast radius

- **`services/observability` public API** — `captureException` → `captureError(ObservedError)`; `initObservability` now takes optional providers. Consumers: `services/exceptions`, the `_app.tsx` error boundary, `features/nfts` (test mock updated).
- **`IObservabilityProvider` contract** — `captureException` → `captureError`. Implementers: `DatadogProvider`, `NoOpProvider`, `CompositeProvider`, new `MixpanelTracingProvider`.
- **`services/exceptions`** — `setErrorSurfacedHandler` / `ErrorSurfacedHandler` removed; `ErrorContext` now re-exported from the observability core (import path preserved).
- **`services/analytics/error-tracking`** — `ErrorSurfacedInput` replaced by `SurfacedError` from the core.
- No RTK Query, feature-flag, chain-config, persistence, or route changes. No shared `packages/**` changes → no mobile impact.

## Risks / not checked

- Web-only; not tested on mobile (no shared-package changes).
- Not exercised against live Datadog/Mixpanel dashboards — verified via unit tests and the local production build only.
- `logger` now resolves the active provider per call instead of binding once at import; behaviour is unchanged in tests, but not micro-benchmarked.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    EX1[services/exceptions<br/>trackError / logError] -->|captureException| OBS1[observability]
    EX1 -.->|setErrorSurfacedHandler<br/>DI callback| MX1[Mixpanel Error Surfaced]
    OBS1 --> DD1[Datadog RUM addError]
  end
  subgraph After
    EX2[services/exceptions<br/>trackError / logError] -->|captureError&#40;ObservedError&#41;| OBS2[observability<br/>active provider]
    APP[_app.tsx composition root] -->|initObservability&#91;providers&#93;| OBS2
    OBS2 --> DDP[DatadogProvider<br/>addError only if isUserFacing]
    OBS2 --> MXP[MixpanelTracingProvider<br/>Error Surfaced, coded only, taxonomy only]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (N/A — web-only, no shared-package changes)
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
