### PR TITLE
feat(safenet): derive check status from decoded events

### DIFF
--- a/packages/utils/src/features/safenet-checks/builders/checkEvents.ts
+++ b/packages/utils/src/features/safenet-checks/builders/checkEvents.ts
@@ -1,0 +1,124 @@
+import { faker } from '@faker-js/faker'
+import {
+  CheckEventType,
+  OracleGeneration,
+  type DisputeResolvedEvent,
+  type Hex,
+  type OracleAttestedEvent,
+  type OracleProposedEvent,
+  type OracleResultEvent,
+  type PlainAttestedEvent,
+  type PlainProposedEvent,
+  type RequestCreatedEvent,
+  type SentinelCommittedEvent,
+  type SentinelRevealedEvent,
+} from '../types'
+
+/**
+ * Direct `NormalizedCheckEvent` factories for status-machine and merge tests —
+ * they build the decoded shape without going through the wire encoding (use the
+ * `rawLogs` builders when you need to exercise the decoder itself).
+ */
+
+let idx = 0
+const hexHash = (): Hex => faker.string.hexadecimal({ length: 64, prefix: '0x', casing: 'lower' }) as Hex
+const addr = (): string => faker.finance.ethereumAddress()
+
+const base = (
+  over?: Partial<{ blockNumber: number; logIndex: number; transactionHash: string; generation: OracleGeneration }>,
+) => ({
+  blockNumber: over?.blockNumber ?? 100 + idx,
+  logIndex: over?.logIndex ?? idx++,
+  transactionHash: over?.transactionHash ?? hexHash(),
+  generation: over?.generation ?? OracleGeneration.STABLE,
+})
+
+export const proposedEvent = (over: Partial<OracleProposedEvent> = {}): OracleProposedEvent => ({
+  ...base(over),
+  type: CheckEventType.ORACLE_PROPOSED,
+  safeTxHash: over.safeTxHash ?? hexHash(),
+  chainId: over.chainId ?? '100',
+  safe: over.safe ?? addr(),
+  epoch: over.epoch ?? '1',
+  oracle: over.oracle ?? addr(),
+})
+
+export const attestedEvent = (over: Partial<OracleAttestedEvent> = {}): OracleAttestedEvent => ({
+  ...base(over),
+  type: CheckEventType.ORACLE_ATTESTED,
+  safeTxHash: over.safeTxHash ?? hexHash(),
+  chainId: over.chainId ?? '100',
+  safe: over.safe ?? addr(),
+  epoch: over.epoch ?? '1',
+  oracle: over.oracle ?? addr(),
+  signatureId: over.signatureId ?? hexHash(),
+  attestation: over.attestation ?? { r: { x: '1', y: '2' }, z: '3' },
+})
+
+export const plainProposedEvent = (over: Partial<PlainProposedEvent> = {}): PlainProposedEvent => ({
+  ...base(over),
+  type: CheckEventType.PLAIN_PROPOSED,
+  safeTxHash: over.safeTxHash ?? hexHash(),
+  chainId: over.chainId ?? '100',
+  safe: over.safe ?? addr(),
+  epoch: over.epoch ?? '1',
+})
+
+export const plainAttestedEvent = (over: Partial<PlainAttestedEvent> = {}): PlainAttestedEvent => ({
+  ...base(over),
+  type: CheckEventType.PLAIN_ATTESTED,
+  safeTxHash: over.safeTxHash ?? hexHash(),
+  chainId: over.chainId ?? '100',
+  safe: over.safe ?? addr(),
+  epoch: over.epoch ?? '1',
+  signatureId: over.signatureId ?? hexHash(),
+  attestation: over.attestation ?? { r: { x: '1', y: '2' }, z: '3' },
+})
+
+export const requestCreatedEvent = (over: Partial<RequestCreatedEvent> = {}): RequestCreatedEvent => ({
+  ...base({ generation: OracleGeneration.V2, ...over }),
+  type: CheckEventType.REQUEST_CREATED,
+  requestId: over.requestId ?? hexHash(),
+  proposer: over.proposer ?? addr(),
+  fee: over.fee ?? '1000',
+  bondTarget: over.bondTarget ?? '5000',
+  deadlineBlock: over.deadlineBlock ?? '150',
+  commitDeadlineBlock: over.commitDeadlineBlock ?? null,
+})
+
+export const sentinelCommittedEvent = (over: Partial<SentinelCommittedEvent> = {}): SentinelCommittedEvent => ({
+  ...base(over),
+  type: CheckEventType.SENTINEL_COMMITTED,
+  requestId: over.requestId ?? hexHash(),
+  sentinel: over.sentinel ?? addr(),
+  bondAmount: over.bondAmount ?? '5000',
+  approved: over.approved ?? null,
+  position: over.position ?? null,
+})
+
+export const sentinelRevealedEvent = (over: Partial<SentinelRevealedEvent> = {}): SentinelRevealedEvent => ({
+  ...base({ generation: OracleGeneration.V2, ...over }),
+  type: CheckEventType.SENTINEL_REVEALED,
+  requestId: over.requestId ?? hexHash(),
+  sentinel: over.sentinel ?? addr(),
+  approved: over.approved ?? true,
+  bondAmount: over.bondAmount ?? '5000',
+  reason: over.reason ?? '',
+})
+
+export const oracleResultEvent = (over: Partial<OracleResultEvent> = {}): OracleResultEvent => ({
+  ...base(over),
+  type: CheckEventType.ORACLE_RESULT,
+  requestId: over.requestId ?? hexHash(),
+  proposer: over.proposer ?? addr(),
+  approved: over.approved ?? true,
+  result: over.result ?? '0x',
+})
+
+export const disputeResolvedEvent = (over: Partial<DisputeResolvedEvent> = {}): DisputeResolvedEvent => ({
+  ...base(over),
+  type: CheckEventType.DISPUTE_RESOLVED,
+  requestId: over.requestId ?? hexHash(),
+  outcome: over.outcome ?? 1,
+  slashed: over.slashed ?? '0',
+})

