### PR TITLE
fix(web): probe fee preview only for the selected token on Max click

### DIFF
--- a/apps/web/src/features/gtf/hooks/__tests__/useResolvedGasToken.test.tsx
+++ b/apps/web/src/features/gtf/hooks/__tests__/useResolvedGasToken.test.tsx
@@ -5,7 +5,6 @@ import { renderHook } from '@/tests/test-utils'
 import { useResolvedGasToken, type FeePreviewTx } from '../useResolvedGasToken'
 import * as useChainsModule from '@/hooks/useChains'
 import * as useSafeInfoModule from '@/hooks/useSafeInfo'
-import * as useBalancesModule from '@/hooks/useBalances'
 import { getNonces } from '@/services/tx/tx-sender/recommendedNonce'
 import * as gatewayApi from '@/store/api/gateway'
 import { chainBuilder } from '@/tests/builders/chains'
@@ -16,14 +15,11 @@ jest.mock('@/services/tx/tx-sender/recommendedNonce', () => ({
   getNonces: jest.fn(),
 }))
 
-// The Create-step probe prices against the recommended next nonce, fetched async via getNonces.
 const RECOMMENDED_NONCE = 7
 
 const ETH_ADDRESS = '0x0000000000000000000000000000000000000000'
-const USDC_ADDRESS = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
 const SAFE_TOKEN_ADDRESS = '0x5aFE3855358E112B5647B952709E6165e1c1eEEe'
 
