### PR TITLE
fix(web): topbar layout regressions from workspace navigation

### DIFF
--- a/apps/web/src/components/common/Header/Topbar/index.test.tsx
+++ b/apps/web/src/components/common/Header/Topbar/index.test.tsx
@@ -233,11 +233,27 @@ describe('Topbar', () => {
       (pathname) => {
         mockIsSpaceRoute.mockReturnValue(false)
         mockUsePathname.mockReturnValue(pathname)
-        render(<Topbar />)
+        const { container } = render(<Topbar />)
         expect(screen.getByTestId('logo-image')).toBeInTheDocument()
         expect(screen.queryByTestId('space-safe-bar')).not.toBeInTheDocument()
+        // The compact logo aligns with the action group instead of top-anchoring the selector row
+        expect(container.querySelector('header')?.className).toMatch(/items-center/)
       },
     )
+
+    it('keeps the compact logo inline but wraps the wide selector on narrow headers', () => {
+      mockIsSpaceRoute.mockReturnValue(false)
+      mockUsePathname.mockReturnValue('/welcome/accounts')
+      const { container: logoContainer } = render(<Topbar />)
+      // The logo group must not take a full-width row that pushes it below the actions
+      expect(logoContainer.querySelector('header')?.outerHTML).not.toMatch(/basis-full/)
+
+      // The wide left content (selector/search) still drops to its own row when cramped
+      mockIsSpaceRoute.mockReturnValue(true)
+      mockUsePathname.mockReturnValue('/home')
+      const { container: selectorContainer } = render(<Topbar />)
+      expect(selectorContainer.querySelector('header')?.outerHTML).toMatch(/basis-full/)
+    })
 
     it('renders the account info slot next to the wallet section', () => {
       mockIsSpaceRoute.mockReturnValue(false)

--- a/apps/web/src/components/common/Header/Topbar/index.tsx
+++ b/apps/web/src/components/common/Header/Topbar/index.tsx
@@ -61,6 +61,8 @@ const Topbar = ({ onMenuToggle, onBatchToggle }: TopbarProps): ReactElement => {
   const isWelcomeListRoute = pathname === AppRoutes.welcome.accounts || pathname === AppRoutes.welcome.spaces
   const urlSafeAddress = useSafeAddressFromUrl()
   const isSettingsWithoutSafe = pathname?.startsWith(AppRoutes.settings.index) === true && !urlSafeAddress
+  // Routes whose left content is the compact Safe logo rather than the wide safe selector.
+  const showLogo = isSettingsWithoutSafe || isWelcomeListRoute
   const safeAddress = useSafeAddress()
   const isProposer = useIsWalletProposer()
   const isSafeOwner = useIsSafeOwner()
@@ -91,7 +93,7 @@ const Topbar = ({ onMenuToggle, onBatchToggle }: TopbarProps): ReactElement => {
   return (
     <>
       <header
-        className={`@container flex flex-wrap ${isSettingsWithoutSafe ? 'items-center' : 'items-start'} gap-y-2 px-6 py-4 bg-secondary dark:bg-background ${
+        className={`@container flex flex-wrap ${showLogo ? 'items-center' : 'items-start'} gap-y-2 px-6 py-4 bg-secondary dark:bg-background ${
           showMenuButton ? 'pl-2' : ''
         }`}
       >
@@ -109,9 +111,14 @@ const Topbar = ({ onMenuToggle, onBatchToggle }: TopbarProps): ReactElement => {
         {/* Left content (context): the safe selector must not shrink so its children stay on
             one line. When the header (container query — accounts for sidebar + route) is too
             narrow to fit both groups, this drops onto its own full-width row below the actions.
-            Below md (sidebar hidden) the wrapped rows align right; at/above md they align left. */}
-        <div className="shrink-0 flex items-center @max-[1100px]:order-1 @max-[1100px]:basis-full max-[899px]:justify-end">
-          {isSettingsWithoutSafe || isWelcomeListRoute ? (
+            Below md (sidebar hidden) the wrapped rows align right; at/above md they align left.
+            The compact logo (welcome/settings) is exempt — it stays inline beside the actions. */}
+        <div
+          className={`shrink-0 flex items-center max-[899px]:justify-end ${
+            showLogo ? '' : '@max-[1100px]:order-1 @max-[1100px]:basis-full'
+          }`}
+        >
+          {showLogo ? (
             <SafeLogo />
           ) : showSpaceSafeBar ? (
             <SpaceSafeBar />
@@ -121,10 +128,15 @@ const Topbar = ({ onMenuToggle, onBatchToggle }: TopbarProps): ReactElement => {
         </div>
 
         {/* Right content (actions): ml-auto pushes it right (page padding) on one row. When the
-            header wraps at/above md (sidebar shown) ml-0 left-aligns it with the context below;
-            below md (sidebar hidden) it keeps ml-auto so the wrapped rows hug the right edge.
+            wide selector wraps to its own row at/above md (sidebar shown) ml-0 left-aligns the
+            actions above it; below md (sidebar hidden) it keeps ml-auto so the wrapped rows hug
+            the right edge. The logo routes never wrap, so the actions stay right at every width.
             One 56px card holding the muted action chips, matching the safe-selector pill. */}
-        <div className="flex items-center gap-1 shrink-0 ml-auto @max-[1100px]:min-[900px]:ml-0 rounded-xl bg-card p-2 shadow-[0px_4px_20px_0px_rgba(0,0,0,0.03)]">
+        <div
+          className={`flex items-center gap-1 shrink-0 ml-auto rounded-xl bg-card p-2 shadow-[0px_4px_20px_0px_rgba(0,0,0,0.03)] ${
+            showLogo ? '' : '@max-[1100px]:min-[900px]:ml-0'
+          }`}
+        >
           {showSafeToken && (
             <div className="hidden sm:block">
               <SafenetStakingButton />

--- a/apps/web/src/components/common/PageLayout/index.tsx
+++ b/apps/web/src/components/common/PageLayout/index.tsx
@@ -18,6 +18,7 @@ import { useRouterGuard } from '@/hooks/useRouterGuard'
 import { useFlowActivationGuard } from '@/hooks/useRouterGuard/activationGuards/useFlowActivationGuard'
 import { useKeyboardObserver } from '@/hooks/useKeyboardObserver'
 import { useIsTopbarElevated } from '@/hooks/useTopbarElevation'
+import { useTopbarHeight } from '@/hooks/useTopbarHeight'
 
 const ONBOARDING_ROUTES = [
   AppRoutes.welcome.createSpace,
@@ -60,6 +61,7 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
   useRouterGuard({ useGuard: useFlowActivationGuard })
   useKeyboardObserver()
   const isTopbarElevated = useIsTopbarElevated()
+  const setTopbarNode = useTopbarHeight()
 
   // Hide sidebar when transaction flow is open
   const isSidebarVisible = isSidebarOpen && !txFlow
@@ -91,6 +93,7 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
       >
         {!hideHeader && (
           <div
+            ref={setTopbarNode}
             className={classnames(css.topbar, {
               [css.topbarElevated]: isTopbarElevated,
             })}

--- a/apps/web/src/components/common/TxModalDialog/styles.module.css
+++ b/apps/web/src/components/common/TxModalDialog/styles.module.css
@@ -1,3 +1,6 @@
+/* --topbar-height is measured live from the topbar element (see useTopbarHeight),
+   so the dialog sits flush against the header at any width — including the wrapped
+   two-row header below 1148px — with no per-viewport override to keep in sync. */
 .dialog {
   top: var(--topbar-height);
   left: 230px;
@@ -70,16 +73,6 @@
   .title {
     position: sticky;
     top: 0;
-  }
-}
-
-/* Between 900–1148px the topbar wraps onto a second row (148px instead of
-   --topbar-height) — see Topbar's @max-[1100px] container classes plus its 48px
-   padding. The elevated topbar (z-index 99) paints over the dialog, so start
-   the dialog below it to keep the close button visible and clickable. */
-@media (min-width: 900px) and (max-width: 1147.95px) {
-  .dialog {
-    top: 148px;
   }
 }
 

--- a/apps/web/src/hooks/__tests__/useTopbarHeight.test.ts
+++ b/apps/web/src/hooks/__tests__/useTopbarHeight.test.ts
@@ -1,0 +1,85 @@
+import { renderHook } from '@testing-library/react'
+import { useTopbarHeight } from '../useTopbarHeight'
+
+const TOPBAR_HEIGHT_VAR = '--topbar-height'
+
+const makeNode = (height: number): HTMLDivElement => {
+  const node = document.createElement('div')
+  Object.defineProperty(node, 'offsetHeight', { configurable: true, value: height })
+  return node
+}
+
+const readVar = () => document.documentElement.style.getPropertyValue(TOPBAR_HEIGHT_VAR)
+
+describe('useTopbarHeight', () => {
+  let observeMock: jest.Mock
+  let disconnectMock: jest.Mock
+  let resizeCallback: ResizeObserverCallback
+  const originalResizeObserver = globalThis.ResizeObserver
+
+  beforeEach(() => {
+    observeMock = jest.fn()
+    disconnectMock = jest.fn()
+    ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = jest.fn((cb: ResizeObserverCallback) => {
+      resizeCallback = cb
+      return { observe: observeMock, unobserve: jest.fn(), disconnect: disconnectMock }
+    })
+  })
+
+  afterEach(() => {
+    document.documentElement.style.removeProperty(TOPBAR_HEIGHT_VAR)
+    ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = originalResizeObserver
+    jest.clearAllMocks()
+  })
+
+  it('publishes the node height to the CSS variable and observes it', () => {
+    const { result } = renderHook(() => useTopbarHeight())
+    const node = makeNode(88)
+
+    result.current(node)
+
+    expect(readVar()).toBe('88px')
+    expect(observeMock).toHaveBeenCalledWith(node)
+  })
+
+  it('updates the variable when the observed element resizes', () => {
+    const { result } = renderHook(() => useTopbarHeight())
+    const node = makeNode(88)
+    result.current(node)
+
+    Object.defineProperty(node, 'offsetHeight', { configurable: true, value: 148 })
+    resizeCallback([], {} as ResizeObserver)
+
+    expect(readVar()).toBe('148px')
+  })
+
+  it('removes the variable and disconnects when the node detaches', () => {
+    const { result } = renderHook(() => useTopbarHeight())
+    result.current(makeNode(88))
+
+    result.current(null)
+
+    expect(disconnectMock).toHaveBeenCalledTimes(1)
+    expect(readVar()).toBe('')
+  })
+
+  it('rebinds to a new node, disconnecting the previous observer', () => {
+    const { result } = renderHook(() => useTopbarHeight())
+    result.current(makeNode(88))
+
+    result.current(makeNode(120))
+
+    expect(disconnectMock).toHaveBeenCalledTimes(1)
+    expect(readVar()).toBe('120px')
+  })
+
+  it('keeps the static default when ResizeObserver is unavailable', () => {
+    ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = undefined
+    const { result } = renderHook(() => useTopbarHeight())
+
+    result.current(makeNode(88))
+
+    expect(readVar()).toBe('')
+    expect(observeMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/hooks/useTopbarHeight.ts
+++ b/apps/web/src/hooks/useTopbarHeight.ts
@@ -1,0 +1,44 @@
+import { useCallback, useRef } from 'react'
+
+const TOPBAR_HEIGHT_VAR = '--topbar-height'
+
+/**
+ * Publishes the topbar's live height to the `--topbar-height` CSS variable so
+ * fixed-position overlays — the tx-flow dialog and the Safe Apps frame — sit
+ * flush against it at any viewport width. A ResizeObserver keeps it in sync as
+ * the header wraps onto extra rows or its content changes, which a hardcoded
+ * value cannot: the header is 88px on wide desktop but wraps taller below 1148px.
+ *
+ * Returns a callback ref for the topbar wrapper. Binding through the node (rather
+ * than a plain ref + effect) means the observer always tracks the live element
+ * and the variable resets to the globals.css default when the topbar unmounts on
+ * header-less routes.
+ */
+export function useTopbarHeight() {
+  const detachRef = useRef<(() => void) | null>(null)
+
+  return useCallback((node: HTMLDivElement | null) => {
+    detachRef.current?.()
+    detachRef.current = null
+
+    // No ResizeObserver (SSR / jsdom): keep the static default from globals.css.
+    if (typeof ResizeObserver === 'undefined') return
+
+    const root = document.documentElement
+    if (!node) {
+      root.style.removeProperty(TOPBAR_HEIGHT_VAR)
+      return
+    }
+
+    const update = () => root.style.setProperty(TOPBAR_HEIGHT_VAR, `${node.offsetHeight}px`)
+    update()
+
+    const observer = new ResizeObserver(update)
+    observer.observe(node)
+
+    detachRef.current = () => {
+      observer.disconnect()
+      root.style.removeProperty(TOPBAR_HEIGHT_VAR)
+    }
+  }, [])
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -47,6 +47,8 @@ button {
 :root {
   --header-height: 56px;
   --footer-height: 67px;
+  /* SSR/first-paint fallback only — useTopbarHeight overwrites this with the
+     topbar's measured height once it mounts. */
   --topbar-height: 100px;
 }
 


### PR DESCRIPTION
## What it solves

Fixes two layout regressions introduced by the workspace-navigation redesign (#8271):

1. **Transaction modal strip** — starting a new transaction (send, spending limit, tx-builder, etc.) left a thin strip of the page showing through below the header, because the header got shorter than the value `--topbar-height` hardcoded.
2. **Welcome header layout** — on the Workspaces / My accounts pages the Safe logo dropped onto its own row below the action bar at narrow-ish widths, and the action bar jumped to the left in the 900–1100px band before snapping back right below 900px.

## How this PR fixes it

**Modal strip:** the topbar height is no longer a magic constant. `--topbar-height` is now published from the topbar element's live `offsetHeight` via a `ResizeObserver`, so the tx-flow dialog (`top: var(--topbar-height)`) and the Safe Apps frame sit flush against the header at every width — including when the header wraps to two rows below 1148px. This let me delete the hardcoded `top: 148px` viewport override, which had itself drifted. The 100px in `globals.css` is now only an SSR/first-paint fallback.

**Header layout:** the compact 24px logo was reusing the *wide safe-selector's* responsive wrap classes (`@max-[1100px]:order-1 basis-full` and `@max-[1100px]:min-[900px]:ml-0`). Those make the wide selector drop to its own row and left-align the actions above it — nonsense for a tiny logo. They're now gated on `!showLogo`, so on logo routes the logo stays top-left and the actions stay pinned right at every width, while Safe routes keep the selector-wrapping behaviour untouched.

## How to test it

1. Open a Safe and start a new transaction (e.g. Spending limit). The modal should sit flush directly under the header — no page strip below it. Resize the window to ~1000px (header wraps to two rows) and confirm it's still flush.
2. Open a Safe App and confirm the app frame fills the area under the header with no gap.
3. Go to the **Workspaces** / **My accounts** landing pages and slowly resize the window between ~850px and ~1300px. The Safe logo must stay top-left and the notification/wallet action bar must stay top-right the whole time — no wrapping to a second row, no left/right jump.

before
<img width="937" height="297" alt="image" src="https://github.com/user-attachments/assets/1d6e99da-dfec-4bc5-997c-9555f7335979" />
<img width="1383" height="380" alt="image" src="https://github.com/user-attachments/assets/3001677d-c059-4b6e-8076-61664f2c0629" />

after
<img width="1464" height="568" alt="image" src="https://github.com/user-attachments/assets/e66fd695-a51b-47ca-9cf1-3601325f63ea" />
<img width="941" height="334" alt="image" src="https://github.com/user-attachments/assets/7fdd396e-99ed-4fe7-a4f0-8d12b1548e14" />

after:

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1["--topbar-height: 100px (hardcoded)"] --> A2["header actually 88px"]
    A2 --> A3["dialog top:100px → 12px page strip shows"]
    B1["logo reuses wide-selector wrap classes"] --> B2["logo drops below actions; action bar jumps left @900-1100px"]
  end
  subgraph After
    C1["ResizeObserver publishes live topbar height"] --> C2["--topbar-height == real header height"]
    C2 --> C3["dialog + Safe Apps frame flush at every width"]
    D1["wrap classes gated on !showLogo"] --> D2["logo top-left, actions top-right, all widths"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