--- a/packages/utils/src/features/safenet-checks/constants.ts
+++ b/packages/utils/src/features/safenet-checks/constants.ts
@@ -1,0 +1,118 @@
+/**
+ * Configuration for the Safenet read layer. Shared web+mobile, so every value
+ * reads the `NEXT_PUBLIC_*` variable first and falls back to `EXPO_PUBLIC_*`.
+ *
+ * These MUST be referenced statically (`process.env.NEXT_PUBLIC_…`). The web
+ * (webpack/Next) and mobile (Expo/Babel) bundlers only inline literal
+ * `process.env.<PREFIX>_*` reads — a dynamic `process.env[…]` lookup is left
+ * untouched and resolves to `undefined` in the browser, silently leaving the
+ * reader with no RPC URLs.
+ */
+
+/** First non-empty value, or `undefined`. */
+const firstDefined = (...values: Array<string | undefined>): string | undefined => {
+  for (const value of values) {
+    if (value !== undefined && value !== '') return value
+  }
+  return undefined
+}
+
+const parseCsv = (value: string | undefined): string[] =>
+  value
+    ? value
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+    : []
+
+/**
+ * The Safenet chain id — feeds BOTH the reader's provider network AND the
+ * EIP-712 domain used to derive request ids. A wrong value silently derives
+ * wrong request ids (checks stuck at SUBMITTED), so the reader asserts it
+ * against `eth_chainId` in development.
+ */
+export const SAFENET_CHAIN_ID =
+  firstDefined(process.env.NEXT_PUBLIC_SAFENET_CHAIN_ID, process.env.EXPO_PUBLIC_SAFENET_CHAIN_ID) ?? '100'
+
+/** Pinned Gnosis RPC endpoints for the read layer (csv). Rotated on failure. */
+export const SAFENET_RPC_URLS = parseCsv(
+  firstDefined(process.env.NEXT_PUBLIC_SAFENET_RPC_URLS, process.env.EXPO_PUBLIC_SAFENET_RPC_URLS) ??
+    'https://rpc.gnosischain.com',
+)
+
+/** Safenet Consensus contract. Default: Gnosis beta deployment. */
+export const SAFENET_CONSENSUS_ADDRESS =
+  firstDefined(process.env.NEXT_PUBLIC_SAFENET_CONSENSUS_ADDRESS, process.env.EXPO_PUBLIC_SAFENET_CONSENSUS_ADDRESS) ??
+  '0x223624cBF099e5a8f8cD5aF22aFa424a1d1acEE9'
+
+/**
+ * Optional FROSTCoordinator override. When unset the reader discovers it via
+ * `Consensus.getCoordinator()`. Default: Gnosis beta deployment.
+ */
+export const SAFENET_COORDINATOR_ADDRESS =
+  firstDefined(
+    process.env.NEXT_PUBLIC_SAFENET_COORDINATOR_ADDRESS,
+    process.env.EXPO_PUBLIC_SAFENET_COORDINATOR_ADDRESS,
+  ) ?? '0xaE27021CEB45316f1efe69D8E362aC07ED3Bd7E4'
+
+/**
+ * Sentinel-oracle allowlist (csv). **Security-critical, and empty by default.**
+ *
+ * `Consensus.proposeOracleTransaction` is permissionless and takes the oracle
+ * address as a caller argument, so the `oracle` field on a proposal event is
+ * attacker-chosen. Sourcing oracle logs from it would let anyone emit a
+ * fabricated `OracleResult(approved=false)` from their own contract and paint
+ * any Safe transaction `MALICIOUS`. The reader therefore only ever reads oracle
+ * events from an address on this list.
+ *
+ * Empty (today's default) means no sentinel oracle is trusted, so the oracle
+ * path is skipped entirely — which matches live beta, where only the validator
+ * attesters run and no sentinel oracle is deployed. Populate this when one is.
+ */
+export const SAFENET_ORACLE_ADDRESSES = parseCsv(
+  firstDefined(process.env.NEXT_PUBLIC_SAFENET_ORACLE_ADDRESSES, process.env.EXPO_PUBLIC_SAFENET_ORACLE_ADDRESSES),
+).map((address) => address.toLowerCase())
+
+// --- Polling / lookback tuning -------------------------------------------------
+
+/** Poll interval before the deadline block. */
+export const POLL_INTERVAL_FAST_MS = 6_000
+
+/** Poll interval in the post-deadline late window (a late BENIGN can still land). */
+export const POLL_INTERVAL_LATE_MS = 30_000
+
+/**
+ * How many blocks past the deadline the reader keeps polling before giving up.
+ * ~1h at Gnosis' ~5s block time, so a late attestation replacing a TIMED_OUT
+ * verdict has time to materialize.
+ */
+export const LATE_WINDOW_BLOCKS = 720
+
+/** Hard cap on how far back the reader scans for a check's first event. */
+export const MAX_LOOKBACK_BLOCKS = 30_000
+
+/** Max block span per `getLogs` call (Gnosis public RPC ceiling). */
+export const GETLOGS_CHUNK_BLOCKS = 10_000
+
+/** Nominal Gnosis block time, used to convert a timestamp into a block estimate. */
+export const BLOCK_TIME_SECONDS = 5
+
+/**
+ * Half-width of the targeted read window, in blocks. When the caller knows when
+ * the Safe transaction happened we scan `estimate ± this` instead of walking back
+ * from the chain head, which makes the read cost constant at any age.
+ *
+ * 5,000 blocks is ~7h either side — the Safenet proposal lands within minutes of
+ * the transaction (before or after it executes), so this is generous slack. The
+ * full window stays within one `getLogs` chunk.
+ */
+export const TARGETED_WINDOW_HALF_BLOCKS = 5_000
+
+/** Stop refining the block estimate once it lands within this many seconds. */
+export const BLOCK_ESTIMATE_TOLERANCE_SECONDS = 600
+
+/** Max refinement round-trips after the first estimate (each costs one RPC call). */
+export const BLOCK_ESTIMATE_MAX_REFINEMENTS = 2
+
+/** Max JSON-RPC calls batched into a single HTTP request by the provider. */
+export const PROVIDER_BATCH_MAX_COUNT = 3

--- a/packages/utils/src/features/safenet-checks/types/index.ts
+++ b/packages/utils/src/features/safenet-checks/types/index.ts
@@ -1,1 +1,3 @@
 export * from './events'
+export * from './status'
+export * from './snapshot'

