### PR TITLE
fix(web): surface address-poisoning flags on trusted rows in onboarding Select Safe accounts [WA-2912]

### DIFF
--- a/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
@@ -129,7 +129,7 @@ const SpaceSafeAccounts = () => {
           No Safe accounts match your search
         </Typography>
       ) : (
-        <>
+        <div className="flex flex-col gap-4">
           {similarAddresses.size > 0 && <SimilarAddressAlert />}
           <SafeAccountsTable
             items={visibleSafes}
@@ -147,7 +147,7 @@ const SpaceSafeAccounts = () => {
                 : undefined
             }
           />
-        </>
+        </div>
       )}
     </>
   )

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/__tests__/SelectSafesOnboarding.test.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/__tests__/SelectSafesOnboarding.test.tsx
@@ -43,14 +43,14 @@ jest.mock('../hooks/useOnboardingNavigation', () => ({
 
 let mockTrustedSafes: AllSafeItems = []
 let mockOwnedSafes: AllSafeItems = []
-let mockFlaggedOwned = new Set<string>()
+let mockFlagged = new Set<string>()
 
 jest.mock('../hooks/useOnboardingSafes', () => ({
   __esModule: true,
   default: () => ({
     trustedSafes: mockTrustedSafes,
     ownedSafes: mockOwnedSafes,
-    flaggedOwnedAddresses: mockFlaggedOwned,
+    flaggedAddresses: mockFlagged,
     handleSearch: jest.fn(),
     hasNoSafes: false,
   }),
@@ -97,7 +97,7 @@ describe('SelectSafesOnboarding — selection wiring', () => {
     capturedListProps = {}
     mockTrustedSafes = [makeSafe('1', '0xA')] as AllSafeItems
     mockOwnedSafes = []
-    mockFlaggedOwned = new Set<string>()
+    mockFlagged = new Set<string>()
     mockWalletValue = { address: '0xWallet' }
   })
 
@@ -111,13 +111,13 @@ describe('SelectSafesOnboarding — selection wiring', () => {
 
   it('passes the selection model (not select-all toggles) to OnboardingSafesList', () => {
     mockOwnedSafes = [makeSafe('10', '0xB')] as AllSafeItems
-    mockFlaggedOwned = new Set(['0xb'])
+    mockFlagged = new Set(['0xb'])
     render(<SelectSafesOnboarding />)
 
     expect(capturedListProps.selectedKeys).toBeInstanceOf(Set)
     expect(typeof capturedListProps.onToggle).toBe('function')
     expect(capturedListProps.isAtLimit).toBe(false)
-    expect(capturedListProps.flaggedOwnedAddresses).toBe(mockFlaggedOwned)
+    expect(capturedListProps.flaggedAddresses).toBe(mockFlagged)
     expect(capturedListProps.trustedSelectAll).toBeUndefined()
     expect(capturedListProps.ownedSelectAll).toBeUndefined()
   })
@@ -138,7 +138,7 @@ describe('SelectSafesOnboarding — wallet connection state', () => {
     capturedListProps = {}
     mockTrustedSafes = [makeSafe('1', '0xA')] as AllSafeItems
     mockOwnedSafes = []
-    mockFlaggedOwned = new Set<string>()
+    mockFlagged = new Set<string>()
     mockWalletValue = { address: '0xWallet' }
   })
 
@@ -174,7 +174,7 @@ describe('SelectSafesOnboarding — step counter reflects the survey flag', () =
     capturedListProps = {}
     mockTrustedSafes = [makeSafe('1', '0xA')] as AllSafeItems
     mockOwnedSafes = []
-    mockFlaggedOwned = new Set<string>()
+    mockFlagged = new Set<string>()
     mockWalletValue = { address: '0xWallet' }
   })
 

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/OnboardingSafesList.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/OnboardingSafesList.tsx
@@ -8,8 +8,8 @@ const COLUMNS: SafeAccountColumnId[] = ['name', 'threshold', 'networks', 'balanc
 interface SafeListProps {
   trustedSafes: AllSafeItems
   ownedSafes: AllSafeItems
-  /** Lowercased owned addresses flagged as similar (address poisoning) — trusted rows are never flagged. */
-  flaggedOwnedAddresses: Set<string>
+  /** Lowercased addresses flagged as look-alikes (address poisoning) — trusted and owned rows alike. */
+  flaggedAddresses: Set<string>
   selectedKeys: Set<string>
   onToggle: (line: AccountLine, nextChecked: boolean) => void
   isAtLimit: boolean
@@ -22,7 +22,7 @@ const SectionLabel = ({ children }: { children: ReactNode }) => (
 const OnboardingSafesList = ({
   trustedSafes,
   ownedSafes,
-  flaggedOwnedAddresses,
+  flaggedAddresses,
   selectedKeys,
   onToggle,
   isAtLimit,
@@ -31,12 +31,15 @@ const OnboardingSafesList = ({
 
   return (
     <div className="flex w-full min-w-0 flex-col gap-4">
+      {flaggedAddresses.size > 0 && <SecurityBanner title="Verify before you trust" />}
+
       {trustedSafes.length > 0 && (
         <div className="flex flex-col gap-2">
           <SectionLabel>My accounts</SectionLabel>
           <SafeAccountsTable
             items={trustedSafes}
             columns={COLUMNS}
+            flaggedAddresses={flaggedAddresses}
             selection={selection}
             data-testid="onboarding-trusted-table"
           />
@@ -46,11 +49,10 @@ const OnboardingSafesList = ({
       {ownedSafes.length > 0 && (
         <div className="flex flex-col gap-2">
           <SectionLabel>Owned safe accounts</SectionLabel>
-          {flaggedOwnedAddresses.size > 0 && <SecurityBanner title="Verify before you trust" />}
           <SafeAccountsTable
             items={ownedSafes}
             columns={COLUMNS}
-            flaggedAddresses={flaggedOwnedAddresses}
+            flaggedAddresses={flaggedAddresses}
             selection={selection}
             data-testid="onboarding-owned-table"
           />

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/__tests__/OnboardingSafesList.test.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/__tests__/OnboardingSafesList.test.tsx
@@ -41,7 +41,7 @@ const buildSafeItem = (address: string, chainId = '1'): SafeItem =>
 const noop = () => {}
 
 const baseProps = {
-  flaggedOwnedAddresses: new Set<string>(),
+  flaggedAddresses: new Set<string>(),
   selectedKeys: new Set<string>(),
   onToggle: noop,
   isAtLimit: false,
@@ -77,35 +77,46 @@ describe('OnboardingSafesList', () => {
     expect(getByTestId('onboarding-owned-table')).toHaveTextContent('0xOwned')
   })
 
-  it('flags only the owned table, never the trusted table', () => {
+  it('passes the flag set to both the trusted and owned tables', () => {
     const { getByTestId } = render(
       <OnboardingSafesList
         trustedSafes={[buildSafeItem('0xTrusted')]}
         ownedSafes={[buildSafeItem('0xOwned')]}
         {...baseProps}
-        flaggedOwnedAddresses={new Set(['0xowned'])}
+        flaggedAddresses={new Set(['0xtrusted', '0xowned'])}
       />,
     )
 
-    expect(getByTestId('onboarding-trusted-table').dataset.flagged).toBe('')
-    expect(getByTestId('onboarding-owned-table').dataset.flagged).toBe('0xowned')
+    expect(getByTestId('onboarding-trusted-table').dataset.flagged).toBe('0xtrusted,0xowned')
+    expect(getByTestId('onboarding-owned-table').dataset.flagged).toBe('0xtrusted,0xowned')
   })
 
-  it('shows the security banner only when an owned safe is flagged', () => {
-    const { queryByTestId, rerender } = render(
-      <OnboardingSafesList trustedSafes={[]} ownedSafes={[buildSafeItem('0xOwned')]} {...baseProps} />,
+  it('shows a single security banner above the sections when any row is flagged', () => {
+    const { queryByTestId, queryAllByTestId, rerender } = render(
+      <OnboardingSafesList
+        trustedSafes={[buildSafeItem('0xTrusted')]}
+        ownedSafes={[buildSafeItem('0xOwned')]}
+        {...baseProps}
+      />,
     )
     expect(queryByTestId('security-banner')).not.toBeInTheDocument()
 
+    // Flagging only a trusted row must surface the banner too (WA-2912).
     rerender(
       <OnboardingSafesList
-        trustedSafes={[]}
+        trustedSafes={[buildSafeItem('0xTrusted')]}
         ownedSafes={[buildSafeItem('0xOwned')]}
         {...baseProps}
-        flaggedOwnedAddresses={new Set(['0xowned'])}
+        flaggedAddresses={new Set(['0xtrusted'])}
       />,
     )
-    expect(queryByTestId('security-banner')).toBeInTheDocument()
+    expect(queryAllByTestId('security-banner')).toHaveLength(1)
+    // Rendered above both section tables
+    const banner = queryByTestId('security-banner')
+    const trustedTable = queryByTestId('onboarding-trusted-table')
+    expect(banner && trustedTable && banner.compareDocumentPosition(trustedTable)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    )
   })
 
   it('passes isAtLimit down to both tables', () => {

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/hooks/__tests__/useOnboardingSafes.test.ts
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/hooks/__tests__/useOnboardingSafes.test.ts
@@ -24,7 +24,7 @@ describe('useOnboardingSafes', () => {
 
     expect(result.current.trustedSafes).toEqual([])
     expect(result.current.ownedSafes).toEqual([])
-    expect(result.current.flaggedOwnedAddresses.size).toBe(0)
+    expect(result.current.flaggedAddresses.size).toBe(0)
   })
 
   it('returns trusted safes from addedSafes', () => {
@@ -125,14 +125,14 @@ describe('useOnboardingSafes', () => {
     expect('safes' in result.current.ownedSafes[0]).toBe(true)
   })
 
-  describe('similar address detection (owned safes only)', () => {
+  describe('similar address detection', () => {
     it('returns empty set when fewer than 2 unique addresses', () => {
       const mockOwned = { '1': ['0xSingle'] }
       jest.spyOn(allOwnedSafes, 'default').mockReturnValue([mockOwned, undefined, false])
 
       const { result } = renderHook(() => useOnboardingSafes())
 
-      expect(result.current.flaggedOwnedAddresses.size).toBe(0)
+      expect(result.current.flaggedAddresses.size).toBe(0)
     })
 
     it('returns empty set when addresses are not similar', () => {
@@ -143,10 +143,10 @@ describe('useOnboardingSafes', () => {
 
       const { result } = renderHook(() => useOnboardingSafes())
 
-      expect(result.current.flaggedOwnedAddresses.size).toBe(0)
+      expect(result.current.flaggedAddresses.size).toBe(0)
     })
 
-    it('flags an owned safe that is similar to a trusted one, but never the trusted safe itself', () => {
+    it('flags both sides of a look-alike pair across trusted and owned lists', () => {
       // Same 6-char prefix and 4-char suffix, differ only in middle
       const addr1 = '0x1234567890abcdef1234567890abcdef12345678' // trusted
       const addr2 = '0x123456eeeeeeeeee1234567890abcdef12345678' // owned look-alike
@@ -164,9 +164,30 @@ describe('useOnboardingSafes', () => {
         },
       })
 
-      // A safe the user trusted at some point is treated as vetted — only the owned look-alike is flagged.
-      expect(result.current.flaggedOwnedAddresses.has(addr2.toLowerCase())).toBe(true)
-      expect(result.current.flaggedOwnedAddresses.has(addr1.toLowerCase())).toBe(false)
+      expect(result.current.flaggedAddresses.has(addr2.toLowerCase())).toBe(true)
+      expect(result.current.flaggedAddresses.has(addr1.toLowerCase())).toBe(true)
+    })
+
+    it('flags a look-alike pair even when both safes are pinned (WA-2912 regression)', () => {
+      // The poisoning scenario QA reproduced: the impostor was already pinned, so both rows
+      // sit in the trusted list — the flag must not go silent there.
+      const real = '0x92b44804CeB2021197F9Aa947dC29797000065c1'
+      const impostor = '0x92b452E85d06FAB52262202f212F6F79000065c1'
+
+      const { result } = renderHook(() => useOnboardingSafes(), {
+        initialReduxState: {
+          addedSafes: {
+            '1': {
+              [real]: { owners: [], threshold: 1 },
+              [impostor]: { owners: [], threshold: 1 },
+            },
+          },
+        },
+      })
+
+      expect(result.current.ownedSafes).toHaveLength(0)
+      expect(result.current.flaggedAddresses.has(real.toLowerCase())).toBe(true)
+      expect(result.current.flaggedAddresses.has(impostor.toLowerCase())).toBe(true)
     })
   })
 })

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/hooks/__tests__/useOnboardingSelection.test.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/hooks/__tests__/useOnboardingSelection.test.tsx
@@ -28,7 +28,7 @@ const setup = (opts: { items?: AllSafeItems; flagged?: Set<string> } = {}) =>
       items: opts.items ?? [],
       control,
       setValue,
-      flaggedOwnedAddresses: opts.flagged ?? new Set<string>(),
+      flaggedAddresses: opts.flagged ?? new Set<string>(),
     })
   })
 
@@ -51,7 +51,7 @@ describe('useOnboardingSelection', () => {
     expect(result.current.selectedKeys.has('1:0xA')).toBe(false)
   })
 
-  it('defers selecting a flagged owned safe until confirmed', () => {
+  it('defers selecting a flagged safe until confirmed', () => {
     const { result } = setup({ flagged: new Set(['0xflagged']) })
 
     act(() => result.current.handleToggle(singleLine('1', '0xFlagged'), true))

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/hooks/useOnboardingSafes.ts
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/hooks/useOnboardingSafes.ts
@@ -28,17 +28,13 @@ const useOnboardingSafes = () => {
     }
   }, [allSafes])
 
-  // Flag against the combined pool (so an owned safe impersonating a trusted one is caught) but
-  // only surface warnings on owned safes — a safe the user trusted at some point is treated as vetted.
+  // Flag against the combined pool and surface every hit, trusted rows included — a poisoned
+  // address the user already pinned is exactly the case the warning must not go silent on (WA-2912).
   const combinedAddresses = useMemo(
     () => [...trustedSafeItems, ...ownedSafeItems].map((s) => s.address),
     [trustedSafeItems, ownedSafeItems],
   )
-  const flaggedCombined = useSimilarityClusters(combinedAddresses).flagged
-  const flaggedOwnedAddresses = useMemo<Set<string>>(() => {
-    const ownedAddresses = new Set(ownedSafeItems.map((s) => s.address.toLowerCase()))
-    return new Set([...flaggedCombined].filter((address) => ownedAddresses.has(address)))
-  }, [flaggedCombined, ownedSafeItems])
+  const flaggedAddresses = useSimilarityClusters(combinedAddresses).flagged
 
   // Group into multi-chain / single-chain and sort
   const trustedGrouped = useMemo<AllSafeItems>(
@@ -63,7 +59,7 @@ const useOnboardingSafes = () => {
   return {
     trustedSafes: searchQuery ? filteredTrusted : trustedGrouped,
     ownedSafes: searchQuery ? filteredOwned : ownedGrouped,
-    flaggedOwnedAddresses,
+    flaggedAddresses,
     handleSearch,
     hasNoSafes,
   }

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/hooks/useOnboardingSafes.ts
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/hooks/useOnboardingSafes.ts
@@ -28,12 +28,8 @@ const useOnboardingSafes = () => {
     }
   }, [allSafes])
 
-  // Flag against the combined pool and surface every hit, trusted rows included — a poisoned
-  // address the user already pinned is exactly the case the warning must not go silent on (WA-2912).
-  const combinedAddresses = useMemo(
-    () => [...trustedSafeItems, ...ownedSafeItems].map((s) => s.address),
-    [trustedSafeItems, ownedSafeItems],
-  )
+  // Trusted rows are deliberately included — a pinned impostor must still warn (WA-2912).
+  const combinedAddresses = useMemo(() => (allSafes ?? []).map((s) => s.address), [allSafes])
   const flaggedAddresses = useSimilarityClusters(combinedAddresses).flagged
 
   // Group into multi-chain / single-chain and sort

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/hooks/useOnboardingSafes.ts
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/hooks/useOnboardingSafes.ts
@@ -29,8 +29,8 @@ const useOnboardingSafes = () => {
   }, [allSafes])
 
   // Trusted rows are deliberately included — a pinned impostor must still warn (WA-2912).
-  const combinedAddresses = useMemo(() => (allSafes ?? []).map((s) => s.address), [allSafes])
-  const flaggedAddresses = useSimilarityClusters(combinedAddresses).flagged
+  const allSafeAddresses = useMemo(() => (allSafes ?? []).map((s) => s.address), [allSafes])
+  const flaggedAddresses = useSimilarityClusters(allSafeAddresses).flagged
 
   // Group into multi-chain / single-chain and sort
   const trustedGrouped = useMemo<AllSafeItems>(

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/hooks/useOnboardingSelection.ts
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/hooks/useOnboardingSelection.ts
@@ -11,16 +11,16 @@ interface Args {
   items: AllSafeItems
   control: Control<AddAccountsFormValues>
   setValue: UseFormSetValue<AddAccountsFormValues>
-  /** Lowercased owned addresses flagged as similar — selecting one requires confirmation. */
-  flaggedOwnedAddresses: Set<string>
+  /** Lowercased addresses flagged as look-alikes — selecting one requires confirmation. */
+  flaggedAddresses: Set<string>
 }
 
 /**
  * Bridges the accounts table's leaf-key selection model to the onboarding form's
  * `selectedSafes` record, reconciling multi-chain parent keys, and gates selection of
- * address-poisoning-flagged owned safes behind a confirmation dialog.
+ * address-poisoning-flagged safes behind a confirmation dialog.
  */
-const useOnboardingSelection = ({ items, control, setValue, flaggedOwnedAddresses }: Args) => {
+const useOnboardingSelection = ({ items, control, setValue, flaggedAddresses }: Args) => {
   const selectedSafes = useWatch({ control, name: 'selectedSafes' }) ?? {}
   const [pendingConfirmation, setPendingConfirmation] = useState<AccountLine | null>(null)
 
@@ -33,8 +33,8 @@ const useOnboardingSelection = ({ items, control, setValue, flaggedOwnedAddresse
     applySafeSelectionToggle(setValue, items, selectedSafes, line, nextChecked)
 
   const handleToggle = (line: AccountLine, nextChecked: boolean) => {
-    // Selecting a flagged owned safe needs explicit confirmation first (address-poisoning defence).
-    if (nextChecked && flaggedOwnedAddresses.has(line.address.toLowerCase())) {
+    // Selecting a flagged safe needs explicit confirmation first (address-poisoning defence).
+    if (nextChecked && flaggedAddresses.has(line.address.toLowerCase())) {
       setPendingConfirmation(line)
       return
     }

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/index.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/index.tsx
@@ -34,7 +34,7 @@ const SelectSafesOnboarding = (): ReactElement => {
   const wallet = useWallet()
   const totalSteps = useOnboardingStepCount()
   const { spaceId, handleBack, handleSkip, redirectToNextStep } = useOnboardingNavigation()
-  const { trustedSafes, ownedSafes, flaggedOwnedAddresses, handleSearch, hasNoSafes } = useOnboardingSafes()
+  const { trustedSafes, ownedSafes, flaggedAddresses, handleSearch, hasNoSafes } = useOnboardingSafes()
   const allSafes = useMemo<AllSafeItems>(() => [...trustedSafes, ...ownedSafes], [trustedSafes, ownedSafes])
   const { formMethods, onSubmit, selectedSafesLength, error, isSubmitting } = useOnboardingSubmit(
     spaceId,
@@ -44,7 +44,7 @@ const SelectSafesOnboarding = (): ReactElement => {
 
   const { control, setValue } = formMethods
   const { selectedKeys, isAtLimit, handleToggle, pendingConfirmation, confirmPending, cancelPending } =
-    useOnboardingSelection({ items: allSafes, control, setValue, flaggedOwnedAddresses })
+    useOnboardingSelection({ items: allSafes, control, setValue, flaggedAddresses })
 
   const { data: space } = useSpacesGetOneV1Query({ id: spaceId ?? '' }, { skip: !spaceId })
   const { allSafes: spaceSafes } = useSpaceSafes()
@@ -128,7 +128,7 @@ const SelectSafesOnboarding = (): ReactElement => {
               <OnboardingSafesList
                 trustedSafes={trustedSafes}
                 ownedSafes={ownedSafes}
-                flaggedOwnedAddresses={flaggedOwnedAddresses}
+                flaggedAddresses={flaggedAddresses}
                 selectedKeys={selectedKeys}
                 onToggle={handleToggle}
                 isAtLimit={isAtLimit}


### PR DESCRIPTION
## What it solves

Resolves: [WA-2912](https://linear.app/safe-global/issue/WA-2912/add-address-poisoning-protection-to-onboarding-select-safe-accounts)

On space onboarding **Step 2 — Select Safe accounts**, look-alike detection already ran over the combined trusted+owned pool, but the result was filtered to owned rows only ("a safe the user trusted at some point is treated as vetted"). When the impostor of a look-alike pair is already pinned, both rows land in **My accounts** and the entire defence goes silent: no banner, no "High similarity" badge, no selection confirmation — exactly the scenario QA reproduced.

"Trusted = real" is the presumption a successful poisoning attack breaks (the victim pins the impostor), so the intra-list warning must mark the whole pair, not just the unpinned side.

## How this PR fixes it

- `useOnboardingSafes`: drop the owned-only post-filter and return the full `useSimilarityClusters` flag set (`flaggedAddresses`). Detection input is unchanged (same combined pool, now mapped directly from `allSafes`).
- `OnboardingSafesList`: pass `flaggedAddresses` to **both** section tables; hoist the "Verify before you trust" banner above the sections, rendered when any row is flagged.
- `useOnboardingSelection`: unchanged confirm-gate now naturally covers trusted rows — selecting any flagged row opens `SimilarityConfirmDialog` first.
- Bonus: on **workspace → Safe accounts**, the "Similar addresses detected" alert sat flush against the table (no spacing); wrapped both in the same `flex-col gap-4` used by the onboarding list.

This matches the semantics of the "Manage trusted Safes" modal, which uses the same `useSimilarityClusters` hook without an owned-only filter.

## How to test it

1. Pin two Safes whose addresses share the first 4 or last 4 hex chars (e.g. `0xABCD…1234` and `0xABCD…ffff`), so both appear under **My accounts**.
2. Start space onboarding and go to Step 2 — expect: banner at the top of the list, "High similarity" badge on both rows, and a confirmation dialog when selecting either.
3. Unpin one of them so it moves to **Owned safe accounts** — the pair stays flagged across both sections.
4. Search for one of the addresses — flags persist in search results.
5. Workspace → Safe accounts with a flagged pair — the alert now has spacing above the table.

## Affected flows

- Space onboarding Step 2 "Select Safe accounts": flag badges, security banner, and selection confirm-gate now also apply to pinned (My accounts) rows.
- Workspace → Safe accounts: visual spacing between the similar-address alert and the table.

## Blast radius

- `SelectSafesOnboarding` internals only (`useOnboardingSafes`, `useOnboardingSelection`, `OnboardingSafesList`, `index`) — no other consumers; the renamed `flaggedAddresses` prop is internal to this feature.
- Reads `useSimilarityClusters` (shared, `@/features/address-poisoning`) — read-only consumer, no changes to the detection engine, thresholds, or the flag-gated anchor path (`ADDRESS_POISONING_PROTECTION`).
- `SafeAccountsTable` consumed with its existing `flaggedAddresses` prop — no changes to the shared table.
- One-line JSX wrapper in `SafeAccounts/index.tsx` (workspace accounts page), layout only.
- No RTK Query, persistence, routing, or mobile impact.

## Risks / not checked

- Did not test on mobile (web-only surface).
- Did not verify with `ADDRESS_POISONING_PROTECTION` disabled (only gates the anchor engine; the intra-list clustering exercised here is always-on).
- Large-account noise: users holding many vanity-prefixed Safes will now see badges on pinned rows too — intended, but not exercised with real large accounts.

## Visual summary

```mermaid
flowchart LR
    A[allSafes] --> B[useSimilarityClusters\nintra-list OR clustering + flag-gated anchor check]
    B --> C{flagged set}
    C -- before --> D[filter to owned only] --> E[owned table badges + banner]
    C -- after --> F[both tables: badges\nbanner above sections\nconfirm-gate on any flagged row]
    style D stroke-dasharray: 5 5
```
### Flag Pinned Safes when there is a similar
- Before:
<img width="1154" height="642" alt="Screenshot 2026-07-27 at 13 03 25" src="https://github.com/user-attachments/assets/b376be7f-8b07-45e6-89c5-edd6da5ce368" />

- After:
<img width="910" height="344" alt="Screenshot 2026-07-27 at 13 02 05" src="https://github.com/user-attachments/assets/dc839048-aaf9-4239-96cc-4400652f4365" />

### Adding some space between banner and table
- Before:
<img width="1661" height="413" alt="Screenshot 2026-07-27 at 13 02 58" src="https://github.com/user-attachments/assets/dba6ab86-9e4c-4215-97dc-4d0be94dcf5a" />

- After:
<img width="1105" height="501" alt="Screenshot 2026-07-27 at 13 01 00" src="https://github.com/user-attachments/assets/44cdb519-b80e-4e4c-a2de-164cada043c6" />



## Checklist

- [ ] I've tested the branch on mobile 📱 (N/A — web-only)
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics changes)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).