### PR TITLE
fix(web): raise WalletConnect QR modal above the onboard connect modal

### DIFF
--- a/apps/web/src/hooks/wallets/wallets.ts
+++ b/apps/web/src/hooks/wallets/wallets.ts
@@ -28,7 +28,9 @@ const walletConnectV2 = (chain: Chain) => {
     projectId: WC_PROJECT_ID,
     qrModalOptions: {
       themeVariables: {
-        '--wcm-z-index': '1302',
+        // Above the web3-onboard connect modal (1450) that spawns it, matching the
+        // private-key popup, so the QR modal isn't hidden behind the wallet list.
+        '--wcm-z-index': '1451',
       },
       themeMode: prefersDarkMode() ? 'dark' : 'light',
     },


### PR DESCRIPTION
## What it solves

The WalletConnect QR modal rendered **behind** the web3-onboard "Connect your wallet" modal, so users picking WalletConnect saw the connecting dialog partially hidden behind the wallet list.

Resolves: N/A (no Linear issue)

## How this PR fixes it

The z-index regression was introduced in #8271, which bumped the web3-onboard connect modal from `1301` → `1450` (to stack above the shadcn dialogs). That PR raised the private-key popup it spawns to `1451`, but left the WalletConnect QR modal's `--wcm-z-index` at `1302` — now below the `1450` connect modal.

The original relationship was onboard `1301` < wcm `1302` (QR modal on top). This restores that ordering by setting `--wcm-z-index` to `1451`, matching the private-key popup — both are sub-flows spawned from the connect modal and are mutually exclusive, so they can share the same layer.

## How to test it

1. Sign out / open the connect-wallet flow so the "Connect your wallet" onboard modal appears.
2. Click **WalletConnect**.
3. The "Connecting to WalletConnect…" QR modal now appears **in front of** the wallet list, not behind it.

## Visual summary

```mermaid
flowchart TB
  subgraph Before["Before (bug)"]
    direction TB
    b1["Onboard connect modal — 1450"]
    b2["WalletConnect QR modal — 1302 (behind)"]
    b1 -.covers.-> b2
  end
  subgraph After["After (fix)"]
    direction TB
    a2["WalletConnect QR modal — 1451 (front)"]
    a1["Onboard connect modal — 1450"]
    a2 -.on top of.-> a1
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).