--- a/packages/utils/src/features/safenet-checks/types/snapshot.ts
+++ b/packages/utils/src/features/safenet-checks/types/snapshot.ts
@@ -1,0 +1,28 @@
+import type { AttestationVerification, CheckStatus } from './status'
+import type { Hex, NormalizedCheckEvent, OracleGeneration } from './events'
+
+/**
+ * The full read-layer view of one check at one poll. Everything numeric is a
+ * decimal `string` so the snapshot is safe to hold in Redux. Recomputed from
+ * scratch each poll from the sorted event set (idempotent, reorg-self-healing);
+ * the monotonic merge is applied on top separately.
+ */
+export type SafenetCheckSnapshot = {
+  safeTxHash: Hex
+  /** The Safenet chain the Consensus contract lives on (e.g. Gnosis '100'). */
+  chainId: string
+  status: CheckStatus
+  /** Which oracle generation drove this check, once known. */
+  generation: OracleGeneration | null
+  /** The oracle request id (equals the oracle-proposal hash), once known. */
+  requestId: Hex | null
+  epoch: string | null
+  oracle: string | null
+  /** Block the check times out at (V1 `deadline` / V2 `revealDeadline`). */
+  deadlineBlock: string | null
+  /** Chain head observed at snapshot time — the deadline is compared to this. */
+  headBlock: string | null
+  attestation: AttestationVerification
+  /** All decoded lifecycle events, sorted ascending by (block, logIndex). */
+  events: NormalizedCheckEvent[]
+}

--- a/packages/utils/src/features/safenet-checks/types/status.ts
+++ b/packages/utils/src/features/safenet-checks/types/status.ts
@@ -1,0 +1,87 @@
+import type { Hex } from './events'
+
+/**
+ * Full lifecycle status. The last two (`AWAITING_VERIFICATION`,
+ * `VERIFICATION_FAILED`) are internal-only: they never reach the UI directly —
+ * {@link toPublicStatus} folds them into the public set. Crucially,
+ * `VERIFICATION_FAILED` never becomes `BENIGN`.
+ */
+export enum CheckStatus {
+  /** Proposed onchain, no oracle activity yet. */
+  SUBMITTED = 'SUBMITTED',
+  /** Oracle request opened / sentinels active, pre-deadline, no verdict. */
+  IN_PROGRESS = 'IN_PROGRESS',
+  /** Attested onchain but the FROST signature has not been verified yet. */
+  AWAITING_VERIFICATION = 'AWAITING_VERIFICATION',
+  /** Attested, but the FROST signature failed verification (terminal). */
+  VERIFICATION_FAILED = 'VERIFICATION_FAILED',
+  /**
+   * Attested AND cryptographically verified. The only green state.
+   *
+   * Reached from either path: the validator set's own deterministic checks
+   * (`TransactionAttested`, what beta runs today) or the sentinel-oracle checks
+   * (`OracleTransactionAttested`, richer checks, not yet live). Both require a
+   * verified FROST signature first.
+   */
+  BENIGN = 'BENIGN',
+  /** A negative verdict was observed (rejected / disapproved). */
+  MALICIOUS = 'MALICIOUS',
+  /** Deadline passed without a resolving verdict (includes frozen disputes). */
+  TIMED_OUT = 'TIMED_OUT',
+  /** The reader could not determine state (RPC/config failure). */
+  UNAVAILABLE = 'UNAVAILABLE',
+}
+
+/** The status values that may be shown to a user. */
+export type PublicCheckStatus =
+  | CheckStatus.SUBMITTED
+  | CheckStatus.IN_PROGRESS
+  | CheckStatus.BENIGN
+  | CheckStatus.MALICIOUS
+  | CheckStatus.TIMED_OUT
+  | CheckStatus.UNAVAILABLE
+
+/**
+ * Map an internal status to its public projection.
+ *
+ * `AWAITING_VERIFICATION` reads as still-working (`IN_PROGRESS`);
+ * `VERIFICATION_FAILED` reads as `TIMED_OUT` (the copy is timeout-style — a
+ * check whose attestation cannot be trusted is treated as not-completed, never
+ * as safe).
+ */
+export const toPublicStatus = (status: CheckStatus): PublicCheckStatus => {
+  switch (status) {
+    case CheckStatus.AWAITING_VERIFICATION:
+      return CheckStatus.IN_PROGRESS
+    case CheckStatus.VERIFICATION_FAILED:
+      return CheckStatus.TIMED_OUT
+    default:
+      return status
+  }
+}
+
+/** Result of verifying an attestation's FROST signature. */
+export enum AttestationVerificationStatus {
+  /** No attestation present, or verification not yet attempted. */
+  UNVERIFIED = 'UNVERIFIED',
+  /** Group key not yet available — retryable, not terminal. */
+  PENDING = 'PENDING',
+  /** Signature verified against the epoch group key. */
+  VERIFIED = 'VERIFIED',
+  /** Signature did not verify — terminal, must never render as BENIGN. */
+  INVALID = 'INVALID',
+}
+
+export type AttestationVerification = {
+  status: AttestationVerificationStatus
+  /** The attestation's signature id, when one exists. */
+  signatureId: Hex | null
+  /** The oracle-proposal hash (a.k.a. requestId) that was verified. */
+  message: Hex | null
+}
+
+export const UNVERIFIED_ATTESTATION: AttestationVerification = {
+  status: AttestationVerificationStatus.UNVERIFIED,
+  signatureId: null,
+  message: null,
+}

