### PR TITLE
fix(web): only offer L2 migration for official mastercopies (WA-2906)

### DIFF
--- a/apps/web/src/features/multichain/components/UnsupportedMastercopyWarning/UnsupportedMasterCopyWarning.tsx
+++ b/apps/web/src/features/multichain/components/UnsupportedMastercopyWarning/UnsupportedMasterCopyWarning.tsx
@@ -29,10 +29,9 @@ export const UnsupportedMastercopyWarning = () => {
 
   if (!showWarning) return null
 
-  // Check if migration is possible based on bytecode comparison
-  const canMigrate =
-    canMigrateUnsupportedMastercopy(safe, bytecodeComparison.result) ||
-    (!isValidMasterCopy(safe.implementationVersionState) && isMigrationToL2Possible(safe))
+  // Migration is offered when the bytecode matches an official L2 singleton
+  // or the Safe runs an official singleton of the wrong chain flavour
+  const canMigrate = canMigrateUnsupportedMastercopy(safe, bytecodeComparison.result) || isMigrationToL2Possible(safe)
 
   return (
     <ActionCard

--- a/apps/web/src/features/security/data/scanners/contractVersion.ts
+++ b/apps/web/src/features/security/data/scanners/contractVersion.ts
@@ -45,7 +45,11 @@ export const contractVersionScanner: SecurityScanner = {
 
     // Unsupported mastercopy — same check as UnsupportedMastercopyWarning
     if (!isValidMasterCopy(implementationVersionState)) {
-      const canMigrateL2 = isMigrationToL2Possible({ version, chainId })
+      const canMigrateL2 = isMigrationToL2Possible({
+        version,
+        chainId,
+        implementation: { value: implementationAddress },
+      })
 
       const score = 10
       return {

--- a/packages/utils/src/services/contracts/__tests__/safeContracts.test.ts
+++ b/packages/utils/src/services/contracts/__tests__/safeContracts.test.ts
@@ -75,31 +75,68 @@ describe('safeContracts', () => {
   })
 
   describe('isMigrationToL2Possible', () => {
+    // Official canonical singleton addresses from safe-deployments
+    const SINGLETON_130_L1 = '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552'
+    const SINGLETON_130_L2 = '0x3E5c63644E683549055b9Be8653de26E0B4CD36E'
+    const SINGLETON_141_L1 = '0x41675C099F32341bf84BFc5382aF534df5C7461a'
+
     const createMockSafe = (overrides?: Partial<SafeState>): SafeState =>
       ({
         nonce: 0,
         chainId: '1',
         version: '1.3.0',
         address: { value: '0x123' },
+        implementation: { value: SINGLETON_130_L1 },
         ...overrides,
       }) as SafeState
 
-    it('should return true for a 1.3.0 Safe with nonce > 0 (migration does not depend on nonce)', () => {
+    it('should return true for a 1.3.0 Safe on the official L1 singleton with nonce > 0 (migration does not depend on nonce)', () => {
       const safe = createMockSafe({ nonce: 5, version: '1.3.0' })
 
       expect(isMigrationToL2Possible(safe)).toBe(true)
     })
 
-    it('should return true for a 1.4.1 Safe with nonce > 0', () => {
-      const safe = createMockSafe({ nonce: 12, version: '1.4.1' })
+    it('should return true for a 1.4.1 Safe on the official L1 singleton with nonce > 0', () => {
+      const safe = createMockSafe({ nonce: 12, version: '1.4.1', implementation: { value: SINGLETON_141_L1 } })
 
       expect(isMigrationToL2Possible(safe)).toBe(true)
     })
 
     it('should return true for versions with build metadata like 1.3.0+L2', () => {
-      const safe = createMockSafe({ nonce: 3, version: '1.3.0+L2' })
+      const safe = createMockSafe({ nonce: 3, version: '1.3.0+L2', implementation: { value: SINGLETON_130_L2 } })
 
       expect(isMigrationToL2Possible(safe)).toBe(true)
+    })
+
+    it('should return false for forks that self-report a supported version but use an unofficial mastercopy', () => {
+      // Third-party forks of the Safe contracts return an official-looking
+      // VERSION() (e.g. 1.3.0) while running modified code at an address that
+      // is not part of any official deployment
+      const safe = createMockSafe({
+        nonce: 4,
+        chainId: '137',
+        version: '1.3.0',
+        implementation: { value: '0x1111111111111111111111111111111111111111' },
+      })
+
+      expect(isMigrationToL2Possible(safe)).toBe(false)
+    })
+
+    it('should return false for unofficial mastercopies even at nonce 0 (pre-existing bug: the old nonce gate allowed them)', () => {
+      const safe = createMockSafe({
+        nonce: 0,
+        chainId: '137',
+        version: '1.3.0',
+        implementation: { value: '0x1111111111111111111111111111111111111111' },
+      })
+
+      expect(isMigrationToL2Possible(safe)).toBe(false)
+    })
+
+    it('should return false when the implementation address is missing', () => {
+      const safe = createMockSafe({ implementation: undefined })
+
+      expect(isMigrationToL2Possible(safe)).toBe(false)
     })
 
     it('should return false for versions not supported by the SafeMigration contract', () => {

--- a/packages/utils/src/services/contracts/__tests__/safeContracts.test.ts
+++ b/packages/utils/src/services/contracts/__tests__/safeContracts.test.ts
@@ -61,6 +61,25 @@ describe('safeContracts', () => {
       expect(typeof canMigrate).toBe('boolean')
     })
 
+    it('should return true for canonical bytecode matches but false for zksync matches', () => {
+      const safe = createMockSafe()
+
+      const canonicalMatch: BytecodeComparisonResult = {
+        isMatch: true,
+        matchedVersion: '1.3.0',
+        matchedDeploymentType: 'canonical',
+      }
+      expect(canMigrateUnsupportedMastercopy(safe, canonicalMatch)).toBe(true)
+
+      // EraVM bytecode cannot be migrated via the canonical SafeMigration flow
+      const zksyncMatch: BytecodeComparisonResult = {
+        isMatch: true,
+        matchedVersion: '1.3.0',
+        matchedDeploymentType: 'zksync',
+      }
+      expect(canMigrateUnsupportedMastercopy(safe, zksyncMatch)).toBe(false)
+    })
+
     it('should return true when all conditions are met', () => {
       const safe = createMockSafe()
       const result: BytecodeComparisonResult = { isMatch: true, matchedVersion: '1.3.0' }
@@ -137,6 +156,20 @@ describe('safeContracts', () => {
       const safe = createMockSafe({ implementation: undefined })
 
       expect(isMigrationToL2Possible(safe)).toBe(false)
+    })
+
+    it('should return false for official zksync-variant mastercopies (EraVM cannot execute the canonical migration)', () => {
+      const ZKSYNC_130_L1 = '0xB00ce5CCcdEf57e539ddcEd01DF43a13855d9910'
+      const ZKSYNC_130_L2 = '0x1727c2c531cf966f902E5927b98490fDFb3b2b70'
+
+      expect(
+        isMigrationToL2Possible(createMockSafe({ chainId: '324', implementation: { value: ZKSYNC_130_L1 } })),
+      ).toBe(false)
+      expect(
+        isMigrationToL2Possible(
+          createMockSafe({ chainId: '324', version: '1.3.0+L2', implementation: { value: ZKSYNC_130_L2 } }),
+        ),
+      ).toBe(false)
     })
 
     it('should return false for versions not supported by the SafeMigration contract', () => {

--- a/packages/utils/src/services/contracts/bytecodeComparison.ts
+++ b/packages/utils/src/services/contracts/bytecodeComparison.ts
@@ -1,6 +1,7 @@
 import { getSafeL2SingletonDeployments } from '@safe-global/safe-deployments'
 import type { SafeVersion } from '@safe-global/types-kit'
 import { keccak256 } from 'ethers'
+import type { DeploymentType } from './deployments'
 
 /**
  * Supported L2 versions for bytecode comparison and migration
@@ -13,6 +14,7 @@ const SUPPORTED_L2_VERSIONS: SafeVersion[] = ['1.3.0', '1.4.1']
 export type BytecodeComparisonResult = {
   isMatch: boolean
   matchedVersion?: SafeVersion
+  matchedDeploymentType?: DeploymentType
 }
 
 /**
@@ -45,12 +47,12 @@ export const compareWithSupportedL2Contracts = async (
     }
 
     // Compare bytecode hash with all deployment variants (canonical, eip155, zksync)
-    const deploymentVariants = Object.values(deployment.deployments)
-    for (const variant of deploymentVariants) {
+    for (const [deploymentType, variant] of Object.entries(deployment.deployments)) {
       if (variant.codeHash === bytecodeHash) {
         return {
           isMatch: true,
           matchedVersion: version,
+          matchedDeploymentType: deploymentType as DeploymentType,
         }
       }
     }

--- a/packages/utils/src/services/contracts/deployments.ts
+++ b/packages/utils/src/services/contracts/deployments.ts
@@ -387,28 +387,6 @@ export type MasterCopyFlavour = {
  * fix would require bytecode inspection (already done in the `!isValidMasterCopy`
  * branch of initSafeSDK) but that adds an RPC round-trip to the happy path.
  */
-/**
- * Checks whether an implementation address is an official Safe singleton
- * deployment (L1 or L2 flavour, any deployment variant) for the given version.
- * The match is address-based and chain-agnostic: official singletons are
- * deployed deterministically, so the address alone identifies the contract.
- * Forks that self-report an official VERSION() do not pass this check.
- * Build metadata in the version (`+L2`, `+Circles`) is ignored.
- */
-export const isOfficialMasterCopy = (implementation: string | undefined, version: string): boolean => {
-  if (!implementation) return false
-  const [cleanVersion] = version.split('+')
-
-  for (const getter of [getSafeSingletonDeployments, getSafeL2SingletonDeployments]) {
-    const deployment = getter({ version: cleanVersion })
-    if (!deployment?.deployments) continue
-    for (const variant of Object.values(deployment.deployments)) {
-      if (variant?.address && sameAddress(implementation, variant.address)) return true
-    }
-  }
-  return false
-}
-
 export const getDeploymentTypeForMasterCopy = (
   implementation: string | undefined,
   version: string,
@@ -438,6 +416,28 @@ export const getDeploymentTypeForMasterCopy = (
   }
 
   return defaults
+}
+
+/**
+ * Checks whether an implementation address is an official Safe singleton
+ * deployment (L1 or L2 flavour, any deployment variant) for the given version.
+ * The match is address-based and chain-agnostic: official singletons are
+ * deployed deterministically, so the address alone identifies the contract.
+ * Forks that self-report an official VERSION() do not pass this check.
+ * Build metadata in the version (`+L2`, `+Circles`) is ignored.
+ */
+export const isOfficialMasterCopy = (implementation: string | undefined, version: string): boolean => {
+  if (!implementation) return false
+  const [cleanVersion] = version.split('+')
+
+  for (const getter of [getSafeSingletonDeployments, getSafeL2SingletonDeployments]) {
+    const deployment = getter({ version: cleanVersion })
+    if (!deployment?.deployments) continue
+    for (const variant of Object.values(deployment.deployments)) {
+      if (variant?.address && sameAddress(implementation, variant.address)) return true
+    }
+  }
+  return false
 }
 
 export const resolveChainAgnosticContractAddresses = (

--- a/packages/utils/src/services/contracts/deployments.ts
+++ b/packages/utils/src/services/contracts/deployments.ts
@@ -419,25 +419,31 @@ export const getDeploymentTypeForMasterCopy = (
 }
 
 /**
- * Checks whether an implementation address is an official Safe singleton
- * deployment (L1 or L2 flavour, any deployment variant) for the given version.
+ * Returns the deployment type of an implementation address if it is an
+ * official Safe singleton deployment (L1 or L2 flavour) for the given
+ * version, or `null` when the address is not an official deployment.
  * The match is address-based and chain-agnostic: official singletons are
  * deployed deterministically, so the address alone identifies the contract.
- * Forks that self-report an official VERSION() do not pass this check.
+ * Forks that self-report an official VERSION() do not match.
  * Build metadata in the version (`+L2`, `+Circles`) is ignored.
  */
-export const isOfficialMasterCopy = (implementation: string | undefined, version: string): boolean => {
-  if (!implementation) return false
+export const getOfficialMasterCopyDeploymentType = (
+  implementation: string | undefined,
+  version: string,
+): DeploymentType | null => {
+  if (!implementation) return null
   const [cleanVersion] = version.split('+')
 
   for (const getter of [getSafeSingletonDeployments, getSafeL2SingletonDeployments]) {
     const deployment = getter({ version: cleanVersion })
     if (!deployment?.deployments) continue
-    for (const variant of Object.values(deployment.deployments)) {
-      if (variant?.address && sameAddress(implementation, variant.address)) return true
+    for (const [deploymentType, variant] of Object.entries(deployment.deployments)) {
+      if (variant?.address && sameAddress(implementation, variant.address)) {
+        return deploymentType as DeploymentType
+      }
     }
   }
-  return false
+  return null
 }
 
 export const resolveChainAgnosticContractAddresses = (

--- a/packages/utils/src/services/contracts/deployments.ts
+++ b/packages/utils/src/services/contracts/deployments.ts
@@ -387,6 +387,28 @@ export type MasterCopyFlavour = {
  * fix would require bytecode inspection (already done in the `!isValidMasterCopy`
  * branch of initSafeSDK) but that adds an RPC round-trip to the happy path.
  */
+/**
+ * Checks whether an implementation address is an official Safe singleton
+ * deployment (L1 or L2 flavour, any deployment variant) for the given version.
+ * The match is address-based and chain-agnostic: official singletons are
+ * deployed deterministically, so the address alone identifies the contract.
+ * Forks that self-report an official VERSION() do not pass this check.
+ * Build metadata in the version (`+L2`, `+Circles`) is ignored.
+ */
+export const isOfficialMasterCopy = (implementation: string | undefined, version: string): boolean => {
+  if (!implementation) return false
+  const [cleanVersion] = version.split('+')
+
+  for (const getter of [getSafeSingletonDeployments, getSafeL2SingletonDeployments]) {
+    const deployment = getter({ version: cleanVersion })
+    if (!deployment?.deployments) continue
+    for (const variant of Object.values(deployment.deployments)) {
+      if (variant?.address && sameAddress(implementation, variant.address)) return true
+    }
+  }
+  return false
+}
+
 export const getDeploymentTypeForMasterCopy = (
   implementation: string | undefined,
   version: string,

--- a/packages/utils/src/services/contracts/safeContracts.ts
+++ b/packages/utils/src/services/contracts/safeContracts.ts
@@ -4,7 +4,7 @@ import type { SafeVersion } from '@safe-global/types-kit'
 import { assertValidSafeVersion } from '@safe-global/utils/services/contracts/utils'
 import { getSafeMigrationDeployments } from '@safe-global/safe-deployments'
 import { SAFE_TO_L2_MIGRATION_VERSION } from '@safe-global/utils/config/constants'
-import { getChainAgnosticAddress } from '@safe-global/utils/services/contracts/deployments'
+import { getChainAgnosticAddress, isOfficialMasterCopy } from '@safe-global/utils/services/contracts/deployments'
 import { isSupportedL2Version, type BytecodeComparisonResult } from './bytecodeComparison'
 
 // `UNKNOWN` is returned if the mastercopy does not match supported ones
@@ -60,9 +60,18 @@ export const _getValidatedGetContractProps = (
  * 1.3.0 and 1.4.1 Safes and does not depend on the Safe's nonce.
  * Only the base version is matched — build metadata such as `+L2` or
  * `+Circles` is ignored.
+ *
+ * The implementation must be an official Safe singleton address: the reported
+ * version comes from the contract's own VERSION() and is also returned by
+ * third-party forks, for which a blind singleton swap is unsafe.
+ * Byte-identical redeployments at unofficial addresses are covered separately
+ * by the bytecode comparison in `canMigrateUnsupportedMastercopy`.
  */
-export const isMigrationToL2Possible = (safe: Pick<SafeState, 'version' | 'chainId'>): boolean => {
+export const isMigrationToL2Possible = (safe: Pick<SafeState, 'version' | 'chainId' | 'implementation'>): boolean => {
   if (!safe.version || !isSupportedL2Version(safe.version)) {
+    return false
+  }
+  if (!isOfficialMasterCopy(safe.implementation?.value, safe.version)) {
     return false
   }
   const deployment = getSafeMigrationDeployments({ version: SAFE_TO_L2_MIGRATION_VERSION })

--- a/packages/utils/src/services/contracts/safeContracts.ts
+++ b/packages/utils/src/services/contracts/safeContracts.ts
@@ -4,7 +4,10 @@ import type { SafeVersion } from '@safe-global/types-kit'
 import { assertValidSafeVersion } from '@safe-global/utils/services/contracts/utils'
 import { getSafeMigrationDeployments } from '@safe-global/safe-deployments'
 import { SAFE_TO_L2_MIGRATION_VERSION } from '@safe-global/utils/config/constants'
-import { getChainAgnosticAddress, isOfficialMasterCopy } from '@safe-global/utils/services/contracts/deployments'
+import {
+  getChainAgnosticAddress,
+  getOfficialMasterCopyDeploymentType,
+} from '@safe-global/utils/services/contracts/deployments'
 import { isSupportedL2Version, type BytecodeComparisonResult } from './bytecodeComparison'
 
 // `UNKNOWN` is returned if the mastercopy does not match supported ones
@@ -33,6 +36,11 @@ export const canMigrateUnsupportedMastercopy = (
 
   // Must have bytecode comparison result with a match
   if (!bytecodeComparisonResult || !bytecodeComparisonResult.isMatch) {
+    return false
+  }
+
+  // zksync (EraVM) bytecode matches cannot use the canonical SafeMigration flow
+  if (bytecodeComparisonResult.matchedDeploymentType === 'zksync') {
     return false
   }
 
@@ -71,7 +79,10 @@ export const isMigrationToL2Possible = (safe: Pick<SafeState, 'version' | 'chain
   if (!safe.version || !isSupportedL2Version(safe.version)) {
     return false
   }
-  if (!isOfficialMasterCopy(safe.implementation?.value, safe.version)) {
+  // Must be an official singleton, and not the zksync variant: EraVM chains
+  // cannot execute the canonical SafeMigration flow this migration builds
+  const deploymentType = getOfficialMasterCopyDeploymentType(safe.implementation?.value, safe.version)
+  if (deploymentType === null || deploymentType === 'zksync') {
     return false
   }
   const deployment = getSafeMigrationDeployments({ version: SAFE_TO_L2_MIGRATION_VERSION })


### PR DESCRIPTION
## What it solves

Resolves: [WA-2906](https://linear.app/safe-global/issue/WA-2906/migration-banner-shown-for-unofficial-mastercopies) (follow-up to WA-1685; QA regression found on RC v1.96.0)

The in-app **Migrate** prompt was shown for Safes running third-party forks of the Safe contracts. `isMigrationToL2Possible` gated on the reported Safe version, but that version comes from the contract's own `VERSION()` — forks running modified code report it too. It also closes a pre-existing hole: the old `nonce === 0` gate offered migration to unofficial mastercopies that hadn't executed a transaction yet.

Executing `SafeMigration.migrateL2Singleton` against unknown code is unsafe: it blindly swaps the singleton pointer without any on-chain check, so incompatible storage layouts or custom fork logic can break or brick the Safe, irreversibly. Such Safes must stay on the CLI (manual review) path.

## How this PR fixes it

`isMigrationToL2Possible` now additionally requires the implementation to be an **official Safe singleton address** — new `isOfficialMasterCopy` helper matching against safe-deployments (L1 + L2 flavour, canonical/eip155/zksync variants, chain-agnostic, released only). Migration is offered only for:

- an official singleton of the wrong chain flavour (e.g. L1 singleton on an L2 chain), any nonce — the WA-1685 case, or
- byte-identical redeployments at unofficial addresses (existing bytecode comparison, unchanged)

Also removes the always-true `!isValidMasterCopy &&` clause from the banner's `canMigrate` expression (the component returns early on valid mastercopies) — behavior-neutral readability fix.

## How to test it

1. Unit specs: `packages/utils` → `yarn jest src/services/contracts/__tests__/safeContracts.test.ts` (17 cases, incl. fork-with-official-version at nonce 0 and nonce > 0 → CLI).
2. Open the QA regression Safe from the WA-2906/WA-1685 threads (unofficial mastercopy, self-reported 1.3.0) → dashboard and Settings → Security show **Use CLI** again.
3. Open a Safe on the official 1.3.0/1.4.1 **L1** singleton on an L2 chain (see WA-1685) → still shows **Migrate**.
4. A supported Safe shows no banner.

## Affected flows

- Owner of an unsupported-mastercopy Safe sees Migrate vs Use CLI decided by mastercopy officiality (dashboard banner, Settings → Security scanner, unknown-contract transaction error)
- Mobile Settings unsupported-mastercopy alert (shared helper)

## Blast radius

- `isMigrationToL2Possible` (packages/utils) — 4 consumers: web `UnsupportedMastercopyWarning`, Security Hub `contractVersion` scanner, `UnknownContractError`, mobile `Settings.container`. All become stricter: unofficial mastercopies no longer offered migration at any nonce.
- New `isOfficialMasterCopy` in `packages/utils/services/contracts/deployments.ts` — pure function over safe-deployments data, no RPC.
- No API/RTK-Query contract, feature flag, or backend changes (CGW `UNKNOWN` semantics untouched).

## Risks / not checked

- Did not execute a migration on-chain; verified to the eligibility decision + unit specs.
- Mobile behavior change inferred from the shared helper (typecheck passes); not tested on device.
- The official-address match is chain-agnostic by design (official singletons are deterministic deployments); a chain hosting different code at an official address is considered infeasible.

## Visual summary

```mermaid
flowchart TD
    A[mastercopy UNKNOWN] --> B{bytecode == official L2?}
    B -- yes --> M[Migrate]
    B -- no --> C{version 1.3.0 / 1.4.1?}
    C -- no --> CLI[Use CLI]
    C -- yes --> D{implementation address in<br/>safe-deployments? ← NEW}
    D -- "yes (official, wrong flavour)" --> M
    D -- "no (third-party fork)" --> CLI
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no event changes; `MIGRATE_MASTERCOPY`/`GET_CLI_MASTERCOPY` volumes shift toward CLI for forks
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).