### PR TITLE
tests(web): connect wallet via seeded storage in e2e

### DIFF
--- a/apps/web/cypress/e2e/happypath/recovery_hp_1.cy.js
+++ b/apps/web/cypress/e2e/happypath/recovery_hp_1.cy.js
@@ -24,7 +24,7 @@ describe('Recovery happy path tests 1', () => {
 
   // Check that recovery can be setup and removed
   it('Verify that recovery can be setup and removed', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.waitForConnectionStatus()
     recovery.clearRecoverers()
     recovery.clickOnSetupRecoveryBtn()

--- a/apps/web/cypress/e2e/happypath/recovery_hp_4.cy.js
+++ b/apps/web/cypress/e2e/happypath/recovery_hp_4.cy.js
@@ -23,7 +23,7 @@ describe('Recovery happy path tests 4', () => {
 
   // Check that recovery can be setup and removed from modules
   it('Verify that recovery can be setup and removed from modules', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.waitForConnectionStatus()
     recovery.clearRecoverers()
     recovery.clickOnSetupRecoveryBtn()

--- a/apps/web/cypress/e2e/happypath/sendfunds_connected_wallet.cy.js
+++ b/apps/web/cypress/e2e/happypath/sendfunds_connected_wallet.cy.js
@@ -79,7 +79,7 @@ describe('Send funds with connected signer happy path tests', { defaultCommandTi
 
     function executeTransactionFlow(fromSafe, toSafe) {
       return cy.visit(constants.balanceNftsUrl + fromSafe).then(() => {
-        wallet.connectSigner(signer)
+        wallet.connectSignerViaStorage(signer)
         nfts.selectNFTs(1)
         nfts.sendNFT()
         nfts.typeRecipientAddress(toSafe)
@@ -113,7 +113,7 @@ describe('Send funds with connected signer happy path tests', { defaultCommandTi
     const targetSafe = safesData.SEP_FUNDS_SAFE_12.substring(4)
     function executeTransactionFlow(fromSafe, toSafe, tokenAmount) {
       visit(constants.BALANCE_URL + fromSafe)
-      wallet.connectSigner(signer)
+      wallet.connectSignerViaStorage(signer)
       assets.clickOnSendBtn(0)
       loadsafe.inputOwnerAddress(0, toSafe)
       assets.checkSelectedToken(constants.tokenAbbreviation.sep)
@@ -169,7 +169,7 @@ describe('Send funds with connected signer happy path tests', { defaultCommandTi
 
     function executeTransactionFlow(fromSafe, toSafe) {
       visit(constants.BALANCE_URL + fromSafe)
-      wallet.connectSigner(signer)
+      wallet.connectSignerViaStorage(signer)
       assets.toggleShowAllTokens(true)
       assets.toggleHideDust(false)
       assets.clickOnSendBtn(1)

--- a/apps/web/cypress/e2e/happypath/sendfunds_queue_1.cy.js
+++ b/apps/web/cypress/e2e/happypath/sendfunds_queue_1.cy.js
@@ -47,7 +47,7 @@ function visit(url) {
 
 function executeTransactionFlow(fromSafe) {
   visit(constants.transactionQueueUrl + fromSafe)
-  wallet.connectSigner(signer)
+  wallet.connectSignerViaStorage(signer)
   createTx.clickOnConfirmBtn(0)
   tx.executeFlow_1()
   cy.wait(5000)
@@ -125,7 +125,7 @@ describe('Send funds from queue happy path tests 1', () => {
   it('Verify 1 signer can execute a tx confirmed by 2 signers', { defaultCommandTimeout: 300000 }, () => {
     function executeTransaction(fromSafe) {
       visit(constants.transactionQueueUrl + fromSafe)
-      wallet.connectSigner(signer)
+      wallet.connectSignerViaStorage(signer)
       createTx.clickOnExecuteBtn(0)
       tx.executeFlow_3()
       cy.wait(5000)

--- a/apps/web/cypress/e2e/happypath/sendfunds_relay.cy.js
+++ b/apps/web/cypress/e2e/happypath/sendfunds_relay.cy.js
@@ -79,7 +79,7 @@ describe('Send funds with relay happy path tests', { defaultCommandTimeout: 3000
     const originatingSafe = safesData.SEP_FUNDS_SAFE_9.substring(4)
     function executeTransactionFlow(fromSafe, toSafe) {
       return cy.visit(constants.balanceNftsUrl + fromSafe).then(() => {
-        wallet.connectSigner(signer)
+        wallet.connectSignerViaStorage(signer)
         nfts.selectNFTs(1)
         nfts.sendNFT()
         nfts.typeRecipientAddress(toSafe)
@@ -117,7 +117,7 @@ describe('Send funds with relay happy path tests', { defaultCommandTimeout: 3000
     const targetSafe = safesData.SEP_FUNDS_SAFE_1.substring(4)
     function executeTransactionFlow(fromSafe, toSafe, tokenAmount) {
       visit(constants.BALANCE_URL + fromSafe)
-      wallet.connectSigner(signer)
+      wallet.connectSignerViaStorage(signer)
       assets.clickOnSendBtn(0)
       loadsafe.inputOwnerAddress(0, toSafe)
       assets.checkSelectedToken(constants.tokenAbbreviation.sep)
@@ -178,7 +178,7 @@ describe('Send funds with relay happy path tests', { defaultCommandTimeout: 3000
 
     function executeTransactionFlow(fromSafe, toSafe) {
       visit(constants.BALANCE_URL + fromSafe)
-      wallet.connectSigner(signer)
+      wallet.connectSignerViaStorage(signer)
       assets.toggleShowAllTokens(true)
       assets.toggleHideDust(false)
       assets.clickOnSendBtn(1)

--- a/apps/web/cypress/e2e/happypath_2/mass_payouts.cy.js
+++ b/apps/web/cypress/e2e/happypath_2/mass_payouts.cy.js
@@ -21,8 +21,7 @@ describe('Mass payouts happy path tests', () => {
     const address1 = getMockAddress()
     const address2 = getMockAddress()
 
-    cy.visit(constants.transactionQueueUrl + staticSafes.SEP_STATIC_SAFE_42)
-    wallet.connectSigner(signer2)
+    wallet.connectSignerViaStorage(signer2, constants.transactionQueueUrl + staticSafes.SEP_STATIC_SAFE_42)
     cy.wait(5000)
     createtx.deleteAllTx()
 

--- a/apps/web/cypress/e2e/happypath_2/nested_safes.cy.js
+++ b/apps/web/cypress/e2e/happypath_2/nested_safes.cy.js
@@ -24,11 +24,9 @@ describe('Nested safes happy path tests', () => {
   it('Verify that batch tx appears in the Queue with create proxy action', () => {
     const safe = 'Created safe'
 
-    cy.visit(constants.transactionQueueUrl + staticSafes.SEP_STATIC_SAFE_39)
-    main.addToAppLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.nestedParentSafe39)
-    cy.reload()
-    wallet.connectSignerViaStorage(signer)
-    cy.wait(5000)
+    wallet.connectSignerViaStorage(signer, constants.transactionQueueUrl + staticSafes.SEP_STATIC_SAFE_39, {
+      extraStorage: { [constants.localStorageKeys.SAFE_v2__addedSafes]: ls.addedSafes.nestedParentSafe39 },
+    })
     createTx.deleteAllTx()
 
     safeNav.clickOnNestedSafesBtn()

--- a/apps/web/cypress/e2e/happypath_2/nested_safes.cy.js
+++ b/apps/web/cypress/e2e/happypath_2/nested_safes.cy.js
@@ -27,7 +27,7 @@ describe('Nested safes happy path tests', () => {
     cy.visit(constants.transactionQueueUrl + staticSafes.SEP_STATIC_SAFE_39)
     main.addToAppLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.nestedParentSafe39)
     cy.reload()
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     cy.wait(5000)
     createTx.deleteAllTx()
 

--- a/apps/web/cypress/e2e/happypath_2/proposers.cy.js
+++ b/apps/web/cypress/e2e/happypath_2/proposers.cy.js
@@ -22,8 +22,7 @@ describe('Happy path Proposers tests', { defaultCommandTimeout: 30000 }, () => {
   })
 
   it('Verify that editing a proposer is only possible for the proposer created by the creator', () => {
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_31)
-    wallet.connectSigner(signer3)
+    wallet.connectSignerViaStorage(signer3, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_31)
     cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
     proposer.verifyEditProposerBtnDisabled(proposerAddress)
 
@@ -41,8 +40,7 @@ describe('Happy path Proposers tests', { defaultCommandTimeout: 30000 }, () => {
   })
 
   it('Verify a proposer can be added', () => {
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_32)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_32)
     cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
     navigation.verifyTxBtnStatus(constants.enabledStates.enabled)
     proposer.deleteAllProposers()

--- a/apps/web/cypress/e2e/happypath_2/tx-builder.cy.js
+++ b/apps/web/cypress/e2e/happypath_2/tx-builder.cy.js
@@ -44,8 +44,7 @@ describe('Transaction Builder happy path tests', { defaultCommandTimeout: 20000 
       iframeSelector = `iframe[id="iframe-${encodeURIComponent(appUrl)}"]`
       const visitUrl = `/apps/open?safe=${safeAppSafes.SEP_SAFEAPP_SAFE_1}&appUrl=${encodeURIComponent(appUrl)}`
 
-      cy.visit(constants.transactionQueueUrl + safeAppSafes.SEP_SAFEAPP_SAFE_1)
-      wallet.connectSigner(signer)
+      wallet.connectSignerViaStorage(signer, constants.transactionQueueUrl + safeAppSafes.SEP_SAFEAPP_SAFE_1)
       cy.wait(5000)
       createtx.deleteAllTx()
       cy.visit(visitUrl)

--- a/apps/web/cypress/e2e/pages/copilot.js
+++ b/apps/web/cypress/e2e/pages/copilot.js
@@ -351,7 +351,7 @@ export function navigateToTransactionAndSetupCopilot(
     },
   })
 
-  walletUtils.connectSigner(signer)
+  walletUtils.connectSignerViaStorage(signer)
 
   clickOnConfirmTransactionBtn()
   verifySafeShieldDisplayed()

--- a/apps/web/cypress/e2e/pages/create_tx.pages.js
+++ b/apps/web/cypress/e2e/pages/create_tx.pages.js
@@ -1141,8 +1141,7 @@ export function checkThatComboButtonOptionIsNotPresent(option) {
 }
 //Functions for the happy path flow
 export function cleanTransactionQueue(safeAddress, signer) {
-  cy.visit(constants.transactionQueueUrl + safeAddress)
-  walletUtils.connectSigner(signer)
+  walletUtils.connectSignerViaStorage(signer, constants.transactionQueueUrl + safeAddress)
   deleteAllTx()
   navigation.clickOnWalletExpandMoreIcon()
   navigation.clickOnDisconnectBtn()
@@ -1167,8 +1166,7 @@ export function deleteTransactionAndSwitchToSigner(signer) {
 
 export function createAddOwnerTransaction(safeAddress, signer, ownerAddress, ownerIndex = 2) {
   // Create add owner transaction
-  cy.visit(constants.setupUrl + safeAddress)
-  walletUtils.connectSigner(signer)
+  walletUtils.connectSignerViaStorage(signer, constants.setupUrl + safeAddress)
   owner.waitForConnectionStatus()
   owner.openManageSignersWindow()
   owner.clickOnAddSignerBtn()

--- a/apps/web/cypress/e2e/pages/create_wallet.pages.js
+++ b/apps/web/cypress/e2e/pages/create_wallet.pages.js
@@ -386,7 +386,7 @@ export function visitWelcomeAccountPage(chain = 'sep') {
 }
 
 export function connectWalletAndCreateSafe(signer) {
-  wallet.connectSigner(signer)
+  wallet.connectSignerViaStorage(signer)
   owner.waitForConnectionStatus()
   clickOnCreateNewSafeBtn()
 }

--- a/apps/web/cypress/e2e/regression/add_owner.cy.js
+++ b/apps/web/cypress/e2e/regression/add_owner.cy.js
@@ -15,71 +15,82 @@ describe('Add Owners tests', () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  beforeEach(() => {
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
-    cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
+  describe('Disconnected', () => {
+    beforeEach(() => {
+      cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
+      cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
+    })
+
+    // Added to prod
+    it('Verify add owner button is disabled for disconnected user', () => {
+      owner.verifyManageSignersBtnIsDisabled()
+    })
   })
 
-  // Added to prod
-  it('Verify add owner button is disabled for disconnected user', () => {
-    owner.verifyManageSignersBtnIsDisabled()
+  describe('Connected', () => {
+    beforeEach(() => {
+      wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
+      cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
+    })
+
+    // Added to prod
+    it('Verify the Add New Owner Form can be opened', () => {
+      owner.openManageSignersWindow()
+    })
+
+    it('Verify error message displayed if character limit is exceeded in Name input', () => {
+      owner.openManageSignersWindow()
+      owner.clickOnAddSignerBtn()
+      owner.typeOwnerNameManage(1, main.generateRandomString(51))
+      owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.exceedChars)
+    })
+
+    //The case should be updated with review "Add owner" field on next page and other options
+    it('Verify that Name field not mandatory', () => {
+      owner.openManageSignersWindow()
+      owner.clickOnAddSignerBtn()
+      owner.typeOwnerAddressManage(1, getMockAddress())
+      owner.clickOnNextBtnManage()
+      owner.verifyConfirmTransactionWindowDisplayed()
+    })
+
+    it('Verify default threshold value. Verify correct threshold calculation', () => {
+      owner.openManageSignersWindow()
+      owner.clickOnAddSignerBtn()
+      owner.typeOwnerAddressManage(1, constants.DEFAULT_OWNER_ADDRESS)
+      owner.verifyThreshold(1, 2)
+    })
+
+    //TBD the case should be updated with additional steps to verify a new owner address and name
+    it('Verify valid Address validation', () => {
+      owner.openManageSignersWindow()
+      owner.clickOnAddSignerBtn()
+      owner.typeOwnerAddressManage(1, constants.SEPOLIA_OWNER_2)
+      owner.clickOnNextBtnManage()
+      owner.verifyConfirmTransactionWindowDisplayed()
+      owner.clickOnBackBtn()
+      owner.typeOwnerAddressManage(1, staticSafes.SEP_STATIC_SAFE_3)
+      owner.clickOnNextBtnManage()
+      owner.verifyConfirmTransactionWindowDisplayed()
+    })
   })
 
-  // Added to prod
-  it('Verify the Add New Owner Form can be opened', () => {
-    wallet.connectSignerViaStorage(signer)
-    owner.openManageSignersWindow()
-  })
-
-  it('Verify error message displayed if character limit is exceeded in Name input', () => {
-    wallet.connectSignerViaStorage(signer)
-    owner.openManageSignersWindow()
-    owner.clickOnAddSignerBtn()
-    owner.typeOwnerNameManage(1, main.generateRandomString(51))
-    owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.exceedChars)
-  })
-
-  it('Verify that the "Name" field is auto-filled with the relevant name from Address Book', () => {
-    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4)
-    addressBook.clickOnCreateEntryBtn()
-    addressBook.typeInName(constants.addresBookContacts.user1.name)
-    addressBook.typeInAddress(constants.addresBookContacts.user1.address)
-    addressBook.clickOnSaveEntryBtn()
-    addressBook.verifyNewEntryAdded(constants.addresBookContacts.user1.name, constants.addresBookContacts.user1.address)
-    wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
-    owner.openManageSignersWindow()
-    owner.clickOnAddSignerBtn()
-    owner.typeOwnerAddressManage(1, constants.addresBookContacts.user1.address)
-    owner.verifyNewOwnerName(1, constants.addresBookContacts.user1.name)
-  })
-  //The case should be updated with review "Add owner" field on next page and other options
-  it('Verify that Name field not mandatory', () => {
-    wallet.connectSignerViaStorage(signer)
-    owner.openManageSignersWindow()
-    owner.clickOnAddSignerBtn()
-    owner.typeOwnerAddressManage(1, getMockAddress())
-    owner.clickOnNextBtnManage()
-    owner.verifyConfirmTransactionWindowDisplayed()
-  })
-
-  it('Verify default threshold value. Verify correct threshold calculation', () => {
-    wallet.connectSignerViaStorage(signer)
-    owner.openManageSignersWindow()
-    owner.clickOnAddSignerBtn()
-    owner.typeOwnerAddressManage(1, constants.DEFAULT_OWNER_ADDRESS)
-    owner.verifyThreshold(1, 2)
-  })
-  //TBD the case should be updated with additional steps to verify a new owner address and name
-  it('Verify valid Address validation', () => {
-    wallet.connectSignerViaStorage(signer)
-    owner.openManageSignersWindow()
-    owner.clickOnAddSignerBtn()
-    owner.typeOwnerAddressManage(1, constants.SEPOLIA_OWNER_2)
-    owner.clickOnNextBtnManage()
-    owner.verifyConfirmTransactionWindowDisplayed()
-    owner.clickOnBackBtn()
-    owner.typeOwnerAddressManage(1, staticSafes.SEP_STATIC_SAFE_3)
-    owner.clickOnNextBtnManage()
-    owner.verifyConfirmTransactionWindowDisplayed()
+  describe('Address book autofill', () => {
+    it('Verify that the "Name" field is auto-filled with the relevant name from Address Book', () => {
+      cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4)
+      addressBook.clickOnCreateEntryBtn()
+      addressBook.typeInName(constants.addresBookContacts.user1.name)
+      addressBook.typeInAddress(constants.addresBookContacts.user1.address)
+      addressBook.clickOnSaveEntryBtn()
+      addressBook.verifyNewEntryAdded(
+        constants.addresBookContacts.user1.name,
+        constants.addresBookContacts.user1.address,
+      )
+      wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
+      owner.openManageSignersWindow()
+      owner.clickOnAddSignerBtn()
+      owner.typeOwnerAddressManage(1, constants.addresBookContacts.user1.address)
+      owner.verifyNewOwnerName(1, constants.addresBookContacts.user1.name)
+    })
   })
 })

--- a/apps/web/cypress/e2e/regression/add_owner.cy.js
+++ b/apps/web/cypress/e2e/regression/add_owner.cy.js
@@ -27,12 +27,12 @@ describe('Add Owners tests', () => {
 
   // Added to prod
   it('Verify the Add New Owner Form can be opened', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.openManageSignersWindow()
   })
 
   it('Verify error message displayed if character limit is exceeded in Name input', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.openManageSignersWindow()
     owner.clickOnAddSignerBtn()
     owner.typeOwnerNameManage(1, main.generateRandomString(51))
@@ -46,8 +46,7 @@ describe('Add Owners tests', () => {
     addressBook.typeInAddress(constants.addresBookContacts.user1.address)
     addressBook.clickOnSaveEntryBtn()
     addressBook.verifyNewEntryAdded(constants.addresBookContacts.user1.name, constants.addresBookContacts.user1.address)
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
     owner.openManageSignersWindow()
     owner.clickOnAddSignerBtn()
     owner.typeOwnerAddressManage(1, constants.addresBookContacts.user1.address)
@@ -55,7 +54,7 @@ describe('Add Owners tests', () => {
   })
   //The case should be updated with review "Add owner" field on next page and other options
   it('Verify that Name field not mandatory', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.openManageSignersWindow()
     owner.clickOnAddSignerBtn()
     owner.typeOwnerAddressManage(1, getMockAddress())
@@ -64,7 +63,7 @@ describe('Add Owners tests', () => {
   })
 
   it('Verify default threshold value. Verify correct threshold calculation', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.openManageSignersWindow()
     owner.clickOnAddSignerBtn()
     owner.typeOwnerAddressManage(1, constants.DEFAULT_OWNER_ADDRESS)
@@ -72,7 +71,7 @@ describe('Add Owners tests', () => {
   })
   //TBD the case should be updated with additional steps to verify a new owner address and name
   it('Verify valid Address validation', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.openManageSignersWindow()
     owner.clickOnAddSignerBtn()
     owner.typeOwnerAddressManage(1, constants.SEPOLIA_OWNER_2)

--- a/apps/web/cypress/e2e/regression/address_book.cy.js
+++ b/apps/web/cypress/e2e/regression/address_book.cy.js
@@ -2,7 +2,6 @@ const path = require('path')
 import { format } from 'date-fns'
 import * as constants from '../../support/constants'
 import * as addressBook from '../../e2e/pages/address_book.page'
-import * as main from '../../e2e/pages/main.page'
 import * as ls from '../../support/localstorage_data.js'
 import * as accountsModal from '../pages/accounts_modal.pages.js'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
@@ -21,110 +20,83 @@ describe('Address book tests', () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  beforeEach(() => {
-    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4)
-  })
+  const seedAddressBook = (value) => (win) =>
+    win.localStorage.setItem(constants.localStorageKeys.SAFE_v2__addressBook, JSON.stringify(value))
 
   it('Verify owners name can be edited', () => {
-    cy.wrap(null)
-      .then(() =>
-        main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sepoliaAddress1),
-      )
-      .then(() =>
-        main.isItemInLocalstorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sepoliaAddress1),
-      )
-      .then(() => {
-        cy.reload()
-        addressBook.clickOnEditEntryBtn()
-        addressBook.typeInNameInput(EDITED_NAME)
-        addressBook.clickOnSaveEntryBtn()
-        addressBook.verifyNameWasChanged(NAME, EDITED_NAME)
-      })
+    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4, {
+      onBeforeLoad: seedAddressBook(ls.addressBookData.sepoliaAddress1),
+    })
+    addressBook.clickOnEditEntryBtn()
+    addressBook.typeInNameInput(EDITED_NAME)
+    addressBook.clickOnSaveEntryBtn()
+    addressBook.verifyNameWasChanged(NAME, EDITED_NAME)
   })
 
   it('Verify the address book file can be exported', () => {
-    cy.wrap(null)
-      .then(() => main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.dataSet))
-      .then(() =>
-        main.isItemInLocalstorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.dataSet),
-      )
-      .then(() => {
-        cy.reload()
-        cy.contains(ls.addressBookData.dataSet[11155111]['0xf405BC611F4a4c89CCB3E4d083099f9C36D966f8'])
-        const date = format(new Date(), 'yyyy-MM-dd', { timeZone: 'UTC' })
-        const fileName = `safe-address-book-${date}.csv`
-        addressBook.clickOnExportFileBtn()
-        addressBook.verifyExportMessage(12)
-        addressBook.confirmExport()
-        const downloadsFolder = Cypress.config('downloadsFolder')
+    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4, {
+      onBeforeLoad: seedAddressBook(ls.addressBookData.dataSet),
+    })
+    cy.contains(ls.addressBookData.dataSet[11155111]['0xf405BC611F4a4c89CCB3E4d083099f9C36D966f8'])
+    const date = format(new Date(), 'yyyy-MM-dd', { timeZone: 'UTC' })
+    const fileName = `safe-address-book-${date}.csv`
+    addressBook.clickOnExportFileBtn()
+    addressBook.verifyExportMessage(12)
+    addressBook.confirmExport()
+    const downloadsFolder = Cypress.config('downloadsFolder')
 
-        cy.readFile(path.join(downloadsFolder, fileName), 'utf-8').then((content) => {
-          const lines = content
-            .replace(/^\uFEFF/, '')
-            .trim()
-            .split('\r\n')
+    cy.readFile(path.join(downloadsFolder, fileName), 'utf-8').then((content) => {
+      const lines = content
+        .replace(/^\uFEFF/, '')
+        .trim()
+        .split('\r\n')
 
-          const [header, ...dataLines] = lines
-          const actualData = dataLines.reduce((acc, line) => {
-            const [address, name, chainId] = line.split(',')
-            acc[chainId] = acc[chainId] || {}
-            acc[chainId][address] = name
-            return acc
-          }, {})
+      const [header, ...dataLines] = lines
+      const actualData = dataLines.reduce((acc, line) => {
+        const [address, name, chainId] = line.split(',')
+        acc[chainId] = acc[chainId] || {}
+        acc[chainId][address] = name
+        return acc
+      }, {})
 
-          Object.keys(ls.addressBookData.dataSet).forEach((chainId) => {
-            cy.log(`Checking chainId: ${chainId}`)
+      Object.keys(ls.addressBookData.dataSet).forEach((chainId) => {
+        cy.log(`Checking chainId: ${chainId}`)
 
-            const actualChainData = actualData[chainId] || {}
-            const expectedChainData = ls.addressBookData.dataSet[chainId]
+        const actualChainData = actualData[chainId] || {}
+        const expectedChainData = ls.addressBookData.dataSet[chainId]
 
-            Object.keys(expectedChainData).forEach((address) => {
-              const actualName = actualChainData[address]
-              const expectedName = expectedChainData[address]
+        Object.keys(expectedChainData).forEach((address) => {
+          const actualName = actualChainData[address]
+          const expectedName = expectedChainData[address]
 
-              cy.log(
-                `ChainId: ${chainId}, Address: ${address}, Actual Name: ${actualName}, Expected Name: ${expectedName}`,
-              )
-              expect(actualName).to.equal(expectedName)
-            })
-          })
+          cy.log(`ChainId: ${chainId}, Address: ${address}, Actual Name: ${actualName}, Expected Name: ${expectedName}`)
+          expect(actualName).to.equal(expectedName)
         })
       })
+    })
   })
 
   it('Verify that importing a csv file does not alter addresses in the Address book not present in the file', () => {
-    cy.wrap(null)
-      .then(() =>
-        main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sepoliaAddress1),
-      )
-      .then(() =>
-        main.isItemInLocalstorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sepoliaAddress1),
-      )
-      .then(() => {
-        cy.wait(1000)
-        cy.reload()
-        addressBook.clickOnImportFileBtn()
-        addressBook.importCSVFile(addressBook.validCSVFile)
-        addressBook.clickOnImportBtn()
-        addressBook.verifyDataImported([constants.RECIPIENT_ADDRESS])
-      })
+    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4, {
+      onBeforeLoad: seedAddressBook(ls.addressBookData.sepoliaAddress1),
+    })
+    addressBook.clickOnImportFileBtn()
+    addressBook.importCSVFile(addressBook.validCSVFile)
+    addressBook.clickOnImportBtn()
+    addressBook.verifyDataImported([constants.RECIPIENT_ADDRESS])
   })
 
   it('Verify Safe name changes after uploading a csv file', () => {
-    cy.wrap(null)
-      .then(() => main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set2))
-      .then(() =>
-        main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.addedSafesImport),
-      )
-      .then(() => {
-        cy.wait(1000)
-        cy.reload()
-        addressBook.clickOnImportFileBtn()
-        addressBook.importCSVFile(addressBook.addedSafesCSVFile)
-        addressBook.clickOnImportBtn()
-        wallet.connectSignerViaStorage(signer)
-        accountsModal.openAccountsModal()
-        accountsModal.verifyAccountsListContains(importedSafe)
-      })
+    wallet.connectSignerViaStorage(signer, constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4, {
+      extraStorage: {
+        [constants.localStorageKeys.SAFE_v2__addedSafes]: ls.addedSafes.set2,
+        [constants.localStorageKeys.SAFE_v2__addressBook]: ls.addressBookData.addedSafesImport,
+      },
+    })
+    addressBook.clickOnImportFileBtn()
+    addressBook.importCSVFile(addressBook.addedSafesCSVFile)
+    addressBook.clickOnImportBtn()
+    accountsModal.openAccountsModal()
+    accountsModal.verifyAccountsListContains(importedSafe)
   })
 })

--- a/apps/web/cypress/e2e/regression/address_book.cy.js
+++ b/apps/web/cypress/e2e/regression/address_book.cy.js
@@ -122,7 +122,7 @@ describe('Address book tests', () => {
         addressBook.clickOnImportFileBtn()
         addressBook.importCSVFile(addressBook.addedSafesCSVFile)
         addressBook.clickOnImportBtn()
-        wallet.connectSigner(signer)
+        wallet.connectSignerViaStorage(signer)
         accountsModal.openAccountsModal()
         accountsModal.verifyAccountsListContains(importedSafe)
       })

--- a/apps/web/cypress/e2e/regression/address_book_2.cy.js
+++ b/apps/web/cypress/e2e/regression/address_book_2.cy.js
@@ -1,6 +1,5 @@
 import * as constants from '../../support/constants.js'
 import * as addressBook from '../pages/address_book.page.js'
-import * as main from '../pages/main.page.js'
 import * as ls from '../../support/localstorage_data.js'
 import * as createtx from '../../e2e/pages/create_tx.pages'
 import * as data from '../../fixtures/txhistory_data_data.json'
@@ -19,13 +18,13 @@ describe('Address book tests - 2', () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  beforeEach(() => {
-    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4)
-  })
+  const seedAddressBook = (value) => (win) =>
+    win.localStorage.setItem(constants.localStorageKeys.SAFE_v2__addressBook, JSON.stringify(value))
 
   it('Verify Name and Address columns sorting works', () => {
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sortingData)
-    cy.reload()
+    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4, {
+      onBeforeLoad: seedAddressBook(ls.addressBookData.sortingData),
+    })
     addressBook.clickOnNameSortBtn()
     addressBook.verifyEntriesOrder()
     addressBook.clickOnNameSortBtn()
@@ -40,8 +39,9 @@ describe('Address book tests - 2', () => {
   })
 
   it('Verify that edit owners name changes the name in the settings', () => {
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sepoliaAddress2)
-    cy.reload()
+    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4, {
+      onBeforeLoad: seedAddressBook(ls.addressBookData.sepoliaAddress2),
+    })
     addressBook.clickOnEditEntryBtn()
     addressBook.typeInNameInput(onwer2)
     addressBook.clickOnSaveEntryBtn()
@@ -66,16 +66,16 @@ describe('Address book tests - 2', () => {
   })
 
   it('Verify by default there 25 rows shown per page', () => {
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.pagination)
-    cy.wait(1000)
-    cy.reload()
+    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4, {
+      onBeforeLoad: seedAddressBook(ls.addressBookData.pagination),
+    })
     addressBook.verifyCountOfSafes(25)
   })
 
   it('Verify that clicking on next and previous page buttons shows safes', () => {
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.pagination)
-    cy.wait(1000)
-    cy.reload()
+    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4, {
+      onBeforeLoad: seedAddressBook(ls.addressBookData.pagination),
+    })
     addressBook.clickOnNextPageBtn()
     addressBook.verifyCountOfSafes(1)
     addressBook.clickOnPrevPageBtn()

--- a/apps/web/cypress/e2e/regression/address_book_3.cy.js
+++ b/apps/web/cypress/e2e/regression/address_book_3.cy.js
@@ -94,7 +94,7 @@ describe('Address book tests - 3', () => {
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sepoliaAddress2)
     cy.wait(1000)
     cy.reload()
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     addressBook.clickOnSendBtn()
     addressBook.verifyRecipientData(recipientData)
   })

--- a/apps/web/cypress/e2e/regression/address_book_3.cy.js
+++ b/apps/web/cypress/e2e/regression/address_book_3.cy.js
@@ -1,6 +1,5 @@
 import * as constants from '../../support/constants.js'
 import * as addressBook from '../pages/address_book.page.js'
-import * as main from '../pages/main.page.js'
 import * as ls from '../../support/localstorage_data.js'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 import * as wallet from '../../support/utils/wallet.js'
@@ -21,81 +20,80 @@ describe('Address book tests - 3', () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  beforeEach(() => {
-    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4)
+  describe('Without pre-seeded data', () => {
+    beforeEach(() => {
+      cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4)
+    })
+
+    it('Verify entry can be added', () => {
+      addressBook.clickOnCreateEntryBtn()
+      addressBook.addEntry(NAME, constants.RECIPIENT_ADDRESS)
+    })
+
+    it('Verify csv file can be imported', () => {
+      addressBook.clickOnImportFileBtn()
+      addressBook.importCSVFile(addressBook.validCSVFile)
+      addressBook.verifyImportBtnStatus(constants.enabledStates.enabled)
+      addressBook.clickOnImportBtn()
+      addressBook.verifyDataImported(addressBook.entries)
+      addressBook.verifyNumberOfRows(4)
+    })
+
+    it('Import a csv file with an empty address/name/network in one row', () => {
+      addressBook.clickOnImportFileBtn()
+      addressBook.importCSVFile(addressBook.emptyCSVFile)
+      addressBook.verifyImportBtnStatus(constants.enabledStates.disabled)
+      addressBook.verifyUploadExportMessage([addressBook.uploadErrorMessages.emptyFile])
+    })
+
+    it('Import a non-csv file', () => {
+      addressBook.clickOnImportFileBtn()
+      addressBook.importCSVFile(addressBook.nonCSVFile)
+      addressBook.verifyImportBtnStatus(constants.enabledStates.disabled)
+      addressBook.verifyUploadExportMessage([addressBook.uploadErrorMessages.fileType])
+    })
+
+    it('Import a csv file with a repeated address and same network', () => {
+      addressBook.clickOnImportFileBtn()
+      addressBook.importCSVFile(addressBook.duplicatedCSVFile)
+      addressBook.verifyImportBtnStatus(constants.enabledStates.enabled)
+      addressBook.clickOnImportBtn()
+      addressBook.verifyDataImported([duplicateEntry])
+      addressBook.verifyNumberOfRows(1)
+    })
+
+    it('Verify modal shows the amount of entries and networks detected', () => {
+      addressBook.clickOnImportFileBtn()
+      addressBook.importCSVFile(addressBook.networksCSVFile)
+      addressBook.verifyImportBtnStatus(constants.enabledStates.enabled)
+      addressBook.verifyModalSummaryMessage(4, 3)
+    })
+
+    it('Verify an entry can be added by ENS name', () => {
+      addressBook.clickOnCreateEntryBtn()
+      addressBook.addEntryByENS(NAME_2, constants.ENS_TEST_SEPOLIA)
+    })
   })
 
-  it('Verify entry can be added', () => {
-    addressBook.clickOnCreateEntryBtn()
-    addressBook.addEntry(NAME, constants.RECIPIENT_ADDRESS)
-  })
+  describe('With pre-seeded data', () => {
+    const seedAddressBook = (value) => (win) =>
+      win.localStorage.setItem(constants.localStorageKeys.SAFE_v2__addressBook, JSON.stringify(value))
 
-  it('Verify entry can be deleted', () => {
-    cy.wrap(null)
-      .then(() =>
-        main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sepoliaAddress1),
-      )
-      .then(() =>
-        main.isItemInLocalstorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sepoliaAddress1),
-      )
-      .then(() => {
-        cy.reload()
-        addressBook.clickDeleteEntryButton()
-        addressBook.clickDeleteEntryModalDeleteButton()
-        addressBook.verifyEditedNameNotExists(EDITED_NAME)
+    it('Verify entry can be deleted', () => {
+      cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4, {
+        onBeforeLoad: seedAddressBook(ls.addressBookData.sepoliaAddress1),
       })
-  })
+      addressBook.clickDeleteEntryButton()
+      addressBook.clickDeleteEntryModalDeleteButton()
+      addressBook.verifyEditedNameNotExists(EDITED_NAME)
+    })
 
-  it('Verify csv file can be imported', () => {
-    addressBook.clickOnImportFileBtn()
-    addressBook.importCSVFile(addressBook.validCSVFile)
-    addressBook.verifyImportBtnStatus(constants.enabledStates.enabled)
-    addressBook.clickOnImportBtn()
-    addressBook.verifyDataImported(addressBook.entries)
-    addressBook.verifyNumberOfRows(4)
-  })
-
-  it('Import a csv file with an empty address/name/network in one row', () => {
-    addressBook.clickOnImportFileBtn()
-    addressBook.importCSVFile(addressBook.emptyCSVFile)
-    addressBook.verifyImportBtnStatus(constants.enabledStates.disabled)
-    addressBook.verifyUploadExportMessage([addressBook.uploadErrorMessages.emptyFile])
-  })
-
-  it('Import a non-csv file', () => {
-    addressBook.clickOnImportFileBtn()
-    addressBook.importCSVFile(addressBook.nonCSVFile)
-    addressBook.verifyImportBtnStatus(constants.enabledStates.disabled)
-    addressBook.verifyUploadExportMessage([addressBook.uploadErrorMessages.fileType])
-  })
-
-  it('Import a csv file with a repeated address and same network', () => {
-    addressBook.clickOnImportFileBtn()
-    addressBook.importCSVFile(addressBook.duplicatedCSVFile)
-    addressBook.verifyImportBtnStatus(constants.enabledStates.enabled)
-    addressBook.clickOnImportBtn()
-    addressBook.verifyDataImported([duplicateEntry])
-    addressBook.verifyNumberOfRows(1)
-  })
-
-  it('Verify modal shows the amount of entries and networks detected', () => {
-    addressBook.clickOnImportFileBtn()
-    addressBook.importCSVFile(addressBook.networksCSVFile)
-    addressBook.verifyImportBtnStatus(constants.enabledStates.enabled)
-    addressBook.verifyModalSummaryMessage(4, 3)
-  })
-
-  it('Verify an entry can be added by ENS name', () => {
-    addressBook.clickOnCreateEntryBtn()
-    addressBook.addEntryByENS(NAME_2, constants.ENS_TEST_SEPOLIA)
-  })
-
-  it('Verify clicking on Send button autofills the recipient filed with correct value', () => {
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sepoliaAddress2)
-    cy.wait(1000)
-    cy.reload()
-    wallet.connectSignerViaStorage(signer)
-    addressBook.clickOnSendBtn()
-    addressBook.verifyRecipientData(recipientData)
+    it('Verify clicking on Send button autofills the recipient filed with correct value', () => {
+      wallet.connectSignerViaStorage(signer, constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4, {
+        extraStorage: { [constants.localStorageKeys.SAFE_v2__addressBook]: ls.addressBookData.sepoliaAddress2 },
+      })
+      addressBook.clickOnSendBtn()
+      addressBook.verifyRecipientData(recipientData)
+    })
   })
 })

--- a/apps/web/cypress/e2e/regression/assets.cy.js
+++ b/apps/web/cypress/e2e/regression/assets.cy.js
@@ -14,46 +14,50 @@ describe('Assets tests', () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  beforeEach(() => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_2)
+  describe('Disconnected', () => {
+    beforeEach(() => {
+      cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_2)
+    })
+
+    it('Verify that "Hide token" button is present and opens the "Hide tokens menu"', () => {
+      assets.toggleShowAllTokens(true)
+      assets.toggleHideDust(false)
+      assets.openHiddenTokensFromManageMenu()
+      assets.verifyEachRowHasCheckbox()
+    })
+
+    it('Verify that Token list dropdown shows options "Default tokens" and "All tokens"', () => {
+      let spamTokens = [
+        assets.currencyAave,
+        assets.currencyTestTokenA,
+        assets.currencyTestTokenB,
+        assets.currencyUSDC,
+        assets.currencyLink,
+        assets.currencyDaiCap,
+      ]
+
+      assets.toggleHideDust(false)
+
+      // On chains without portfolio support (Sepolia), trusted filtering is disabled, so
+      // "Default tokens" behaves like "All tokens". Asserting the two modes show different
+      // lists requires a portfolio-supported chain (e.g. mainnet).
+      // Mirrors the same assertions in smoke/assets.cy.js.
+      assets.toggleShowAllTokens(false)
+      main.verifyValuesExist(assets.tokenListTable, [constants.tokenNames.sepoliaEther, ...spamTokens])
+
+      assets.toggleShowAllTokens(true)
+      spamTokens.push(constants.tokenNames.sepoliaEther)
+      main.verifyValuesExist(assets.tokenListTable, spamTokens)
+    })
   })
 
-  it('Verify that "Hide token" button is present and opens the "Hide tokens menu"', () => {
-    assets.toggleShowAllTokens(true)
-    assets.toggleHideDust(false)
-    assets.openHiddenTokensFromManageMenu()
-    assets.verifyEachRowHasCheckbox()
-  })
-
-  it('Verify that clicking the button with an owner opens the Send funds form', () => {
-    wallet.connectSignerViaStorage(signer)
-    assets.toggleShowAllTokens(true)
-    assets.toggleHideDust(false)
-    cy.wait(2000)
-    assets.clickOnSendBtnAssetsTable(0)
-  })
-
-  it('Verify that Token list dropdown shows options "Default tokens" and "All tokens"', () => {
-    let spamTokens = [
-      assets.currencyAave,
-      assets.currencyTestTokenA,
-      assets.currencyTestTokenB,
-      assets.currencyUSDC,
-      assets.currencyLink,
-      assets.currencyDaiCap,
-    ]
-
-    assets.toggleHideDust(false)
-
-    // On chains without portfolio support (Sepolia), trusted filtering is disabled, so
-    // "Default tokens" behaves like "All tokens". Asserting the two modes show different
-    // lists requires a portfolio-supported chain (e.g. mainnet).
-    // Mirrors the same assertions in smoke/assets.cy.js.
-    assets.toggleShowAllTokens(false)
-    main.verifyValuesExist(assets.tokenListTable, [constants.tokenNames.sepoliaEther, ...spamTokens])
-
-    assets.toggleShowAllTokens(true)
-    spamTokens.push(constants.tokenNames.sepoliaEther)
-    main.verifyValuesExist(assets.tokenListTable, spamTokens)
+  describe('Connected', () => {
+    it('Verify that clicking the button with an owner opens the Send funds form', () => {
+      wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_2)
+      assets.toggleShowAllTokens(true)
+      assets.toggleHideDust(false)
+      cy.wait(2000)
+      assets.clickOnSendBtnAssetsTable(0)
+    })
   })
 })

--- a/apps/web/cypress/e2e/regression/assets.cy.js
+++ b/apps/web/cypress/e2e/regression/assets.cy.js
@@ -26,7 +26,7 @@ describe('Assets tests', () => {
   })
 
   it('Verify that clicking the button with an owner opens the Send funds form', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     assets.toggleShowAllTokens(true)
     assets.toggleHideDust(false)
     cy.wait(2000)

--- a/apps/web/cypress/e2e/regression/assets_2.cy.js
+++ b/apps/web/cypress/e2e/regression/assets_2.cy.js
@@ -36,8 +36,7 @@ describe('Assets 2 tests', () => {
   })
 
   it('Verify Proposers have the Send and Swap buttons enabled', () => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_31)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_31)
     assets.toggleShowAllTokens(false)
     assets.toggleHideDust(false)
     main.verifyValuesExist(assets.tokenListTable, [constants.tokenNames.sepoliaEther])

--- a/apps/web/cypress/e2e/regression/batch_tx.cy.js
+++ b/apps/web/cypress/e2e/regression/batch_tx.cy.js
@@ -1,6 +1,5 @@
 import * as batch from '../pages/batches.pages'
 import * as constants from '../../support/constants'
-import * as main from '../../e2e/pages/main.page'
 import * as owner from '../../e2e/pages/owners.pages.js'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 import * as wallet from '../../support/utils/wallet.js'
@@ -22,94 +21,92 @@ describe('Batch transaction tests', { defaultCommandTimeout: 30000 }, () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  beforeEach(() => {
-    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_2)
-    owner.waitForConnectionStatus()
-  })
+  describe('Building a batch', () => {
+    beforeEach(() => {
+      wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_2)
+      owner.waitForConnectionStatus()
+    })
 
-  it('Verify the Add batch button is present in a transaction form', () => {
-    //The "true" is to validate that the add to batch button is not visible if "Yes, execute" is selected
-    batch.addNewTransactionToBatch(getMockAddress(), currentNonce, funds_first_tx)
-  })
+    it('Verify the Add batch button is present in a transaction form', () => {
+      //The "true" is to validate that the add to batch button is not visible if "Yes, execute" is selected
+      batch.addNewTransactionToBatch(getMockAddress(), currentNonce, funds_first_tx)
+    })
 
-  it('Verify a second transaction can be added to the batch', () => {
-    batch.addNewTransactionToBatch(getMockAddress(), currentNonce, funds_first_tx)
-    cy.wait(1000)
-    batch.addNewTransactionToBatch(getMockAddress(), currentNonce, funds_first_tx)
-    batch.verifyBatchIconCount(2)
-    batch.clickOnBatchCounter()
-    batch.verifyAmountTransactionsInBatch(2)
-  })
+    it('Verify a second transaction can be added to the batch', () => {
+      batch.addNewTransactionToBatch(getMockAddress(), currentNonce, funds_first_tx)
+      cy.wait(1000)
+      batch.addNewTransactionToBatch(getMockAddress(), currentNonce, funds_first_tx)
+      batch.verifyBatchIconCount(2)
+      batch.clickOnBatchCounter()
+      batch.verifyAmountTransactionsInBatch(2)
+    })
 
-  it('Verify that clicking on "Confirm batch" button opens confirm batch modal with listed transactions', () => {
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__batch, ls.batchData.entry0)
-    cy.reload()
-    batch.clickOnBatchCounter()
-    batch.clickOnConfirmBatchBtn()
-    cy.contains(funds_first_tx).parents('ul').as('TransactionList')
-    cy.get('@TransactionList').find('li').eq(0).contains(funds_first_tx)
-    cy.get('@TransactionList').find('li').eq(1).contains(funds_second_tx)
-    cy.contains(batch.addToBatchBtn).should('have.length', 0)
-  })
+    it('Verify the "New transaction" button in Add batch modal is enabled/disabled for different users types', () => {
+      navigation.clickOnWalletExpandMoreIcon()
+      navigation.clickOnDisconnectBtn()
+      wallet.connectSigner(signer)
+      batch.openBatchtransactionsModal()
+      batch.verifyNewTxButtonStatus(constants.enabledStates.enabled)
+      batch.closeBatchtransactionsModal()
+      navigation.clickOnWalletExpandMoreIcon()
+      navigation.clickOnDisconnectBtn()
+      wallet.connectSigner(signer2)
+      owner.waitForConnectionStatus()
+      batch.verifyNewTxButtonStatus(constants.enabledStates.disabled)
+      navigation.clickOnWalletExpandMoreIcon()
+      navigation.clickOnDisconnectBtn()
+      batch.verifyNewTxButtonStatus(constants.enabledStates.disabled)
+    })
 
-  it('Verify the "New transaction" button in Add batch modal is enabled/disabled for different users types', () => {
-    navigation.clickOnWalletExpandMoreIcon()
-    navigation.clickOnDisconnectBtn()
-    wallet.connectSigner(signer)
-    batch.openBatchtransactionsModal()
-    batch.verifyNewTxButtonStatus(constants.enabledStates.enabled)
-    batch.closeBatchtransactionsModal()
-    navigation.clickOnWalletExpandMoreIcon()
-    navigation.clickOnDisconnectBtn()
-    wallet.connectSigner(signer2)
-    owner.waitForConnectionStatus()
-    batch.verifyNewTxButtonStatus(constants.enabledStates.disabled)
-    navigation.clickOnWalletExpandMoreIcon()
-    navigation.clickOnDisconnectBtn()
-    batch.verifyNewTxButtonStatus(constants.enabledStates.disabled)
-  })
+    it('Verify that the Add batch button is not present on non-safe pages', () => {
+      const urls = [constants.welcomeUrl, constants.appSettingsUrl, constants.appsUrl]
 
-  it('Verify a batched tx can be expanded and collapsed', () => {
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__batch, ls.batchData.entry0)
-    cy.reload()
-    cy.wait(4000)
-    batch.clickOnBatchCounter()
-    cy.contains(funds_first_tx).parents('ul').as('TransactionList')
-    cy.get('@TransactionList').find('li').eq(0).contains(funds_first_tx).click()
-    batch.isTxExpanded(0, true)
-    cy.get('@TransactionList').find('li').eq(0).contains(funds_first_tx).click()
-    batch.isTxExpanded(0, false)
-  })
+      urls.forEach((url) => {
+        cy.visit(url)
+        cy.get(batch.batchTxTopBar).should('not.exist')
+      })
+    })
 
-  it('Verify that the Add batch button is not present on non-safe pages', () => {
-    const urls = [constants.welcomeUrl, constants.appSettingsUrl, constants.appsUrl]
-
-    urls.forEach((url) => {
-      cy.visit(url)
-      cy.get(batch.batchTxTopBar).should('not.exist')
+    it('Verify a transaction can be added to the batch', () => {
+      batch.addNewTransactionToBatch(constants.EOA, currentNonce, funds_first_tx)
+      batch.verifyBatchIconCount(1)
+      batch.clickOnBatchCounter()
+      batch.verifyAmountTransactionsInBatch(1)
     })
   })
 
-  it('Verify a transaction can be added to the batch', () => {
-    wallet.connectSignerViaStorage(signer)
-    batch.addNewTransactionToBatch(constants.EOA, currentNonce, funds_first_tx)
-    batch.verifyBatchIconCount(1)
-    batch.clickOnBatchCounter()
-    batch.verifyAmountTransactionsInBatch(1)
-  })
-
-  it('Verify a transaction can be removed from the batch', () => {
-    cy.wrap(null)
-      .then(() => main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__batch, ls.batchData.entry0))
-      .then(() => main.isItemInLocalstorage(constants.localStorageKeys.SAFE_v2__batch, ls.batchData.entry0))
-      .then(() => {
-        cy.reload()
-        wallet.connectSignerViaStorage(signer)
-        batch.clickOnBatchCounter()
-        cy.contains(batch.batchedTransactionsStr).should('be.visible').parents('aside').find('ul > li').as('BatchList')
-        cy.get('@BatchList').find(batch.deleteTransactionbtn).eq(0).click()
-        cy.get('@BatchList').should('have.length', 1)
-        cy.get('@BatchList').contains(funds_first_tx).should('not.exist')
+  describe('Operating on a pre-seeded batch', () => {
+    beforeEach(() => {
+      wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_2, {
+        extraStorage: { [constants.localStorageKeys.SAFE_v2__batch]: ls.batchData.entry0 },
       })
+      owner.waitForConnectionStatus()
+    })
+
+    it('Verify that clicking on "Confirm batch" button opens confirm batch modal with listed transactions', () => {
+      batch.clickOnBatchCounter()
+      batch.clickOnConfirmBatchBtn()
+      cy.contains(funds_first_tx).parents('ul').as('TransactionList')
+      cy.get('@TransactionList').find('li').eq(0).contains(funds_first_tx)
+      cy.get('@TransactionList').find('li').eq(1).contains(funds_second_tx)
+      cy.contains(batch.addToBatchBtn).should('have.length', 0)
+    })
+
+    it('Verify a batched tx can be expanded and collapsed', () => {
+      batch.clickOnBatchCounter()
+      cy.contains(funds_first_tx).parents('ul').as('TransactionList')
+      cy.get('@TransactionList').find('li').eq(0).contains(funds_first_tx).click()
+      batch.isTxExpanded(0, true)
+      cy.get('@TransactionList').find('li').eq(0).contains(funds_first_tx).click()
+      batch.isTxExpanded(0, false)
+    })
+
+    it('Verify a transaction can be removed from the batch', () => {
+      batch.clickOnBatchCounter()
+      cy.contains(batch.batchedTransactionsStr).should('be.visible').parents('aside').find('ul > li').as('BatchList')
+      cy.get('@BatchList').find(batch.deleteTransactionbtn).eq(0).click()
+      cy.get('@BatchList').should('have.length', 1)
+      cy.get('@BatchList').contains(funds_first_tx).should('not.exist')
+    })
   })
 })

--- a/apps/web/cypress/e2e/regression/batch_tx.cy.js
+++ b/apps/web/cypress/e2e/regression/batch_tx.cy.js
@@ -23,8 +23,7 @@ describe('Batch transaction tests', { defaultCommandTimeout: 30000 }, () => {
   })
 
   beforeEach(() => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_2)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_2)
     owner.waitForConnectionStatus()
   })
 
@@ -92,7 +91,7 @@ describe('Batch transaction tests', { defaultCommandTimeout: 30000 }, () => {
   })
 
   it('Verify a transaction can be added to the batch', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     batch.addNewTransactionToBatch(constants.EOA, currentNonce, funds_first_tx)
     batch.verifyBatchIconCount(1)
     batch.clickOnBatchCounter()
@@ -105,7 +104,7 @@ describe('Batch transaction tests', { defaultCommandTimeout: 30000 }, () => {
       .then(() => main.isItemInLocalstorage(constants.localStorageKeys.SAFE_v2__batch, ls.batchData.entry0))
       .then(() => {
         cy.reload()
-        wallet.connectSigner(signer)
+        wallet.connectSignerViaStorage(signer)
         batch.clickOnBatchCounter()
         cy.contains(batch.batchedTransactionsStr).should('be.visible').parents('aside').find('ul > li').as('BatchList')
         cy.get('@BatchList').find(batch.deleteTransactionbtn).eq(0).click()

--- a/apps/web/cypress/e2e/regression/bulk_execution.cy.js
+++ b/apps/web/cypress/e2e/regression/bulk_execution.cy.js
@@ -27,7 +27,7 @@ describe('Bulk execution', () => {
   it('Verify that Bulk Execution is available for a few fully signed txs located one by one', () => {
     cy.visit(constants.transactionQueueUrl + fundsSafes.SEP_FUNDS_SAFE_14)
     main.acceptCookies()
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     create_tx.verifyBulkExecuteBtnIsEnabled(2)
     create_tx.verifyEnabledBulkExecuteBtnTooltip()
   })
@@ -38,8 +38,7 @@ describe('Bulk execution', () => {
     () => {
       const actions = ['1Send', '2removeOwner']
 
-      cy.visit(constants.transactionQueueUrl + fundsSafes.SEP_FUNDS_SAFE_14)
-      wallet.connectSigner(signer)
+      wallet.connectSignerViaStorage(signer, constants.transactionQueueUrl + fundsSafes.SEP_FUNDS_SAFE_14)
       main.acceptCookies()
       create_tx.verifyBulkExecuteBtnIsEnabled(2).click()
       create_tx.verifyBulkConfirmationScreen(2, actions)
@@ -53,8 +52,7 @@ describe('Bulk execution', () => {
       const actions = ['Wrapped Ether', 'addOwnerWithThreshold', 'Sent']
       const tx = '3 transactions'
 
-      cy.visit(constants.transactionsHistoryUrl + fundsSafes.SEP_FUNDS_SAFE_14)
-      wallet.connectSigner(signer)
+      wallet.connectSignerViaStorage(signer, constants.transactionsHistoryUrl + fundsSafes.SEP_FUNDS_SAFE_14)
       main.acceptCookies()
       create_tx.verifyBulkTxHistoryBlock(create_tx.bulkTxs, tx, actions)
     },

--- a/apps/web/cypress/e2e/regression/bulk_execution.cy.js
+++ b/apps/web/cypress/e2e/regression/bulk_execution.cy.js
@@ -25,9 +25,8 @@ describe('Bulk execution', () => {
   })
 
   it('Verify that Bulk Execution is available for a few fully signed txs located one by one', () => {
-    cy.visit(constants.transactionQueueUrl + fundsSafes.SEP_FUNDS_SAFE_14)
+    wallet.connectSignerViaStorage(signer, constants.transactionQueueUrl + fundsSafes.SEP_FUNDS_SAFE_14)
     main.acceptCookies()
-    wallet.connectSignerViaStorage(signer)
     create_tx.verifyBulkExecuteBtnIsEnabled(2)
     create_tx.verifyEnabledBulkExecuteBtnTooltip()
   })

--- a/apps/web/cypress/e2e/regression/copilot.cy.js
+++ b/apps/web/cypress/e2e/regression/copilot.cy.js
@@ -20,8 +20,7 @@ describe('Safe Copilot tests', { defaultCommandTimeout: 30000 }, () => {
   // ========================================
 
   it('[Widget General] Verify that Safe Shield empty state is shown on New Transaction start before scanning', () => {
-    cy.visit(constants.BALANCE_URL + staticSafes.MATIC_STATIC_SAFE_30)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.MATIC_STATIC_SAFE_30)
     createtx.clickOnNewtransactionBtn()
     createtx.clickOnSendTokensBtn()
     copilot.verifySafeShieldDisplayed()

--- a/apps/web/cypress/e2e/regression/create_safe_cf.cy.js
+++ b/apps/web/cypress/e2e/regression/create_safe_cf.cy.js
@@ -29,7 +29,7 @@ describe('CF Safe regression tests', () => {
   it('Verify "Add native assets" button opens a modal with a QR code and the safe address', () => {
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__undeployedSafes, ls.undeployedSafe.safe1)
     cy.reload()
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.waitForConnectionStatus()
     createwallet.clickOnAddFundsBtn()
     main.verifyElementsIsVisible([createwallet.qrCode, createwallet.addressInfo])
@@ -38,7 +38,7 @@ describe('CF Safe regression tests', () => {
   it('Verify QR code switch status change works in "Add native assets" modal', () => {
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__undeployedSafes, ls.undeployedSafe.safe1)
     cy.reload()
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.waitForConnectionStatus()
     createwallet.clickOnAddFundsBtn()
     createwallet.checkQRCodeSwitchStatus(constants.checkboxStates.unchecked)
@@ -62,8 +62,7 @@ describe('CF Safe regression tests', () => {
 
   it('Verify clicking on "Activate now" button opens safe activation flow', () => {
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__undeployedSafes, ls.undeployedSafe.safe1)
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_0)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_0)
     owner.waitForConnectionStatus()
     createwallet.clickOnActivateAccountBtn(1)
     cy.contains(createwallet.deployWalletStr)

--- a/apps/web/cypress/e2e/regression/create_safe_cf.cy.js
+++ b/apps/web/cypress/e2e/regression/create_safe_cf.cy.js
@@ -16,29 +16,31 @@ describe('CF Safe regression tests', () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  beforeEach(() => {
-    cy.visit(constants.homeUrl + staticSafes.SEP_STATIC_SAFE_0)
-  })
+  const seedUndeployedSafe = (win) =>
+    win.localStorage.setItem(
+      constants.localStorageKeys.SAFE_v2__undeployedSafes,
+      JSON.stringify(ls.undeployedSafe.safe1),
+    )
+  const undeployedSafeStorage = { [constants.localStorageKeys.SAFE_v2__undeployedSafes]: ls.undeployedSafe.safe1 }
 
   it('Verify "0 out of 2 step completed" is shown in the dashboard', () => {
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__undeployedSafes, ls.undeployedSafe.safe1)
-    cy.reload()
+    cy.visit(constants.homeUrl + staticSafes.SEP_STATIC_SAFE_0, { onBeforeLoad: seedUndeployedSafe })
     createwallet.checkInitialStepsDisplayed()
   })
 
   it('Verify "Add native assets" button opens a modal with a QR code and the safe address', () => {
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__undeployedSafes, ls.undeployedSafe.safe1)
-    cy.reload()
-    wallet.connectSignerViaStorage(signer)
+    wallet.connectSignerViaStorage(signer, constants.homeUrl + staticSafes.SEP_STATIC_SAFE_0, {
+      extraStorage: undeployedSafeStorage,
+    })
     owner.waitForConnectionStatus()
     createwallet.clickOnAddFundsBtn()
     main.verifyElementsIsVisible([createwallet.qrCode, createwallet.addressInfo])
   })
 
   it('Verify QR code switch status change works in "Add native assets" modal', () => {
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__undeployedSafes, ls.undeployedSafe.safe1)
-    cy.reload()
-    wallet.connectSignerViaStorage(signer)
+    wallet.connectSignerViaStorage(signer, constants.homeUrl + staticSafes.SEP_STATIC_SAFE_0, {
+      extraStorage: undeployedSafeStorage,
+    })
     owner.waitForConnectionStatus()
     createwallet.clickOnAddFundsBtn()
     createwallet.checkQRCodeSwitchStatus(constants.checkboxStates.unchecked)
@@ -47,22 +49,19 @@ describe('CF Safe regression tests', () => {
   })
 
   it('Verify "Notifications" in the settings are disabled', () => {
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__undeployedSafes, ls.undeployedSafe.safe1)
-    cy.reload()
-    cy.visit(constants.notificationsUrl + staticSafes.SEP_STATIC_SAFE_0)
+    cy.visit(constants.notificationsUrl + staticSafes.SEP_STATIC_SAFE_0, { onBeforeLoad: seedUndeployedSafe })
     createwallet.checkNotificationsSwitchIs(constants.enabledStates.disabled)
   })
 
   it('Verify in assets, that a "Add funds" block is present', () => {
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__undeployedSafes, ls.undeployedSafe.safe1)
-    cy.reload()
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_0)
+    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_0, { onBeforeLoad: seedUndeployedSafe })
     main.verifyElementsIsVisible([createwallet.addFundsSection, createwallet.noTokensAlert])
   })
 
   it('Verify clicking on "Activate now" button opens safe activation flow', () => {
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__undeployedSafes, ls.undeployedSafe.safe1)
-    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_0)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_0, {
+      extraStorage: undeployedSafeStorage,
+    })
     owner.waitForConnectionStatus()
     createwallet.clickOnActivateAccountBtn(1)
     cy.contains(createwallet.deployWalletStr)

--- a/apps/web/cypress/e2e/regression/create_safe_simple.cy.js
+++ b/apps/web/cypress/e2e/regression/create_safe_simple.cy.js
@@ -98,23 +98,23 @@ describe('Safe creation tests', () => {
   })
 
   it('Verify duplicated signer error using the autocomplete feature', () => {
-    cy.visit(constants.createNewSafeSepoliaUrl + '?chain=sep')
-    cy.wrap(null)
-      .then(() =>
-        main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sameOwnerName),
-      )
-      .then(() => {
-        cy.reload()
-        createwallet.waitForConnectionMsgDisappear()
-        createwallet.selectMultiNetwork(1, constants.networks.sepolia.toLowerCase())
-        createwallet.clickOnYourSafeAccountPreview()
-        createwallet.clickOnNextBtn()
-        createwallet.clickOnAddNewOwnerBtn()
-        createwallet.clickOnSignerAddressInput(1)
-        main.verifyMinimumElementsCount(createwallet.addressAutocompleteOptions, 2)
-        createwallet.selectSignerOnAutocomplete(2)
-        owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.ownerAdded)
-      })
+    cy.visit(constants.createNewSafeSepoliaUrl + '?chain=sep', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem(
+          constants.localStorageKeys.SAFE_v2__addressBook,
+          JSON.stringify(ls.addressBookData.sameOwnerName),
+        )
+      },
+    })
+    createwallet.waitForConnectionMsgDisappear()
+    createwallet.selectMultiNetwork(1, constants.networks.sepolia.toLowerCase())
+    createwallet.clickOnYourSafeAccountPreview()
+    createwallet.clickOnNextBtn()
+    createwallet.clickOnAddNewOwnerBtn()
+    createwallet.clickOnSignerAddressInput(1)
+    main.verifyMinimumElementsCount(createwallet.addressAutocompleteOptions, 2)
+    createwallet.selectSignerOnAutocomplete(2)
+    owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.ownerAdded)
   })
 
   it('Verify Next button is disabled until switching to network is done', () => {

--- a/apps/web/cypress/e2e/regression/create_tx.cy.js
+++ b/apps/web/cypress/e2e/regression/create_tx.cy.js
@@ -26,8 +26,7 @@ describe('Create transactions tests', () => {
 
   // Added to prod
   it('Verify submitting a tx and that clicking on notification shows the transaction in queue', () => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
     createtx.clickOnNewtransactionBtn()
     createtx.clickOnSendTokensBtn()
     happyPathToStepTwo()
@@ -45,8 +44,7 @@ describe('Create transactions tests', () => {
 
   it('Verify relay is available on tx execution', () => {
     let safe = main.changeSafeChainName(staticSafes.MATIC_STATIC_SAFE_28, 'sep')
-    cy.visit(constants.BALANCE_URL + safe)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + safe)
     createtx.clickOnNewtransactionBtn()
     createtx.clickOnSendTokensBtn()
     happyPathToStepTwo()

--- a/apps/web/cypress/e2e/regression/create_tx_2.cy.js
+++ b/apps/web/cypress/e2e/regression/create_tx_2.cy.js
@@ -23,8 +23,7 @@ describe('Create transactions tests 2', () => {
   })
 
   beforeEach(() => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
     createtx.clickOnNewtransactionBtn()
     createtx.clickOnSendTokensBtn()
   })

--- a/apps/web/cypress/e2e/regression/load_safe_2.cy.js
+++ b/apps/web/cypress/e2e/regression/load_safe_2.cy.js
@@ -13,6 +13,10 @@ const ownerNames = ['Automation owner']
 const ownerSepolia = ['Automation owner Sepolia']
 const ownerEth = ['Automation owner Eth']
 
+const seedStorage = (entries) => (win) => {
+  Object.entries(entries).forEach(([key, value]) => win.localStorage.setItem(key, JSON.stringify(value)))
+}
+
 describe('Load Safe tests 2', () => {
   before(() => {
     getSafes(CATEGORIES.funds)
@@ -25,90 +29,88 @@ describe('Load Safe tests 2', () => {
       })
   })
 
-  beforeEach(() => {
-    cy.visit(constants.loadNewSafeSepoliaUrl)
-    cy.wait(2000)
+  describe('Without pre-seeded data', () => {
+    beforeEach(() => {
+      cy.visit(constants.loadNewSafeSepoliaUrl)
+      cy.wait(2000)
+    })
+
+    it('Verify Safe address checksum', () => {
+      safe.verifyAddressCheckSum(staticSafes.SEP_STATIC_SAFE_13)
+      safe.verifyAddressInputValue(staticSafes.SEP_STATIC_SAFE_13)
+      safe.inputAddress(staticSafes.SEP_STATIC_SAFE_13.split(':')[1].toLowerCase())
+      safe.verifyAddressInputValue(staticSafes.SEP_STATIC_SAFE_13)
+    })
+
+    it('Verify owner name cannot be longer than 50 characters', () => {
+      safe.inputAddress(staticSafes.SEP_STATIC_SAFE_13)
+      safe.clickOnNextBtn()
+      safe.inputOwnerName(0, main.generateRandomString(51))
+      owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.exceedChars)
+    })
+
+    it('Verify names with primary ENS name are filled by default', () => {
+      safe.inputAddress(staticSafes.SEP_STATIC_SAFE_13)
+      safe.clickOnNextBtn()
+      safe.verifyOnwerNameENS(1, constants.ENS_TEST_SEPOLIA_VALID)
+    })
+
+    it('Verify random text is in the safe address input is not allowed', () => {
+      safe.inputAddress(main.generateRandomString(10))
+      owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.invalidFormat)
+    })
+
+    it('Verify a valid address can be entered', () => {
+      safe.inputAddress(getMockAddress())
+      safe.verifyAddresFormatIsValid()
+    })
+
+    it('Verify that the wrong prefix is not allowed', () => {
+      safe.inputAddress(`eth:${getMockAddress()}`)
+      owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.prefixMismatch)
+      safe.verifyNextButtonStatus(constants.enabledStates.disabled)
+    })
   })
 
-  it('Verify names in address book are filled by default from address book', () => {
-    cy.wrap(null)
-      .then(() =>
-        main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sameOwnerName),
-      )
-      .then(() => {
-        cy.reload()
-        safe.inputAddress(staticSafes.SEP_STATIC_SAFE_13)
-        safe.clickOnNextBtn()
-        safe.verifyOwnerNames(ownerNames)
-        safe.verifyOnwerInputIsNotEmpty(0)
+  describe('With pre-seeded data', () => {
+    it('Verify names in address book are filled by default from address book', () => {
+      cy.visit(constants.loadNewSafeSepoliaUrl, {
+        onBeforeLoad: seedStorage({
+          [constants.localStorageKeys.SAFE_v2__addressBook]: ls.addressBookData.sameOwnerName,
+        }),
       })
-  })
+      safe.inputAddress(staticSafes.SEP_STATIC_SAFE_13)
+      safe.clickOnNextBtn()
+      safe.verifyOwnerNames(ownerNames)
+      safe.verifyOnwerInputIsNotEmpty(0)
+    })
 
-  it('Verify Safe address checksum', () => {
-    safe.verifyAddressCheckSum(staticSafes.SEP_STATIC_SAFE_13)
-    safe.verifyAddressInputValue(staticSafes.SEP_STATIC_SAFE_13)
-    safe.inputAddress(staticSafes.SEP_STATIC_SAFE_13.split(':')[1].toLowerCase())
-    safe.verifyAddressInputValue(staticSafes.SEP_STATIC_SAFE_13)
-  })
-
-  it('Verify owner name cannot be longer than 50 characters', () => {
-    safe.inputAddress(staticSafes.SEP_STATIC_SAFE_13)
-    safe.clickOnNextBtn()
-    safe.inputOwnerName(0, main.generateRandomString(51))
-    owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.exceedChars)
-  })
-
-  it('Verify names with primary ENS name are filled by default', () => {
-    safe.inputAddress(staticSafes.SEP_STATIC_SAFE_13)
-    safe.clickOnNextBtn()
-    safe.verifyOnwerNameENS(1, constants.ENS_TEST_SEPOLIA_VALID)
-  })
-
-  it('Verify correct owner names are displayed for certain networks', () => {
-    cy.wrap(null)
-      .then(() =>
-        main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sameOwnerName),
-      )
-      .then(() => {
-        cy.reload()
-        safe.clickNetworkSelector(constants.networks.sepolia)
-        safe.selectEth()
-        safe.inputAddress(fundSafes.ETH_FUNDS_SAFE_13)
-        safe.clickOnNextBtn()
-        safe.verifyOwnerNames(ownerEth)
-        safe.clickOnBackBtn()
-        safe.clickNetworkSelector(constants.networks.ethereum)
-        safe.selectSepolia()
-        safe.inputAddress(staticSafes.SEP_STATIC_SAFE_13)
-        safe.clickOnNextBtn()
-        safe.verifyOwnerNames(ownerSepolia)
+    it('Verify correct owner names are displayed for certain networks', () => {
+      cy.visit(constants.loadNewSafeSepoliaUrl, {
+        onBeforeLoad: seedStorage({
+          [constants.localStorageKeys.SAFE_v2__addressBook]: ls.addressBookData.sameOwnerName,
+        }),
       })
-  })
+      safe.clickNetworkSelector(constants.networks.sepolia)
+      safe.selectEth()
+      safe.inputAddress(fundSafes.ETH_FUNDS_SAFE_13)
+      safe.clickOnNextBtn()
+      safe.verifyOwnerNames(ownerEth)
+      safe.clickOnBackBtn()
+      safe.clickNetworkSelector(constants.networks.ethereum)
+      safe.selectSepolia()
+      safe.inputAddress(staticSafes.SEP_STATIC_SAFE_13)
+      safe.clickOnNextBtn()
+      safe.verifyOwnerNames(ownerSepolia)
+    })
 
-  it('Verify random text is in the safe address input is not allowed', () => {
-    safe.inputAddress(main.generateRandomString(10))
-    owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.invalidFormat)
-  })
-
-  it('Verify a valid address can be entered', () => {
-    safe.inputAddress(getMockAddress())
-    safe.verifyAddresFormatIsValid()
-  })
-
-  it('Verify that safes already added to the watchlist cannot be added again', () => {
-    cy.wrap(null)
-      .then(() => main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set1))
-      .then(() => {
-        cy.reload()
-        safe.inputAddress(staticSafes.SEP_STATIC_SAFE_13)
-        owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.safeAlreadyAdded)
-        safe.verifyNextButtonStatus(constants.enabledStates.disabled)
+    it('Verify that safes already added to the watchlist cannot be added again', () => {
+      cy.visit(constants.loadNewSafeSepoliaUrl, {
+        onBeforeLoad: seedStorage({ [constants.localStorageKeys.SAFE_v2__addedSafes]: ls.addedSafes.set1 }),
       })
-  })
-
-  it('Verify that the wrong prefix is not allowed', () => {
-    safe.inputAddress(`eth:${getMockAddress()}`)
-    owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.prefixMismatch)
-    safe.verifyNextButtonStatus(constants.enabledStates.disabled)
+      safe.inputAddress(staticSafes.SEP_STATIC_SAFE_13)
+      owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.safeAlreadyAdded)
+      safe.verifyNextButtonStatus(constants.enabledStates.disabled)
+    })
   })
 })

--- a/apps/web/cypress/e2e/regression/mass_payouts.cy.js
+++ b/apps/web/cypress/e2e/regression/mass_payouts.cy.js
@@ -21,24 +21,21 @@ describe('Mass payouts tests', () => {
   })
 
   it('Verify that the "Add recipient" button is displayed for the targeted safes on New Tx form', () => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
     createtx.clickOnNewtransactionBtn()
     createtx.clickOnSendTokensBtn()
     createtx.verifyAddRecipientBtnIsVisible()
   })
 
   it('Verify that users can add up to 5 recipients', () => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
     createtx.clickOnNewtransactionBtn()
     createtx.clickOnSendTokensBtn()
     createtx.checkMaxRecipientReached()
   })
 
   it('Verify that "Remove recipient" deletes the recipient field', () => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
     createtx.clickOnNewtransactionBtn()
     createtx.clickOnSendTokensBtn()
     createtx.clickOnAddRecipientBtn()
@@ -48,8 +45,7 @@ describe('Mass payouts tests', () => {
   })
 
   it('Verify that "Remove recipient" deletes the recipient field', () => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_8)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_8)
     createtx.clickOnNewtransactionBtn()
     createtx.clickOnSendTokensBtn()
     spendinglimit.selectSpendingLimitOption()
@@ -57,8 +53,7 @@ describe('Mass payouts tests', () => {
   })
 
   it('Verify the "Max" button sets the full amount', () => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
     createtx.clickOnNewtransactionBtn()
     createtx.clickOnSendTokensBtn()
     createtx.clickOnAddRecipientBtn()
@@ -68,8 +63,7 @@ describe('Mass payouts tests', () => {
   })
 
   it('Verify "insufficient amount" error for the same token during send to a few recipients', () => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
     createtx.clickOnNewtransactionBtn()
     createtx.clickOnSendTokensBtn()
     createtx.clickOnAddRecipientBtn()
@@ -85,8 +79,7 @@ describe('Mass payouts tests', () => {
     const address1 = getMockAddress()
     const address2 = getMockAddress()
 
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
     createtx.clickOnNewtransactionBtn()
     createtx.clickOnSendTokensBtn()
     createtx.clickOnAddRecipientBtn()

--- a/apps/web/cypress/e2e/regression/messages_offchain.cy.js
+++ b/apps/web/cypress/e2e/regression/messages_offchain.cy.js
@@ -22,8 +22,7 @@ describe('Offchain Messages tests', () => {
   })
 
   it('Verify confirmation window is displayed for unsigned message', () => {
-    cy.visit(constants.transactionsMessagesUrl + staticSafes.SEP_STATIC_SAFE_26)
-    wallet.connectSigner(signer2)
+    wallet.connectSignerViaStorage(signer2, constants.transactionsMessagesUrl + staticSafes.SEP_STATIC_SAFE_26)
     messages.clickOnMessageSignBtn(0)
     msg_confirmation_modal.verifyConfirmationWindowTitle(modal.modalTitiles.confirmMsg)
     msg_confirmation_modal.verifyMessagePresent(messages.offchainMessage)

--- a/apps/web/cypress/e2e/regression/messages_popup.cy.js
+++ b/apps/web/cypress/e2e/regression/messages_popup.cy.js
@@ -18,20 +18,22 @@ describe('Messages popup window tests', () => {
   })
 
   beforeEach(() => {
-    cy.visit(constants.appsCustomUrl + staticSafes.SEP_STATIC_SAFE_10)
+    cy.visit(constants.appsCustomUrl + staticSafes.SEP_STATIC_SAFE_10, {
+      onBeforeLoad(win) {
+        win.localStorage.setItem(
+          constants.localStorageKeys.SAFE_v2__customSafeApps_11155111,
+          JSON.stringify(ls.customApps(constants.safeTestAppurl).safeTestApp),
+        )
+        win.localStorage.setItem(
+          constants.localStorageKeys.SAFE_v2__SafeApps__browserPermissions,
+          JSON.stringify(ls.appPermissions(constants.safeTestAppurl).grantedPermissions),
+        )
+      },
+    })
     iframeSelector = `iframe[id="iframe-${encodeURIComponent(constants.safeTestAppurl)}"]`
   })
 
   it('Verify off-chain message popup window can be triggered', () => {
-    main.addToLocalStorage(
-      constants.localStorageKeys.SAFE_v2__customSafeApps_11155111,
-      ls.customApps(constants.safeTestAppurl).safeTestApp,
-    )
-    main.addToLocalStorage(
-      constants.localStorageKeys.SAFE_v2__SafeApps__browserPermissions,
-      ls.appPermissions(constants.safeTestAppurl).grantedPermissions,
-    )
-    cy.reload()
     apps.clickOnApp(safeApp)
     apps.clickOnOpenSafeAppBtn()
     main.getIframeBody(iframeSelector).within(() => {
@@ -42,16 +44,6 @@ describe('Messages popup window tests', () => {
   })
 
   it('Verify on-chain message popup window can be triggered', () => {
-    main.addToLocalStorage(
-      constants.localStorageKeys.SAFE_v2__customSafeApps_11155111,
-      ls.customApps(constants.safeTestAppurl).safeTestApp,
-    )
-    main.addToLocalStorage(
-      constants.localStorageKeys.SAFE_v2__SafeApps__browserPermissions,
-      ls.appPermissions(constants.safeTestAppurl).grantedPermissions,
-    )
-
-    cy.reload()
     apps.clickOnApp(safeApp)
     apps.clickOnOpenSafeAppBtn()
     main.getIframeBody(iframeSelector).within(() => {
@@ -66,15 +58,6 @@ describe('Messages popup window tests', () => {
 
   it('Verify warning message is displayed when 0x0000000 is used as a message', () => {
     const msgHash = '0x0000000'
-    main.addToLocalStorage(
-      constants.localStorageKeys.SAFE_v2__customSafeApps_11155111,
-      ls.customApps(constants.safeTestAppurl).safeTestApp,
-    )
-    main.addToLocalStorage(
-      constants.localStorageKeys.SAFE_v2__SafeApps__browserPermissions,
-      ls.appPermissions(constants.safeTestAppurl).grantedPermissions,
-    )
-    cy.reload()
     apps.clickOnApp(safeApp)
     apps.clickOnOpenSafeAppBtn()
     main.getIframeBody(iframeSelector).within(() => {

--- a/apps/web/cypress/e2e/regression/multichain_network.cy.js
+++ b/apps/web/cypress/e2e/regression/multichain_network.cy.js
@@ -17,11 +17,12 @@ describe('Multichain add network tests', { defaultCommandTimeout: 60000 }, () =>
   })
 
   beforeEach(() => {
-    cy.visit(constants.BALANCE_URL + staticSafes.MATIC_STATIC_SAFE_28)
-    cy.wait(2000)
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set5)
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.multichain)
-    wallet.connectSignerViaStorage(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.MATIC_STATIC_SAFE_28, {
+      extraStorage: {
+        [constants.localStorageKeys.SAFE_v2__addedSafes]: ls.addedSafes.set5,
+        [constants.localStorageKeys.SAFE_v2__addressBook]: ls.addressBookData.multichain,
+      },
+    })
   })
 
   it('Verify CF safe can be created when adding a new network from more options menu', () => {

--- a/apps/web/cypress/e2e/regression/multichain_network.cy.js
+++ b/apps/web/cypress/e2e/regression/multichain_network.cy.js
@@ -21,7 +21,7 @@ describe('Multichain add network tests', { defaultCommandTimeout: 60000 }, () =>
     cy.wait(2000)
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set5)
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.multichain)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
   })
 
   it('Verify CF safe can be created when adding a new network from more options menu', () => {

--- a/apps/web/cypress/e2e/regression/multichain_networkswitch.cy.js
+++ b/apps/web/cypress/e2e/regression/multichain_networkswitch.cy.js
@@ -27,8 +27,7 @@ describe('Multichain header network switch tests', { defaultCommandTimeout: 3000
 
   it('Verify the list of networks where the safe is already deployed with the same address when all networks added', () => {
     let safe = main.changeSafeChainName(staticSafes.MATIC_STATIC_SAFE_28, 'sep')
-    cy.visit(constants.BALANCE_URL + safe)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + safe)
     network.addNetwork(constants.networks.ethereum)
     cy.contains(network.createSafeMsg(constants.networks.ethereum))
     network.clickChainNavigationButton()

--- a/apps/web/cypress/e2e/regression/multichain_safe_selector.cy.js
+++ b/apps/web/cypress/e2e/regression/multichain_safe_selector.cy.js
@@ -21,7 +21,7 @@ describe('Multichain safe selector tests', { defaultCommandTimeout: 60000 }, () 
     cy.wait(2000)
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set5WithSingleSafe)
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.multichain)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
   })
 
   it('Verify balance of the safe group', () => {

--- a/apps/web/cypress/e2e/regression/multichain_safe_selector.cy.js
+++ b/apps/web/cypress/e2e/regression/multichain_safe_selector.cy.js
@@ -1,5 +1,4 @@
 import * as constants from '../../support/constants.js'
-import * as main from '../pages/main.page.js'
 import * as safeNav from '../pages/safe_navigation.pages.js'
 import * as accountsModal from '../pages/accounts_modal.pages.js'
 import * as ls from '../../support/localstorage_data.js'
@@ -17,11 +16,12 @@ describe('Multichain safe selector tests', { defaultCommandTimeout: 60000 }, () 
   })
 
   beforeEach(() => {
-    cy.visit(constants.BALANCE_URL + staticSafes.MATIC_STATIC_SAFE_28)
-    cy.wait(2000)
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set5WithSingleSafe)
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.multichain)
-    wallet.connectSignerViaStorage(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.MATIC_STATIC_SAFE_28, {
+      extraStorage: {
+        [constants.localStorageKeys.SAFE_v2__addedSafes]: ls.addedSafes.set5WithSingleSafe,
+        [constants.localStorageKeys.SAFE_v2__addressBook]: ls.addressBookData.multichain,
+      },
+    })
   })
 
   it('Verify balance of the safe group', () => {

--- a/apps/web/cypress/e2e/regression/multichain_setup_new.cy.js
+++ b/apps/web/cypress/e2e/regression/multichain_setup_new.cy.js
@@ -25,11 +25,12 @@ describe('Multichain setup tests', { defaultCommandTimeout: 60000 }, () => {
   })
 
   beforeEach(() => {
-    cy.visit(constants.BALANCE_URL + staticSafes.MATIC_STATIC_SAFE_28)
-    cy.wait(2000)
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set5)
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.multichain)
-    wallet.connectSignerViaStorage(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.MATIC_STATIC_SAFE_28, {
+      extraStorage: {
+        [constants.localStorageKeys.SAFE_v2__addedSafes]: ls.addedSafes.set5,
+        [constants.localStorageKeys.SAFE_v2__addressBook]: ls.addressBookData.multichain,
+      },
+    })
   })
 
   // Renamed from: 'Verify that batch tx with safe activation is not allowed for the CF safes'

--- a/apps/web/cypress/e2e/regression/multichain_setup_new.cy.js
+++ b/apps/web/cypress/e2e/regression/multichain_setup_new.cy.js
@@ -29,7 +29,7 @@ describe('Multichain setup tests', { defaultCommandTimeout: 60000 }, () => {
     cy.wait(2000)
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set5)
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.multichain)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
   })
 
   // Renamed from: 'Verify that batch tx with safe activation is not allowed for the CF safes'

--- a/apps/web/cypress/e2e/regression/nested_safes_fund_asset.cy.js
+++ b/apps/web/cypress/e2e/regression/nested_safes_fund_asset.cy.js
@@ -24,7 +24,7 @@ describe('Nested safes fund asset tests', () => {
     cy.reload()
     main.setupSafeSettingsWithAllTokens().then(() => {
       cy.reload()
-      wallet.connectSigner(signer)
+      wallet.connectSignerViaStorage(signer)
       safeNav.clickOnNestedSafesBtn()
       // This safe has no existing nested safes, so no intro screen - just click add
       nsafes.clickOnAddNestedSafeBtn()

--- a/apps/web/cypress/e2e/regression/nested_safes_fund_asset.cy.js
+++ b/apps/web/cypress/e2e/regression/nested_safes_fund_asset.cy.js
@@ -7,7 +7,6 @@ import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 import * as wallet from '../../support/utils/wallet.js'
 import * as owner from '../pages/owners.pages.js'
 import * as assets from '../pages/assets.pages.js'
-import * as main from '../pages/main.page.js'
 
 let staticSafes = []
 const walletCredentials = JSON.parse(Cypress.env('CYPRESS_WALLET_CREDENTIALS'))
@@ -19,16 +18,15 @@ describe('Nested safes fund asset tests', () => {
   })
 
   beforeEach(() => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_45)
-    main.addToAppLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.nestedParentSafe45)
-    cy.reload()
-    main.setupSafeSettingsWithAllTokens().then(() => {
-      cy.reload()
-      wallet.connectSignerViaStorage(signer)
-      safeNav.clickOnNestedSafesBtn()
-      // This safe has no existing nested safes, so no intro screen - just click add
-      nsafes.clickOnAddNestedSafeBtn()
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_45, {
+      extraStorage: {
+        [constants.localStorageKeys.SAFE_v2__addedSafes]: ls.addedSafes.nestedParentSafe45,
+        [constants.localStorageKeys.SAFE_v2__settings]: ls.safeSettings.slimitSettings,
+      },
     })
+    safeNav.clickOnNestedSafesBtn()
+    // This safe has no existing nested safes, so no intro screen - just click add
+    nsafes.clickOnAddNestedSafeBtn()
   })
 
   it('Verify that the token can be selected from the drop-down', () => {

--- a/apps/web/cypress/e2e/regression/nested_safes_review.cy.js
+++ b/apps/web/cypress/e2e/regression/nested_safes_review.cy.js
@@ -1,5 +1,4 @@
 import * as constants from '../../support/constants.js'
-import * as main from '../pages/main.page.js'
 import * as sideBar from '../pages/sidebar.pages.js'
 import * as safeNav from '../pages/safe_navigation.pages.js'
 import * as ls from '../../support/localstorage_data.js'
@@ -20,10 +19,11 @@ describe('Nested safes review step tests', () => {
   beforeEach(() => {
     // Set large viewport to ensure modal content is fully visible
     cy.viewport(1400, 1200)
-    cy.visit(constants.transactionQueueUrl + staticSafes.SEP_STATIC_SAFE_45)
-    main.addToAppLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.nestedParentSafe45)
-    cy.reload()
-    wallet.connectSignerViaStorage(signer)
+    wallet.connectSignerViaStorage(signer, constants.transactionQueueUrl + staticSafes.SEP_STATIC_SAFE_45, {
+      extraStorage: {
+        [constants.localStorageKeys.SAFE_v2__addedSafes]: ls.addedSafes.nestedParentSafe45,
+      },
+    })
     safeNav.clickOnNestedSafesBtn()
     // This safe has no existing nested safes, so no intro screen - just click add
     nsafes.clickOnAddNestedSafeBtn()

--- a/apps/web/cypress/e2e/regression/nested_safes_review.cy.js
+++ b/apps/web/cypress/e2e/regression/nested_safes_review.cy.js
@@ -23,7 +23,7 @@ describe('Nested safes review step tests', () => {
     cy.visit(constants.transactionQueueUrl + staticSafes.SEP_STATIC_SAFE_45)
     main.addToAppLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.nestedParentSafe45)
     cy.reload()
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     safeNav.clickOnNestedSafesBtn()
     // This safe has no existing nested safes, so no intro screen - just click add
     nsafes.clickOnAddNestedSafeBtn()

--- a/apps/web/cypress/e2e/regression/nfts.cy.js
+++ b/apps/web/cypress/e2e/regression/nfts.cy.js
@@ -30,8 +30,7 @@ describe('NFTs tests', () => {
   })
 
   beforeEach(() => {
-    cy.visit(constants.balanceNftsUrl + staticSafes.SEP_STATIC_SAFE_2)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.balanceNftsUrl + staticSafes.SEP_STATIC_SAFE_2)
     nfts.waitForNftItems(2)
   })
 
@@ -87,8 +86,7 @@ describe('NFTs tests', () => {
 
   // Added to prod
   it('Verify Send NFT transaction has been created', () => {
-    cy.visit(constants.balanceNftsUrl + nftsSafes.SEP_NFT_SAFE_1)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.balanceNftsUrl + nftsSafes.SEP_NFT_SAFE_1)
     nfts.verifyInitialNFTData()
     nfts.selectNFTs(1)
     nfts.sendNFT()

--- a/apps/web/cypress/e2e/regression/proposers.cy.js
+++ b/apps/web/cypress/e2e/regression/proposers.cy.js
@@ -28,7 +28,7 @@ describe('Proposers tests', () => {
   beforeEach(() => {
     cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_31)
     cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
   })
 
   it('Verify the proposers section on the Set up in the settings when there are no proposers', () => {

--- a/apps/web/cypress/e2e/regression/proposers.cy.js
+++ b/apps/web/cypress/e2e/regression/proposers.cy.js
@@ -26,9 +26,8 @@ describe('Proposers tests', () => {
   })
 
   beforeEach(() => {
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_31)
+    wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_31)
     cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
-    wallet.connectSignerViaStorage(signer)
   })
 
   it('Verify the proposers section on the Set up in the settings when there are no proposers', () => {
@@ -67,13 +66,6 @@ describe('Proposers tests', () => {
     proposer.verifyEditProposerBtnDisabled(proposerAddress)
   })
 
-  it('Verify that the address book name of the proposers overwrites the name given during its creation', () => {
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.proposers)
-    cy.reload()
-    cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
-    proposer.checkProposerData([proposerNameAD])
-  })
-
   it('Verify if the address book entry of propers name is removed, then the name given during its creation shows again', () => {
     proposer.checkProposerData([proposerName])
   })
@@ -94,5 +86,15 @@ describe('Proposers tests', () => {
   it('Verify a tx with the "proposal" status shows the details of a proposer', () => {
     cy.visit(constants.transactionUrl + staticSafes.SEP_STATIC_SAFE_31 + proposedTx)
     proposer.verifyProposerInTxActionList(proposerAddress2)
+  })
+
+  describe('With a pre-seeded address book', () => {
+    it('Verify that the address book name of the proposers overwrites the name given during its creation', () => {
+      wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_31, {
+        extraStorage: { [constants.localStorageKeys.SAFE_v2__addressBook]: ls.addressBookData.proposers },
+      })
+      cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
+      proposer.checkProposerData([proposerNameAD])
+    })
   })
 })

--- a/apps/web/cypress/e2e/regression/proposers_2.cy.js
+++ b/apps/web/cypress/e2e/regression/proposers_2.cy.js
@@ -22,9 +22,8 @@ describe('Proposers 2 tests', () => {
   })
 
   it('Verify a proposers is capable of propose transactions', () => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_33)
+    wallet.connectSignerViaStorage(signer2, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_33)
     assets.toggleHideDust(false)
-    wallet.connectSignerViaStorage(signer2)
     createtx.clickOnNewtransactionBtn()
     createtx.clickOnSendTokensBtn()
     createtx.typeRecipientAddress(getMockAddress())

--- a/apps/web/cypress/e2e/regression/proposers_2.cy.js
+++ b/apps/web/cypress/e2e/regression/proposers_2.cy.js
@@ -24,7 +24,7 @@ describe('Proposers 2 tests', () => {
   it('Verify a proposers is capable of propose transactions', () => {
     cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_33)
     assets.toggleHideDust(false)
-    wallet.connectSigner(signer2)
+    wallet.connectSignerViaStorage(signer2)
     createtx.clickOnNewtransactionBtn()
     createtx.clickOnSendTokensBtn()
     createtx.typeRecipientAddress(getMockAddress())
@@ -34,27 +34,23 @@ describe('Proposers 2 tests', () => {
   })
 
   it('Verify a proposers cannot confirm a transaction', () => {
-    cy.visit(constants.transactionQueueUrl + staticSafes.SEP_STATIC_SAFE_31)
-    wallet.connectSigner(signer2)
+    wallet.connectSignerViaStorage(signer2, constants.transactionQueueUrl + staticSafes.SEP_STATIC_SAFE_31)
     tx.verifyTxConfirmBtnDisabled()
   })
 
   it('Verify a proposer cannot edit himself', () => {
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_31)
-    wallet.connectSigner(signer2)
+    wallet.connectSignerViaStorage(signer2, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_31)
     proposer.verifyEditProposerBtnDisabled(proposerAddress)
   })
 
   it('Verify a proposer cannot edit or remove other proposers', () => {
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_33)
-    wallet.connectSigner(signer2)
+    wallet.connectSignerViaStorage(signer2, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_33)
     proposer.verifyEditProposerBtnDisabled(proposerAddress_2)
     proposer.verifyDeleteProposerBtnIsDisabled(proposerAddress_2)
   })
 
   it('Verify that deleting a proposer is only possible by creator', () => {
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_33)
-    wallet.connectSigner(signer3)
+    wallet.connectSignerViaStorage(signer3, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_33)
     proposer.verifyEditProposerBtnDisabled(proposerAddress_2)
     proposer.verifyDeleteProposerBtnIsDisabled(proposerAddress_2)
     proposer.verifyEditProposerBtnDisabled(proposerAddress)

--- a/apps/web/cypress/e2e/regression/recovery.cy.js
+++ b/apps/web/cypress/e2e/regression/recovery.cy.js
@@ -54,7 +54,7 @@ describe('Recovery regression tests', { defaultCommandTimeout: 50000 }, () => {
   it('Verify that guardian can not delete or edit recovery set up on Security and Login', () => {
     cy.visit(constants.securityUrl + recoverySafes.SEP_RECOVERY_SAFE_4)
     cy.clearLocalStorage()
-    wallet.connectSigner(guardian)
+    wallet.connectSignerViaStorage(guardian)
     main.acceptCookies()
     recovery.postponeRecovery()
     recovery.verifyRecoveryTableDisplayed()
@@ -126,7 +126,7 @@ describe('Recovery regression tests', { defaultCommandTimeout: 50000 }, () => {
     const confirmationData = [recovery.recoveryOptions.fiveMin, recovery.recoveryOptions.oneHr]
     cy.visit(constants.securityUrl + recoverySafes.SEP_RECOVERY_SAFE_4)
     cy.clearLocalStorage()
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     main.acceptCookies()
     recovery.verifyRecoveryTableDisplayed()
     recovery.verifyRecovererSettings(settings)
@@ -171,7 +171,7 @@ describe('Recovery regression tests', { defaultCommandTimeout: 50000 }, () => {
     ]
     cy.visit(constants.securityUrl + recoverySafes.SEP_RECOVERY_SAFE_4)
     cy.clearLocalStorage()
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     main.acceptCookies()
     recovery.verifyRecoveryTableDisplayed()
     recovery.clickOnEditRecoverer()

--- a/apps/web/cypress/e2e/regression/recovery.cy.js
+++ b/apps/web/cypress/e2e/regression/recovery.cy.js
@@ -67,7 +67,7 @@ describe('Recovery regression tests', { defaultCommandTimeout: 50000 }, () => {
   it('Verify that during the first connection to the safe "Proposal to recover account" modal is displayed for the guardian', () => {
     cy.visit(constants.securityUrl + recoverySafes.SEP_RECOVERY_SAFE_4)
     cy.clearLocalStorage()
-    wallet.connectSigner(guardian)
+    wallet.connectSignerViaStorage(guardian)
     main.acceptCookies()
     recovery.verifyRecoveryProposalDialog(constants.elementExistanceStates.exist)
     navigation.clickOnWalletExpandMoreIcon()
@@ -77,7 +77,7 @@ describe('Recovery regression tests', { defaultCommandTimeout: 50000 }, () => {
   it('Verify that "Account recovery" widget is displayed in the header for the Guardian', () => {
     cy.visit(constants.homeUrl + recoverySafes.SEP_RECOVERY_SAFE_4)
     cy.clearLocalStorage()
-    wallet.connectSigner(guardian)
+    wallet.connectSignerViaStorage(guardian)
     main.acceptCookies()
     recovery.clickOnRecoverLaterBtn()
     dashboard.expandActionRequiredPanel()
@@ -89,7 +89,7 @@ describe('Recovery regression tests', { defaultCommandTimeout: 50000 }, () => {
   it('Verify that recover later option is cached and "Proposal to account recovery" modal is not displayed on next safe opening', () => {
     cy.visit(constants.securityUrl + recoverySafes.SEP_RECOVERY_SAFE_4)
     cy.clearLocalStorage()
-    wallet.connectSigner(guardian)
+    wallet.connectSignerViaStorage(guardian)
     main.acceptCookies()
     recovery.clickOnRecoverLaterBtn()
     cy.reload()
@@ -102,7 +102,7 @@ describe('Recovery regression tests', { defaultCommandTimeout: 50000 }, () => {
   it('Verify that "Proposal to account recovery" modal is not displayed if the user is not guardian', () => {
     cy.visit(constants.securityUrl + recoverySafes.SEP_RECOVERY_SAFE_4)
     cy.clearLocalStorage()
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     main.acceptCookies()
     recovery.verifyRecoveryProposalDialog(constants.elementExistanceStates.not_exist)
     navigation.clickOnWalletExpandMoreIcon()
@@ -112,7 +112,7 @@ describe('Recovery regression tests', { defaultCommandTimeout: 50000 }, () => {
   it('Verify that the guardian can not delete recovery set up on Modules', () => {
     cy.visit(constants.modulesUrl + recoverySafes.SEP_RECOVERY_SAFE_4)
     cy.clearLocalStorage()
-    wallet.connectSigner(guardian)
+    wallet.connectSignerViaStorage(guardian)
     main.acceptCookies()
     recovery.postponeRecovery()
     main.verifyElementsStatus([modules.moduleRemoveIcon], constants.enabledStates.disabled)
@@ -144,7 +144,7 @@ describe('Recovery regression tests', { defaultCommandTimeout: 50000 }, () => {
   it('Verify that set up recovery flow can be canceled before submitting tx', () => {
     cy.visit(constants.securityUrl + staticSafes.SEP_STATIC_SAFE_13)
     cy.clearLocalStorage()
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     main.acceptCookies()
     recovery.clickOnSetupRecoveryBtn()
     recovery.clickOnNextBtn()
@@ -187,7 +187,7 @@ describe('Recovery regression tests', { defaultCommandTimeout: 50000 }, () => {
   it('Verify that recovery tx is opened after clicking on "Start recovery" button in the widget', () => {
     cy.visit(constants.securityUrl + recoverySafes.SEP_RECOVERY_SAFE_4)
     cy.clearLocalStorage()
-    wallet.connectSigner(guardian)
+    wallet.connectSignerViaStorage(guardian)
     main.acceptCookies()
     recovery.clickOnRecoverLaterBtn()
     cy.visit(constants.homeUrl + recoverySafes.SEP_RECOVERY_SAFE_4)

--- a/apps/web/cypress/e2e/regression/recovery_2.cy.js
+++ b/apps/web/cypress/e2e/regression/recovery_2.cy.js
@@ -29,7 +29,7 @@ describe('Recovery regression tests 2', { defaultCommandTimeout: 50000 }, () => 
   it('Verify "Edit Recovery" flow start from the Recovery widget', () => {
     cy.visit(constants.securityUrl + recoverySafes.SEP_RECOVERY_SAFE_4)
     cy.clearLocalStorage()
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     main.acceptCookies()
     recovery.verifyRecoveryTableDisplayed()
     recovery.clickOnEditRecoverer()
@@ -39,7 +39,7 @@ describe('Recovery regression tests 2', { defaultCommandTimeout: 50000 }, () => 
   it('Verify that Recovery widget has "Edit recovery" button when the recovery module is enabled', () => {
     cy.visit(constants.securityUrl + recoverySafes.SEP_RECOVERY_SAFE_4)
     cy.clearLocalStorage()
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     main.acceptCookies()
     recovery.verifyRecoveryTableDisplayed()
     main.verifyElementsCount(recovery.editRecovererBtn, 1)
@@ -48,7 +48,7 @@ describe('Recovery regression tests 2', { defaultCommandTimeout: 50000 }, () => 
   it('Verify that the "Set up recovery" button starts the set up recovery flow when no enabled recovery module in the safe', () => {
     cy.visit(constants.securityUrl + staticSafes.SEP_STATIC_SAFE_13)
     cy.clearLocalStorage()
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     main.acceptCookies()
     recovery.clickOnSetupRecoveryBtn()
     recovery.verifyRecoveryModalDisplayed()
@@ -57,7 +57,7 @@ describe('Recovery regression tests 2', { defaultCommandTimeout: 50000 }, () => 
   it('Verify that there is validation for the Guardian address field', () => {
     cy.visit(constants.securityUrl + staticSafes.SEP_STATIC_SAFE_13)
     cy.clearLocalStorage()
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     main.acceptCookies()
     recovery.clickOnSetupRecoveryBtn()
     recovery.clickOnNextBtn()

--- a/apps/web/cypress/e2e/regression/remove_owner.cy.js
+++ b/apps/web/cypress/e2e/regression/remove_owner.cy.js
@@ -15,56 +15,66 @@ describe('Remove Owners tests', () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  beforeEach(() => {
-    cy.intercept('GET', constants.transactionHistoryEndpoint).as('History')
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_13)
-    cy.wait('@History', { timeout: 20000 })
-    cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
+  describe('Disconnected', () => {
+    beforeEach(() => {
+      cy.intercept('GET', constants.transactionHistoryEndpoint).as('History')
+      cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_13)
+      cy.wait('@History', { timeout: 20000 })
+      cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
+    })
+
+    it('Verify that "Remove" icon is visible', () => {
+      owner.verifyRemoveBtnIsEnabled().should('have.length', 2)
+    })
+
+    it('Verify remove owner button is disabled for disconnected user', () => {
+      owner.verifyRemoveBtnIsDisabled()
+    })
   })
 
-  it('Verify that "Remove" icon is visible', () => {
-    owner.verifyRemoveBtnIsEnabled().should('have.length', 2)
+  describe('Connected', () => {
+    beforeEach(() => {
+      cy.intercept('GET', constants.transactionHistoryEndpoint).as('History')
+      wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_13)
+      cy.wait('@History', { timeout: 20000 })
+      cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
+    })
+
+    it('Verify owner removal form can be opened', () => {
+      owner.openRemoveOwnerWindow(1)
+    })
+
+    it('Verify that threshold input displays the upper limit as the current safe number of owners minus one', () => {
+      owner.openRemoveOwnerWindow(1)
+      owner.verifyThresholdLimit(1, 1)
+      owner.getThresholdOptions().should('have.length', 1)
+    })
+
+    // Added to prod
+    it('Verify owner deletion transaction has been created', () => {
+      owner.waitForConnectionStatus()
+      owner.openRemoveOwnerWindow(1)
+      cy.wait(3000)
+      createwallet.clickOnNextBtn()
+      //This method creates the @removedAddress alias
+      owner.getAddressToBeRemoved()
+      owner.verifyOwnerDeletionWindowDisplayed()
+      createTx.changeNonce(10)
+      createTx.clickOnContinueSignTransactionBtn()
+      createTx.clickOnSignTransactionBtn()
+      createTx.waitForProposeRequest()
+      createTx.clickViewTransaction()
+      createTx.clickOnTransactionItemByName('removeOwner')
+      createTx.verifyTxDestinationAddress('@removedAddress')
+    })
   })
 
-  it('Verify remove button does not exist for Non-Owner when there is only 1 owner in the safe', () => {
-    cy.intercept('GET', constants.transactionHistoryEndpoint).as('History')
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_3)
-    cy.wait('@History', { timeout: 20000 })
-    main.verifyElementsCount(owner.removeOwnerBtn, 0)
-  })
-
-  it('Verify remove owner button is disabled for disconnected user', () => {
-    owner.verifyRemoveBtnIsDisabled()
-  })
-
-  it('Verify owner removal form can be opened', () => {
-    wallet.connectSignerViaStorage(signer)
-    owner.openRemoveOwnerWindow(1)
-  })
-
-  it('Verify that threshold input displays the upper limit as the current safe number of owners minus one', () => {
-    wallet.connectSignerViaStorage(signer)
-    owner.openRemoveOwnerWindow(1)
-    owner.verifyThresholdLimit(1, 1)
-    owner.getThresholdOptions().should('have.length', 1)
-  })
-
-  // Added to prod
-  it('Verify owner deletion transaction has been created', () => {
-    wallet.connectSignerViaStorage(signer)
-    owner.waitForConnectionStatus()
-    owner.openRemoveOwnerWindow(1)
-    cy.wait(3000)
-    createwallet.clickOnNextBtn()
-    //This method creates the @removedAddress alias
-    owner.getAddressToBeRemoved()
-    owner.verifyOwnerDeletionWindowDisplayed()
-    createTx.changeNonce(10)
-    createTx.clickOnContinueSignTransactionBtn()
-    createTx.clickOnSignTransactionBtn()
-    createTx.waitForProposeRequest()
-    createTx.clickViewTransaction()
-    createTx.clickOnTransactionItemByName('removeOwner')
-    createTx.verifyTxDestinationAddress('@removedAddress')
+  describe('Single-owner safe', () => {
+    it('Verify remove button does not exist for Non-Owner when there is only 1 owner in the safe', () => {
+      cy.intercept('GET', constants.transactionHistoryEndpoint).as('History')
+      cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_3)
+      cy.wait('@History', { timeout: 20000 })
+      main.verifyElementsCount(owner.removeOwnerBtn, 0)
+    })
   })
 })

--- a/apps/web/cypress/e2e/regression/remove_owner.cy.js
+++ b/apps/web/cypress/e2e/regression/remove_owner.cy.js
@@ -38,12 +38,12 @@ describe('Remove Owners tests', () => {
   })
 
   it('Verify owner removal form can be opened', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.openRemoveOwnerWindow(1)
   })
 
   it('Verify that threshold input displays the upper limit as the current safe number of owners minus one', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.openRemoveOwnerWindow(1)
     owner.verifyThresholdLimit(1, 1)
     owner.getThresholdOptions().should('have.length', 1)
@@ -51,7 +51,7 @@ describe('Remove Owners tests', () => {
 
   // Added to prod
   it('Verify owner deletion transaction has been created', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.waitForConnectionStatus()
     owner.openRemoveOwnerWindow(1)
     cy.wait(3000)

--- a/apps/web/cypress/e2e/regression/replace_owner.cy.js
+++ b/apps/web/cypress/e2e/regression/replace_owner.cy.js
@@ -19,85 +19,94 @@ describe('Replace Owners tests', () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  beforeEach(() => {
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
-    cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
+  describe('Disconnected', () => {
+    beforeEach(() => {
+      cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
+      cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
+    })
+
+    it('Verify Tooltip displays correct message for disconnected user', () => {
+      owner.verifyReplaceBtnIsDisabled()
+    })
   })
 
-  it('Verify Tooltip displays correct message for disconnected user', () => {
-    owner.verifyReplaceBtnIsDisabled()
+  describe('Connected', () => {
+    beforeEach(() => {
+      wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
+      cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
+      owner.waitForConnectionStatus()
+    })
+
+    // TODO: Check unit tests
+    it('Verify max characters in name field', () => {
+      owner.openReplaceOwnerWindow(0)
+      owner.typeOwnerName(main.generateRandomString(51))
+      owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.exceedChars)
+    })
+
+    it('Verify that Name field not mandatory. Verify confirmation for owner replacement is displayed', () => {
+      owner.openReplaceOwnerWindow(0)
+      owner.typeOwnerAddress(getMockAddress())
+      owner.clickOnNextBtn()
+      owner.verifyConfirmTransactionWindowDisplayed()
+    })
+
+    it('Verify relevant error messages are displayed in Address input', () => {
+      owner.openReplaceOwnerWindow(0)
+      owner.typeOwnerAddress(main.generateRandomString(10))
+      owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.invalidFormat)
+
+      owner.typeOwnerAddress(getMockAddress().toUpperCase())
+      owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.invalidChecksum)
+
+      owner.typeOwnerAddress(staticSafes.SEP_STATIC_SAFE_4)
+      owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.ownSafe)
+
+      owner.typeOwnerAddress(getMockAddress().replace('A', 'a'))
+      owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.invalidChecksum)
+
+      owner.typeOwnerAddress(constants.DEFAULT_OWNER_ADDRESS)
+      owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.alreadyAdded)
+    })
   })
 
-  // TODO: Check unit tests
-  it('Verify max characters in name field', () => {
-    wallet.connectSignerViaStorage(signer)
-    owner.waitForConnectionStatus()
-    owner.openReplaceOwnerWindow(0)
-    owner.typeOwnerName(main.generateRandomString(51))
-    owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.exceedChars)
+  describe('With a pre-seeded address book', () => {
+    it('Verify that Address input auto-fills with related value', () => {
+      wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4, {
+        extraStorage: { [constants.localStorageKeys.SAFE_v2__addressBook]: ls.addressBookData.autofillData },
+      })
+      owner.waitForConnectionStatus()
+      owner.openReplaceOwnerWindow(0)
+      owner.typeOwnerAddress(constants.addresBookContacts.user1.address)
+      owner.verifyNewOwnerName(constants.addresBookContacts.user1.name)
+    })
   })
 
-  it('Verify that Address input auto-fills with related value', () => {
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.autofillData)
-    wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
-    owner.waitForConnectionStatus()
-    owner.openReplaceOwnerWindow(0)
-    owner.typeOwnerAddress(constants.addresBookContacts.user1.address)
-    owner.verifyNewOwnerName(constants.addresBookContacts.user1.name)
-  })
-
-  it('Verify that Name field not mandatory. Verify confirmation for owner replacement is displayed', () => {
-    wallet.connectSignerViaStorage(signer)
-    owner.waitForConnectionStatus()
-    owner.openReplaceOwnerWindow(0)
-    owner.typeOwnerAddress(getMockAddress())
-    owner.clickOnNextBtn()
-    owner.verifyConfirmTransactionWindowDisplayed()
-  })
-
-  it('Verify relevant error messages are displayed in Address input', () => {
-    wallet.connectSignerViaStorage(signer)
-    owner.waitForConnectionStatus()
-    owner.openReplaceOwnerWindow(0)
-    owner.typeOwnerAddress(main.generateRandomString(10))
-    owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.invalidFormat)
-
-    owner.typeOwnerAddress(getMockAddress().toUpperCase())
-    owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.invalidChecksum)
-
-    owner.typeOwnerAddress(staticSafes.SEP_STATIC_SAFE_4)
-    owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.ownSafe)
-
-    owner.typeOwnerAddress(getMockAddress().replace('A', 'a'))
-    owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.invalidChecksum)
-
-    owner.typeOwnerAddress(constants.DEFAULT_OWNER_ADDRESS)
-    owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.alreadyAdded)
-  })
-
-  it("Verify 'Replace' tx is created. GA tx_created", () => {
-    const tx_created = [
-      {
-        eventLabel: events.txCreatedSwapOwner.eventLabel,
-        eventCategory: events.txCreatedSwapOwner.category,
-        eventAction: events.txCreatedSwapOwner.action,
-        event: events.txCreatedSwapOwner.eventName,
-        safeAddress: staticSafes.SEP_STATIC_SAFE_25.slice(6),
-      },
-    ]
-    wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_25)
-    owner.waitForConnectionStatus()
-    owner.openReplaceOwnerWindow(1)
-    cy.wait(1000)
-    owner.typeOwnerName(ownerName)
-    owner.typeOwnerAddress(constants.SEPOLIA_OWNER_2)
-    createTx.changeNonce(0)
-    owner.clickOnNextBtn()
-    createTx.clickOnContinueSignTransactionBtn()
-    createTx.clickOnSignTransactionBtn()
-    createTx.clickViewTransaction()
-    createTx.verifyReplacedSigner(ownerName)
-    getEvents()
-    checkDataLayerEvents(tx_created)
+  describe('On another safe', () => {
+    it("Verify 'Replace' tx is created. GA tx_created", () => {
+      const tx_created = [
+        {
+          eventLabel: events.txCreatedSwapOwner.eventLabel,
+          eventCategory: events.txCreatedSwapOwner.category,
+          eventAction: events.txCreatedSwapOwner.action,
+          event: events.txCreatedSwapOwner.eventName,
+          safeAddress: staticSafes.SEP_STATIC_SAFE_25.slice(6),
+        },
+      ]
+      wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_25)
+      owner.waitForConnectionStatus()
+      owner.openReplaceOwnerWindow(1)
+      cy.wait(1000)
+      owner.typeOwnerName(ownerName)
+      owner.typeOwnerAddress(constants.SEPOLIA_OWNER_2)
+      createTx.changeNonce(0)
+      owner.clickOnNextBtn()
+      createTx.clickOnContinueSignTransactionBtn()
+      createTx.clickOnSignTransactionBtn()
+      createTx.clickViewTransaction()
+      createTx.verifyReplacedSigner(ownerName)
+      getEvents()
+      checkDataLayerEvents(tx_created)
+    })
   })
 })

--- a/apps/web/cypress/e2e/regression/replace_owner.cy.js
+++ b/apps/web/cypress/e2e/regression/replace_owner.cy.js
@@ -30,7 +30,7 @@ describe('Replace Owners tests', () => {
 
   // TODO: Check unit tests
   it('Verify max characters in name field', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.waitForConnectionStatus()
     owner.openReplaceOwnerWindow(0)
     owner.typeOwnerName(main.generateRandomString(51))
@@ -39,8 +39,7 @@ describe('Replace Owners tests', () => {
 
   it('Verify that Address input auto-fills with related value', () => {
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.autofillData)
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
     owner.waitForConnectionStatus()
     owner.openReplaceOwnerWindow(0)
     owner.typeOwnerAddress(constants.addresBookContacts.user1.address)
@@ -48,7 +47,7 @@ describe('Replace Owners tests', () => {
   })
 
   it('Verify that Name field not mandatory. Verify confirmation for owner replacement is displayed', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.waitForConnectionStatus()
     owner.openReplaceOwnerWindow(0)
     owner.typeOwnerAddress(getMockAddress())
@@ -57,7 +56,7 @@ describe('Replace Owners tests', () => {
   })
 
   it('Verify relevant error messages are displayed in Address input', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.waitForConnectionStatus()
     owner.openReplaceOwnerWindow(0)
     owner.typeOwnerAddress(main.generateRandomString(10))
@@ -86,8 +85,7 @@ describe('Replace Owners tests', () => {
         safeAddress: staticSafes.SEP_STATIC_SAFE_25.slice(6),
       },
     ]
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_25)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_25)
     owner.waitForConnectionStatus()
     owner.openReplaceOwnerWindow(1)
     cy.wait(1000)

--- a/apps/web/cypress/e2e/regression/safe_selector.cy.js
+++ b/apps/web/cypress/e2e/regression/safe_selector.cy.js
@@ -82,15 +82,13 @@ describe('Safe selector tests - pin/unpin and undeployed safes', () => {
   })
 
   it('Verify "Add accounts" button is displayed on the accounts page', () => {
-    cy.visit(constants.welcomeAccountsSepoliaUrl)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.welcomeAccountsSepoliaUrl)
     accountsModal.verifyAddAccountsButtonVisible()
   })
 
   it('Verify a safe can be removed from the trusted list', () => {
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.sidebarTrustedSafe1Safe2)
-    cy.visit(constants.homeUrl + staticSafes.SEP_STATIC_SAFE_9)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.homeUrl + staticSafes.SEP_STATIC_SAFE_9)
     accountsModal.openAccountsModal()
     accountsModal.verifyPinnedAccountsSectionVisible()
     accountsModal.unpinSafeByName(sideBar.sideBarSafes.safe1short)
@@ -102,8 +100,7 @@ describe('Safe selector tests - pin/unpin and undeployed safes', () => {
   it('Verify undeployed safe appears in the trusted list', () => {
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set6_undeployed_safe)
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__undeployedSafes, ls.undeployedSafe.safe1)
-    cy.visit(constants.homeUrl + staticSafes.SEP_STATIC_SAFE_9)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.homeUrl + staticSafes.SEP_STATIC_SAFE_9)
     accountsModal.openAccountsModal()
     accountsModal.verifyPinnedAccountsSectionVisible()
     accountsModal.verifyPinnedSafeExists(sideBar.sideBarSafes.safe4short)
@@ -111,7 +108,7 @@ describe('Safe selector tests - pin/unpin and undeployed safes', () => {
 
   it('Verify untrusted safe can be added to trusted list from dashboard action required panel', () => {
     cy.visit(constants.homeUrl + staticSafes.SEP_STATIC_SAFE_9, { skipAutoTrust: true })
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     dashboard.verifyActionRequiredCard({ messages: [dashboard.nonPinnedWarningTitle] })
     dashboard.clickActionInPanel(dashboard.trustThisSafeButtonTestId)
     dashboard.verifyTrustDialogVisible()
@@ -174,31 +171,27 @@ describe('Safe selector tests - accounts modal actions', () => {
   })
 
   it('Verify Import button is present on the accounts page', () => {
-    cy.visit(constants.welcomeAccountsSepoliaUrl)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.welcomeAccountsSepoliaUrl)
     accountsModal.verifyImportBtnVisible()
   })
 
   it('Verify safes added to watchlist appear in the accounts modal', () => {
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set4)
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
-    wallet.connectSigner(signer1)
+    wallet.connectSignerViaStorage(signer1, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
     accountsModal.openAccountsModal()
     accountsModal.verifyAccountsListContains(sideBar.sideBarSafes.safe3short)
   })
 
   it('Verify missing signature info is shown for a safe in the accounts modal', () => {
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.sidebarTrustedPendingSafe1)
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_7)
-    wallet.connectSigner(signer2)
+    wallet.connectSignerViaStorage(signer2, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_7)
     accountsModal.openAccountsModal()
     accountsModal.verifyMissingSignatureInfoExists()
   })
 
   it('Verify balance is displayed in the accounts modal safe item', () => {
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.sidebarTrustedPendingSafe1)
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_7)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_7)
     accountsModal.openAccountsModal()
     accountsModal.verifyFiatBalanceExists()
   })
@@ -234,8 +227,7 @@ describe('Safe selector tests - watchlist in dropdown', () => {
 
   it('Verify that safes the user does not own appear in the safe selector dropdown after adding them', () => {
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set4)
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
-    wallet.connectSigner(signer2)
+    wallet.connectSignerViaStorage(signer2, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
 
     safeNav.openSelector()
 
@@ -244,8 +236,7 @@ describe('Safe selector tests - watchlist in dropdown', () => {
 
   it('Verify that safes the user owns appear in the safe selector dropdown after adding them', () => {
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set4)
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
-    wallet.connectSigner(signer1)
+    wallet.connectSignerViaStorage(signer1, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
 
     safeNav.openSelector()
 
@@ -254,8 +245,7 @@ describe('Safe selector tests - watchlist in dropdown', () => {
 
   it('Verify that a watched safe with a pending tx appears in the safe selector dropdown', () => {
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.sidebarTrustedPendingSafe1)
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
-    wallet.connectSigner(signer2)
+    wallet.connectSignerViaStorage(signer2, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
 
     safeNav.openSelector()
 
@@ -278,8 +268,7 @@ describe('Safe selector tests - new transaction button states', () => {
   })
 
   it('Verify the new transaction button is enabled for proposers', () => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_31)
-    wallet.connectSigner(signer1)
+    wallet.connectSignerViaStorage(signer1, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_31)
 
     navigation.verifyTxBtnStatus(constants.enabledStates.enabled)
   })
@@ -291,15 +280,13 @@ describe('Safe selector tests - new transaction button states', () => {
   })
 
   it('Verify the new transaction button is disabled for connected non-owners', () => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_7)
-    wallet.connectSigner(signer1)
+    wallet.connectSignerViaStorage(signer1, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_7)
 
     navigation.verifyTxBtnStatus(constants.enabledStates.disabled)
   })
 
   it('Verify the new transaction button is enabled for non-owners with spending limits', () => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_11)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_11)
 
     navigation.verifyTxBtnStatus(constants.enabledStates.enabled)
   })
@@ -311,8 +298,7 @@ describe('Safe selector tests - add safe button', () => {
   })
 
   it('Verify selecting an existing safe from Add accounts opens the load flow', () => {
-    cy.visit(constants.welcomeAccountsSepoliaUrl)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.welcomeAccountsSepoliaUrl)
 
     accountsModal.clickAddAccountsSelectExistingAndVerifyLoadFlow()
   })
@@ -326,8 +312,7 @@ describe('Safe selector tests - threshold tag visible for owners and non-owners'
   it('Verify the threshold badge is shown on safe cards for both owner and non-owner safes', () => {
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set3)
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.addedSafes)
-    cy.visit(constants.homeUrl + staticSafes.SEP_STATIC_SAFE_11)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.homeUrl + staticSafes.SEP_STATIC_SAFE_11)
     accountsModal.openAccountsModal()
 
     accountsModal.verifyThresholdBadgeOnSafeCard('Added owner')

--- a/apps/web/cypress/e2e/regression/safe_selector.cy.js
+++ b/apps/web/cypress/e2e/regression/safe_selector.cy.js
@@ -107,8 +107,7 @@ describe('Safe selector tests - pin/unpin and undeployed safes', () => {
   })
 
   it('Verify untrusted safe can be added to trusted list from dashboard action required panel', () => {
-    cy.visit(constants.homeUrl + staticSafes.SEP_STATIC_SAFE_9, { skipAutoTrust: true })
-    wallet.connectSignerViaStorage(signer)
+    wallet.connectSignerViaStorage(signer, constants.homeUrl + staticSafes.SEP_STATIC_SAFE_9, { skipAutoTrust: true })
     dashboard.verifyActionRequiredCard({ messages: [dashboard.nonPinnedWarningTitle] })
     dashboard.clickActionInPanel(dashboard.trustThisSafeButtonTestId)
     dashboard.verifyTrustDialogVisible()

--- a/apps/web/cypress/e2e/regression/safe_selector.cy.js
+++ b/apps/web/cypress/e2e/regression/safe_selector.cy.js
@@ -82,7 +82,7 @@ describe('Safe selector tests - pin/unpin and undeployed safes', () => {
   })
 
   it('Verify "Add accounts" button is displayed on the accounts page', () => {
-    wallet.connectSignerViaStorage(signer, constants.welcomeAccountsSepoliaUrl)
+    wallet.connectSignerViaStorage(signer, constants.welcomeAccountsSepoliaUrl, { waitForConnection: false })
     accountsModal.verifyAddAccountsButtonVisible()
   })
 
@@ -170,7 +170,7 @@ describe('Safe selector tests - accounts modal actions', () => {
   })
 
   it('Verify Import button is present on the accounts page', () => {
-    wallet.connectSignerViaStorage(signer, constants.welcomeAccountsSepoliaUrl)
+    wallet.connectSignerViaStorage(signer, constants.welcomeAccountsSepoliaUrl, { waitForConnection: false })
     accountsModal.verifyImportBtnVisible()
   })
 
@@ -297,7 +297,7 @@ describe('Safe selector tests - add safe button', () => {
   })
 
   it('Verify selecting an existing safe from Add accounts opens the load flow', () => {
-    wallet.connectSignerViaStorage(signer, constants.welcomeAccountsSepoliaUrl)
+    wallet.connectSignerViaStorage(signer, constants.welcomeAccountsSepoliaUrl, { waitForConnection: false })
 
     accountsModal.clickAddAccountsSelectExistingAndVerifyLoadFlow()
   })

--- a/apps/web/cypress/e2e/regression/sidebar_new.cy.js
+++ b/apps/web/cypress/e2e/regression/sidebar_new.cy.js
@@ -20,13 +20,12 @@ describe('Sidebar tests', () => {
   })
 
   it('Verify New transaction button enabled for owners', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     sideBar.verifyNewTxBtnStatus(constants.enabledStates.enabled)
   })
 
   it('Verify New transaction button enabled for beneficiaries who are non-owners', () => {
-    cy.visit(constants.homeUrl + staticSafes.SEP_STATIC_SAFE_11)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.homeUrl + staticSafes.SEP_STATIC_SAFE_11)
     sideBar.verifyNewTxBtnStatus(constants.enabledStates.enabled)
   })
 

--- a/apps/web/cypress/e2e/regression/sidebar_new.cy.js
+++ b/apps/web/cypress/e2e/regression/sidebar_new.cy.js
@@ -15,43 +15,47 @@ describe('Sidebar tests', () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  beforeEach(() => {
-    cy.visit(constants.homeUrl + staticSafes.SEP_STATIC_SAFE_9)
+  describe('Disconnected', () => {
+    beforeEach(() => {
+      cy.visit(constants.homeUrl + staticSafes.SEP_STATIC_SAFE_9)
+    })
+
+    it('Verify New Transaction button disabled for non-owners', () => {
+      sideBar.verifyNewTxBtnStatus(constants.enabledStates.disabled)
+    })
+
+    it('Verify the side menu buttons exist', () => {
+      sideBar.verifySideListItemsNew()
+    })
+
+    it('Verify counter in the "Transaction" menu item if there are tx in the queue tab', () => {
+      sideBar.verifyTxCounterNew(1)
+    })
+
+    it('Verify that clicking on Bridge in the sidebar opens the exchange iframe', () => {
+      const iframeSelector = `iframe[src*="${constants.bridgeWidget}"]`
+
+      clickOnBridgeOption()
+      swaps.acceptLegalDisclaimer()
+
+      cy.get(iframeSelector).should('be.visible')
+      cy.get(iframeSelector).then(($iframe) => {
+        const $body = $iframe.contents().find('body')
+        cy.wrap($body).should('exist')
+        cy.wrap($body).contains(exchangeStr).should('be.visible')
+      })
+    })
   })
 
-  it('Verify New transaction button enabled for owners', () => {
-    wallet.connectSignerViaStorage(signer)
-    sideBar.verifyNewTxBtnStatus(constants.enabledStates.enabled)
-  })
+  describe('Connected', () => {
+    it('Verify New transaction button enabled for owners', () => {
+      wallet.connectSignerViaStorage(signer, constants.homeUrl + staticSafes.SEP_STATIC_SAFE_9)
+      sideBar.verifyNewTxBtnStatus(constants.enabledStates.enabled)
+    })
 
-  it('Verify New transaction button enabled for beneficiaries who are non-owners', () => {
-    wallet.connectSignerViaStorage(signer, constants.homeUrl + staticSafes.SEP_STATIC_SAFE_11)
-    sideBar.verifyNewTxBtnStatus(constants.enabledStates.enabled)
-  })
-
-  it('Verify New Transaction button disabled for non-owners', () => {
-    sideBar.verifyNewTxBtnStatus(constants.enabledStates.disabled)
-  })
-
-  it('Verify the side menu buttons exist', () => {
-    sideBar.verifySideListItemsNew()
-  })
-
-  it('Verify counter in the "Transaction" menu item if there are tx in the queue tab', () => {
-    sideBar.verifyTxCounterNew(1)
-  })
-
-  it('Verify that clicking on Bridge in the sidebar opens the exchange iframe', () => {
-    const iframeSelector = `iframe[src*="${constants.bridgeWidget}"]`
-
-    clickOnBridgeOption()
-    swaps.acceptLegalDisclaimer()
-
-    cy.get(iframeSelector).should('be.visible')
-    cy.get(iframeSelector).then(($iframe) => {
-      const $body = $iframe.contents().find('body')
-      cy.wrap($body).should('exist')
-      cy.wrap($body).contains(exchangeStr).should('be.visible')
+    it('Verify New transaction button enabled for beneficiaries who are non-owners', () => {
+      wallet.connectSignerViaStorage(signer, constants.homeUrl + staticSafes.SEP_STATIC_SAFE_11)
+      sideBar.verifyNewTxBtnStatus(constants.enabledStates.enabled)
     })
   })
 })

--- a/apps/web/cypress/e2e/regression/spaces_dashboard.cy.js
+++ b/apps/web/cypress/e2e/regression/spaces_dashboard.cy.js
@@ -8,8 +8,7 @@ const owner = walletCredentials.OWNER_1_PRIVATE_KEY
 
 describe('Spaces dashboard tests', () => {
   beforeEach(() => {
-    cy.visit(constants.spacesUrl)
-    wallet.connectSigner(owner)
+    wallet.connectSignerViaStorage(owner, constants.spacesUrl)
     space.clickOnSignInBtn()
     space.waitForSpacesWelcomeReady()
     space.visitSpaceDashboard(staticSpaces.dashboardWithSafes.uuid)
@@ -160,8 +159,7 @@ Safe Selector through Spaces empty dashboard: commented out; remove this block c
 
 describe('Spaces empty dashboard tests', () => {
   beforeEach(() => {
-    cy.visit(constants.spacesUrl)
-    wallet.connectSigner(owner)
+    wallet.connectSignerViaStorage(owner, constants.spacesUrl)
     space.clickOnSignInBtn()
     space.visitSpaceDashboard(staticSpaces.emptyGettingStarted.uuid)
   })

--- a/apps/web/cypress/e2e/regression/spending_limits.cy.js
+++ b/apps/web/cypress/e2e/regression/spending_limits.cy.js
@@ -28,7 +28,7 @@ describe('Spending limits tests', () => {
   })
 
   it('Verify resetAllowance and setAllowance actions are shown if a part of allowance was used', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     spendinglimit.clickOnNewSpendingLimitBtn()
     spendinglimit.enterBeneficiaryAddress(signerAddress)
     spendinglimit.enterSpendingLimitAmount(0.1)
@@ -38,8 +38,7 @@ describe('Spending limits tests', () => {
   })
 
   it('Verify only setAllowance action is shown if allowance was not used', () => {
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_23)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_23)
     spendinglimit.clickOnNewSpendingLimitBtn()
     spendinglimit.enterBeneficiaryAddress(signerAddress)
     spendinglimit.enterSpendingLimitAmount(0.1)
@@ -51,7 +50,7 @@ describe('Spending limits tests', () => {
   // Added to prod
   it('Verify that the Review step shows beneficiary, amount allowed, reset time', () => {
     //Assume that default reset time is set to One time
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     spendinglimit.clickOnNewSpendingLimitBtn()
     spendinglimit.enterBeneficiaryAddress(getMockAddress())
     spendinglimit.enterSpendingLimitAmount(0.1)
@@ -70,28 +69,28 @@ describe('Spending limits tests', () => {
 
   // Added to prod
   it('Verify Spending limit option is available when selecting the corresponding token', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     navigation.clickOnNewTxBtn()
     tx.clickOnSendTokensBtn()
     spendinglimit.verifyTxOptionExist([spendinglimit.spendingLimitTxOption])
   })
 
   it('Verify spending limit option shows available amount', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     navigation.clickOnNewTxBtn()
     tx.clickOnSendTokensBtn()
     spendinglimit.verifySpendingOptionShowsBalance([spendingLimitBalance])
   })
 
   it('Verify when owner is a delegate, standard tx and spending limit tx are present', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     navigation.clickOnNewTxBtn()
     tx.clickOnSendTokensBtn()
     spendinglimit.verifyTxOptionExist([spendinglimit.spendingLimitTxOption, spendinglimit.standardTx])
   })
 
   it('Verify when spending limit is selected the nonce field is removed', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     navigation.clickOnNewTxBtn()
     tx.clickOnSendTokensBtn()
     spendinglimit.selectSpendingLimitOption()
@@ -99,7 +98,7 @@ describe('Spending limits tests', () => {
   })
 
   it('Verify "Max" button value set to be no more than the allowed amount', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     navigation.clickOnNewTxBtn()
     tx.clickOnSendTokensBtn()
     spendinglimit.clickOnMaxBtn()
@@ -107,14 +106,14 @@ describe('Spending limits tests', () => {
   })
 
   it('Verify selecting a native token from the dropdown in new tx', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     navigation.clickOnNewTxBtn()
     tx.clickOnSendTokensBtn()
     spendinglimit.selectToken(constants.tokenNames.sepoliaEther)
   })
 
   it('Verify that when replacing spending limit for the same owner, previous values are displayed in red', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     spendinglimit.clickOnNewSpendingLimitBtn()
     spendinglimit.enterBeneficiaryAddress(constants.DEFAULT_OWNER_ADDRESS)
     spendinglimit.enterSpendingLimitAmount(newTokenAmount)
@@ -125,7 +124,7 @@ describe('Spending limits tests', () => {
   })
 
   it('Verify that when editing spending limit for owner who used some of it, relevant actions are displayed', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     spendinglimit.clickOnNewSpendingLimitBtn()
     spendinglimit.enterBeneficiaryAddress(constants.SPENDING_LIMIT_ADDRESS_2)
     spendinglimit.enterSpendingLimitAmount(newTokenAmount)
@@ -141,7 +140,7 @@ describe('Spending limits tests', () => {
   it('Verify that when multiple assets are available, they are displayed in token dropdown', () => {
     main.setupSafeSettingsWithAllTokens().then(() => {
       cy.reload()
-      wallet.connectSigner(signer)
+      wallet.connectSignerViaStorage(signer)
       navigation.clickOnNewTxBtn()
       tx.clickOnSendTokensBtn()
       spendinglimit.clickOnTokenDropdown()
@@ -159,7 +158,7 @@ describe('Spending limits tests', () => {
       )
       .then(() => {
         cy.reload()
-        wallet.connectSigner(signer)
+        wallet.connectSignerViaStorage(signer)
         spendinglimit.clickOnNewSpendingLimitBtn()
         spendinglimit.enterBeneficiaryAddress(constants.DEFAULT_OWNER_ADDRESS.substring(30))
         spendinglimit.selectRecipient(constants.DEFAULT_OWNER_ADDRESS)
@@ -172,7 +171,7 @@ describe('Spending limits tests', () => {
 
   it('Verify that the enableModule action shows the correct AllowanceModule address for Sepolia', () => {
     spendinglimit.visitSpendingLimitsPage(staticSafes.SEP_STATIC_SAFE_47)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     spendinglimit.clickOnNewSpendingLimitBtn()
     spendinglimit.enterBeneficiaryAddress(signerAddress)
     spendinglimit.enterSpendingLimitAmount(1)
@@ -188,7 +187,7 @@ describe('Spending limits tests', () => {
     spendinglimit.visitSpendingLimitsPage(staticSafes.MATIC_STATIC_SAFE_34)
     main.setupSafeSettingsWithAllTokens().then(() => {
       spendinglimit.visitSpendingLimitsPage(staticSafes.MATIC_STATIC_SAFE_34)
-      wallet.connectSigner(signer)
+      wallet.connectSignerViaStorage(signer)
       spendinglimit.clickOnNewSpendingLimitBtn()
       spendinglimit.enterBeneficiaryAddress(signerAddress)
       spendinglimit.enterSpendingLimitAmount(1)

--- a/apps/web/cypress/e2e/regression/spending_limits.cy.js
+++ b/apps/web/cypress/e2e/regression/spending_limits.cy.js
@@ -22,171 +22,152 @@ describe('Spending limits tests', () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  beforeEach(() => {
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_8)
-    cy.get(spendinglimit.spendingLimitsSection).should('be.visible')
+  describe('Connected on the default safe', () => {
+    beforeEach(() => {
+      wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_8)
+      cy.get(spendinglimit.spendingLimitsSection).should('be.visible')
+    })
+
+    it('Verify resetAllowance and setAllowance actions are shown if a part of allowance was used', () => {
+      spendinglimit.clickOnNewSpendingLimitBtn()
+      spendinglimit.enterBeneficiaryAddress(signerAddress)
+      spendinglimit.enterSpendingLimitAmount(0.1)
+      spendinglimit.clickOnNextBtn()
+      spendinglimit.verifyActionCount(2)
+      spendinglimit.verifyActionNames([
+        spendinglimit.actionNames.resetAllowance,
+        spendinglimit.actionNames.setAllowance,
+      ])
+    })
+
+    // Added to prod
+    it('Verify that the Review step shows beneficiary, amount allowed, reset time', () => {
+      //Assume that default reset time is set to One time
+      spendinglimit.clickOnNewSpendingLimitBtn()
+      spendinglimit.enterBeneficiaryAddress(getMockAddress())
+      spendinglimit.enterSpendingLimitAmount(0.1)
+      spendinglimit.clickOnNextBtn()
+      spendinglimit.checkReviewData(
+        tokenAmount,
+        getMockAddress(),
+        spendinglimit.timePeriodOptions.oneTime.split(' ').join('-'),
+      )
+    })
+
+    // Added to prod
+    it('Verify Spending limit option is available when selecting the corresponding token', () => {
+      navigation.clickOnNewTxBtn()
+      tx.clickOnSendTokensBtn()
+      spendinglimit.verifyTxOptionExist([spendinglimit.spendingLimitTxOption])
+    })
+
+    it('Verify spending limit option shows available amount', () => {
+      navigation.clickOnNewTxBtn()
+      tx.clickOnSendTokensBtn()
+      spendinglimit.verifySpendingOptionShowsBalance([spendingLimitBalance])
+    })
+
+    it('Verify when owner is a delegate, standard tx and spending limit tx are present', () => {
+      navigation.clickOnNewTxBtn()
+      tx.clickOnSendTokensBtn()
+      spendinglimit.verifyTxOptionExist([spendinglimit.spendingLimitTxOption, spendinglimit.standardTx])
+    })
+
+    it('Verify when spending limit is selected the nonce field is removed', () => {
+      navigation.clickOnNewTxBtn()
+      tx.clickOnSendTokensBtn()
+      spendinglimit.selectSpendingLimitOption()
+      spendinglimit.verifyNonceState(constants.elementExistanceStates.not_exist)
+    })
+
+    it('Verify "Max" button value set to be no more than the allowed amount', () => {
+      navigation.clickOnNewTxBtn()
+      tx.clickOnSendTokensBtn()
+      spendinglimit.clickOnMaxBtn()
+      spendinglimit.checkMaxValue()
+    })
+
+    it('Verify selecting a native token from the dropdown in new tx', () => {
+      navigation.clickOnNewTxBtn()
+      tx.clickOnSendTokensBtn()
+      spendinglimit.selectToken(constants.tokenNames.sepoliaEther)
+    })
+
+    it('Verify that when replacing spending limit for the same owner, previous values are displayed in red', () => {
+      spendinglimit.clickOnNewSpendingLimitBtn()
+      spendinglimit.enterBeneficiaryAddress(constants.DEFAULT_OWNER_ADDRESS)
+      spendinglimit.enterSpendingLimitAmount(newTokenAmount)
+      spendinglimit.clickOnTimePeriodDropdown()
+      spendinglimit.selectTimePeriod(spendinglimit.timePeriodOptions.fiveMin)
+      tx.clickOnNextBtn()
+      spendinglimit.verifyOldValuesAreDisplayed()
+    })
+
+    it('Verify that when editing spending limit for owner who used some of it, relevant actions are displayed', () => {
+      spendinglimit.clickOnNewSpendingLimitBtn()
+      spendinglimit.enterBeneficiaryAddress(constants.SPENDING_LIMIT_ADDRESS_2)
+      spendinglimit.enterSpendingLimitAmount(newTokenAmount)
+      spendinglimit.clickOnTimePeriodDropdown()
+      spendinglimit.selectTimePeriod(spendinglimit.timePeriodOptions.oneTime)
+      tx.clickOnNextBtn()
+      spendinglimit.verifyActionNamesAreDisplayed([
+        constants.TXActionNames.resetAllowance,
+        constants.TXActionNames.setAllowance,
+      ])
+    })
   })
 
-  it('Verify resetAllowance and setAllowance actions are shown if a part of allowance was used', () => {
-    wallet.connectSignerViaStorage(signer)
-    spendinglimit.clickOnNewSpendingLimitBtn()
-    spendinglimit.enterBeneficiaryAddress(signerAddress)
-    spendinglimit.enterSpendingLimitAmount(0.1)
-    spendinglimit.clickOnNextBtn()
-    spendinglimit.verifyActionCount(2)
-    spendinglimit.verifyActionNames([spendinglimit.actionNames.resetAllowance, spendinglimit.actionNames.setAllowance])
+  describe('Disconnected on the default safe', () => {
+    beforeEach(() => {
+      cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_8)
+      cy.get(spendinglimit.spendingLimitsSection).should('be.visible')
+    })
+
+    // Added to prod
+    it('Verify values and trash icons are displayed in Beneficiary table', () => {
+      spendinglimit.verifyBeneficiaryTable()
+    })
+
+    it('Verify explorer links contain Sepolia link', () => {
+      tx.verifyNumberOfExternalLinks(3)
+    })
   })
 
-  it('Verify only setAllowance action is shown if allowance was not used', () => {
-    wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_23)
-    spendinglimit.clickOnNewSpendingLimitBtn()
-    spendinglimit.enterBeneficiaryAddress(signerAddress)
-    spendinglimit.enterSpendingLimitAmount(0.1)
-    spendinglimit.clickOnNextBtn()
-    spendinglimit.verifyActionCount(0)
-    spendinglimit.verifyDecodedTxSummary([spendinglimit.actionNames.setAllowance])
-  })
+  describe('Other safes and pre-seeded data', () => {
+    it('Verify only setAllowance action is shown if allowance was not used', () => {
+      wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_23)
+      cy.get(spendinglimit.spendingLimitsSection).should('be.visible')
+      spendinglimit.clickOnNewSpendingLimitBtn()
+      spendinglimit.enterBeneficiaryAddress(signerAddress)
+      spendinglimit.enterSpendingLimitAmount(0.1)
+      spendinglimit.clickOnNextBtn()
+      spendinglimit.verifyActionCount(0)
+      spendinglimit.verifyDecodedTxSummary([spendinglimit.actionNames.setAllowance])
+    })
 
-  // Added to prod
-  it('Verify that the Review step shows beneficiary, amount allowed, reset time', () => {
-    //Assume that default reset time is set to One time
-    wallet.connectSignerViaStorage(signer)
-    spendinglimit.clickOnNewSpendingLimitBtn()
-    spendinglimit.enterBeneficiaryAddress(getMockAddress())
-    spendinglimit.enterSpendingLimitAmount(0.1)
-    spendinglimit.clickOnNextBtn()
-    spendinglimit.checkReviewData(
-      tokenAmount,
-      getMockAddress(),
-      spendinglimit.timePeriodOptions.oneTime.split(' ').join('-'),
-    )
-  })
-
-  // Added to prod
-  it('Verify values and trash icons are displayed in Beneficiary table', () => {
-    spendinglimit.verifyBeneficiaryTable()
-  })
-
-  // Added to prod
-  it('Verify Spending limit option is available when selecting the corresponding token', () => {
-    wallet.connectSignerViaStorage(signer)
-    navigation.clickOnNewTxBtn()
-    tx.clickOnSendTokensBtn()
-    spendinglimit.verifyTxOptionExist([spendinglimit.spendingLimitTxOption])
-  })
-
-  it('Verify spending limit option shows available amount', () => {
-    wallet.connectSignerViaStorage(signer)
-    navigation.clickOnNewTxBtn()
-    tx.clickOnSendTokensBtn()
-    spendinglimit.verifySpendingOptionShowsBalance([spendingLimitBalance])
-  })
-
-  it('Verify when owner is a delegate, standard tx and spending limit tx are present', () => {
-    wallet.connectSignerViaStorage(signer)
-    navigation.clickOnNewTxBtn()
-    tx.clickOnSendTokensBtn()
-    spendinglimit.verifyTxOptionExist([spendinglimit.spendingLimitTxOption, spendinglimit.standardTx])
-  })
-
-  it('Verify when spending limit is selected the nonce field is removed', () => {
-    wallet.connectSignerViaStorage(signer)
-    navigation.clickOnNewTxBtn()
-    tx.clickOnSendTokensBtn()
-    spendinglimit.selectSpendingLimitOption()
-    spendinglimit.verifyNonceState(constants.elementExistanceStates.not_exist)
-  })
-
-  it('Verify "Max" button value set to be no more than the allowed amount', () => {
-    wallet.connectSignerViaStorage(signer)
-    navigation.clickOnNewTxBtn()
-    tx.clickOnSendTokensBtn()
-    spendinglimit.clickOnMaxBtn()
-    spendinglimit.checkMaxValue()
-  })
-
-  it('Verify selecting a native token from the dropdown in new tx', () => {
-    wallet.connectSignerViaStorage(signer)
-    navigation.clickOnNewTxBtn()
-    tx.clickOnSendTokensBtn()
-    spendinglimit.selectToken(constants.tokenNames.sepoliaEther)
-  })
-
-  it('Verify that when replacing spending limit for the same owner, previous values are displayed in red', () => {
-    wallet.connectSignerViaStorage(signer)
-    spendinglimit.clickOnNewSpendingLimitBtn()
-    spendinglimit.enterBeneficiaryAddress(constants.DEFAULT_OWNER_ADDRESS)
-    spendinglimit.enterSpendingLimitAmount(newTokenAmount)
-    spendinglimit.clickOnTimePeriodDropdown()
-    spendinglimit.selectTimePeriod(spendinglimit.timePeriodOptions.fiveMin)
-    tx.clickOnNextBtn()
-    spendinglimit.verifyOldValuesAreDisplayed()
-  })
-
-  it('Verify that when editing spending limit for owner who used some of it, relevant actions are displayed', () => {
-    wallet.connectSignerViaStorage(signer)
-    spendinglimit.clickOnNewSpendingLimitBtn()
-    spendinglimit.enterBeneficiaryAddress(constants.SPENDING_LIMIT_ADDRESS_2)
-    spendinglimit.enterSpendingLimitAmount(newTokenAmount)
-    spendinglimit.clickOnTimePeriodDropdown()
-    spendinglimit.selectTimePeriod(spendinglimit.timePeriodOptions.oneTime)
-    tx.clickOnNextBtn()
-    spendinglimit.verifyActionNamesAreDisplayed([
-      constants.TXActionNames.resetAllowance,
-      constants.TXActionNames.setAllowance,
-    ])
-  })
-
-  it('Verify that when multiple assets are available, they are displayed in token dropdown', () => {
-    main.setupSafeSettingsWithAllTokens().then(() => {
-      cy.reload()
-      wallet.connectSignerViaStorage(signer)
+    it('Verify that when multiple assets are available, they are displayed in token dropdown', () => {
+      wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_8, {
+        extraStorage: { [constants.localStorageKeys.SAFE_v2__settings]: ls.safeSettings.slimitSettings },
+      })
+      cy.get(spendinglimit.spendingLimitsSection).should('be.visible')
       navigation.clickOnNewTxBtn()
       tx.clickOnSendTokensBtn()
       spendinglimit.clickOnTokenDropdown()
       spendinglimit.verifyMandatoryTokensExist()
     })
-  })
 
-  it('Verify that beneficiary can be retried from address book', () => {
-    cy.wrap(null)
-      .then(() =>
-        main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sepoliaAddress2),
-      )
-      .then(() =>
-        main.isItemInLocalstorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sepoliaAddress2),
-      )
-      .then(() => {
-        cy.reload()
-        wallet.connectSignerViaStorage(signer)
-        spendinglimit.clickOnNewSpendingLimitBtn()
-        spendinglimit.enterBeneficiaryAddress(constants.DEFAULT_OWNER_ADDRESS.substring(30))
-        spendinglimit.selectRecipient(constants.DEFAULT_OWNER_ADDRESS)
+    it('Verify that beneficiary can be retried from address book', () => {
+      wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_8, {
+        extraStorage: { [constants.localStorageKeys.SAFE_v2__addressBook]: ls.addressBookData.sepoliaAddress2 },
       })
-  })
+      cy.get(spendinglimit.spendingLimitsSection).should('be.visible')
+      spendinglimit.clickOnNewSpendingLimitBtn()
+      spendinglimit.enterBeneficiaryAddress(constants.DEFAULT_OWNER_ADDRESS.substring(30))
+      spendinglimit.selectRecipient(constants.DEFAULT_OWNER_ADDRESS)
+    })
 
-  it('Verify explorer links contain Sepolia link', () => {
-    tx.verifyNumberOfExternalLinks(3)
-  })
-
-  it('Verify that the enableModule action shows the correct AllowanceModule address for Sepolia', () => {
-    spendinglimit.visitSpendingLimitsPage(staticSafes.SEP_STATIC_SAFE_47)
-    wallet.connectSignerViaStorage(signer)
-    spendinglimit.clickOnNewSpendingLimitBtn()
-    spendinglimit.enterBeneficiaryAddress(signerAddress)
-    spendinglimit.enterSpendingLimitAmount(1)
-    spendinglimit.clickOnNextBtn()
-
-    spendinglimit.verifyActionNames([spendinglimit.actionNames.enableModule])
-    spendinglimit.verifyEnableModuleAddress(constants.ALLOWANCE_MODULE_V0_1_0)
-  })
-
-  it('Verify that the enableModule action shows the correct AllowanceModule address for Polygon', () => {
-    // setupSafeSettingsWithAllTokens is required: the Polygon safe has near-zero MATIC balance
-    // which triggers the "hide small tokens" filter, leaving the token selector empty
-    spendinglimit.visitSpendingLimitsPage(staticSafes.MATIC_STATIC_SAFE_34)
-    main.setupSafeSettingsWithAllTokens().then(() => {
-      spendinglimit.visitSpendingLimitsPage(staticSafes.MATIC_STATIC_SAFE_34)
+    it('Verify that the enableModule action shows the correct AllowanceModule address for Sepolia', () => {
+      spendinglimit.visitSpendingLimitsPage(staticSafes.SEP_STATIC_SAFE_47)
       wallet.connectSignerViaStorage(signer)
       spendinglimit.clickOnNewSpendingLimitBtn()
       spendinglimit.enterBeneficiaryAddress(signerAddress)
@@ -194,7 +175,24 @@ describe('Spending limits tests', () => {
       spendinglimit.clickOnNextBtn()
 
       spendinglimit.verifyActionNames([spendinglimit.actionNames.enableModule])
-      spendinglimit.verifyEnableModuleAddress(constants.ALLOWANCE_MODULE_V0_1_1)
+      spendinglimit.verifyEnableModuleAddress(constants.ALLOWANCE_MODULE_V0_1_0)
+    })
+
+    it('Verify that the enableModule action shows the correct AllowanceModule address for Polygon', () => {
+      // setupSafeSettingsWithAllTokens is required: the Polygon safe has near-zero MATIC balance
+      // which triggers the "hide small tokens" filter, leaving the token selector empty
+      spendinglimit.visitSpendingLimitsPage(staticSafes.MATIC_STATIC_SAFE_34)
+      main.setupSafeSettingsWithAllTokens().then(() => {
+        spendinglimit.visitSpendingLimitsPage(staticSafes.MATIC_STATIC_SAFE_34)
+        wallet.connectSignerViaStorage(signer)
+        spendinglimit.clickOnNewSpendingLimitBtn()
+        spendinglimit.enterBeneficiaryAddress(signerAddress)
+        spendinglimit.enterSpendingLimitAmount(1)
+        spendinglimit.clickOnNextBtn()
+
+        spendinglimit.verifyActionNames([spendinglimit.actionNames.enableModule])
+        spendinglimit.verifyEnableModuleAddress(constants.ALLOWANCE_MODULE_V0_1_1)
+      })
     })
   })
 })

--- a/apps/web/cypress/e2e/regression/swaps.cy.js
+++ b/apps/web/cypress/e2e/regression/swaps.cy.js
@@ -18,9 +18,8 @@ describe('Swaps tests', () => {
 
   beforeEach(() => {
     cy.intercept('GET', constants.transactionHistoryEndpoint).as('History')
-    cy.visit(constants.swapUrl + staticSafes.SEP_STATIC_SAFE_1)
+    wallet.connectSignerViaStorage(signer, constants.swapUrl + staticSafes.SEP_STATIC_SAFE_1)
     cy.wait('@History', { timeout: 20000 })
-    wallet.connectSignerViaStorage(signer)
     iframeSelector = `iframe[src*="${constants.swapWidget}"]`
   })
 

--- a/apps/web/cypress/e2e/regression/swaps.cy.js
+++ b/apps/web/cypress/e2e/regression/swaps.cy.js
@@ -20,7 +20,7 @@ describe('Swaps tests', () => {
     cy.intercept('GET', constants.transactionHistoryEndpoint).as('History')
     cy.visit(constants.swapUrl + staticSafes.SEP_STATIC_SAFE_1)
     cy.wait('@History', { timeout: 20000 })
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     iframeSelector = `iframe[src*="${constants.swapWidget}"]`
   })
 

--- a/apps/web/cypress/e2e/regression/swaps_tokens.cy.js
+++ b/apps/web/cypress/e2e/regression/swaps_tokens.cy.js
@@ -17,41 +17,50 @@ describe('Swaps token tests', () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  beforeEach(() => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_1)
-    assets.toggleShowAllTokens(true)
-    assets.toggleHideDust(false)
-  })
-
-  // Added to prod
-  it(
-    'Verify that clicking the swap from assets tab, autofills that token automatically in the form',
-    { defaultCommandTimeout: 30000 },
-    () => {
-      wallet.connectSignerViaStorage(signer)
-      swaps.clickOnAssetSwapBtn(0)
-      swaps.acceptLegalDisclaimer()
-      cy.wait(2000)
-      main.getIframeBody(iframeSelector).within(() => {
-        swaps.verifySelectedInputCurrancy(swaps.swapTokens.eth)
-      })
-    },
-  )
-
-  it('Verify swap button are displayed in assets table and dashboard', () => {
-    assets.toggleShowAllTokens(true)
-    assets.toggleHideDust(false)
-    swaps.verifyAssetsPageSwapButtonsCount(4)
-
-    cy.window().then((window) => {
-      window.localStorage.setItem(
-        constants.localStorageKeys.SAFE_v2__settings,
-        JSON.stringify(ls.safeSettings.slimitSettings),
-      )
+  describe('Disconnected', () => {
+    beforeEach(() => {
+      cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_1)
+      assets.toggleShowAllTokens(true)
+      assets.toggleHideDust(false)
     })
 
-    cy.visit(constants.homeUrl + staticSafes.SEP_STATIC_SAFE_1)
-    swaps.verifyDashboardPageSwapButtonsCount(4)
-    main.verifyElementsCount(swaps.dashboardSwapBtn, 1)
+    it('Verify swap button are displayed in assets table and dashboard', () => {
+      assets.toggleShowAllTokens(true)
+      assets.toggleHideDust(false)
+      swaps.verifyAssetsPageSwapButtonsCount(4)
+
+      cy.visit(constants.homeUrl + staticSafes.SEP_STATIC_SAFE_1, {
+        onBeforeLoad(win) {
+          win.localStorage.setItem(
+            constants.localStorageKeys.SAFE_v2__settings,
+            JSON.stringify(ls.safeSettings.slimitSettings),
+          )
+        },
+      })
+      swaps.verifyDashboardPageSwapButtonsCount(4)
+      main.verifyElementsCount(swaps.dashboardSwapBtn, 1)
+    })
+  })
+
+  describe('Connected', () => {
+    beforeEach(() => {
+      wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_1)
+      assets.toggleShowAllTokens(true)
+      assets.toggleHideDust(false)
+    })
+
+    // Added to prod
+    it(
+      'Verify that clicking the swap from assets tab, autofills that token automatically in the form',
+      { defaultCommandTimeout: 30000 },
+      () => {
+        swaps.clickOnAssetSwapBtn(0)
+        swaps.acceptLegalDisclaimer()
+        cy.wait(2000)
+        main.getIframeBody(iframeSelector).within(() => {
+          swaps.verifySelectedInputCurrancy(swaps.swapTokens.eth)
+        })
+      },
+    )
   })
 })

--- a/apps/web/cypress/e2e/regression/swaps_tokens.cy.js
+++ b/apps/web/cypress/e2e/regression/swaps_tokens.cy.js
@@ -28,7 +28,7 @@ describe('Swaps token tests', () => {
     'Verify that clicking the swap from assets tab, autofills that token automatically in the form',
     { defaultCommandTimeout: 30000 },
     () => {
-      wallet.connectSigner(signer)
+      wallet.connectSignerViaStorage(signer)
       swaps.clickOnAssetSwapBtn(0)
       swaps.acceptLegalDisclaimer()
       cy.wait(2000)

--- a/apps/web/cypress/e2e/regression/twaps_integration.cy.js
+++ b/apps/web/cypress/e2e/regression/twaps_integration.cy.js
@@ -19,9 +19,8 @@ describe('TWAP tests', { defaultCommandTimeout: 30000 }, () => {
 
   beforeEach(() => {
     cy.intercept('GET', constants.transactionHistoryEndpoint).as('History')
-    cy.visit(constants.swapUrl + staticSafes.SEP_STATIC_SAFE_27)
+    wallet.connectSignerViaStorage(signer, constants.swapUrl + staticSafes.SEP_STATIC_SAFE_27)
     cy.wait('@History', { timeout: 20000 })
-    wallet.connectSignerViaStorage(signer)
     iframeSelector = `iframe[src*="${constants.swapWidget}"]`
   })
 

--- a/apps/web/cypress/e2e/regression/twaps_integration.cy.js
+++ b/apps/web/cypress/e2e/regression/twaps_integration.cy.js
@@ -21,7 +21,7 @@ describe('TWAP tests', { defaultCommandTimeout: 30000 }, () => {
     cy.intercept('GET', constants.transactionHistoryEndpoint).as('History')
     cy.visit(constants.swapUrl + staticSafes.SEP_STATIC_SAFE_27)
     cy.wait('@History', { timeout: 20000 })
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     iframeSelector = `iframe[src*="${constants.swapWidget}"]`
   })
 

--- a/apps/web/cypress/e2e/regression/tx_notes.cy.js
+++ b/apps/web/cypress/e2e/regression/tx_notes.cy.js
@@ -38,8 +38,7 @@ describe('Transaction notes tests', () => {
   })
 
   it('Verify the tx notes field only allows 60 characters', () => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
     createtx.clickOnNewtransactionBtn()
     createtx.clickOnSendTokensBtn()
     happyPathToStepTwo()
@@ -47,8 +46,7 @@ describe('Transaction notes tests', () => {
   })
 
   it('Verify the tx note information message', () => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_6)
     createtx.clickOnNewtransactionBtn()
     createtx.clickOnSendTokensBtn()
     happyPathToStepTwo()
@@ -71,16 +69,14 @@ describe('Transaction notes tests', () => {
   })
 
   it('Verify no tx note field is present when signing a message', () => {
-    cy.visit(constants.transactionsMessagesUrl + staticSafes.SEP_STATIC_SAFE_26)
-    wallet.connectSigner(signer2)
+    wallet.connectSignerViaStorage(signer2, constants.transactionsMessagesUrl + staticSafes.SEP_STATIC_SAFE_26)
     messages.clickOnMessageSignBtn(0)
     msg_confirmation_modal.verifyMessagePresent(messages.offchainMessage)
     main.verifyElementsCount(createtx.noteTextField, 0)
   })
 
   it('Verify no tx note field is present during the use of a spending limit', () => {
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_8)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_8)
     navigation.clickOnNewTxBtn()
     createtx.clickOnSendTokensBtn()
     createtx.typeRecipientAddress(constants.EOA)
@@ -91,8 +87,7 @@ describe('Transaction notes tests', () => {
   })
 
   it('Verify that in a send funds tx the note field shows up in the execution part of the form', () => {
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_8)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_8)
     navigation.clickOnNewTxBtn()
     createtx.clickOnSendTokensBtn()
     createtx.typeRecipientAddress(constants.EOA)
@@ -103,8 +98,7 @@ describe('Transaction notes tests', () => {
   })
 
   it('Verify no tx note is present during a recovery tx', () => {
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_8)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_8)
     navigation.clickOnNewTxBtn()
     createtx.clickOnSendTokensBtn()
     createtx.typeRecipientAddress(constants.EOA)

--- a/apps/web/cypress/e2e/regression/tx_queue_delete_btn.cy.js
+++ b/apps/web/cypress/e2e/regression/tx_queue_delete_btn.cy.js
@@ -23,8 +23,10 @@ describe('Transaction queue Delete button tests', { defaultCommandTimeout: 30000
   })
 
   it('Verify the option to Delete tx is available in the Reject tx modal for the next tx to be executed', () => {
-    cy.visit(constants.transactionUrl + staticSafes.SEP_STATIC_SAFE_7 + nextTxToBeExecuted)
-    wallet.connectSigner(signer2)
+    wallet.connectSignerViaStorage(
+      signer2,
+      constants.transactionUrl + staticSafes.SEP_STATIC_SAFE_7 + nextTxToBeExecuted,
+    )
     create_tx.clickOnRejectBtn()
     create_tx.verifyTxRejectModalVisible()
     create_tx.verifyDeleteChoiceBtnStatus(constants.enabledStates.enabled)

--- a/apps/web/cypress/e2e/regression/tx_queue_reject_btn.cy.js
+++ b/apps/web/cypress/e2e/regression/tx_queue_reject_btn.cy.js
@@ -36,7 +36,7 @@ describe('Transaction queue Reject button tests', { defaultCommandTimeout: 30000
   it('Verify that Reject button is disabled out for non-owners and disconnected users', () => {
     cy.visit(constants.transactionUrl + staticSafes.SEP_STATIC_SAFE_34 + swaps.swapTxs.sellQLimitOrder)
     create_tx.verifyRejectBtnDisabled()
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     create_tx.verifyRejectBtnDisabled()
     navigation.clickOnWalletExpandMoreIcon()
     navigation.clickOnDisconnectBtn()
@@ -49,8 +49,10 @@ describe('Transaction queue Reject button tests', { defaultCommandTimeout: 30000
   })
 
   it('Verify that clicking rejection with an owner opens a modal with the Reject option', () => {
-    cy.visit(constants.transactionUrl + staticSafes.SEP_STATIC_SAFE_34 + swaps.swapTxs.sellQLimitOrder)
-    wallet.connectSigner(signer2)
+    wallet.connectSignerViaStorage(
+      signer2,
+      constants.transactionUrl + staticSafes.SEP_STATIC_SAFE_34 + swaps.swapTxs.sellQLimitOrder,
+    )
     create_tx.clickOnRejectBtn()
     create_tx.verifyTxRejectModalVisible()
     navigation.clickOnWalletExpandMoreIcon()
@@ -75,8 +77,10 @@ describe('Transaction queue Reject button tests', { defaultCommandTimeout: 30000
   })
 
   it('Verify a Reject tx cannot be "Added as batch"', () => {
-    cy.visit(constants.transactionUrl + staticSafes.SEP_STATIC_SAFE_34 + swaps.swapTxs.sellQLimitOrder)
-    wallet.connectSigner(signer2)
+    wallet.connectSignerViaStorage(
+      signer2,
+      constants.transactionUrl + staticSafes.SEP_STATIC_SAFE_34 + swaps.swapTxs.sellQLimitOrder,
+    )
     create_tx.clickOnRejectBtn()
     create_tx.verifyTxRejectModalVisible()
     create_tx.clickOnRejectionChoiceBtn(1)

--- a/apps/web/cypress/e2e/regression/tx_queue_replace_btn.cy.js
+++ b/apps/web/cypress/e2e/regression/tx_queue_replace_btn.cy.js
@@ -21,8 +21,10 @@ describe('Transaction queue Replace button tests', { defaultCommandTimeout: 3000
   })
 
   it('Verify "Reject tx" modal has the Replace tx option', () => {
-    cy.visit(constants.transactionUrl + staticSafes.SEP_STATIC_SAFE_34 + swaps.swapTxs.sellQLimitOrder)
-    wallet.connectSigner(signer2)
+    wallet.connectSignerViaStorage(
+      signer2,
+      constants.transactionUrl + staticSafes.SEP_STATIC_SAFE_34 + swaps.swapTxs.sellQLimitOrder,
+    )
     create_tx.clickOnRejectBtn()
     create_tx.verifyTxRejectModalVisible()
     create_tx.verifyReplaceChoiceBtnVisible()

--- a/apps/web/cypress/e2e/safe-apps/drain_account.spec.cy.js
+++ b/apps/web/cypress/e2e/safe-apps/drain_account.spec.cy.js
@@ -28,7 +28,7 @@ describe('Drain Account tests', { defaultCommandTimeout: 40000 }, () => {
   })
 
   it('Verify drain can be created', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     cy.enter(iframeSelector).then((getBody) => {
       getBody().findByLabelText(safeapps.recipientStr).type(getMockAddress())
       getBody().findAllByText(safeapps.transferEverythingStr).click()

--- a/apps/web/cypress/e2e/smoke/add_owner.cy.js
+++ b/apps/web/cypress/e2e/smoke/add_owner.cy.js
@@ -14,45 +14,47 @@ describe('[SMOKE] Add Owners tests', () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  beforeEach(() => {
-    cy.intercept('GET', constants.transactionHistoryEndpoint).as('History')
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
-    cy.wait('@History', { timeout: 20000 })
-    main.verifyElementsExist([navigation.setupSection])
+  describe('Connected', () => {
+    beforeEach(() => {
+      cy.intercept('GET', constants.transactionHistoryEndpoint).as('History')
+      wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
+      cy.wait('@History', { timeout: 20000 })
+      main.verifyElementsExist([navigation.setupSection])
+    })
+
+    // TODO: Check if this test is covered with unit tests
+    it('[SMOKE] Verify relevant error messages are displayed in Address input', () => {
+      owner.openManageSignersWindow()
+      owner.clickOnAddSignerBtn()
+
+      owner.typeOwnerAddressManage(1, main.generateRandomString(10))
+
+      owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.invalidFormat)
+
+      owner.typeOwnerAddressManage(1, constants.addresBookContacts.user1.address.toUpperCase())
+      owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.invalidChecksum)
+
+      owner.typeOwnerAddressManage(1, staticSafes.SEP_STATIC_SAFE_4)
+      owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.ownSafeManage)
+
+      owner.typeOwnerAddressManage(1, constants.addresBookContacts.user1.address.replace('F', 'f'))
+      owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.invalidChecksum)
+
+      owner.typeOwnerAddressManage(1, constants.DEFAULT_OWNER_ADDRESS)
+      owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.ownerAdded)
+    })
+
+    it('[SMOKE] Verify the presence of "Manage Signers" button', () => {
+      owner.verifyManageSignersBtnIsEnabled()
+    })
   })
 
-  // TODO: Check if this test is covered with unit tests
-  it('[SMOKE] Verify relevant error messages are displayed in Address input', () => {
-    wallet.connectSignerViaStorage(signer)
-    owner.openManageSignersWindow()
-    owner.clickOnAddSignerBtn()
-
-    owner.typeOwnerAddressManage(1, main.generateRandomString(10))
-
-    owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.invalidFormat)
-
-    owner.typeOwnerAddressManage(1, constants.addresBookContacts.user1.address.toUpperCase())
-    owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.invalidChecksum)
-
-    owner.typeOwnerAddressManage(1, staticSafes.SEP_STATIC_SAFE_4)
-    owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.ownSafeManage)
-
-    owner.typeOwnerAddressManage(1, constants.addresBookContacts.user1.address.replace('F', 'f'))
-    owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.invalidChecksum)
-
-    owner.typeOwnerAddressManage(1, constants.DEFAULT_OWNER_ADDRESS)
-    owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.ownerAdded)
-  })
-
-  it('[SMOKE] Verify the presence of "Manage Signers" button', () => {
-    wallet.connectSignerViaStorage(signer)
-    owner.verifyManageSignersBtnIsEnabled()
-  })
-
-  it('[SMOKE] Verify "Manage Signers" button is disabled for Non-Owner', () => {
-    cy.intercept('GET', constants.transactionHistoryEndpoint).as('History')
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_3)
-    cy.wait('@History', { timeout: 20000 })
-    owner.verifyManageSignersBtnIsDisabled()
+  describe('Non-owner safe', () => {
+    it('[SMOKE] Verify "Manage Signers" button is disabled for Non-Owner', () => {
+      cy.intercept('GET', constants.transactionHistoryEndpoint).as('History')
+      cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_3)
+      cy.wait('@History', { timeout: 20000 })
+      owner.verifyManageSignersBtnIsDisabled()
+    })
   })
 })

--- a/apps/web/cypress/e2e/smoke/add_owner.cy.js
+++ b/apps/web/cypress/e2e/smoke/add_owner.cy.js
@@ -23,7 +23,7 @@ describe('[SMOKE] Add Owners tests', () => {
 
   // TODO: Check if this test is covered with unit tests
   it('[SMOKE] Verify relevant error messages are displayed in Address input', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.openManageSignersWindow()
     owner.clickOnAddSignerBtn()
 
@@ -45,7 +45,7 @@ describe('[SMOKE] Add Owners tests', () => {
   })
 
   it('[SMOKE] Verify the presence of "Manage Signers" button', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.verifyManageSignersBtnIsEnabled()
   })
 

--- a/apps/web/cypress/e2e/smoke/address_book.cy.js
+++ b/apps/web/cypress/e2e/smoke/address_book.cy.js
@@ -1,6 +1,5 @@
 import * as constants from '../../support/constants'
 import * as addressBook from '../../e2e/pages/address_book.page'
-import * as main from '../../e2e/pages/main.page'
 import * as ls from '../../support/localstorage_data.js'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 
@@ -13,14 +12,18 @@ describe('[SMOKE] Address book tests', () => {
 
   beforeEach(() => {
     cy.intercept('GET', constants.transactionHistoryEndpoint).as('History')
-    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4)
+    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4, {
+      onBeforeLoad(win) {
+        win.localStorage.setItem(
+          constants.localStorageKeys.SAFE_v2__addressBook,
+          JSON.stringify(ls.addressBookData.sepoliaAddress1),
+        )
+      },
+    })
     cy.wait('@History', { timeout: 20000 })
   })
 
   it('[SMOKE] Verify empty name is not allowed when editing', () => {
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sepoliaAddress1)
-    cy.wait(1000)
-    cy.reload()
     addressBook.clickOnEditEntryBtn()
     addressBook.verifyEmptyOwnerNameNotAllowed()
   })

--- a/apps/web/cypress/e2e/smoke/batch_tx.cy.js
+++ b/apps/web/cypress/e2e/smoke/batch_tx.cy.js
@@ -1,6 +1,5 @@
 import * as batch from '../pages/batches.pages'
 import * as constants from '../../support/constants'
-import * as main from '../../e2e/pages/main.page'
 import * as ls from '../../support/localstorage_data.js'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 import * as wallet from '../../support/utils/wallet.js'
@@ -19,40 +18,40 @@ describe('[SMOKE] Batch transaction tests', { defaultCommandTimeout: 30000 }, ()
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  beforeEach(() => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_2)
+  describe('Empty batch', () => {
+    beforeEach(() => {
+      cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_2)
+    })
+
+    it('[SMOKE] Verify empty batch list can be opened', () => {
+      batch.openBatchtransactionsModal()
+      cy.contains(batch.addInitialTransactionStr).should('be.visible')
+    })
   })
 
-  it('[SMOKE] Verify empty batch list can be opened', () => {
-    batch.openBatchtransactionsModal()
-    cy.contains(batch.addInitialTransactionStr).should('be.visible')
-  })
-
-  it('[SMOKE] Verify a transaction is visible in a batch', () => {
-    cy.wrap(null)
-      .then(() => main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__batch, ls.batchData.entry1))
-      .then(() => {
-        cy.reload()
-        batch.verifyBatchIconCount(1)
-        batch.clickOnBatchCounter()
-        batch.verifyAmountTransactionsInBatch(1)
+  describe('Pre-seeded batch', () => {
+    it('[SMOKE] Verify a transaction is visible in a batch', () => {
+      cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_2, {
+        onBeforeLoad(win) {
+          win.localStorage.setItem(constants.localStorageKeys.SAFE_v2__batch, JSON.stringify(ls.batchData.entry1))
+        },
       })
-  })
+      batch.verifyBatchIconCount(1)
+      batch.clickOnBatchCounter()
+      batch.verifyAmountTransactionsInBatch(1)
+    })
 
-  it('[SMOKE] Verify the batch can be confirmed and related transactions exist in the form', () => {
-    cy.wrap(null)
-      .then(() => main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__batch, ls.batchData.entry0))
-      .then(() => main.isItemInLocalstorage(constants.localStorageKeys.SAFE_v2__batch, ls.batchData.entry0))
-      .then(() => {
-        cy.reload()
-        wallet.connectSignerViaStorage(signer)
-        batch.clickOnBatchCounter()
-        batch.clickOnConfirmBatchBtn()
-        batch.verifyBatchTransactionsCount(2)
-        batch.clickOnBatchCounter()
-        cy.contains(funds_first_tx).parents('ul').as('TransactionList')
-        cy.get('@TransactionList').find('li').eq(0).contains(funds_first_tx)
-        cy.get('@TransactionList').find('li').eq(1).contains(funds_second_tx)
+    it('[SMOKE] Verify the batch can be confirmed and related transactions exist in the form', () => {
+      wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_2, {
+        extraStorage: { [constants.localStorageKeys.SAFE_v2__batch]: ls.batchData.entry0 },
       })
+      batch.clickOnBatchCounter()
+      batch.clickOnConfirmBatchBtn()
+      batch.verifyBatchTransactionsCount(2)
+      batch.clickOnBatchCounter()
+      cy.contains(funds_first_tx).parents('ul').as('TransactionList')
+      cy.get('@TransactionList').find('li').eq(0).contains(funds_first_tx)
+      cy.get('@TransactionList').find('li').eq(1).contains(funds_second_tx)
+    })
   })
 })

--- a/apps/web/cypress/e2e/smoke/batch_tx.cy.js
+++ b/apps/web/cypress/e2e/smoke/batch_tx.cy.js
@@ -45,7 +45,7 @@ describe('[SMOKE] Batch transaction tests', { defaultCommandTimeout: 30000 }, ()
       .then(() => main.isItemInLocalstorage(constants.localStorageKeys.SAFE_v2__batch, ls.batchData.entry0))
       .then(() => {
         cy.reload()
-        wallet.connectSigner(signer)
+        wallet.connectSignerViaStorage(signer)
         batch.clickOnBatchCounter()
         batch.clickOnConfirmBatchBtn()
         batch.verifyBatchTransactionsCount(2)

--- a/apps/web/cypress/e2e/smoke/create_tx.cy.js
+++ b/apps/web/cypress/e2e/smoke/create_tx.cy.js
@@ -17,8 +17,7 @@ describe('[SMOKE] Create transactions tests', () => {
   })
 
   beforeEach(() => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_10)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_10)
     createtx.clickOnNewtransactionBtn()
     createtx.clickOnSendTokensBtn()
   })

--- a/apps/web/cypress/e2e/smoke/import_export_data.cy.js
+++ b/apps/web/cypress/e2e/smoke/import_export_data.cy.js
@@ -1,5 +1,4 @@
 import * as file from '../pages/import_export.pages'
-import * as main from '../pages/main.page'
 import * as constants from '../../support/constants'
 import * as ls from '../../support/localstorage_data.js'
 import * as selector from '../pages/safe_navigation.pages'
@@ -7,97 +6,76 @@ import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 
 let staticSafes = []
 
+const seedStorage = (entries) => (win) => {
+  Object.entries(entries).forEach(([key, value]) => win.localStorage.setItem(key, JSON.stringify(value)))
+}
+
 describe('[SMOKE] Import Export Data tests', { defaultCommandTimeout: 20000 }, () => {
   before(async () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  beforeEach(() => {
-    cy.visit(constants.dataSettingsUrl)
-  })
-
   it('[SMOKE] Verify Safe can be accessed after test file upload', () => {
     const safe = constants.SEPOLIA_CSV_ENTRY.name
 
-    cy.wrap(null)
-      .then(() => main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set1))
-      .then(() =>
-        main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.importedSafe),
-      )
-      .then(() => {
-        cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
-        return selector.openSelector()
-      })
-      .then(() => {
-        selector.verifyItemExistsInSelector(safe)
-        selector.clickOnSafe(safe)
-      })
+    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4, {
+      onBeforeLoad: seedStorage({
+        [constants.localStorageKeys.SAFE_v2__addedSafes]: ls.addedSafes.set1,
+        [constants.localStorageKeys.SAFE_v2__addressBook]: ls.addressBookData.importedSafe,
+      }),
+    })
+    selector.openSelector()
+    selector.verifyItemExistsInSelector(safe)
+    selector.clickOnSafe(safe)
   })
 
   it('[SMOKE] Verify address book imported data', () => {
-    cy.wrap(null)
-      .then(() => main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set1))
-      .then(() =>
-        main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.importedSafe),
-      )
-      .then(() => {
-        cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_13)
-        file.verifyImportedAddressBookData()
-      })
+    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_13, {
+      onBeforeLoad: seedStorage({
+        [constants.localStorageKeys.SAFE_v2__addedSafes]: ls.addedSafes.set1,
+        [constants.localStorageKeys.SAFE_v2__addressBook]: ls.addressBookData.importedSafe,
+      }),
+    })
+    file.verifyImportedAddressBookData()
   })
 
   it('[SMOKE] Verify pinned apps', () => {
     const appNames = ['Transaction Builder']
-    cy.visit(constants.appsUrlGeneral + staticSafes.SEP_STATIC_SAFE_13)
-      .then(() => cy.wrap(null))
-      .then(() => main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set1))
-      .then(() =>
-        main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.importedSafe),
-      )
-      .then(() =>
-        main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__safeApps, ls.pinnedApps.transactionBuilder),
-      )
-      .then(() => {
-        cy.reload()
-        file.verifyPinnedApps(appNames)
-      })
+    cy.visit(constants.appsUrlGeneral + staticSafes.SEP_STATIC_SAFE_13, {
+      onBeforeLoad: seedStorage({
+        [constants.localStorageKeys.SAFE_v2__addedSafes]: ls.addedSafes.set1,
+        [constants.localStorageKeys.SAFE_v2__addressBook]: ls.addressBookData.importedSafe,
+        [constants.localStorageKeys.SAFE_v2__safeApps]: ls.pinnedApps.transactionBuilder,
+      }),
+    })
+    file.verifyPinnedApps(appNames)
   })
 
   it('[SMOKE] Verify imported data in settings', () => {
     const checked = [file.darkModeStr]
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_13)
-      .then(() => cy.wrap(null))
-      .then(() => main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__settings, ls.safeSettings.settings1))
-      .then(() =>
-        main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__safeApps, ls.pinnedApps.transactionBuilder),
-      )
-      .then(() => main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set1))
-      .then(() =>
-        main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.importedSafe),
-      )
-      .then(() => {
-        cy.reload()
-        file.clickOnAppearenceBtn()
-        file.verifyCheckboxes(checked, true)
-      })
+    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_13, {
+      onBeforeLoad: seedStorage({
+        [constants.localStorageKeys.SAFE_v2__settings]: ls.safeSettings.settings1,
+        [constants.localStorageKeys.SAFE_v2__safeApps]: ls.pinnedApps.transactionBuilder,
+        [constants.localStorageKeys.SAFE_v2__addedSafes]: ls.addedSafes.set1,
+        [constants.localStorageKeys.SAFE_v2__addressBook]: ls.addressBookData.importedSafe,
+      }),
+    })
+    file.clickOnAppearenceBtn()
+    file.verifyCheckboxes(checked, true)
   })
 
   it('[SMOKE] Verify data for export in Data tab', () => {
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_13)
-      .then(() => cy.wrap(null))
-      .then(() => main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__settings, ls.safeSettings.settings1))
-      .then(() => main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set1))
-      .then(() =>
-        main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__safeApps, ls.pinnedApps.transactionBuilder),
-      )
-      .then(() =>
-        main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.importedSafe),
-      )
-      .then(() => {
-        cy.reload()
-        file.clickOnDataTab()
-        file.verifyImportModalData()
-        file.verifyFileDownload()
-      })
+    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_13, {
+      onBeforeLoad: seedStorage({
+        [constants.localStorageKeys.SAFE_v2__settings]: ls.safeSettings.settings1,
+        [constants.localStorageKeys.SAFE_v2__addedSafes]: ls.addedSafes.set1,
+        [constants.localStorageKeys.SAFE_v2__safeApps]: ls.pinnedApps.transactionBuilder,
+        [constants.localStorageKeys.SAFE_v2__addressBook]: ls.addressBookData.importedSafe,
+      }),
+    })
+    file.clickOnDataTab()
+    file.verifyImportModalData()
+    file.verifyFileDownload()
   })
 })

--- a/apps/web/cypress/e2e/smoke/replace_owner.cy.js
+++ b/apps/web/cypress/e2e/smoke/replace_owner.cy.js
@@ -19,7 +19,7 @@ describe('[SMOKE] Replace Owners tests', () => {
   })
 
   it('[SMOKE] Verify that "Replace" icon is visible', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.verifyReplaceBtnIsEnabled()
   })
 
@@ -29,7 +29,7 @@ describe('[SMOKE] Replace Owners tests', () => {
   })
 
   it('[SMOKE] Verify that the owner replacement form is opened', () => {
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer)
     owner.waitForConnectionStatus()
     owner.openReplaceOwnerWindow(0)
   })

--- a/apps/web/cypress/e2e/smoke/replace_owner.cy.js
+++ b/apps/web/cypress/e2e/smoke/replace_owner.cy.js
@@ -1,5 +1,4 @@
 import * as constants from '../../support/constants'
-import * as main from '../../e2e/pages/main.page'
 import * as owner from '../pages/owners.pages'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 import * as wallet from '../../support/utils/wallet.js'
@@ -13,24 +12,26 @@ describe('[SMOKE] Replace Owners tests', () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  beforeEach(() => {
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
-    cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
+  describe('Connected', () => {
+    beforeEach(() => {
+      wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
+      cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
+    })
+
+    it('[SMOKE] Verify that "Replace" icon is visible', () => {
+      owner.verifyReplaceBtnIsEnabled()
+    })
+
+    it('[SMOKE] Verify that the owner replacement form is opened', () => {
+      owner.waitForConnectionStatus()
+      owner.openReplaceOwnerWindow(0)
+    })
   })
 
-  it('[SMOKE] Verify that "Replace" icon is visible', () => {
-    wallet.connectSignerViaStorage(signer)
-    owner.verifyReplaceBtnIsEnabled()
-  })
-
-  it('[SMOKE] Verify owner replace button is disabled for Non-Owner', () => {
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_3)
-    owner.verifyReplaceBtnIsDisabled()
-  })
-
-  it('[SMOKE] Verify that the owner replacement form is opened', () => {
-    wallet.connectSignerViaStorage(signer)
-    owner.waitForConnectionStatus()
-    owner.openReplaceOwnerWindow(0)
+  describe('Non-owner safe', () => {
+    it('[SMOKE] Verify owner replace button is disabled for Non-Owner', () => {
+      cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_3)
+      owner.verifyReplaceBtnIsDisabled()
+    })
   })
 })

--- a/apps/web/cypress/e2e/smoke/safe_selector.cy.js
+++ b/apps/web/cypress/e2e/smoke/safe_selector.cy.js
@@ -1,5 +1,4 @@
 import * as constants from '../../support/constants.js'
-import * as main from '../pages/main.page.js'
 import * as safeSelector from '../pages/safe_navigation.pages.js'
 import * as ls from '../../support/localstorage_data.js'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
@@ -14,14 +13,19 @@ describe('[SMOKE] Safe selector tests', { defaultCommandTimeout: 60000, ...const
   })
 
   it('[SMOKE] Verify the safe selector dropdown displays multichain safes', () => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
     // Add multichain safe data (safe3 on Sepolia + Ethereum)
-    main.addToAppLocalStorage(
-      constants.localStorageKeys.SAFE_v2__addedSafes,
-      ls.addedSafes.sidebarTrustedSafe3TwoChains,
-    )
-    main.addToAppLocalStorage(constants.localStorageKeys.SAFE_v2__undeployedSafes, ls.undeployedSafe.safes2)
-    cy.reload()
+    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9, {
+      onBeforeLoad(win) {
+        win.localStorage.setItem(
+          constants.localStorageKeys.SAFE_v2__addedSafes,
+          JSON.stringify(ls.addedSafes.sidebarTrustedSafe3TwoChains),
+        )
+        win.localStorage.setItem(
+          constants.localStorageKeys.SAFE_v2__undeployedSafes,
+          JSON.stringify(ls.undeployedSafe.safes2),
+        )
+      },
+    })
 
     // Chains are fetched at runtime now (no build-time seed) and the selector
     // snapshots its safe list when opened, so it must only be opened once chain

--- a/apps/web/cypress/e2e/smoke/spending_limits.cy.js
+++ b/apps/web/cypress/e2e/smoke/spending_limits.cy.js
@@ -15,8 +15,7 @@ describe('[SMOKE] Spending limits tests', () => {
   })
 
   beforeEach(() => {
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_8)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_8)
     owner.waitForConnectionStatus()
     cy.get(spendinglimit.spendingLimitsSection).should('be.visible')
     spendinglimit.clickOnNewSpendingLimitBtn()

--- a/apps/web/cypress/e2e/visual/address_book.cy.js
+++ b/apps/web/cypress/e2e/visual/address_book.cy.js
@@ -14,9 +14,14 @@ describe('[VISUAL] Address book screenshots', { defaultCommandTimeout: 60000, ..
 
   beforeEach(() => {
     mockVisualTestApis()
-    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sepoliaAddress1)
-    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4)
-    cy.reload()
+    cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4, {
+      onBeforeLoad(win) {
+        win.localStorage.setItem(
+          constants.localStorageKeys.SAFE_v2__addressBook,
+          JSON.stringify(ls.addressBookData.sepoliaAddress1),
+        )
+      },
+    })
   })
 
   it('[VISUAL] Screenshot address book page with entries', () => {

--- a/apps/web/cypress/e2e/visual/batch_tx.cy.js
+++ b/apps/web/cypress/e2e/visual/batch_tx.cy.js
@@ -27,10 +27,12 @@ describe(
     })
 
     it('[VISUAL] Screenshot batch list with transaction', () => {
-      main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__batch, ls.batchData.entry1)
-      cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_2)
+      cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_2, {
+        onBeforeLoad(win) {
+          win.localStorage.setItem(constants.localStorageKeys.SAFE_v2__batch, JSON.stringify(ls.batchData.entry1))
+        },
+      })
       main.awaitVisualStability()
-      cy.reload()
       batch.clickOnBatchCounter()
       main.awaitVisualStability()
     })

--- a/apps/web/cypress/e2e/visual/create_tx_flow.cy.js
+++ b/apps/web/cypress/e2e/visual/create_tx_flow.cy.js
@@ -20,8 +20,7 @@ describe(
 
     beforeEach(() => {
       mockVisualTestApis()
-      cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_10)
-      wallet.connectSigner(signer)
+      wallet.connectSignerViaStorage(signer, constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_10)
       createtx.clickOnNewtransactionBtn()
       createtx.clickOnSendTokensBtn()
       main.awaitVisualStability()

--- a/apps/web/cypress/e2e/visual/owner_management.cy.js
+++ b/apps/web/cypress/e2e/visual/owner_management.cy.js
@@ -20,8 +20,7 @@ describe(
 
     beforeEach(() => {
       mockVisualTestApis()
-      cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
-      wallet.connectSigner(signer)
+      wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
       main.awaitVisualStability()
     })
 

--- a/apps/web/cypress/e2e/visual/sidebar.cy.js
+++ b/apps/web/cypress/e2e/visual/sidebar.cy.js
@@ -17,13 +17,18 @@ describe('[VISUAL] Sidebar screenshots', { defaultCommandTimeout: 60000, ...cons
   })
 
   it('[VISUAL] Screenshot sidebar with multichain safes expanded', () => {
-    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
-    main.addToAppLocalStorage(
-      constants.localStorageKeys.SAFE_v2__addedSafes,
-      ls.addedSafes.sidebarTrustedSafe3TwoChains,
-    )
-    main.addToAppLocalStorage(constants.localStorageKeys.SAFE_v2__undeployedSafes, ls.undeployedSafe.safes2)
-    cy.reload()
+    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9, {
+      onBeforeLoad(win) {
+        win.localStorage.setItem(
+          constants.localStorageKeys.SAFE_v2__addedSafes,
+          JSON.stringify(ls.addedSafes.sidebarTrustedSafe3TwoChains),
+        )
+        win.localStorage.setItem(
+          constants.localStorageKeys.SAFE_v2__undeployedSafes,
+          JSON.stringify(ls.undeployedSafe.safes2),
+        )
+      },
+    })
 
     sideBar.openSidebar()
     sideBar.searchSafe(sideBar.sideBarSafes.multichain_short_)

--- a/apps/web/cypress/e2e/visual/spending_limits.cy.js
+++ b/apps/web/cypress/e2e/visual/spending_limits.cy.js
@@ -18,8 +18,7 @@ describe('[VISUAL] Spending limits screenshots', { defaultCommandTimeout: 60000,
 
   beforeEach(() => {
     mockVisualTestApis()
-    cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_8)
-    wallet.connectSigner(signer)
+    wallet.connectSignerViaStorage(signer, constants.setupUrl + staticSafes.SEP_STATIC_SAFE_8)
     owner.waitForConnectionStatus()
     spendinglimit.clickOnNewSpendingLimitBtn()
     main.awaitVisualStability()

--- a/apps/web/cypress/support/constants.js
+++ b/apps/web/cypress/support/constants.js
@@ -323,8 +323,10 @@ export const localStorageKeys = {
   SAFE_v2__pendingCfDeletes: 'SAFE_v2__pendingCfDeletes',
   SAFE_v2__visitedSafes: 'SAFE_v2__visitedSafes',
   SAFE_v2__auth: 'SAFE_v2__auth',
+  SAFE_v2__lastWallet: 'SAFE_v2__lastWallet',
 }
 
 export const sessionStorageKeys = {
   SAFE_v2__classicViewEnabled: 'SAFE_v2__classicViewEnabled',
+  SAFE_v2__privateKeyModulePK: 'SAFE_v2__privateKeyModulePK',
 }

--- a/apps/web/cypress/support/utils/wallet.js
+++ b/apps/web/cypress/support/utils/wallet.js
@@ -97,15 +97,23 @@ export function connectSigner(signer) {
  *
  * @param {string} signer - Private key of the signer to connect.
  * @param {string} [url] - URL to visit; omit to seed the current window and reload.
- * @param {object} [visitOptions] - Extra cy.visit options; its onBeforeLoad runs after seeding.
+ * @param {object} [options] - Extra cy.visit options; its onBeforeLoad runs after seeding.
+ * @param {Record<string, unknown>} [options.extraStorage] - localStorage entries to seed in
+ *   onBeforeLoad (values are JSON-stringified). Use to pre-seed persisted state (e.g. a batch)
+ *   on the single load, replacing a later addToLocalStorage + cy.reload().
  */
-export function connectSignerViaStorage(signer, url, visitOptions = {}) {
+export function connectSignerViaStorage(signer, url, { extraStorage, ...visitOptions } = {}) {
   const seed = (win) => {
     win.localStorage.setItem(constants.localStorageKeys.SAFE_v2__lastWallet, JSON.stringify(PRIVATE_KEY_MODULE_LABEL))
     win.sessionStorage.setItem(
       constants.sessionStorageKeys.SAFE_v2__privateKeyModulePK,
       JSON.stringify({ isOpen: false, privateKey: signer }),
     )
+    if (extraStorage) {
+      Object.entries(extraStorage).forEach(([key, value]) => {
+        win.localStorage.setItem(key, JSON.stringify(value))
+      })
+    }
   }
 
   if (url) {

--- a/apps/web/cypress/support/utils/wallet.js
+++ b/apps/web/cypress/support/utils/wallet.js
@@ -101,8 +101,11 @@ export function connectSigner(signer) {
  * @param {Record<string, unknown>} [options.extraStorage] - localStorage entries to seed in
  *   onBeforeLoad (values are JSON-stringified). Use to pre-seed persisted state (e.g. a batch)
  *   on the single load, replacing a later addToLocalStorage + cy.reload().
+ * @param {boolean} [options.waitForConnection=true] - Wait for the connected-wallet header chip
+ *   before resolving. The wallet reconnects asynchronously after load, so proceeding immediately
+ *   can race the connection. Set false on pages that don't render that chip (e.g. welcome/accounts).
  */
-export function connectSignerViaStorage(signer, url, { extraStorage, ...visitOptions } = {}) {
+export function connectSignerViaStorage(signer, url, { extraStorage, waitForConnection = true, ...visitOptions } = {}) {
   const seed = (win) => {
     win.localStorage.setItem(constants.localStorageKeys.SAFE_v2__lastWallet, JSON.stringify(PRIVATE_KEY_MODULE_LABEL))
     win.sessionStorage.setItem(
@@ -117,15 +120,22 @@ export function connectSignerViaStorage(signer, url, { extraStorage, ...visitOpt
   }
 
   if (url) {
-    return cy.visit(url, {
+    cy.visit(url, {
       ...visitOptions,
       onBeforeLoad(win) {
         seed(win)
         visitOptions.onBeforeLoad?.(win)
       },
     })
+  } else {
+    cy.window().then(seed)
+    cy.reload()
   }
 
-  cy.window().then(seed)
-  return cy.reload()
+  // The last wallet reconnects asynchronously after the page loads (useOnboard ->
+  // connectLastWallet), so wait for the header's connected-wallet chip before proceeding;
+  // otherwise the test can act while the wallet is still (briefly) disconnected.
+  if (waitForConnection) {
+    cy.get('[data-testid="open-account-center"]', { timeout: 30000 }).should('exist')
+  }
 }

--- a/apps/web/cypress/support/utils/wallet.js
+++ b/apps/web/cypress/support/utils/wallet.js
@@ -1,4 +1,6 @@
 import * as main from '../../e2e/pages/main.page'
+import * as constants from '../constants'
+import { PRIVATE_KEY_MODULE_LABEL } from '../../../src/services/private-key-module/constants'
 
 const onboardv2 = 'onboard-v2'
 const pkInput = '[data-testid="private-key-input"]'
@@ -76,4 +78,46 @@ export function connectSigner(signer) {
   enterPrivateKey().then(() => {
     main.closeOutreachPopup()
   })
+}
+
+/**
+ * Connects the private-key signer by seeding storage, so the app auto-reconnects without opening
+ * the connect-wallet modal. Skips the slow UI flow of connectSigner().
+ *
+ * The app reconnects the last wallet on startup (useOnboard -> connectLastWallet): it reads the
+ * wallet label from localStorage and the key from sessionStorage, and connects silently because
+ * isWalletUnlocked() returns true for the private-key module. Both slots must exist before app JS
+ * runs on the load that connects.
+ *
+ * Two modes:
+ * - With `url`: seeds in onBeforeLoad and visits (single load, fastest). Use to replace an adjacent
+ *   `cy.visit(url)` + `connectSigner(signer)`.
+ * - Without `url`: seeds the already-loaded window and reloads. Use when the visit happened earlier
+ *   (e.g. in beforeEach) and only the connect is in the test body.
+ *
+ * @param {string} signer - Private key of the signer to connect.
+ * @param {string} [url] - URL to visit; omit to seed the current window and reload.
+ * @param {object} [visitOptions] - Extra cy.visit options; its onBeforeLoad runs after seeding.
+ */
+export function connectSignerViaStorage(signer, url, visitOptions = {}) {
+  const seed = (win) => {
+    win.localStorage.setItem(constants.localStorageKeys.SAFE_v2__lastWallet, JSON.stringify(PRIVATE_KEY_MODULE_LABEL))
+    win.sessionStorage.setItem(
+      constants.sessionStorageKeys.SAFE_v2__privateKeyModulePK,
+      JSON.stringify({ isOpen: false, privateKey: signer }),
+    )
+  }
+
+  if (url) {
+    return cy.visit(url, {
+      ...visitOptions,
+      onBeforeLoad(win) {
+        seed(win)
+        visitOptions.onBeforeLoad?.(win)
+      },
+    })
+  }
+
+  cy.window().then(seed)
+  return cy.reload()
 }

--- a/apps/web/cypress/support/utils/wallet.js
+++ b/apps/web/cypress/support/utils/wallet.js
@@ -136,6 +136,6 @@ export function connectSignerViaStorage(signer, url, { extraStorage, waitForConn
   // connectLastWallet), so wait for the header's connected-wallet chip before proceeding;
   // otherwise the test can act while the wallet is still (briefly) disconnected.
   if (waitForConnection) {
-    cy.get('[data-testid="open-account-center"]', { timeout: 30000 }).should('exist')
+    cy.get('[data-testid="open-account-center"]').should('exist')
   }
 }

--- a/apps/web/cypress/support/utils/wallet.js
+++ b/apps/web/cypress/support/utils/wallet.js
@@ -133,9 +133,9 @@ export function connectSignerViaStorage(signer, url, { extraStorage, waitForConn
   }
 
   // The last wallet reconnects asynchronously after the page loads (useOnboard ->
-  // connectLastWallet), so wait for the header's connected-wallet chip before proceeding;
-  // otherwise the test can act while the wallet is still (briefly) disconnected.
+  // connectLastWallet), so wait for the header's connected-wallet chip to be visible before
+  // proceeding; otherwise the test can act while the wallet is still (briefly) disconnected.
   if (waitForConnection) {
-    cy.get('[data-testid="open-account-center"]').should('exist')
+    cy.get('[data-testid="open-account-center"]').should('be.visible')
   }
 }


### PR DESCRIPTION
## What it solves

Nearly every Cypress test connected the signer through the full connect-wallet UI — open the Onboard modal, pick "Private key", type the key, wait. That's ~7s of mostly hardcoded `cy.wait` per connect and the flakiest part of the suite.

Resolves: N/A (no Linear ticket)

## How this PR fixes it

The app already auto-reconnects the last wallet on startup (`useOnboard → connectLastWallet`): it reads the wallet label from `localStorage` and the key from `sessionStorage`, and connects silently because `isWalletUnlocked()` returns `true` for the private-key module. New `connectSignerViaStorage(signer, url?)` seeds both slots **before app JS runs** (via `cy.visit`'s `onBeforeLoad`, or seed + `cy.reload()` when the visit already happened), so no modal is ever opened.

Gotchas / non-obvious decisions:

- **27 sites intentionally keep the UI `connectSigner`** — mid-flow signer switches (disconnect → reconnect a *different* signer → act on an already-open dialog, e.g. `switchToSignerAndConfirm`, `recovery`, `tx_queue_*`) can't use seeding: it needs a reload/re-visit that would destroy the in-page state. These *are* the connect/switch-wallet flow, incl. the `create_safe_simple_3` "Verify a Wallet can be connected" test.
- **Net saving is ~5s per connect, not 7s.** The app still needs ~1.3–2s after page load to lazily initialise the web3 stack (`LazyWeb3Init` is `next/dynamic({ ssr: false })` followed by a sequential dynamic-import waterfall). That latency existed with the old flow too — this PR only removes the artificial `cy.wait`s layered on top. There is no `setTimeout`/sleep in the connect path.

## How to test it

1. Set `CYPRESS_WALLET_CREDENTIALS` and serve the web app.
2. Run the three specs that exercise every code path:
   ```
   yarn workspace @safe-global/web cypress:run --spec "cypress/e2e/regression/batch_tx.cy.js,cypress/e2e/smoke/add_owner.cy.js,cypress/e2e/regression/recovery.cy.js"
   ```
   `batch_tx` (visit-merge + kept switch), `add_owner` (reload path), `recovery` (switch-heavy).
3. Confirm each connects (owner-gated UI becomes enabled) with the connect-wallet modal never appearing.

## Affected flows

- Cypress e2e **wallet connection setup** across `smoke/`, `regression/`, `happypath/`, `happypath_2/`, `visual/`, `safe-apps/`.

## Blast radius

- `support/utils/wallet.js` (`connectSignerViaStorage`), `support/constants.js` (two storage keys) — **test-only; no app/runtime code changed**.
- 3 shared page objects (`create_tx.pages.js`, `create_wallet.pages.js`, `copilot.js`) — their connect helpers.
- 139 "entry" connects migrated to seeded storage; 27 connect/switch-flow connects kept on the UI flow.

## Risks / not checked

- Not run against the full suite in this environment (no `CYPRESS_WALLET_CREDENTIALS`). Mechanism verified with a throwaway key against the running app; the three representative specs above should confirm in CI.
- Switch-site detection is a conservative heuristic (disconnect within 6 lines above). Kept sites are always safe (original behaviour); the 6 borderline reload migrations were manually confirmed to be *previous-`it`* cleanup, not mid-flow switches.
- No mobile impact (web e2e only).

## Visual summary

```mermaid
flowchart LR
  subgraph Before["Before — UI modal flow (~7s of cy.wait)"]
    direction TB
    A1[cy.visit] --> B1[click Connect wallet]
    B1 --> C1[select Private key in Onboard modal]
    C1 --> D1[type key + connect]
    D1 --> E1[cy.wait 3s + 2s + 2s]
  end
  subgraph After["After — seeded storage (~2s: app web3 init only)"]
    direction TB
    A2["connectSignerViaStorage seeds<br/>localStorage.lastWallet +<br/>sessionStorage.privateKeyModulePK"] --> B2[cy.visit onBeforeLoad / cy.reload]
    B2 --> C2["app auto-reconnects on load<br/>(useOnboard → connectLastWallet)"]
  end
  Before -.->|"~5s saved per connect"| After
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