--- a/packages/utils/src/features/safenet-checks/utils/__tests__/computePollingInterval.test.ts
+++ b/packages/utils/src/features/safenet-checks/utils/__tests__/computePollingInterval.test.ts
@@ -1,0 +1,71 @@
+import { computePollingInterval } from '../computePollingInterval'
+import { LATE_WINDOW_BLOCKS, POLL_INTERVAL_FAST_MS, POLL_INTERVAL_LATE_MS } from '../../constants'
+import { CheckStatus } from '../../types'
+
+describe('computePollingInterval', () => {
+  it.each([CheckStatus.BENIGN, CheckStatus.MALICIOUS, CheckStatus.VERIFICATION_FAILED])(
+    'stops polling on the terminal status %s',
+    (status) => {
+      expect(computePollingInterval({ status, headBlock: '10', deadlineBlock: '150' })).toEqual({
+        shouldPoll: false,
+        intervalMs: 0,
+      })
+    },
+  )
+
+  it('polls fast before the deadline', () => {
+    expect(computePollingInterval({ status: CheckStatus.IN_PROGRESS, headBlock: '140', deadlineBlock: '150' })).toEqual(
+      {
+        shouldPoll: true,
+        intervalMs: POLL_INTERVAL_FAST_MS,
+      },
+    )
+  })
+
+  it('polls fast at head == deadline (still in-window)', () => {
+    expect(computePollingInterval({ status: CheckStatus.IN_PROGRESS, headBlock: '150', deadlineBlock: '150' })).toEqual(
+      {
+        shouldPoll: true,
+        intervalMs: POLL_INTERVAL_FAST_MS,
+      },
+    )
+  })
+
+  it('polls fast when the deadline is unknown', () => {
+    expect(computePollingInterval({ status: CheckStatus.SUBMITTED, headBlock: '140', deadlineBlock: null })).toEqual({
+      shouldPoll: true,
+      intervalMs: POLL_INTERVAL_FAST_MS,
+    })
+  })
+
+  it('polls slowly in the post-deadline late window (a late BENIGN can still land)', () => {
+    expect(computePollingInterval({ status: CheckStatus.TIMED_OUT, headBlock: '200', deadlineBlock: '150' })).toEqual({
+      shouldPoll: true,
+      intervalMs: POLL_INTERVAL_LATE_MS,
+    })
+  })
+
+  it('polls slowly right up to the end of the late window', () => {
+    const deadline = 150
+    const head = deadline + LATE_WINDOW_BLOCKS
+    expect(
+      computePollingInterval({
+        status: CheckStatus.TIMED_OUT,
+        headBlock: String(head),
+        deadlineBlock: String(deadline),
+      }),
+    ).toEqual({ shouldPoll: true, intervalMs: POLL_INTERVAL_LATE_MS })
+  })
+
+  it('stops once the late window closes', () => {
+    const deadline = 150
+    const head = deadline + LATE_WINDOW_BLOCKS + 1
+    expect(
+      computePollingInterval({
+        status: CheckStatus.TIMED_OUT,
+        headBlock: String(head),
+        deadlineBlock: String(deadline),
+      }),
+    ).toEqual({ shouldPoll: false, intervalMs: 0 })
+  })
+})

--- a/packages/utils/src/features/safenet-checks/utils/__tests__/deriveCheckState.test.ts
+++ b/packages/utils/src/features/safenet-checks/utils/__tests__/deriveCheckState.test.ts
@@ -1,0 +1,177 @@
+import { deriveCheckState } from '../deriveCheckState'
+import {
+  attestedEvent,
+  disputeResolvedEvent,
+  oracleResultEvent,
+  plainAttestedEvent,
+  plainProposedEvent,
+  proposedEvent,
+  requestCreatedEvent,
+  sentinelCommittedEvent,
+  sentinelRevealedEvent,
+} from '../../builders/checkEvents'
+import {
+  AttestationVerificationStatus,
+  CheckStatus,
+  OracleGeneration,
+  UNVERIFIED_ATTESTATION,
+  type AttestationVerification,
+  type NormalizedCheckEvent,
+} from '../../types'
+
+const verification = (status: AttestationVerificationStatus): AttestationVerification => ({
+  status,
+  signatureId: '0xsig',
+  message: '0xmsg',
+})
+
+const derive = (
+  events: NormalizedCheckEvent[],
+  headBlock: string | null = '140',
+  attestation: AttestationVerification = UNVERIFIED_ATTESTATION,
+) => deriveCheckState({ events, headBlock, attestation })
+
+// A request that times out at block 150.
+const request = () => requestCreatedEvent({ deadlineBlock: '150', commitDeadlineBlock: '150' })
+
+describe('deriveCheckState — precedence table', () => {
+  it('SUBMITTED when only proposed', () => {
+    expect(derive([proposedEvent()])).toBe(CheckStatus.SUBMITTED)
+  })
+
+  it('UNAVAILABLE for an empty event set — nothing was ever proposed for this hash', () => {
+    expect(derive([])).toBe(CheckStatus.UNAVAILABLE)
+  })
+
+  describe('non-oracle path (validator-run deterministic checks)', () => {
+    const plain = () => [plainProposedEvent(), plainAttestedEvent()]
+
+    it('BENIGN once the attestation verifies — the validators ran their checks', () => {
+      expect(derive(plain(), '100', verification(AttestationVerificationStatus.VERIFIED))).toBe(CheckStatus.BENIGN)
+    })
+
+    it('never BENIGN on an unverified attestation', () => {
+      expect(derive(plain(), '100', verification(AttestationVerificationStatus.PENDING))).toBe(
+        CheckStatus.AWAITING_VERIFICATION,
+      )
+    })
+
+    it('VERIFICATION_FAILED on a signature that does not verify', () => {
+      expect(derive(plain(), '100', verification(AttestationVerificationStatus.INVALID))).toBe(
+        CheckStatus.VERIFICATION_FAILED,
+      )
+    })
+
+    it('SUBMITTED while only the proposal has landed', () => {
+      expect(derive([plainProposedEvent()])).toBe(CheckStatus.SUBMITTED)
+    })
+
+    it('loses to a negative oracle verdict on the same hash', () => {
+      expect(
+        derive(
+          [plainAttestedEvent(), oracleResultEvent({ approved: false })],
+          '100',
+          verification(AttestationVerificationStatus.VERIFIED),
+        ),
+      ).toBe(CheckStatus.MALICIOUS)
+    })
+  })
+
+  it('IN_PROGRESS once a request is open, pre-deadline', () => {
+    expect(derive([proposedEvent(), request()], '140')).toBe(CheckStatus.IN_PROGRESS)
+  })
+
+  it('IN_PROGRESS on V2 commit activity (no verdict yet)', () => {
+    const events = [proposedEvent(), request(), sentinelCommittedEvent({ generation: OracleGeneration.V2 })]
+    expect(derive(events, '140')).toBe(CheckStatus.IN_PROGRESS)
+  })
+
+  it('positive OracleResult alone is NOT BENIGN — it is IN_PROGRESS', () => {
+    const events = [proposedEvent(), request(), oracleResultEvent({ approved: true })]
+    expect(derive(events, '140')).toBe(CheckStatus.IN_PROGRESS)
+  })
+
+  it('AWAITING_VERIFICATION when attested but not yet verified', () => {
+    const events = [proposedEvent(), request(), attestedEvent()]
+    expect(derive(events, '140', UNVERIFIED_ATTESTATION)).toBe(CheckStatus.AWAITING_VERIFICATION)
+    expect(derive(events, '140', verification(AttestationVerificationStatus.PENDING))).toBe(
+      CheckStatus.AWAITING_VERIFICATION,
+    )
+  })
+
+  it('BENIGN only when attested AND verified', () => {
+    const events = [proposedEvent(), request(), attestedEvent(), oracleResultEvent({ approved: true })]
+    expect(derive(events, '140', verification(AttestationVerificationStatus.VERIFIED))).toBe(CheckStatus.BENIGN)
+  })
+
+  it('VERIFICATION_FAILED when attested but signature invalid — never BENIGN', () => {
+    const events = [proposedEvent(), request(), attestedEvent()]
+    const status = derive(events, '140', verification(AttestationVerificationStatus.INVALID))
+    expect(status).toBe(CheckStatus.VERIFICATION_FAILED)
+    expect(status).not.toBe(CheckStatus.BENIGN)
+  })
+
+  it('a lone V1 negative commit is NOT a verdict — one sentinel cannot red-flag a tx', () => {
+    const events = [
+      proposedEvent(),
+      request(),
+      sentinelCommittedEvent({ generation: OracleGeneration.V1, approved: false }),
+    ]
+    expect(derive(events, '140')).toBe(CheckStatus.IN_PROGRESS)
+  })
+
+  it('a lone V2 negative reveal is NOT a verdict — the oracle resolves by unanimity', () => {
+    const events = [proposedEvent(), request(), sentinelRevealedEvent({ approved: false })]
+    expect(derive(events, '140')).toBe(CheckStatus.IN_PROGRESS)
+  })
+
+  it('MALICIOUS on a negative OracleResult', () => {
+    const events = [proposedEvent(), request(), oracleResultEvent({ approved: false })]
+    expect(derive(events, '140')).toBe(CheckStatus.MALICIOUS)
+  })
+
+  it('TIMED_OUT past the deadline with no verdict', () => {
+    expect(derive([proposedEvent(), request()], '151')).toBe(CheckStatus.TIMED_OUT)
+  })
+
+  it('TIMED_OUT for a frozen dispute past the deadline', () => {
+    const events = [proposedEvent(), request(), disputeResolvedEvent()]
+    expect(derive(events, '151')).toBe(CheckStatus.TIMED_OUT)
+  })
+})
+
+describe('deriveCheckState — head == deadline boundary', () => {
+  it('stays IN_PROGRESS at head == deadline (reveal window is inclusive)', () => {
+    expect(derive([proposedEvent(), request()], '150')).toBe(CheckStatus.IN_PROGRESS)
+  })
+
+  it('TIMED_OUT one block later', () => {
+    expect(derive([proposedEvent(), request()], '151')).toBe(CheckStatus.TIMED_OUT)
+  })
+})
+
+describe('deriveCheckState — late verdicts beat the deadline', () => {
+  it('late BENIGN: attested+verified past deadline is BENIGN, not TIMED_OUT', () => {
+    const events = [proposedEvent(), request(), attestedEvent()]
+    expect(derive(events, '999', verification(AttestationVerificationStatus.VERIFIED))).toBe(CheckStatus.BENIGN)
+  })
+
+  it('late MALICIOUS: a negative verdict past deadline is MALICIOUS, not TIMED_OUT', () => {
+    const events = [proposedEvent(), request(), oracleResultEvent({ approved: false })]
+    expect(derive(events, '999')).toBe(CheckStatus.MALICIOUS)
+  })
+
+  it('VERIFICATION_FAILED past deadline stays VERIFICATION_FAILED, not TIMED_OUT', () => {
+    const events = [proposedEvent(), request(), attestedEvent()]
+    expect(derive(events, '999', verification(AttestationVerificationStatus.INVALID))).toBe(
+      CheckStatus.VERIFICATION_FAILED,
+    )
+  })
+})
+
+describe('deriveCheckState — negative verdict outranks a verified attestation', () => {
+  it('MALICIOUS wins over attested+verified when both are present', () => {
+    const events = [proposedEvent(), request(), attestedEvent(), oracleResultEvent({ approved: false })]
+    expect(derive(events, '140', verification(AttestationVerificationStatus.VERIFIED))).toBe(CheckStatus.MALICIOUS)
+  })
+})