-// Probing requires both the GTF flag and a RELAY_FEE relayer on the chain.
 const mockChain = chainBuilder()
   .with({
     chainId: '1',
@@ -53,38 +49,6 @@ const erc20Tx: FeePreviewTx = {
   data: '0xa9059cbb00000000000000000000000038d48fada993b749691e93e4e62259c488bcb766000000000000000000000000000000000000000000000000000ffcb9e57d4000',
   operation: OperationType.Call,
 }
-
-const ethBalance = {
-  balance: '1000000000000000000',
-  fiatBalance: '2500',
-  fiatConversion: '2500',
-  tokenInfo: { address: ETH_ADDRESS, decimals: 18, logoUri: '', name: 'Ether', symbol: 'ETH', type: 'NATIVE_TOKEN' },
-}
-const usdcBalance = {
-  balance: '100000000',
-  fiatBalance: '100',
-  fiatConversion: '1',
-  tokenInfo: { address: USDC_ADDRESS, decimals: 6, logoUri: '', name: 'USD Coin', symbol: 'USDC', type: 'ERC20' },
-}
-const safeTokenBalance = {
-  balance: '5000000000000000000',
-  fiatBalance: '10',
-  fiatConversion: '2',
-  tokenInfo: {
-    address: SAFE_TOKEN_ADDRESS,
-    decimals: 18,
-    logoUri: '',
-    name: 'Safe',
-    symbol: 'SAFE',
-    type: 'ERC20',
-  },
-}
-
-const buildBalances = (items: unknown[]): ReturnType<typeof useBalancesModule.default> => ({
-  balances: { fiatTotal: '1000', items: items as never },
-  loaded: true,
-  loading: false,
-})
 
 const successfulProbe = {
   data: { txData: { gasToken: ETH_ADDRESS } },
@@ -124,7 +88,6 @@ describe('useResolvedGasToken', () => {
   })
 
   it('returns resolving while the tx payload is undefined', () => {
-    jest.spyOn(useBalancesModule, 'default').mockReturnValue(buildBalances([ethBalance]))
     jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockReturnValue(loadingProbe)
 
     const { result } = renderHook(() => useResolvedGasToken(ETH_ADDRESS, undefined))
@@ -132,16 +95,20 @@ describe('useResolvedGasToken', () => {
     expect(result.current.status).toBe('resolving')
   })
 
-  it('resolves to the first alternative that probes successfully (ETH wins immediately)', async () => {
-    jest.spyOn(useBalancesModule, 'default').mockReturnValue(buildBalances([ethBalance, safeTokenBalance]))
+  // Regression (PLA-1774): only the sent token is ever probed — no cascade over held tokens.
+  it('probes only the sent token and resolves to it on 200', async () => {
     const spy = jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockReturnValue(successfulProbe)
 
     const { result } = renderHook(() => useResolvedGasToken(SAFE_TOKEN_ADDRESS, erc20Tx))
 
-    await waitFor(() => expect(result.current).toEqual({ status: 'resolved', address: ETH_ADDRESS }))
-    // The probe is priced against the recommended next nonce, not the Safe's current nonce.
+    await waitFor(() => expect(result.current).toEqual({ status: 'resolved', address: SAFE_TOKEN_ADDRESS }))
     expect(spy.mock.calls.at(-1)?.[0]).toMatchObject({
-      tx: expect.objectContaining({ gasToken: ETH_ADDRESS, nonce: RECOMMENDED_NONCE }),
+      tx: expect.objectContaining({ gasToken: SAFE_TOKEN_ADDRESS, nonce: RECOMMENDED_NONCE }),
+    })
+    spy.mock.calls.forEach(([arg]) => {
+      if (arg !== skipToken) {
+        expect((arg as { tx: { gasToken: string } }).tx.gasToken).toBe(SAFE_TOKEN_ADDRESS)
+      }
     })
   })
 
@@ -149,10 +116,9 @@ describe('useResolvedGasToken', () => {
   // back to the Safe current nonce so the probe still fires and resolution progresses.
   it('falls back to the current Safe nonce and still resolves when getNonces rejects', async () => {
     ;(getNonces as jest.Mock).mockRejectedValue(new Error('RPC down'))
-    jest.spyOn(useBalancesModule, 'default').mockReturnValue(buildBalances([ethBalance, safeTokenBalance]))
     const spy = jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockReturnValue(successfulProbe)
 
-    const { result } = renderHook(() => useResolvedGasToken(SAFE_TOKEN_ADDRESS, erc20Tx))
+    const { result } = renderHook(() => useResolvedGasToken(ETH_ADDRESS, nativeTx))
 
     await waitFor(() => expect(result.current).toEqual({ status: 'resolved', address: ETH_ADDRESS }))
     expect(spy.mock.calls.at(-1)?.[0]).toMatchObject({
@@ -160,23 +126,7 @@ describe('useResolvedGasToken', () => {
     })
   })
 
-  it('falls through from errored alternatives to the sent token when it probes 200', async () => {
-    jest.spyOn(useBalancesModule, 'default').mockReturnValue(buildBalances([ethBalance, safeTokenBalance]))
-    // ETH (the alternative, tried first) errors; the sent token (SAFE) probes 200. Keyed by the
-    // candidate gasToken rather than call order — the async nonce fetch adds extra renders.
-    jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockImplementation((arg) => {
-      const gasToken =
-        arg && typeof arg === 'object' && 'tx' in arg ? (arg as { tx: { gasToken: string } }).tx.gasToken : undefined
-      return gasToken === ETH_ADDRESS ? erroredProbe : successfulProbe
-    })
-
-    const { result } = renderHook(() => useResolvedGasToken(SAFE_TOKEN_ADDRESS, erc20Tx))
-
-    await waitFor(() => expect(result.current).toEqual({ status: 'resolved', address: SAFE_TOKEN_ADDRESS }))
-  })
-
-  it('blocks when every candidate errors (including the sent token)', async () => {
-    jest.spyOn(useBalancesModule, 'default').mockReturnValue(buildBalances([safeTokenBalance]))
+  it('blocks when the sent token probe errors', async () => {
     jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockReturnValue(erroredProbe)
 
     const { result } = renderHook(() => useResolvedGasToken(SAFE_TOKEN_ADDRESS, erc20Tx))
@@ -184,26 +134,7 @@ describe('useResolvedGasToken', () => {
     await waitFor(() => expect(result.current).toEqual({ status: 'blocked' }))
   })
 
-  it('resolves to sent token (banner-shown case) when it is the only held candidate and probes 200', async () => {
-    jest.spyOn(useBalancesModule, 'default').mockReturnValue(buildBalances([safeTokenBalance]))
-    jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockReturnValue(successfulProbe)
-
-    const { result } = renderHook(() => useResolvedGasToken(SAFE_TOKEN_ADDRESS, erc20Tx))
-
-    await waitFor(() => expect(result.current).toEqual({ status: 'resolved', address: SAFE_TOKEN_ADDRESS }))
-  })
-
-  it('handles sent token already being the only candidate (e.g. sending ETH when Safe holds ETH)', async () => {
-    jest.spyOn(useBalancesModule, 'default').mockReturnValue(buildBalances([ethBalance]))
-    jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockReturnValue(successfulProbe)
-
-    const { result } = renderHook(() => useResolvedGasToken(ETH_ADDRESS, nativeTx))
-
-    await waitFor(() => expect(result.current).toEqual({ status: 'resolved', address: ETH_ADDRESS }))
-  })
-
-  it('returns resolving while probe is in-flight', () => {
-    jest.spyOn(useBalancesModule, 'default').mockReturnValue(buildBalances([ethBalance, safeTokenBalance]))
+  it('returns resolving while the probe is in-flight', () => {
     jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockReturnValue(loadingProbe)
 
     const { result } = renderHook(() => useResolvedGasToken(SAFE_TOKEN_ADDRESS, erc20Tx))
@@ -217,7 +148,6 @@ describe('useResolvedGasToken', () => {
         .with({ ...mockChain, relayer: null })
         .build(),
     )
-    jest.spyOn(useBalancesModule, 'default').mockReturnValue(buildBalances([ethBalance, safeTokenBalance]))
     const spy = jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockReturnValue(loadingProbe)
 
     const { result } = renderHook(() => useResolvedGasToken(SAFE_TOKEN_ADDRESS, erc20Tx))
@@ -225,17 +155,5 @@ describe('useResolvedGasToken', () => {
     expect(result.current).toEqual({ status: 'blocked' })
     expect(spy.mock.calls.length).toBeGreaterThan(0)
     spy.mock.calls.forEach(([arg]) => expect(arg).toBe(skipToken))
-  })
-
-  it('ignores usdcBalance entry when sentTokenAddress dedupes', async () => {
-    // send USDC — candidates should dedupe (USDC appears once as sent token, not as alternative)
-    jest.spyOn(useBalancesModule, 'default').mockReturnValue(buildBalances([usdcBalance]))
-    const spy = jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockReturnValue(successfulProbe)
-
-    const usdcTx: FeePreviewTx = { ...erc20Tx, to: USDC_ADDRESS }
-    const { result } = renderHook(() => useResolvedGasToken(USDC_ADDRESS, usdcTx))
-
-    await waitFor(() => expect(result.current).toEqual({ status: 'resolved', address: USDC_ADDRESS }))
-    expect(spy.mock.calls.at(-1)?.[0]).toMatchObject({ tx: expect.objectContaining({ gasToken: USDC_ADDRESS }) })
   })
 })

--- a/apps/web/src/features/gtf/hooks/useResolvedGasToken.ts
+++ b/apps/web/src/features/gtf/hooks/useResolvedGasToken.ts
@@ -1,12 +1,9 @@
-import { useEffect, useMemo, useState } from 'react'
 import { skipToken } from '@reduxjs/toolkit/query'
-import { sameAddress } from '@safe-global/utils/utils/addresses'
 import type { OperationType } from '@safe-global/types-kit'
 import useAsync from '@safe-global/utils/hooks/useAsync'
 
 import { useCurrentChain } from '@/hooks/useChains'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import useBalances from '@/hooks/useBalances'
 import { getNonces } from '@/services/tx/tx-sender/recommendedNonce'
 import { useGetGtfFeePreviewQuery } from '@/store/api/gateway'
 import { toSupportedFiatCode } from '@/store/api/gateway/gtfFeePreview'
@@ -25,12 +22,8 @@ export type FeePreviewTx = {
 }
 
 /**
- * Resolution of the gas token for a Safe-paid transaction.
- *
- * - `resolving`: the cascade is still probing or not enough context to start
- * - `resolved`: a token (at `address`) successfully passed a `/fees/preview` probe
- * - `blocked`: fees cannot be paid from the Safe — every candidate probe errored (including the
- *   sent token), or the chain has no RELAY_FEE relayer so previews are impossible
+ * `blocked` means fees cannot be paid in the sent token — the probe errored, or the chain has
+ * no RELAY_FEE relayer so previews are impossible.
  */
 export type ResolvedGasTokenState =
   | { status: 'resolving' }
@@ -38,23 +31,14 @@ export type ResolvedGasTokenState =
   | { status: 'blocked' }
 
 /**
- * Walk the Safe's balances probing `/fees/preview` per token. The sent token is guaranteed last
- * as the fallback, so any other held token is preferred if the backend says it can cover fees.
- * Stops at the first probe that returns 200. If every probe errors, resolution is `blocked`.
- *
- * On chains without a RELAY_FEE relayer no probe can ever succeed, so the hook returns
- * `blocked` immediately without firing a single request.
- *
- * The `tx` payload is what each probe submits alongside the candidate `gasToken`. Callers on the
- * Create step typically build it from form state via `createTokenTransferParams`; on Review it
- * comes from `SafeTxContext.safeTx.data`. When `tx` is `undefined` (form incomplete), the hook
- * returns `resolving` without firing a probe.
+ * Probe `/fees/preview` for the sent token only — probing every held token flooded the CGW and
+ * tripped rate limits (PLA-1774). No relayer on the chain → `blocked` without firing a request;
+ * `tx` undefined (form incomplete) → `resolving` without firing one.
  */
 export const useResolvedGasToken = (
   sentTokenAddress: string | undefined,
   tx: FeePreviewTx | undefined,
 ): ResolvedGasTokenState => {
-  const { balances } = useBalances()
   const { safe, safeAddress } = useSafeInfo()
   const chain = useCurrentChain()
   const currency = useAppSelector(selectCurrency)
@@ -74,71 +58,39 @@ export const useResolvedGasToken = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [safeAddress, safe.chainId, safe.deployed, safe.nonce, safe.txQueuedTag, safe.txHistoryTag])
 
-  const candidates = useMemo(() => {
-    if (!balances?.items || !sentTokenAddress) return []
-
-    const alternatives = balances.items
-      .filter((b) => BigInt(b.balance) > 0n)
-      .filter((b) => !sameAddress(b.tokenInfo.address, sentTokenAddress))
-      .map((b) => b.tokenInfo.address)
-
-    // Sent token is always the fallback, tried after every alternative.
-    return [...alternatives, sentTokenAddress]
-  }, [balances, sentTokenAddress])
-
-  const candidatesKey = candidates.join(',')
-  const [index, setIndex] = useState(0)
-
-  useEffect(() => {
-    setIndex(0)
-  }, [candidatesKey])
-
-  const currentCandidate = candidates[index]
-
-  const canProbe = Boolean(
+  const probeArg =
     isGtfFeePreviewAvailable(chain) &&
-      currentCandidate &&
-      tx &&
-      chain?.chainId &&
-      safeAddress &&
-      safe.threshold > 0 &&
-      recommendedNonce !== undefined,
-  )
-
-  const probe = useGetGtfFeePreviewQuery(
-    canProbe && tx && chain && recommendedNonce !== undefined
+    sentTokenAddress &&
+    tx &&
+    chain &&
+    safeAddress &&
+    safe.threshold > 0 &&
+    recommendedNonce !== undefined
       ? {
           chainId: chain.chainId,
           safeAddress,
           tx: {
             ...tx,
-            gasToken: currentCandidate,
+            gasToken: sentTokenAddress,
             numberSignatures: safe.threshold,
             nonce: recommendedNonce,
             fiatCode: toSupportedFiatCode(currency),
           },
         }
-      : skipToken,
-  )
+      : skipToken
 
-  useEffect(() => {
-    if (!canProbe) return
-    if (probe.isLoading || probe.isFetching) return
-    if (probe.error && index < candidates.length - 1) {
-      setIndex((i) => i + 1)
-    }
-  }, [probe.isLoading, probe.isFetching, probe.error, canProbe, index, candidates.length])
+  const probe = useGetGtfFeePreviewQuery(probeArg)
 
   if (!isGtfFeePreviewAvailable(chain)) {
     return { status: 'blocked' }
   }
-  if (candidates.length === 0 || !canProbe) {
+  if (probeArg === skipToken) {
     return { status: 'resolving' }
   }
   if (probe.data) {
-    return { status: 'resolved', address: currentCandidate }
+    return { status: 'resolved', address: probeArg.tx.gasToken }
   }
-  if (probe.error && index >= candidates.length - 1) {
+  if (probe.error) {
     return { status: 'blocked' }
   }
   return { status: 'resolving' }

--- a/apps/web/src/features/gtf/hooks/useResolvedGasToken.ts
+++ b/apps/web/src/features/gtf/hooks/useResolvedGasToken.ts
@@ -62,7 +62,6 @@ export const useResolvedGasToken = (
     isGtfFeePreviewAvailable(chain) &&
     sentTokenAddress &&
     tx &&
-    chain &&
     safeAddress &&
     safe.threshold > 0 &&
     recommendedNonce !== undefined

--- a/apps/web/src/features/gtf/utils/isGtfFeePreviewAvailable.ts
+++ b/apps/web/src/features/gtf/utils/isGtfFeePreviewAvailable.ts
@@ -12,5 +12,5 @@ const PREVIEW_RELAYER_TYPES: ReadonlyArray<Relayer['type']> = ['RELAY_FEE', 'GTF
  * the fee section still renders, but as signer-pays with a free execution
  * fee, and the preview endpoint must never be called.
  */
-export const isGtfFeePreviewAvailable = (chain: Chain | undefined): boolean =>
+export const isGtfFeePreviewAvailable = (chain: Chain | undefined): chain is Chain =>
   !!chain && hasFeature(chain, FEATURES.GTF) && PREVIEW_RELAYER_TYPES.includes(chain.relayer?.type ?? null)


### PR DESCRIPTION
## What it solves

Resolves: https://linear.app/safe-global/issue/PLA-1774/clicking-on-max-triggers-preview-endpoint-call-for-all-tokens

Clicking Max in the token transfer flow probed /fees/preview once per held token, advancing to the next candidate on every error with no cap. For a Safe holding hundreds of tokens: a burst of hundreds of doomed requests in seconds → CGW ingress rate limit trips → session-wide 429s.

## How this PR fixes it

Deletes the candidate cascade in `useResolvedGasToken`. The hook now fires exactly one `/fees/preview` probe for the token selected in the dropdown:

RecipientRow (the only consumer) already only showed the banner when the resolved token equals the sent token, so the alternative-token probes were dead weight, deleting them changes network behavior but not UI.

## How to test it

1.  Open a Safe holding many tokens on a GTF-enabled chain
2.  New transaction → Send tokens, pick a recipient and a token, click Max
3.  Network tab: exactly one /fees/preview request, with gasToken = the selected token
4.  Banner appears if the probe returns 200; switching tokens re-probes only the new selection

## Affected flows

- Token transfer → Max click → fee banner ("Your max send amount accounts for fees paid in X")

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [X] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [X] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
