### PR TITLE
fix: validate setGuard target against the guard interface

### DIFF
--- a/apps/mobile/src/features/SafeShield/hooks/useThreatAnalysis.ts
+++ b/apps/mobile/src/features/SafeShield/hooks/useThreatAnalysis.ts
@@ -1,8 +1,12 @@
-import { useThreatAnalysis as useThreatAnalysisUtils } from '@safe-global/utils/features/safe-shield/hooks'
+import {
+  useThreatAnalysis as useThreatAnalysisUtils,
+  useThreatAnalysisWithGuard,
+} from '@safe-global/utils/features/safe-shield/hooks'
 import { useAppSelector } from '@/src/store/hooks'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { selectActiveSigner } from '@/src/store/activeSignerSlice'
 import useSafeInfo from '@/src/hooks/useSafeInfo'
+import { useWeb3ReadOnly } from '@/src/hooks/wallets/web3'
 import type { SafeTransaction } from '@safe-global/types-kit'
 
 export function useThreatAnalysis(overrideSafeTx?: SafeTransaction) {
@@ -12,13 +16,21 @@ export function useThreatAnalysis(overrideSafeTx?: SafeTransaction) {
   const { safe } = useSafeInfo()
   const activeSigner = useAppSelector((state) => selectActiveSigner(state, activeSafe.address))
   const walletAddress = activeSigner?.value ?? ''
+  const web3ReadOnly = useWeb3ReadOnly()
 
-  return useThreatAnalysisUtils({
+  const threat = useThreatAnalysisUtils({
     safeAddress: safeAddress as `0x${string}`,
     chainId,
     data: overrideSafeTx,
     walletAddress,
     origin: undefined,
     safeVersion: safe.version || undefined,
+  })
+
+  return useThreatAnalysisWithGuard(threat, {
+    safeTx: overrideSafeTx,
+    safeAddress,
+    safeVersion: safe.version,
+    web3ReadOnly,
   })
 }

--- a/apps/web/src/features/safe-shield/hooks/__tests__/useThreatAnalysis.test.tsx
+++ b/apps/web/src/features/safe-shield/hooks/__tests__/useThreatAnalysis.test.tsx
@@ -9,6 +9,9 @@ jest.mock('@safe-global/utils/features/safe-shield/hooks', () => ({
   useThreatAnalysis: jest.fn(),
   useThreatAnalysisHypernative: jest.fn(),
   useThreatAnalysisHypernativeMessage: jest.fn(),
+  // Identity passthrough — the guard check is covered by its own unit test; here we only assert
+  // the threat-merging behaviour of the wrapper.
+  useThreatAnalysisWithGuard: jest.fn((threat) => threat),
 }))
 
 jest.mock('../../components/useNestedTransaction', () => ({

--- a/apps/web/src/features/safe-shield/hooks/useThreatAnalysis.ts
+++ b/apps/web/src/features/safe-shield/hooks/useThreatAnalysis.ts
@@ -38,7 +38,7 @@ export function useThreatAnalysis(
   const txToAnalyze = overrideSafeTx || safeTx || safeMessage
 
   const safeTxToCheck = (txToAnalyze && 'data' in txToAnalyze ? txToAnalyze : undefined) as SafeTransaction | undefined
-  const { isNested, isNestedLoading } = useNestedTransaction(safeTxToCheck, chain)
+  const { isNested, isNestedLoading, nestedSafeInfo, nestedSafeTx } = useNestedTransaction(safeTxToCheck, chain)
 
   const mainTxProps = useMemo(
     () => ({
@@ -97,10 +97,11 @@ export function useThreatAnalysis(
     return [combinedResult, mainError || nestedError, mainLoading || nestedLoading]
   }, [threatAnalysis, nestedThreatAnalysis, isNested, isNestedLoading, eligibilityLoading])
 
-  return useThreatAnalysisWithGuard(combinedThreatAnalysis, {
-    safeTx: safeTxToCheck,
-    safeAddress,
-    safeVersion: version,
-    web3ReadOnly,
-  })
+  // A nested tx executes its setGuard on the nested Safe, so validate the guard against the nested
+  // tx and Safe; otherwise the outer execTransaction hides the setGuard and the check is skipped.
+  const guardCheckParams = isNested
+    ? { safeTx: nestedSafeTx, safeAddress: nestedSafeInfo?.address.value, safeVersion: nestedSafeInfo?.version }
+    : { safeTx: safeTxToCheck, safeAddress, safeVersion: version }
+
+  return useThreatAnalysisWithGuard(combinedThreatAnalysis, { ...guardCheckParams, web3ReadOnly })
 }

--- a/apps/web/src/features/safe-shield/hooks/useThreatAnalysis.ts
+++ b/apps/web/src/features/safe-shield/hooks/useThreatAnalysis.ts
@@ -1,8 +1,10 @@
 import {
   useThreatAnalysis as useThreatAnalysisUtils,
   useThreatAnalysisHypernative,
+  useThreatAnalysisWithGuard,
 } from '@safe-global/utils/features/safe-shield/hooks'
 import { useSigner } from '@/hooks/wallets/useWallet'
+import { useWeb3ReadOnly } from '@/hooks/wallets/web3ReadOnly'
 import { useContext, useMemo } from 'react'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import useSafeInfo from '@/hooks/useSafeInfo'
@@ -23,6 +25,7 @@ export function useThreatAnalysis(
     safeAddress,
   } = useSafeInfo()
   const signer = useSigner()
+  const web3ReadOnly = useWeb3ReadOnly()
   const { safeTx, safeMessage, safeMessageHash, txOrigin } = useContext(SafeTxContext)
   const walletAddress = signer?.address ?? ''
   const isHypernativeFeatureEnabled = useIsHypernativeFeatureEnabled()
@@ -94,5 +97,10 @@ export function useThreatAnalysis(
     return [combinedResult, mainError || nestedError, mainLoading || nestedLoading]
   }, [threatAnalysis, nestedThreatAnalysis, isNested, isNestedLoading, eligibilityLoading])
 
-  return combinedThreatAnalysis
+  return useThreatAnalysisWithGuard(combinedThreatAnalysis, {
+    safeTx: safeTxToCheck,
+    safeAddress,
+    safeVersion: version,
+    web3ReadOnly,
+  })
 }

--- a/packages/utils/src/features/safe-shield/hooks/__tests__/useGuardCheck.test.ts
+++ b/packages/utils/src/features/safe-shield/hooks/__tests__/useGuardCheck.test.ts
@@ -1,0 +1,212 @@
+import { faker } from '@faker-js/faker'
+import { renderHook, waitFor } from '@testing-library/react'
+import { encodeMultiSendData } from '@safe-global/protocol-kit'
+import { getAddress, JsonRpcProvider, ZeroAddress } from 'ethers'
+import type { SafeTransaction } from '@safe-global/types-kit'
+import { ERC721__factory, Multi_send__factory, Safe__factory } from '@safe-global/utils/types/contracts'
+import { decodeSetGuardTargets, useGuardCheck } from '../useGuardCheck'
+import { Severity, ThreatStatus } from '../../types'
+
+jest.mock('@safe-global/utils/types/contracts', () => {
+  const actual = jest.requireActual('@safe-global/utils/types/contracts')
+  return {
+    ...actual,
+    ERC721__factory: {
+      ...actual.ERC721__factory,
+      connect: jest.fn(),
+    },
+  }
+})
+
+const safeInterface = Safe__factory.createInterface()
+const multiSendInterface = Multi_send__factory.createInterface()
+const mockedConnect = ERC721__factory.connect as jest.Mock
+
+const mockSupportsInterface = (impl: () => Promise<boolean>) => {
+  mockedConnect.mockReturnValue({ supportsInterface: jest.fn().mockImplementation(impl) })
+}
+
+const encodeSetGuard = (guard: string) => safeInterface.encodeFunctionData('setGuard', [guard])
+
+// The hook only reads safeTx.data.{to,data}; build a minimal transaction targeting `to`.
+const makeTx = (to: string, data: string): SafeTransaction =>
+  ({ data: { to, value: '0', data, operation: 0 } }) as unknown as SafeTransaction
+
+const makeSetGuardTx = (guard: string, to: string): SafeTransaction => makeTx(to, encodeSetGuard(guard))
+
+// Wraps inner calls in a MultiSend batch (operation 1, delegatecall to the MultiSend contract).
+const makeMultiSendTx = (inner: Array<{ to: string; data: string }>): SafeTransaction => {
+  const transactions = encodeMultiSendData(inner.map(({ to, data }) => ({ to, value: '0', data, operation: 0 })))
+  return makeTx(
+    getAddress(faker.finance.ethereumAddress()),
+    multiSendInterface.encodeFunctionData('multiSend', [transactions]),
+  )
+}
+
+const web3ReadOnly = {} as JsonRpcProvider
+
+describe('decodeSetGuardTargets', () => {
+  const safeAddress = getAddress(faker.finance.ethereumAddress())
+  const guard = getAddress(faker.finance.ethereumAddress())
+
+  it('decodes the guard address for a setGuard call targeting the Safe', () => {
+    expect(decodeSetGuardTargets(makeSetGuardTx(guard, safeAddress), safeAddress)).toEqual([guard])
+  })
+
+  it('decodes a setGuard nested in a MultiSend batch', () => {
+    const other = getAddress(faker.finance.ethereumAddress())
+    const tx = makeMultiSendTx([
+      { to: other, data: '0xdeadbeef' },
+      { to: safeAddress, data: encodeSetGuard(guard) },
+    ])
+    expect(decodeSetGuardTargets(tx, safeAddress)).toEqual([guard])
+  })
+
+  it('ignores a nested setGuard targeting a different contract', () => {
+    const other = getAddress(faker.finance.ethereumAddress())
+    const tx = makeMultiSendTx([{ to: other, data: encodeSetGuard(guard) }])
+    expect(decodeSetGuardTargets(tx, safeAddress)).toEqual([])
+  })
+
+  it('returns empty when the transaction targets a different contract', () => {
+    const other = getAddress(faker.finance.ethereumAddress())
+    expect(decodeSetGuardTargets(makeSetGuardTx(guard, other), safeAddress)).toEqual([])
+  })
+
+  it('returns empty for a non-setGuard transaction', () => {
+    expect(decodeSetGuardTargets(makeTx(safeAddress, '0xdeadbeef'), safeAddress)).toEqual([])
+  })
+
+  it('returns empty when there is no transaction', () => {
+    expect(decodeSetGuardTargets(undefined, safeAddress)).toEqual([])
+  })
+})
+
+describe('useGuardCheck', () => {
+  const safeAddress = getAddress(faker.finance.ethereumAddress())
+  const guard = getAddress(faker.finance.ethereumAddress())
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const renderGuardCheck = (props: Parameters<typeof useGuardCheck>[0]) => renderHook(() => useGuardCheck(props))
+
+  it('flags a guard that does not implement the interface (supportsInterface returns false)', async () => {
+    mockSupportsInterface(() => Promise.resolve(false))
+
+    const { result } = renderGuardCheck({
+      safeTx: makeSetGuardTx(guard, safeAddress),
+      safeAddress,
+      safeVersion: '1.3.0',
+      web3ReadOnly,
+    })
+
+    await waitFor(() => expect(result.current[2]).toBe(false))
+
+    const [findings] = result.current
+    expect(findings).toHaveLength(1)
+    expect(findings?.[0].type).toBe(ThreatStatus.INVALID_GUARD)
+    expect(findings?.[0].severity).toBe(Severity.CRITICAL)
+    expect(findings?.[0].addresses?.[0].address).toBe(guard)
+  })
+
+  it('flags an invalid guard nested in a MultiSend batch', async () => {
+    mockSupportsInterface(() => Promise.resolve(false))
+    const other = getAddress(faker.finance.ethereumAddress())
+    const tx = makeMultiSendTx([
+      { to: other, data: '0xdeadbeef' },
+      { to: safeAddress, data: encodeSetGuard(guard) },
+    ])
+
+    const { result } = renderGuardCheck({ safeTx: tx, safeAddress, safeVersion: '1.3.0', web3ReadOnly })
+
+    await waitFor(() => expect(result.current[2]).toBe(false))
+    expect(result.current[0]?.[0].type).toBe(ThreatStatus.INVALID_GUARD)
+    expect(result.current[0]?.[0].addresses?.[0].address).toBe(guard)
+  })
+
+  it('flags a guard when the interface check reverts (EOA / no ERC-165)', async () => {
+    mockSupportsInterface(() => Promise.reject(new Error('call revert exception')))
+
+    const { result } = renderGuardCheck({
+      safeTx: makeSetGuardTx(guard, safeAddress),
+      safeAddress,
+      safeVersion: '1.3.0',
+      web3ReadOnly,
+    })
+
+    await waitFor(() => expect(result.current[2]).toBe(false))
+    expect(result.current[0]?.[0].type).toBe(ThreatStatus.INVALID_GUARD)
+  })
+
+  it('does not flag a guard that implements the interface', async () => {
+    mockSupportsInterface(() => Promise.resolve(true))
+
+    const { result } = renderGuardCheck({
+      safeTx: makeSetGuardTx(guard, safeAddress),
+      safeAddress,
+      safeVersion: '1.3.0',
+      web3ReadOnly,
+    })
+
+    await waitFor(() => expect(result.current[2]).toBe(false))
+    expect(result.current[0]).toEqual([])
+  })
+
+  it('skips the check when removing a guard (address(0))', async () => {
+    mockSupportsInterface(() => Promise.resolve(false))
+
+    const { result } = renderGuardCheck({
+      safeTx: makeSetGuardTx(ZeroAddress, safeAddress),
+      safeAddress,
+      safeVersion: '1.3.0',
+      web3ReadOnly,
+    })
+
+    await waitFor(() => expect(result.current[2]).toBe(false))
+    expect(result.current[0]).toBeUndefined()
+    expect(mockedConnect).not.toHaveBeenCalled()
+  })
+
+  it('skips the check on Safes >= 1.4.1 (contract self-protects)', async () => {
+    mockSupportsInterface(() => Promise.resolve(false))
+
+    const { result } = renderGuardCheck({
+      safeTx: makeSetGuardTx(guard, safeAddress),
+      safeAddress,
+      safeVersion: '1.4.1',
+      web3ReadOnly,
+    })
+
+    await waitFor(() => expect(result.current[2]).toBe(false))
+    expect(result.current[0]).toBeUndefined()
+    expect(mockedConnect).not.toHaveBeenCalled()
+  })
+
+  it('skips non-setGuard transactions', async () => {
+    mockSupportsInterface(() => Promise.resolve(false))
+    const tx = {
+      data: { to: safeAddress, value: '0', data: '0xdeadbeef', operation: 0 },
+    } as unknown as SafeTransaction
+
+    const { result } = renderGuardCheck({ safeTx: tx, safeAddress, safeVersion: '1.3.0', web3ReadOnly })
+
+    await waitFor(() => expect(result.current[2]).toBe(false))
+    expect(result.current[0]).toBeUndefined()
+    expect(mockedConnect).not.toHaveBeenCalled()
+  })
+
+  it('skips when no read-only provider is available', async () => {
+    const { result } = renderGuardCheck({
+      safeTx: makeSetGuardTx(guard, safeAddress),
+      safeAddress,
+      safeVersion: '1.3.0',
+      web3ReadOnly: undefined,
+    })
+
+    await waitFor(() => expect(result.current[2]).toBe(false))
+    expect(result.current[0]).toBeUndefined()
+    expect(mockedConnect).not.toHaveBeenCalled()
+  })
+})

--- a/packages/utils/src/features/safe-shield/hooks/__tests__/useGuardCheck.test.ts
+++ b/packages/utils/src/features/safe-shield/hooks/__tests__/useGuardCheck.test.ts
@@ -28,18 +28,22 @@ const mockSupportsInterface = (impl: () => Promise<boolean>) => {
 
 const encodeSetGuard = (guard: string) => safeInterface.encodeFunctionData('setGuard', [guard])
 
-// The hook only reads safeTx.data.{to,data}; build a minimal transaction targeting `to`.
-const makeTx = (to: string, data: string): SafeTransaction =>
-  ({ data: { to, value: '0', data, operation: 0 } }) as unknown as SafeTransaction
+// Builds an ethers-shaped rejection so the hook can classify reverts vs. transport failures.
+const rpcError = (code: string): Error => Object.assign(new Error(code), { code })
+
+// The hook only reads safeTx.data.{to,data,operation}; build a minimal transaction targeting `to`.
+const makeTx = (to: string, data: string, operation = 0): SafeTransaction =>
+  ({ data: { to, value: '0', data, operation } }) as unknown as SafeTransaction
 
 const makeSetGuardTx = (guard: string, to: string): SafeTransaction => makeTx(to, encodeSetGuard(guard))
 
 // Wraps inner calls in a MultiSend batch (operation 1, delegatecall to the MultiSend contract).
-const makeMultiSendTx = (inner: Array<{ to: string; data: string }>): SafeTransaction => {
+const makeMultiSendTx = (inner: Array<{ to: string; data: string }>, operation = 1): SafeTransaction => {
   const transactions = encodeMultiSendData(inner.map(({ to, data }) => ({ to, value: '0', data, operation: 0 })))
   return makeTx(
     getAddress(faker.finance.ethereumAddress()),
     multiSendInterface.encodeFunctionData('multiSend', [transactions]),
+    operation,
   )
 }
 
@@ -65,6 +69,11 @@ describe('decodeSetGuardTargets', () => {
   it('ignores a nested setGuard targeting a different contract', () => {
     const other = getAddress(faker.finance.ethereumAddress())
     const tx = makeMultiSendTx([{ to: other, data: encodeSetGuard(guard) }])
+    expect(decodeSetGuardTargets(tx, safeAddress)).toEqual([])
+  })
+
+  it('ignores a MultiSend-shaped payload that is not a delegatecall', () => {
+    const tx = makeMultiSendTx([{ to: safeAddress, data: encodeSetGuard(guard) }], 0)
     expect(decodeSetGuardTargets(tx, safeAddress)).toEqual([])
   })
 
@@ -127,7 +136,7 @@ describe('useGuardCheck', () => {
   })
 
   it('flags a guard when the interface check reverts (EOA / no ERC-165)', async () => {
-    mockSupportsInterface(() => Promise.reject(new Error('call revert exception')))
+    mockSupportsInterface(() => Promise.reject(rpcError('BAD_DATA')))
 
     const { result } = renderGuardCheck({
       safeTx: makeSetGuardTx(guard, safeAddress),
@@ -138,6 +147,22 @@ describe('useGuardCheck', () => {
 
     await waitFor(() => expect(result.current[2]).toBe(false))
     expect(result.current[0]?.[0].type).toBe(ThreatStatus.INVALID_GUARD)
+  })
+
+  it('does not flag a guard when the interface check hits a transport error', async () => {
+    mockSupportsInterface(() => Promise.reject(rpcError('TIMEOUT')))
+
+    const { result } = renderGuardCheck({
+      safeTx: makeSetGuardTx(guard, safeAddress),
+      safeAddress,
+      safeVersion: '1.3.0',
+      web3ReadOnly,
+    })
+
+    await waitFor(() => expect(result.current[2]).toBe(false))
+    // Inconclusive failure surfaces as an error, never a false "bricked Safe" finding.
+    expect(result.current[0]).toBeUndefined()
+    expect(result.current[1]).toBeInstanceOf(Error)
   })
 
   it('does not flag a guard that implements the interface', async () => {

--- a/packages/utils/src/features/safe-shield/hooks/__tests__/useThreatAnalysisWithGuard.test.ts
+++ b/packages/utils/src/features/safe-shield/hooks/__tests__/useThreatAnalysisWithGuard.test.ts
@@ -1,0 +1,79 @@
+import { renderHook } from '@testing-library/react'
+import type { AsyncResult } from '@safe-global/utils/hooks/useAsync'
+import { useThreatAnalysisWithGuard } from '../useThreatAnalysisWithGuard'
+import { useGuardCheck, type InvalidGuardResult } from '../useGuardCheck'
+import { Severity, ThreatStatus, type ThreatAnalysisResults } from '../../types'
+
+jest.mock('../useGuardCheck', () => ({
+  useGuardCheck: jest.fn(),
+}))
+
+const mockedUseGuardCheck = useGuardCheck as jest.Mock
+
+const invalidGuard: InvalidGuardResult = {
+  severity: Severity.CRITICAL,
+  type: ThreatStatus.INVALID_GUARD,
+  title: 'Invalid transaction guard',
+  description: 'nope',
+  addresses: [{ address: '0xguard' }],
+}
+
+const threatResults = {
+  THREAT: [{ type: ThreatStatus.MALICIOUS }],
+  CUSTOM_CHECKS: [{ type: ThreatStatus.CUSTOM_CHECKS_FAILED }],
+  BALANCE_CHANGE: [],
+  request_id: 'req-1',
+} as unknown as ThreatAnalysisResults
+
+const renderWrapper = (threat: AsyncResult<ThreatAnalysisResults> | undefined) =>
+  renderHook(() => useThreatAnalysisWithGuard(threat, { safeTx: undefined, safeAddress: '0x1', safeVersion: '1.3.0' }))
+
+describe('useThreatAnalysisWithGuard', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns the threat result untouched when there is no invalid-guard finding', () => {
+    mockedUseGuardCheck.mockReturnValue([[], undefined, false])
+
+    const { result } = renderWrapper([threatResults, undefined, false])
+
+    expect(result.current[0]).toBe(threatResults)
+  })
+
+  it('prepends the guard finding to THREAT and preserves other groups', () => {
+    mockedUseGuardCheck.mockReturnValue([[invalidGuard], undefined, false])
+
+    const { result } = renderWrapper([threatResults, undefined, false])
+    const [merged] = result.current
+
+    expect(merged?.THREAT?.[0]).toBe(invalidGuard)
+    expect(merged?.THREAT).toHaveLength(2)
+    expect(merged?.CUSTOM_CHECKS).toEqual(threatResults.CUSTOM_CHECKS)
+    expect(merged?.BALANCE_CHANGE).toEqual(threatResults.BALANCE_CHANGE)
+    expect(merged?.request_id).toBe('req-1')
+  })
+
+  it('surfaces a guard finding even when the threat result is still empty', () => {
+    mockedUseGuardCheck.mockReturnValue([[invalidGuard], undefined, false])
+
+    const { result } = renderWrapper([undefined, undefined, false])
+
+    expect(result.current[0]?.THREAT).toEqual([invalidGuard])
+  })
+
+  it('stays loading while either the threat or the guard check is loading', () => {
+    mockedUseGuardCheck.mockReturnValue([undefined, undefined, true])
+
+    const { result } = renderWrapper([threatResults, undefined, false])
+
+    expect(result.current[2]).toBe(true)
+  })
+
+  it('passes through the threat error', () => {
+    mockedUseGuardCheck.mockReturnValue([[], undefined, false])
+    const error = new Error('threat failed')
+
+    const { result } = renderWrapper([undefined, error, false])
+
+    expect(result.current[1]).toBe(error)
+  })
+})

--- a/packages/utils/src/features/safe-shield/hooks/index.ts
+++ b/packages/utils/src/features/safe-shield/hooks/index.ts
@@ -1,6 +1,8 @@
 export { useCounterpartyAnalysis } from './useCounterpartyAnalysis'
+export { useGuardCheck } from './useGuardCheck'
 export { useRecipientAnalysis } from './useRecipientAnalysis'
 export { useThreatAnalysis } from './useThreatAnalysis'
+export { useThreatAnalysisWithGuard } from './useThreatAnalysisWithGuard'
 export { useThreatAnalysisHypernative } from './useThreatAnalysisHypernative'
 export { useThreatAnalysisHypernativeBatch } from './useThreatAnalysisHypernativeBatch'
 export { useThreatAnalysisHypernativeMessage } from './useThreatAnalysisHypernativeMessage'

--- a/packages/utils/src/features/safe-shield/hooks/useGuardCheck.ts
+++ b/packages/utils/src/features/safe-shield/hooks/useGuardCheck.ts
@@ -1,0 +1,130 @@
+import { useMemo } from 'react'
+import { getAddress, isAddress, JsonRpcProvider, ZeroAddress } from 'ethers'
+import semverSatisfies from 'semver/functions/satisfies'
+import { decodeMultiSendData } from '@safe-global/protocol-kit'
+import type { SafeTransaction } from '@safe-global/types-kit'
+import { ERC721__factory, Multi_send__factory, Safe__factory } from '@safe-global/utils/types/contracts'
+import useAsync, { type AsyncResult } from '@safe-global/utils/hooks/useAsync'
+import { type AnalysisResult, Severity, ThreatStatus } from '../types'
+
+const safeInterface = Safe__factory.createInterface()
+const SET_GUARD_SELECTOR = safeInterface.getFunction('setGuard').selector
+const MULTI_SEND_SELECTOR = Multi_send__factory.createInterface().getFunction('multiSend').selector
+
+// Safe Guard interface id: type(Guard).interfaceId (checkTransaction ^ checkAfterExecution).
+const GUARD_INTERFACE_ID = '0xe6d7a83a'
+
+// setGuard gained the ERC-165 interface check in v1.4.1, so only older Safes can be bricked.
+const VULNERABLE_TO_INVALID_GUARD = '<1.4.1'
+
+export type InvalidGuardResult = AnalysisResult<ThreatStatus.INVALID_GUARD>
+
+// setGuard is `authorized`, so a genuine call targets the Safe itself.
+const decodeGuardFromCall = (to?: string, data?: string, safeAddress?: string): string | undefined => {
+  if (!data || !to || !data.startsWith(SET_GUARD_SELECTOR)) {
+    return undefined
+  }
+  if (safeAddress && isAddress(to) && isAddress(safeAddress) && getAddress(to) !== getAddress(safeAddress)) {
+    return undefined
+  }
+  try {
+    const [guard] = safeInterface.decodeFunctionData('setGuard', data)
+    return typeof guard === 'string' ? guard : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Collects every guard address a Safe transaction would set, whether via a direct `setGuard` call
+ * or one nested inside a MultiSend batch.
+ *
+ * @param safeTx - The Safe transaction being analysed
+ * @param safeAddress - The Safe address a genuine setGuard call must target
+ * @returns The guard addresses being set (empty if the transaction sets none)
+ */
+export const decodeSetGuardTargets = (safeTx?: SafeTransaction, safeAddress?: string): string[] => {
+  const { to, data } = safeTx?.data ?? {}
+  if (!data) {
+    return []
+  }
+
+  const direct = decodeGuardFromCall(to, data, safeAddress)
+  if (direct) {
+    return [direct]
+  }
+
+  if (data.startsWith(MULTI_SEND_SELECTOR)) {
+    try {
+      return decodeMultiSendData(data)
+        .map((inner) => decodeGuardFromCall(inner.to, inner.data, safeAddress))
+        .filter((guard): guard is string => !!guard)
+    } catch {
+      return []
+    }
+  }
+
+  return []
+}
+
+const buildInvalidGuardResult = (guardAddress: string): InvalidGuardResult => ({
+  severity: Severity.CRITICAL,
+  type: ThreatStatus.INVALID_GUARD,
+  title: 'Invalid transaction guard',
+  description:
+    'This address does not implement the required transaction guard interface. Setting it as the guard would block every transaction and permanently brick this Safe.',
+  addresses: [{ address: guardAddress }],
+})
+
+const validateGuardInterface = async (
+  guardAddress: string,
+  web3ReadOnly: JsonRpcProvider,
+): Promise<InvalidGuardResult | undefined> => {
+  try {
+    // ERC721__factory reused only for its ERC-165 `supportsInterface` method.
+    const supportsGuardInterface = await ERC721__factory.connect(guardAddress, web3ReadOnly).supportsInterface(
+      GUARD_INTERFACE_ID,
+    )
+    return supportsGuardInterface ? undefined : buildInvalidGuardResult(guardAddress)
+  } catch {
+    // EOA, non-contract, or a contract without ERC-165 — cannot be a valid guard.
+    return buildInvalidGuardResult(guardAddress)
+  }
+}
+
+/**
+ * Validates the target(s) of a `setGuard` transaction (direct or inside a MultiSend) against the
+ * Safe guard interface. Runs only for Safes below v1.4.1, which do not reject an invalid guard
+ * on-chain and would otherwise be bricked. Returns an INVALID_GUARD finding per invalid guard.
+ */
+export const useGuardCheck = ({
+  safeTx,
+  safeAddress,
+  safeVersion,
+  web3ReadOnly,
+}: {
+  safeTx?: SafeTransaction
+  safeAddress?: string
+  safeVersion?: string | null
+  web3ReadOnly?: JsonRpcProvider
+}): AsyncResult<InvalidGuardResult[]> => {
+  const guardTargets = useMemo(
+    // address(0) removes the guard, which is always safe.
+    () => decodeSetGuardTargets(safeTx, safeAddress).filter((addr) => getAddress(addr) !== ZeroAddress),
+    [safeTx, safeAddress],
+  )
+
+  const isVulnerableVersion = !safeVersion || semverSatisfies(safeVersion, VULNERABLE_TO_INVALID_GUARD)
+  const shouldCheck = guardTargets.length > 0 && isVulnerableVersion && !!web3ReadOnly
+  const guardKey = guardTargets.join(',')
+
+  return useAsync<InvalidGuardResult[]>(() => {
+    if (!shouldCheck || !web3ReadOnly) {
+      return undefined
+    }
+    return Promise.all(guardTargets.map((guard) => validateGuardInterface(guard, web3ReadOnly))).then((results) =>
+      results.filter((result): result is InvalidGuardResult => !!result),
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- guardKey tracks guardTargets by value
+  }, [shouldCheck, guardKey, web3ReadOnly])
+}

--- a/packages/utils/src/features/safe-shield/hooks/useGuardCheck.ts
+++ b/packages/utils/src/features/safe-shield/hooks/useGuardCheck.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { getAddress, isAddress, JsonRpcProvider, ZeroAddress } from 'ethers'
 import semverSatisfies from 'semver/functions/satisfies'
 import { decodeMultiSendData } from '@safe-global/protocol-kit'
-import type { SafeTransaction } from '@safe-global/types-kit'
+import { OperationType, type SafeTransaction } from '@safe-global/types-kit'
 import { ERC721__factory, Multi_send__factory, Safe__factory } from '@safe-global/utils/types/contracts'
 import useAsync, { type AsyncResult } from '@safe-global/utils/hooks/useAsync'
 import { type AnalysisResult, Severity, ThreatStatus } from '../types'
@@ -54,7 +54,9 @@ export const decodeSetGuardTargets = (safeTx?: SafeTransaction, safeAddress?: st
     return [direct]
   }
 
-  if (data.startsWith(MULTI_SEND_SELECTOR)) {
+  // A genuine MultiSend batch is delegate-called; a plain call that merely starts with the
+  // selector cannot execute the inner setGuard, so ignore it to avoid false positives.
+  if (data.startsWith(MULTI_SEND_SELECTOR) && safeTx?.data.operation === OperationType.DelegateCall) {
     try {
       return decodeMultiSendData(data)
         .map((inner) => decodeGuardFromCall(inner.to, inner.data, safeAddress))
@@ -76,6 +78,14 @@ const buildInvalidGuardResult = (guardAddress: string): InvalidGuardResult => ({
   addresses: [{ address: guardAddress }],
 })
 
+// ethers reports a reverted call or an undecodable response (EOA / non-ERC-165 contract) with these
+// codes. Any other rejection (network down, timeout, rate limit) is a transport failure, not proof
+// the guard is invalid, so it must not raise a "bricked Safe" finding.
+const CONTRACT_REJECTION_CODES = new Set(['CALL_EXCEPTION', 'BAD_DATA'])
+
+const isContractRejection = (error: unknown): boolean =>
+  CONTRACT_REJECTION_CODES.has((error as { code?: string })?.code ?? '')
+
 const validateGuardInterface = async (
   guardAddress: string,
   web3ReadOnly: JsonRpcProvider,
@@ -86,9 +96,13 @@ const validateGuardInterface = async (
       GUARD_INTERFACE_ID,
     )
     return supportsGuardInterface ? undefined : buildInvalidGuardResult(guardAddress)
-  } catch {
+  } catch (error) {
     // EOA, non-contract, or a contract without ERC-165 — cannot be a valid guard.
-    return buildInvalidGuardResult(guardAddress)
+    if (isContractRejection(error)) {
+      return buildInvalidGuardResult(guardAddress)
+    }
+    // Inconclusive transport error: surface it via useAsync rather than crying wolf.
+    throw error
   }
 }
 
@@ -110,7 +124,7 @@ export const useGuardCheck = ({
 }): AsyncResult<InvalidGuardResult[]> => {
   const guardTargets = useMemo(
     // address(0) removes the guard, which is always safe.
-    () => decodeSetGuardTargets(safeTx, safeAddress).filter((addr) => getAddress(addr) !== ZeroAddress),
+    () => decodeSetGuardTargets(safeTx, safeAddress).filter((addr) => addr.toLowerCase() !== ZeroAddress),
     [safeTx, safeAddress],
   )
 

--- a/packages/utils/src/features/safe-shield/hooks/useThreatAnalysisWithGuard.ts
+++ b/packages/utils/src/features/safe-shield/hooks/useThreatAnalysisWithGuard.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react'
+import type { JsonRpcProvider } from 'ethers'
+import type { SafeTransaction } from '@safe-global/types-kit'
+import type { AsyncResult } from '@safe-global/utils/hooks/useAsync'
+import type { ThreatAnalysisResults } from '../types'
+import { useGuardCheck } from './useGuardCheck'
+
+/**
+ * Augments a threat-analysis result with a client-side `setGuard` interface check, merging any
+ * invalid-guard finding into the THREAT group.
+ *
+ * @param threat - The threat-analysis result to augment
+ * @param params - Guard-check inputs (transaction, Safe address/version, read-only provider)
+ */
+export function useThreatAnalysisWithGuard(
+  threat: AsyncResult<ThreatAnalysisResults> | undefined,
+  {
+    safeTx,
+    safeAddress,
+    safeVersion,
+    web3ReadOnly,
+  }: {
+    safeTx?: SafeTransaction
+    safeAddress?: string
+    safeVersion?: string | null
+    web3ReadOnly?: JsonRpcProvider
+  },
+): AsyncResult<ThreatAnalysisResults> {
+  const [guardResults, , guardLoading] = useGuardCheck({ safeTx, safeAddress, safeVersion, web3ReadOnly })
+  const [threatData, threatError, threatLoading = false] = threat ?? [undefined, undefined, false]
+
+  const merged = useMemo<ThreatAnalysisResults | undefined>(() => {
+    if (!guardResults?.length) {
+      return threatData
+    }
+    return { ...(threatData ?? {}), THREAT: [...guardResults, ...(threatData?.THREAT ?? [])] }
+  }, [threatData, guardResults])
+
+  return [merged, threatError, threatLoading || guardLoading]
+}

--- a/packages/utils/src/features/safe-shield/types/index.ts
+++ b/packages/utils/src/features/safe-shield/types/index.ts
@@ -61,6 +61,7 @@ export type StatusGroupType<T extends StatusGroup> = {
     | ThreatStatus.OWNERSHIP_CHANGE
     | ThreatStatus.MODULE_CHANGE
     | ThreatStatus.HYPERNATIVE_GUARD
+    | ThreatStatus.INVALID_GUARD
     | CommonSharedStatus.FAILED
   [StatusGroup.CUSTOM_CHECKS]: ThreatStatus.NO_THREAT | ThreatStatus.CUSTOM_CHECKS_FAILED
   [StatusGroup.DEADLOCK]:
@@ -108,6 +109,8 @@ export enum ThreatStatus {
   OWNERSHIP_CHANGE = 'OWNERSHIP_CHANGE', // 9F
   MODULE_CHANGE = 'MODULE_CHANGE', // 9G
   HYPERNATIVE_GUARD = 'HYPERNATIVE_GUARD', // used only for Safes with Hypernative Guard installed
+  // 9I — client-side check: setGuard target does not implement the Guard interface (bricks pre-1.4.1 Safes)
+  INVALID_GUARD = 'INVALID_GUARD',
 }
 
 export enum DeadlockStatus {


### PR DESCRIPTION
## What it solves

On Safes below v1.4.1, `setGuard` accepts any address without checking it implements the guard interface, so a wrong address permanently bricks the Safe.

Resolves: [WA-2805](https://linear.app/safe-global/issue/WA-2805/check-setguard-target-is-a-valid-guard-address)

## How this PR fixes it

Adds a client-side Safe Shield check that decodes a `setGuard` call (direct or nested in a MultiSend) and, on affected Safe versions, verifies the target implements the guard interface via ERC-165. An invalid target surfaces as a critical finding that requires risk confirmation. Runs on both web and mobile; v1.4.1+ Safes are skipped since the contract rejects invalid guards on-chain.

## How to test it

1. On a pre-1.4.1 Safe, build a `setGuard` transaction (Transaction Builder) pointing at a random/EOA address.
2. Open the confirmation flow and check Safe Shield flags a critical "Invalid transaction guard" issue requiring confirmation.
3. Repeat with a valid guard address (and with `setGuard` removing the guard) — no warning.
4. Confirm a v1.4.1+ Safe shows no client-side guard warning.

## Screenshots

N/A - no new UI (existing Safe Shield issue card).

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

Co-authored-by: Valens <valens@safe.global>

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