--- a/packages/utils/src/features/safenet-checks/utils/__tests__/mergeMonotonic.test.ts
+++ b/packages/utils/src/features/safenet-checks/utils/__tests__/mergeMonotonic.test.ts
@@ -1,0 +1,90 @@
+import { mergeMonotonic } from '../mergeMonotonic'
+import { CheckStatus } from '../../types'
+
+const ALL = Object.values(CheckStatus)
+
+describe('mergeMonotonic', () => {
+  it('takes the incoming status on first observation (null pinned)', () => {
+    for (const next of ALL) {
+      expect(mergeMonotonic(null, next)).toBe(next)
+    }
+  })
+
+  it('is idempotent when pinned equals next', () => {
+    for (const status of ALL) {
+      expect(mergeMonotonic(status, status)).toBe(status)
+    }
+  })
+
+  describe('terminal verdicts are sticky', () => {
+    it('never walks back a BENIGN verdict, except to MALICIOUS', () => {
+      for (const next of ALL) {
+        const expected = next === CheckStatus.MALICIOUS ? CheckStatus.MALICIOUS : CheckStatus.BENIGN
+        expect(mergeMonotonic(CheckStatus.BENIGN, next)).toBe(expected)
+      }
+    })
+
+    it('lets a late arbitration result override a shown BENIGN', () => {
+      expect(mergeMonotonic(CheckStatus.BENIGN, CheckStatus.MALICIOUS)).toBe(CheckStatus.MALICIOUS)
+    })
+
+    it('never walks back a MALICIOUS verdict', () => {
+      for (const next of ALL) {
+        expect(mergeMonotonic(CheckStatus.MALICIOUS, next)).toBe(CheckStatus.MALICIOUS)
+      }
+    })
+  })
+
+  describe('late upgrades from TIMED_OUT', () => {
+    it('a late BENIGN replaces TIMED_OUT', () => {
+      expect(mergeMonotonic(CheckStatus.TIMED_OUT, CheckStatus.BENIGN)).toBe(CheckStatus.BENIGN)
+    })
+
+    it('a late MALICIOUS replaces TIMED_OUT', () => {
+      expect(mergeMonotonic(CheckStatus.TIMED_OUT, CheckStatus.MALICIOUS)).toBe(CheckStatus.MALICIOUS)
+    })
+
+    it('does not regress TIMED_OUT back to IN_PROGRESS or SUBMITTED', () => {
+      expect(mergeMonotonic(CheckStatus.TIMED_OUT, CheckStatus.IN_PROGRESS)).toBe(CheckStatus.TIMED_OUT)
+      expect(mergeMonotonic(CheckStatus.TIMED_OUT, CheckStatus.SUBMITTED)).toBe(CheckStatus.TIMED_OUT)
+    })
+  })
+
+  describe('VERIFICATION_FAILED never becomes BENIGN', () => {
+    it('keeps VERIFICATION_FAILED when a BENIGN arrives', () => {
+      expect(mergeMonotonic(CheckStatus.VERIFICATION_FAILED, CheckStatus.BENIGN)).toBe(CheckStatus.VERIFICATION_FAILED)
+    })
+
+    it('allows an escalation to MALICIOUS', () => {
+      expect(mergeMonotonic(CheckStatus.VERIFICATION_FAILED, CheckStatus.MALICIOUS)).toBe(CheckStatus.MALICIOUS)
+    })
+  })
+
+  describe('non-terminal progress', () => {
+    it('advances SUBMITTED → IN_PROGRESS', () => {
+      expect(mergeMonotonic(CheckStatus.SUBMITTED, CheckStatus.IN_PROGRESS)).toBe(CheckStatus.IN_PROGRESS)
+    })
+
+    it('does not regress IN_PROGRESS → SUBMITTED', () => {
+      expect(mergeMonotonic(CheckStatus.IN_PROGRESS, CheckStatus.SUBMITTED)).toBe(CheckStatus.IN_PROGRESS)
+    })
+
+    it('advances IN_PROGRESS → TIMED_OUT (stall path)', () => {
+      expect(mergeMonotonic(CheckStatus.IN_PROGRESS, CheckStatus.TIMED_OUT)).toBe(CheckStatus.TIMED_OUT)
+    })
+  })
+
+  describe('a transient UNAVAILABLE never clobbers a known status', () => {
+    it('keeps every real pinned status when next is UNAVAILABLE', () => {
+      for (const pinned of ALL) {
+        if (pinned === CheckStatus.UNAVAILABLE) continue
+        expect(mergeMonotonic(pinned, CheckStatus.UNAVAILABLE)).toBe(pinned)
+      }
+    })
+
+    it('recovers from a pinned UNAVAILABLE to any real status', () => {
+      expect(mergeMonotonic(CheckStatus.UNAVAILABLE, CheckStatus.IN_PROGRESS)).toBe(CheckStatus.IN_PROGRESS)
+      expect(mergeMonotonic(CheckStatus.UNAVAILABLE, CheckStatus.BENIGN)).toBe(CheckStatus.BENIGN)
+    })
+  })
+})

--- a/packages/utils/src/features/safenet-checks/utils/computePollingInterval.ts
+++ b/packages/utils/src/features/safenet-checks/utils/computePollingInterval.ts
@@ -1,0 +1,53 @@
+import { LATE_WINDOW_BLOCKS, POLL_INTERVAL_FAST_MS, POLL_INTERVAL_LATE_MS } from '../constants'
+import { CheckStatus } from '../types'
+
+export type PollingInput = {
+  status: CheckStatus
+  /** Current chain head as a decimal string, or null if unknown. */
+  headBlock: string | null
+  /** The check's deadline block as a decimal string, or null if unknown. */
+  deadlineBlock: string | null
+}
+
+export type PollingDecision = {
+  shouldPoll: boolean
+  /** Interval in ms; 0 when polling has stopped. */
+  intervalMs: number
+}
+
+const STOP: PollingDecision = { shouldPoll: false, intervalMs: 0 }
+
+/**
+ * Decide whether and how often to re-poll a check.
+ *
+ * Stops permanently on a settled verdict (`BENIGN`, `MALICIOUS`) or terminal
+ * `VERIFICATION_FAILED`. Otherwise polls fast (6s) up to and including the
+ * deadline block, then slowly (30s) through a ~1h late window so a late
+ * `BENIGN`/`MALICIOUS` can still replace a `TIMED_OUT`, and finally stops once
+ * the late window closes.
+ */
+export const computePollingInterval = ({ status, headBlock, deadlineBlock }: PollingInput): PollingDecision => {
+  if (status === CheckStatus.BENIGN || status === CheckStatus.MALICIOUS || status === CheckStatus.VERIFICATION_FAILED) {
+    return STOP
+  }
+
+  // ponytail: UNAVAILABLE stops immediately rather than backing off. Ceiling —
+  // a check proposed after this read lands is not picked up until the user hits
+  // re-check. Without this a transaction that never had a check (most of them)
+  // polls a public RPC every 6s forever, once per rendered row.
+  if (status === CheckStatus.UNAVAILABLE) return STOP
+
+  const head = headBlock !== null ? BigInt(headBlock) : null
+  const deadline = deadlineBlock !== null ? BigInt(deadlineBlock) : null
+
+  if (deadline === null || head === null || head <= deadline) {
+    return { shouldPoll: true, intervalMs: POLL_INTERVAL_FAST_MS }
+  }
+
+  const lateWindowEnd = deadline + BigInt(LATE_WINDOW_BLOCKS)
+  if (head <= lateWindowEnd) {
+    return { shouldPoll: true, intervalMs: POLL_INTERVAL_LATE_MS }
+  }
+
+  return STOP
+}

--- a/packages/utils/src/features/safenet-checks/utils/deriveCheckState.ts
+++ b/packages/utils/src/features/safenet-checks/utils/deriveCheckState.ts
@@ -1,0 +1,108 @@
+import {
+  AttestationVerificationStatus,
+  CheckEventType,
+  CheckStatus,
+  type AttestationVerification,
+  type NormalizedCheckEvent,
+} from '../types'
+
+export type DeriveCheckStateInput = {
+  /** All decoded events for one check (order-independent; derive is a fold). */
+  events: ReadonlyArray<NormalizedCheckEvent>
+  /** FROST verification result for the attestation, if any. */
+  attestation: AttestationVerification
+  /** Current chain head as a decimal string, or null if unknown. */
+  headBlock: string | null
+}
+
+/** Highest deadline block across the check's request events, or null. */
+const deadlineBlockOf = (events: ReadonlyArray<NormalizedCheckEvent>): bigint | null => {
+  let deadline: bigint | null = null
+  for (const event of events) {
+    if (event.type === CheckEventType.REQUEST_CREATED) {
+      const value = BigInt(event.deadlineBlock)
+      if (deadline === null || value > deadline) deadline = value
+    }
+  }
+  return deadline
+}
+
+/**
+ * True if the oracle has SETTLED on a rejection.
+ *
+ * Only `OracleResult` counts. A single sentinel's `Committed`/`Revealed` is one
+ * bonded vote, not a verdict: the oracle resolves by unanimity, and a split goes
+ * to arbitration which can still approve. Treating one dissent as final would
+ * let any single sentinel permanently red-flag a transaction, and `MALICIOUS` is
+ * terminal.
+ */
+const hasNegativeVerdict = (events: ReadonlyArray<NormalizedCheckEvent>): boolean =>
+  events.some((event) => event.type === CheckEventType.ORACLE_RESULT && event.approved === false)
+
+/** True once anything at all has been observed for this hash. */
+const hasAnyProposal = (events: ReadonlyArray<NormalizedCheckEvent>): boolean =>
+  events.some((event) => event.type === CheckEventType.ORACLE_PROPOSED || event.type === CheckEventType.PLAIN_PROPOSED)
+
+const hasOracleActivity = (events: ReadonlyArray<NormalizedCheckEvent>): boolean =>
+  events.some(
+    (event) =>
+      event.type === CheckEventType.REQUEST_CREATED ||
+      event.type === CheckEventType.SENTINEL_COMMITTED ||
+      event.type === CheckEventType.SENTINEL_REVEALED ||
+      event.type === CheckEventType.ORACLE_RESULT ||
+      event.type === CheckEventType.DISPUTE_RESOLVED,
+  )
+
+/**
+ * Derive the internal check status from a check's full event set.
+ *
+ * Recompute-from-scratch each poll (idempotent, reorg-self-healing). Precedence,
+ * highest first:
+ *
+ *  1. A negative verdict → `MALICIOUS` (even late, even past deadline).
+ *  2. Attested → `BENIGN` if the FROST signature verified, `VERIFICATION_FAILED`
+ *     if it did not (never `BENIGN`), else `AWAITING_VERIFICATION`. This sits
+ *     above the deadline check so a late-but-verified attestation replaces a
+ *     would-be `TIMED_OUT`.
+ *  3. Past the deadline block (`head > deadline`) → `TIMED_OUT` (incl. frozen
+ *     disputes, which never emit a resolving `OracleResult`).
+ *  4. Any oracle lifecycle activity → `IN_PROGRESS` (a positive `OracleResult`
+ *     alone lands here — it is NOT `BENIGN` without a verified attestation).
+ *  5. Otherwise → `SUBMITTED`.
+ */
+export const deriveCheckState = ({ events, attestation, headBlock }: DeriveCheckStateInput): CheckStatus => {
+  if (hasNegativeVerdict(events)) return CheckStatus.MALICIOUS
+
+  const attested = events.some((event) => event.type === CheckEventType.ORACLE_ATTESTED)
+  if (attested) {
+    if (attestation.status === AttestationVerificationStatus.VERIFIED) return CheckStatus.BENIGN
+    if (attestation.status === AttestationVerificationStatus.INVALID) return CheckStatus.VERIFICATION_FAILED
+    return CheckStatus.AWAITING_VERIFICATION
+  }
+
+  // Non-oracle path: the validator set ran its own deterministic checks and
+  // attested the result. That is a real passed check, so it resolves to BENIGN —
+  // but only on a verified signature, exactly like the oracle path. Sits below
+  // the oracle branch (richer checks win) and above the deadline check (it is a
+  // settled outcome, not a pending one).
+  const plainAttested = events.some((event) => event.type === CheckEventType.PLAIN_ATTESTED)
+  if (plainAttested) {
+    if (attestation.status === AttestationVerificationStatus.VERIFIED) return CheckStatus.BENIGN
+    if (attestation.status === AttestationVerificationStatus.INVALID) return CheckStatus.VERIFICATION_FAILED
+    return CheckStatus.AWAITING_VERIFICATION
+  }
+
+  const deadline = deadlineBlockOf(events)
+  if (deadline !== null && headBlock !== null && BigInt(headBlock) > deadline) {
+    return CheckStatus.TIMED_OUT
+  }
+
+  if (hasOracleActivity(events)) return CheckStatus.IN_PROGRESS
+
+  // `SUBMITTED` means "we saw the proposal, nothing has happened yet" — it must
+  // require an actual proposal event. Falling through to it on an empty event
+  // set claimed a check was in flight for every transaction that never had one.
+  if (hasAnyProposal(events)) return CheckStatus.SUBMITTED
+
+  return CheckStatus.UNAVAILABLE
+}

--- a/packages/utils/src/features/safenet-checks/utils/mergeMonotonic.ts
+++ b/packages/utils/src/features/safenet-checks/utils/mergeMonotonic.ts
@@ -1,0 +1,68 @@
+import { CheckStatus } from '../types'
+
+/**
+ * Monotonic merge — the "never take back a verdict" layer, applied on top of the
+ * recompute-from-scratch status so a poll (or a reorg) can't visibly walk a
+ * verdict backwards.
+ *
+ * For each already-pinned status, the table lists which incoming statuses are
+ * allowed to replace it; anything else keeps the pinned status. Highlights:
+ *  - `MALICIOUS` is terminal. `BENIGN` is terminal except for `MALICIOUS`: a
+ *    late arbitration result is the one correction that increases safety, so it
+ *    is the only transition allowed to override a shown verdict.
+ *  - A late `BENIGN` or `MALICIOUS` may replace `TIMED_OUT` (the two allowed
+ *    late upgrades).
+ *  - `VERIFICATION_FAILED` may become `MALICIOUS` but never `BENIGN`.
+ *  - A transient `UNAVAILABLE` never overwrites a known status.
+ */
+const ALLOWED_TRANSITIONS: Record<CheckStatus, ReadonlyArray<CheckStatus>> = {
+  [CheckStatus.UNAVAILABLE]: [
+    CheckStatus.SUBMITTED,
+    CheckStatus.IN_PROGRESS,
+    CheckStatus.AWAITING_VERIFICATION,
+    CheckStatus.TIMED_OUT,
+    CheckStatus.VERIFICATION_FAILED,
+    CheckStatus.BENIGN,
+    CheckStatus.MALICIOUS,
+  ],
+  [CheckStatus.SUBMITTED]: [
+    CheckStatus.IN_PROGRESS,
+    CheckStatus.AWAITING_VERIFICATION,
+    CheckStatus.TIMED_OUT,
+    CheckStatus.VERIFICATION_FAILED,
+    CheckStatus.BENIGN,
+    CheckStatus.MALICIOUS,
+  ],
+  [CheckStatus.IN_PROGRESS]: [
+    CheckStatus.AWAITING_VERIFICATION,
+    CheckStatus.TIMED_OUT,
+    CheckStatus.VERIFICATION_FAILED,
+    CheckStatus.BENIGN,
+    CheckStatus.MALICIOUS,
+  ],
+  [CheckStatus.AWAITING_VERIFICATION]: [
+    CheckStatus.TIMED_OUT,
+    CheckStatus.VERIFICATION_FAILED,
+    CheckStatus.BENIGN,
+    CheckStatus.MALICIOUS,
+  ],
+  [CheckStatus.TIMED_OUT]: [CheckStatus.VERIFICATION_FAILED, CheckStatus.BENIGN, CheckStatus.MALICIOUS],
+  [CheckStatus.VERIFICATION_FAILED]: [CheckStatus.MALICIOUS],
+  [CheckStatus.BENIGN]: [CheckStatus.MALICIOUS],
+  [CheckStatus.MALICIOUS]: [],
+}
+
+/**
+ * Merge a freshly-derived status onto the pinned one.
+ *
+ * @param pinned - the previously-committed status, or null on first observation
+ * @param next - the status just derived from the current event set
+ * @returns the status to show/persist
+ */
+export const mergeMonotonic = (pinned: CheckStatus | null | undefined, next: CheckStatus): CheckStatus => {
+  if (pinned == null) return next
+  if (pinned === next) return pinned
+  // A transient fetch failure must never clobber a known status.
+  if (next === CheckStatus.UNAVAILABLE) return pinned
+  return ALLOWED_TRANSITIONS[pinned].includes(next) ? next : pinned
+}


### PR DESCRIPTION
## What it solves

Resolves: part 3 of 5 replacing #8368 (closed — 4.2k lines was too large to review).

> **Stacked on the decode PR.** Merge order: #8369 → decode → **this** → reader → wiring.

This PR answers one question: **are the state transitions right?**

It turns the decoded events from the previous PR into a status a user could be shown. Still pure functions — a fold over events, no chain access.

## How this PR fixes it

- **`types/status.ts`** — the public status (`SUBMITTED` / `IN_PROGRESS` / `BENIGN` / `MALICIOUS` / `TIMED_OUT` / `UNAVAILABLE`) and the attestation-verification result.
- **`utils/deriveCheckState.ts`** — an order-independent fold. Events arrive from chunked `eth_getLogs` calls in no guaranteed order, so the derivation must not depend on arrival sequence.
- **`utils/mergeMonotonic.ts`** — reconciles the new derivation with what was already shown.
- **`utils/computePollingInterval.ts`** — fast near submission, slow in the late window, stopped once terminal.
- **`constants.ts`** — chain, contract, and polling configuration, dual-prefixed for web (`NEXT_PUBLIC_*`) and mobile (`EXPO_PUBLIC_*`).

### The three rules worth your attention

**1. `BENIGN` is underivable without a FROST signature that verified.** There is no path to a positive verdict that skips the crypto in #8369. If you can find one, that's the bug worth finding in this PR.

**2. One sentinel's commit or reveal is not a verdict.** It is a single bonded vote. The oracle resolves by unanimity, and a split goes to arbitration that can still approve. Only a settled `OracleResult(approved=false)` is `MALICIOUS`. Treating a single sentinel's reveal as settled would show "malicious" for transactions that end up approved.

**3. Verdicts never walk backwards, with exactly one exception.** A late `MALICIOUS` may replace an already-shown `BENIGN`. That is the only correction that increases safety, so it is the only one allowed. The reverse — downgrading a shown `MALICIOUS` — is forbidden.

`mergeMonotonic`'s transition table is exhaustive over all 80 status pairs and the test asserts each one.

### On `constants.ts`

It lands here because `computePollingInterval` needs the poll constants. It also holds `SAFENET_ORACLE_ADDRESSES`, which is a **security-relevant allowlist** whose consumer arrives in the reader PR — see that PR for why it exists and why it is empty by default. Flagging it rather than splitting the file across two PRs.

## How to test it

```bash
yarn workspace @safe-global/utils test --testPathPattern 'safenet-checks'
yarn workspace @safe-global/utils type-check
```

92 tests, 8 suites (cumulative with the two PRs below it).

## Affected flows

None. Nothing imports this yet.

## Blast radius

- **New files only**, under `packages/utils/src/features/safenet-checks/`.
- **`constants.ts` reads env vars** but is not evaluated by anything yet.
- **Mobile**: shared package, dual-prefixed env handled, nothing calls it.
- No dependencies added, no feature flags wired, no persistence, no routes.

## Risks / not checked

- **`UNAVAILABLE` is overloaded**: "no check exists for this transaction" and "the read failed" are the same state. That is fine while nothing renders, but it needs distinct copy before it is user-facing. Tracked as W10; not fixed here.
- **The status machine is validated against synthesized event sequences**, not against a corpus of real check lifecycles from beta. The orderings tested are the ones we could think of.
- **Arbitration and dispute outcomes are decoded but barely exercised** — `DisputeResolved` has no beta traffic to test against.
- **Not tested on mobile.**

## Visual summary

```mermaid
stateDiagram-v2
  [*] --> SUBMITTED: proposal seen
  SUBMITTED --> IN_PROGRESS: sentinel activity
  IN_PROGRESS --> BENIGN: attestation VERIFIED
  SUBMITTED --> BENIGN: attestation VERIFIED
  IN_PROGRESS --> MALICIOUS: settled OracleResult(approved=false)
  IN_PROGRESS --> TIMED_OUT: head > deadlineBlock
  SUBMITTED --> TIMED_OUT: head > deadlineBlock
  BENIGN --> MALICIOUS: late negative — the ONLY backwards move allowed
  MALICIOUS --> [*]
  TIMED_OUT --> [*]

  note right of BENIGN
    unreachable without a
    FROST signature that verified
  end note
  note right of MALICIOUS
    one sentinel commit/reveal is
    a bonded vote, NOT a verdict —
    the oracle resolves by unanimity
  end note
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — n/a, no mobile code path reaches this yet
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
