### PR TITLE
feat(safenet): read a check's lifecycle from Gnosis Chain

### DIFF
--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -5,4 +5,7 @@ module.exports = {
   collectCoverage: true,
   collectCoverageFrom: ['<rootDir>/src/**/*.ts'],
   testEnvironment: 'jest-fixed-jsdom',
+  // Opt-in integration specs (`*.integration.test.ts`) hit a live devnet and are
+  // run separately via `yarn test:integration` — never in the default/turbo run.
+  testPathIgnorePatterns: [...(preset.testPathIgnorePatterns ?? []), '\\.integration\\.test\\.ts$'],
 }

--- a/packages/utils/jest.integration.config.js
+++ b/packages/utils/jest.integration.config.js
@@ -1,0 +1,15 @@
+const preset = require('../../config/test/presets/jest-preset')
+
+/**
+ * Opt-in integration config: runs only `*.integration.test.ts` in a node
+ * environment against a live Safenet network (sim :8546 / devnet :8547) selected
+ * by `SAFENET_IT_RPC`. Excluded from the default config and from turbo — invoke
+ * explicitly with `yarn test:integration`. Specs self-skip (with a clear message)
+ * when `SAFENET_IT_RPC` is unset.
+ */
+module.exports = {
+  ...preset,
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/**/*.integration.test.ts'],
+  collectCoverage: false,
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,6 +5,7 @@
   "version": "1.0.0",
   "scripts": {
     "test": "jest",
+    "test:integration": "jest --config jest.integration.config.js",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "type-check": "tsc --noEmit",

--- a/packages/utils/src/features/safenet-checks/builders/index.ts
+++ b/packages/utils/src/features/safenet-checks/builders/index.ts
@@ -1,0 +1,2 @@
+export * from './rawLogs'
+export * from './checkEvents'

--- a/packages/utils/src/features/safenet-checks/services/__tests__/safenetReader.integration.test.ts
+++ b/packages/utils/src/features/safenet-checks/services/__tests__/safenetReader.integration.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { SafenetReader } from '../safenetReader'
+import { AttestationVerificationStatus, CheckEventType, type Hex, type OracleAttestedEvent } from '../../types'
+
+/**
+ * Opt-in integration spec — runs only under `yarn test:integration` against a
+ * live Safenet network. Point it at the devnet (repo-HEAD V2 + real validators +
+ * AlwaysApproveOracle) so the real-FROST green path can be exercised:
+ *
+ *   SAFENET_IT_RPC=http://127.0.0.1:8547 SAFENET_IT_CHAIN_ID=31337 \
+ *     yarn workspace @safe-global/utils test:integration
+ *
+ * Consensus / coordinator addresses and the single-entry oracle allowlist default
+ * to the checked-in devnet golden vector but can be overridden with
+ * SAFENET_CONSENSUS / SAFENET_COORDINATOR / SAFENET_ORACLE (e.g. the
+ * SENTINEL_ORACLE_V2 emitter for log correlation).
+ * Precondition: `make devnet-up`.
+ */
+type Golden = {
+  chainId: string
+  consensus: string
+  coordinator: string
+  oracle: string
+  epoch: string
+  safeTxHash: Hex
+  requestId: Hex
+  signatureId: Hex
+  groupKey: { x: string; y: string }
+  r: { x: string; y: string }
+  z: string
+}
+
+const golden: Golden = JSON.parse(
+  readFileSync(join(__dirname, '../../__fixtures__/devnet-attestation.golden.json'), 'utf8'),
+)
+
+const RPC = process.env.SAFENET_IT_RPC
+
+const goldenAttested = (): OracleAttestedEvent => ({
+  blockNumber: 0,
+  logIndex: 0,
+  transactionHash: '0x' + '00'.repeat(32),
+  generation: 'STABLE' as OracleAttestedEvent['generation'],
+  type: CheckEventType.ORACLE_ATTESTED,
+  safeTxHash: golden.safeTxHash,
+  chainId: golden.chainId,
+  safe: golden.oracle,
+  epoch: golden.epoch,
+  oracle: golden.oracle,
+  signatureId: golden.signatureId,
+  attestation: { r: { x: golden.r.x, y: golden.r.y }, z: golden.z },
+})
+
+const makeReader = () =>
+  new SafenetReader({
+    rpcUrls: [RPC as string],
+    chainId: process.env.SAFENET_IT_CHAIN_ID ?? golden.chainId,
+    consensus: process.env.SAFENET_CONSENSUS ?? golden.consensus,
+    coordinator: process.env.SAFENET_COORDINATOR ?? golden.coordinator,
+    oracles: [process.env.SAFENET_ORACLE ?? golden.oracle],
+  })
+
+if (!RPC) {
+  describe('SafenetReader integration (skipped)', () => {
+    it('requires SAFENET_IT_RPC — set it to run against a live network', () => {
+      console.warn(
+        '[safenet integration] SAFENET_IT_RPC unset — skipping live checks. Run:\n' +
+          '  SAFENET_IT_RPC=http://127.0.0.1:8547 SAFENET_IT_CHAIN_ID=31337 ' +
+          'yarn workspace @safe-global/utils test:integration',
+      )
+      expect(RPC).toBeUndefined()
+    })
+  })
+} else {
+  describe('SafenetReader integration — live devnet', () => {
+    jest.setTimeout(30_000)
+
+    it('loads the epoch group public key live and matches the golden vector', async () => {
+      const key = await makeReader().loadGroupKey(golden.epoch)
+      expect(key).toEqual(golden.groupKey)
+    })
+
+    it('verifies the real FROST attestation against the live group key (VERIFIED)', async () => {
+      const result = await makeReader().verifyAttestation(goldenAttested())
+      expect(result.status).toBe(AttestationVerificationStatus.VERIFIED)
+    })
+
+    it('derives the same requestId from the on-chain Proposed event (when in lookback range)', async () => {
+      const read = await makeReader().fetchCheckState(golden.safeTxHash)
+      const proposed = read.events.find((event) => event.type === CheckEventType.ORACLE_PROPOSED)
+      if (!proposed) {
+        console.warn('[safenet integration] Proposed event outside the lookback window — skipping requestId equality')
+        return
+      }
+      expect(read.requestId).toBe(golden.requestId)
+    })
+  })
+}

--- a/packages/utils/src/features/safenet-checks/services/__tests__/safenetReader.test.ts
+++ b/packages/utils/src/features/safenet-checks/services/__tests__/safenetReader.test.ts
@@ -1,0 +1,455 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { Interface } from 'ethers'
+import { SafenetReader } from '../safenetReader'
+import { CONSENSUS_READ_ABI, COORDINATOR_READ_ABI, CONSENSUS_TOPIC0S } from '../../abi'
+import { deriveRequestId } from '../../utils'
+import { resetLogCounter, buildV1Lifecycle } from '../../builders'
+import type { RawLog } from '../../utils/decodeLogs'
+import { AttestationVerificationStatus, CheckEventType, type Hex, type OracleAttestedEvent } from '../../types'
+
+// Mirrors the fixed addresses the raw-log builders encode (see builders/rawLogs.ts).
+const CONSENSUS = '0x223624cBF099e5a8f8cD5aF22aFa424a1d1acEE9'
+const ORACLE = '0x00000000000000000000000000000000000000AA'
+const CHAIN_ID = '100'
+
+const consensusRead = new Interface([...CONSENSUS_READ_ABI])
+const coordinatorRead = new Interface([...COORDINATOR_READ_ABI])
+
+type GetLogsFilter = { address?: string; topics: unknown[]; fromBlock: number; toBlock: number }
+
+type RpcConfig = {
+  url: string
+  chainId?: string
+  head?: number
+  headTimestamp?: number
+  logs?: RawLog[]
+  epochGroupId?: string
+  coordinator?: string
+  groupKey?: { x: string; y: string }
+  failGroupKey?: boolean
+  failEverything?: boolean
+}
+
+const hexToNum = (value: string): number => Number(BigInt(value))
+
+const toRpcLog = (log: RawLog) => ({
+  address: log.address ?? ORACLE,
+  topics: log.topics,
+  data: log.data,
+  blockNumber: '0x' + log.blockNumber.toString(16),
+  transactionHash: log.transactionHash,
+  transactionIndex: '0x0',
+  blockHash: '0x' + '11'.repeat(32),
+  logIndex: '0x' + log.logIndex.toString(16),
+  removed: false,
+})
+
+const filterLogs = (logs: RawLog[], filter: GetLogsFilter): RawLog[] => {
+  const topic0s = (Array.isArray(filter.topics[0]) ? filter.topics[0] : [filter.topics[0]]) as string[]
+  const topic1 = filter.topics[1] as string | undefined
+  return logs.filter((log) => {
+    if (filter.address && (log.address ?? '').toLowerCase() !== filter.address.toLowerCase()) return false
+    if (!topic0s.includes(log.topics[0])) return false
+    if (topic1 && log.topics[1] !== topic1) return false
+    return log.blockNumber >= filter.fromBlock && log.blockNumber <= filter.toBlock
+  })
+}
+
+/** One JSON-RPC endpoint recorder + responder. Handles single and batched bodies. */
+const makeEndpoint = (config: RpcConfig) => {
+  const getLogsCalls: GetLogsFilter[] = []
+  const methods: string[] = []
+
+  const respondOne = (req: { id: number; method: string; params: unknown[] }) => {
+    methods.push(req.method)
+    if (config.failEverything) {
+      return { jsonrpc: '2.0', id: req.id, error: { code: -32000, message: 'endpoint down' } }
+    }
+    const ok = (result: unknown) => ({ jsonrpc: '2.0', id: req.id, result })
+    const err = (message: string) => ({ jsonrpc: '2.0', id: req.id, error: { code: 3, message } })
+
+    switch (req.method) {
+      case 'eth_chainId':
+        return ok('0x' + Number(config.chainId ?? CHAIN_ID).toString(16))
+      case 'eth_blockNumber':
+        return ok('0x' + (config.head ?? 0).toString(16))
+      case 'eth_getBlockByNumber': {
+        const head = config.head ?? 0
+        const tag = req.params[0] as string
+        const number = tag === 'latest' ? head : hexToNum(tag)
+        // Synthetic timestamps on a 5s cadence, so block estimation is exact.
+        const timestamp = Math.max(0, (config.headTimestamp ?? 1_000_000) - (head - number) * 5)
+        return ok({
+          number: '0x' + number.toString(16),
+          timestamp: '0x' + timestamp.toString(16),
+          hash: '0x' + '22'.repeat(32),
+          parentHash: '0x' + '33'.repeat(32),
+          nonce: '0x0000000000000000',
+          difficulty: '0x0',
+          gasLimit: '0x1c9c380',
+          gasUsed: '0x0',
+          miner: '0x' + '00'.repeat(20),
+          extraData: '0x',
+          baseFeePerGas: '0x7',
+          transactions: [],
+        })
+      }
+      case 'eth_getLogs': {
+        const raw = req.params[0] as { address?: string; topics: unknown[]; fromBlock: string; toBlock: string }
+        const filter: GetLogsFilter = {
+          address: raw.address,
+          topics: raw.topics,
+          fromBlock: hexToNum(raw.fromBlock),
+          toBlock: hexToNum(raw.toBlock),
+        }
+        getLogsCalls.push(filter)
+        return ok(filterLogs(config.logs ?? [], filter).map(toRpcLog))
+      }
+      case 'eth_call': {
+        const call = req.params[0] as { to: string; data: string }
+        const selector = call.data.slice(0, 10)
+        if (selector === consensusRead.getFunction('getEpochGroupId')!.selector) {
+          return ok(
+            consensusRead.encodeFunctionResult('getEpochGroupId', [config.epochGroupId ?? '0x' + '00'.repeat(32)]),
+          )
+        }
+        if (selector === consensusRead.getFunction('getCoordinator')!.selector) {
+          return ok(consensusRead.encodeFunctionResult('getCoordinator', [config.coordinator ?? ORACLE]))
+        }
+        if (selector === coordinatorRead.getFunction('groupKey')!.selector) {
+          if (config.failGroupKey) return err('group key not ready')
+          const gk = config.groupKey ?? { x: '1', y: '2' }
+          return ok(coordinatorRead.encodeFunctionResult('groupKey', [[BigInt(gk.x), BigInt(gk.y)]]))
+        }
+        return err('unexpected eth_call')
+      }
+      default:
+        return err(`unhandled ${req.method}`)
+    }
+  }
+
+  const handler = http.post(config.url, async ({ request }) => {
+    const body = (await request.json()) as
+      | { id: number; method: string; params: unknown[] }
+      | Array<{ id: number; method: string; params: unknown[] }>
+    const response = Array.isArray(body) ? body.map(respondOne) : respondOne(body)
+    return HttpResponse.json(response)
+  })
+
+  return { handler, getLogsCalls, methods }
+}
+
+const consensusCalls = (calls: GetLogsFilter[]): GetLogsFilter[] =>
+  calls.filter((c) => (Array.isArray(c.topics[0]) ? (c.topics[0] as string[]) : []).includes(CONSENSUS_TOPIC0S[0]))
+
+const oracleCalls = (calls: GetLogsFilter[]): GetLogsFilter[] =>
+  calls.filter((c) => !(Array.isArray(c.topics[0]) ? (c.topics[0] as string[]) : []).includes(CONSENSUS_TOPIC0S[0]))
+
+const makeReader = (over: Partial<ConstructorParameters<typeof SafenetReader>[0]> = {}, url = 'http://rpc.test/1') =>
+  new SafenetReader({
+    rpcUrls: [url],
+    chainId: CHAIN_ID,
+    consensus: CONSENSUS,
+    coordinator: ORACLE,
+    oracles: [ORACLE],
+    ...over,
+  })
+
+/** A V1 lifecycle whose sentinel requestId equals the reader's derived requestId. */
+const lifecycleFor = (safeTxHash: Hex): RawLog[] => {
+  resetLogCounter()
+  const requestId = deriveRequestId({ chainId: CHAIN_ID, consensus: CONSENSUS, epoch: '1', oracle: ORACLE, safeTxHash })
+  return buildV1Lifecycle({ safeTxHash, requestId, oracle: ORACLE, epoch: 1n })
+}
+
+const SAFE_TX_HASH = ('0x' + 'ab'.repeat(32)) as Hex
+
+let server: ReturnType<typeof setupServer>
+afterEach(() => server?.close())
+
+describe('SafenetReader.fetchCheckState', () => {
+  it('bootstraps from the chain head and returns the sorted, decoded event set', async () => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs: lifecycleFor(SAFE_TX_HASH) })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader().fetchCheckState(SAFE_TX_HASH)
+
+    expect(endpoint.methods).toContain('eth_getBlockByNumber')
+    expect(result.headBlock).toBe('25000')
+    expect(result.safeTxHash).toBe(SAFE_TX_HASH)
+    // Proposed + NewRequest + Committed + OracleResult + Attested.
+    expect(result.events.map((e) => e.type)).toEqual([
+      CheckEventType.ORACLE_PROPOSED,
+      CheckEventType.REQUEST_CREATED,
+      CheckEventType.SENTINEL_COMMITTED,
+      CheckEventType.ORACLE_RESULT,
+      CheckEventType.ORACLE_ATTESTED,
+    ])
+    // Sorted ascending by (blockNumber, logIndex).
+    const keys = result.events.map((e) => e.blockNumber * 1e6 + e.logIndex)
+    expect(keys).toEqual([...keys].sort((a, b) => a - b))
+    expect(result.requestId).toBe(
+      deriveRequestId({
+        chainId: CHAIN_ID,
+        consensus: CONSENSUS,
+        epoch: '1',
+        oracle: ORACLE,
+        safeTxHash: SAFE_TX_HASH,
+      }),
+    )
+    expect(result.epoch).toBe('1')
+    expect(result.deadlineBlock).toBe('150')
+  })
+
+  it('chunks the lookback window into ≤10k-block getLogs for each of the two filters', async () => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs: lifecycleFor(SAFE_TX_HASH) })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader().fetchCheckState(SAFE_TX_HASH)
+
+    const cons = consensusCalls(endpoint.getLogsCalls)
+    const orac = oracleCalls(endpoint.getLogsCalls)
+    expect(cons.map((c) => [c.fromBlock, c.toBlock])).toEqual([
+      [0, 9999],
+      [10_000, 19_999],
+      [20_000, 25_000],
+    ])
+    expect(orac.map((c) => [c.fromBlock, c.toBlock])).toEqual([
+      [0, 9999],
+      [10_000, 19_999],
+      [20_000, 25_000],
+    ])
+  })
+
+  it('caps the scan at exactly 30k blocks — 3 whole chunks, no degenerate 4th', async () => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 45_000, logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader().fetchCheckState(SAFE_TX_HASH)
+
+    const calls = consensusCalls(endpoint.getLogsCalls)
+    expect(calls[0].fromBlock).toBe(15_001)
+    expect(calls).toHaveLength(3)
+  })
+
+  it('targets a narrow window around the transaction timestamp instead of scanning back from the head', async () => {
+    // Head is block 1,000,000 at t=1,000,000s, blocks every 5s (see the mock).
+    // A transaction 100,000s earlier sits at block 1,000,000 − 20,000 = 980,000.
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 1_000_000, headTimestamp: 1_000_000, logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader().fetchCheckState(SAFE_TX_HASH, { timestampMs: 900_000 * 1000 })
+
+    const call = consensusCalls(endpoint.getLogsCalls)[0]
+    expect(call.fromBlock).toBe(975_000)
+    expect(call.toBlock).toBe(984_999)
+  })
+
+  it('reads an old check in a single getLogs — cost does not grow with age', async () => {
+    const HEAD_TS = 1_800_000_000
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 9_000_000, headTimestamp: HEAD_TS, logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    // A year-old transaction: the head-relative scan could never have reached it.
+    await makeReader().fetchCheckState(SAFE_TX_HASH, { timestampMs: (HEAD_TS - 31_536_000) * 1000 })
+
+    expect(consensusCalls(endpoint.getLogsCalls)).toHaveLength(1)
+  })
+
+  it('falls back to the head-relative scan when no timestamp is given', async () => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 45_000, logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader().fetchCheckState(SAFE_TX_HASH)
+
+    expect(consensusCalls(endpoint.getLogsCalls)[0].fromBlock).toBe(15_001)
+  })
+
+  it('targets Proposed.oracle for the oracle getLogs when no override is set', async () => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs: lifecycleFor(SAFE_TX_HASH) })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader().fetchCheckState(SAFE_TX_HASH)
+
+    for (const call of oracleCalls(endpoint.getLogsCalls)) {
+      expect(call.address?.toLowerCase()).toBe(ORACLE.toLowerCase())
+    }
+  })
+
+  it('ignores a proposal naming an oracle that is not on the allowlist', async () => {
+    // proposeOracleTransaction is permissionless, so the oracle address in the
+    // event is attacker-chosen. An unlisted one must not be read from at all.
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs: lifecycleFor(SAFE_TX_HASH) })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader({ oracles: ['0x000000000000000000000000000000000000dEaD'] }).fetchCheckState(
+      SAFE_TX_HASH,
+    )
+
+    expect(oracleCalls(endpoint.getLogsCalls)).toHaveLength(0)
+    expect(result.requestId).toBeNull()
+    expect(result.events.every((event) => event.type !== CheckEventType.ORACLE_RESULT)).toBe(true)
+  })
+
+  it("skips the oracle path entirely when the allowlist is empty (today's default)", async () => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs: lifecycleFor(SAFE_TX_HASH) })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader({ oracles: [] }).fetchCheckState(SAFE_TX_HASH)
+
+    expect(oracleCalls(endpoint.getLogsCalls)).toHaveLength(0)
+    expect(result.requestId).toBeNull()
+  })
+
+  it('propagates the failure when every RPC endpoint is down', async () => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', failEverything: true })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await expect(makeReader().fetchCheckState(SAFE_TX_HASH)).rejects.toBeDefined()
+  })
+
+  it('rotates to the next endpoint when the first one fails', async () => {
+    const down = makeEndpoint({ url: 'http://rpc.test/1', failEverything: true })
+    const up = makeEndpoint({ url: 'http://rpc.test/2', head: 25_000, logs: lifecycleFor(SAFE_TX_HASH) })
+    server = setupServer(down.handler, up.handler)
+    server.listen()
+
+    const reader = new SafenetReader({
+      rpcUrls: ['http://rpc.test/1', 'http://rpc.test/2'],
+      chainId: CHAIN_ID,
+      consensus: CONSENSUS,
+      coordinator: ORACLE,
+      oracles: [],
+    })
+    const result = await reader.fetchCheckState(SAFE_TX_HASH)
+    expect(result.headBlock).toBe('25000')
+    expect(up.methods.length).toBeGreaterThan(0)
+  })
+})
+
+describe('SafenetReader chain-id assertion (dev-only, one-shot)', () => {
+  it('logs a loud error when the RPC chain id disagrees with SAFENET_CHAIN_ID', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', chainId: '31337', head: 10, logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader({ chainId: '100' }).fetchCheckState(SAFE_TX_HASH)
+
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('chain id mismatch'))
+    spy.mockRestore()
+  })
+
+  it('stays silent when the RPC chain id matches', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', chainId: '100', head: 10, logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader({ chainId: '100' }).fetchCheckState(SAFE_TX_HASH)
+
+    expect(spy).not.toHaveBeenCalled()
+    spy.mockRestore()
+  })
+})
+
+describe('SafenetReader.verifyAttestation', () => {
+  type Golden = {
+    chainId: string
+    consensus: string
+    coordinator: string
+    oracle: string
+    epoch: string
+    safeTxHash: Hex
+    requestId: Hex
+    signatureId: Hex
+    groupId: Hex
+    groupKey: { x: string; y: string }
+    r: { x: string; y: string }
+    z: string
+  }
+  const golden: Golden = JSON.parse(
+    readFileSync(join(__dirname, '../../__fixtures__/devnet-attestation.golden.json'), 'utf8'),
+  )
+
+  const attestedEvent = (): OracleAttestedEvent => ({
+    blockNumber: 1,
+    logIndex: 0,
+    transactionHash: '0x' + '00'.repeat(32),
+    generation: 'STABLE' as OracleAttestedEvent['generation'],
+    type: CheckEventType.ORACLE_ATTESTED,
+    safeTxHash: golden.safeTxHash,
+    chainId: golden.chainId,
+    safe: golden.oracle,
+    epoch: golden.epoch,
+    oracle: golden.oracle,
+    signatureId: golden.signatureId,
+    attestation: { r: { x: golden.r.x, y: golden.r.y }, z: golden.z },
+  })
+
+  const readerForGolden = (over: Partial<RpcConfig> = {}) => {
+    const endpoint = makeEndpoint({
+      url: 'http://rpc.test/g',
+      chainId: golden.chainId,
+      epochGroupId: golden.groupId,
+      coordinator: golden.coordinator,
+      groupKey: golden.groupKey,
+      ...over,
+    })
+    server = setupServer(endpoint.handler)
+    server.listen()
+    const reader = new SafenetReader({
+      rpcUrls: ['http://rpc.test/g'],
+      chainId: golden.chainId,
+      consensus: golden.consensus,
+      coordinator: golden.coordinator,
+      oracles: [golden.oracle],
+    })
+    return { reader, endpoint }
+  }
+
+  it('resolves VERIFIED for the real devnet attestation (getEpochGroupId → groupKey → FROST)', async () => {
+    const { reader } = readerForGolden()
+    const result = await reader.verifyAttestation(attestedEvent())
+    expect(result).toEqual({
+      status: AttestationVerificationStatus.VERIFIED,
+      signatureId: golden.signatureId,
+      message: golden.requestId,
+    })
+  })
+
+  it('resolves PENDING (retryable) when the group key cannot be fetched', async () => {
+    const { reader } = readerForGolden({ failGroupKey: true })
+    const result = await reader.verifyAttestation(attestedEvent())
+    expect(result.status).toBe(AttestationVerificationStatus.PENDING)
+  })
+
+  it('resolves INVALID (terminal) when the signature does not verify against the group key', async () => {
+    const tampered = { x: (BigInt(golden.groupKey.x) + 1n).toString(), y: golden.groupKey.y }
+    const { reader } = readerForGolden({ groupKey: tampered })
+    const result = await reader.verifyAttestation(attestedEvent())
+    expect(result.status).toBe(AttestationVerificationStatus.INVALID)
+  })
+
+  it('caches terminal outcomes by signatureId (no second group-key fetch)', async () => {
+    const { reader, endpoint } = readerForGolden()
+    await reader.verifyAttestation(attestedEvent())
+    const callsAfterFirst = endpoint.methods.filter((m) => m === 'eth_call').length
+    await reader.verifyAttestation(attestedEvent())
+    const callsAfterSecond = endpoint.methods.filter((m) => m === 'eth_call').length
+    expect(callsAfterSecond).toBe(callsAfterFirst)
+  })
+})

--- a/packages/utils/src/features/safenet-checks/services/index.ts
+++ b/packages/utils/src/features/safenet-checks/services/index.ts
@@ -1,0 +1,1 @@
+export * from './safenetReader'

--- a/packages/utils/src/features/safenet-checks/services/safenetReader.ts
+++ b/packages/utils/src/features/safenet-checks/services/safenetReader.ts
@@ -1,0 +1,432 @@
+import { Contract, JsonRpcProvider, type Log } from 'ethers'
+import { CONSENSUS_READ_ABI, CONSENSUS_TOPIC0S, COORDINATOR_READ_ABI, SENTINEL_TOPIC0S } from '../abi'
+import {
+  BLOCK_ESTIMATE_MAX_REFINEMENTS,
+  BLOCK_ESTIMATE_TOLERANCE_SECONDS,
+  BLOCK_TIME_SECONDS,
+  GETLOGS_CHUNK_BLOCKS,
+  MAX_LOOKBACK_BLOCKS,
+  PROVIDER_BATCH_MAX_COUNT,
+  SAFENET_CHAIN_ID,
+  SAFENET_CONSENSUS_ADDRESS,
+  SAFENET_COORDINATOR_ADDRESS,
+  SAFENET_ORACLE_ADDRESSES,
+  SAFENET_RPC_URLS,
+  TARGETED_WINDOW_HALF_BLOCKS,
+} from '../constants'
+import {
+  AttestationVerificationStatus,
+  CheckEventType,
+  OracleGeneration,
+  type AttestationVerification,
+  type Hex,
+  type NormalizedCheckEvent,
+  type OracleAttestedEvent,
+  type PlainAttestedEvent,
+  type OracleProposedEvent,
+} from '../types'
+import { decodeLogs, oracleProposalHash, plainProposalHash, type RawLog } from '../utils'
+import { verifyAttestation as verifyFrostAttestation } from '../utils/frost'
+
+/**
+ * Everything one poll reads off-chain for a single check, before the query layer
+ * folds in FROST verification and the monotonic merge. Numeric values are decimal
+ * strings so the result is Redux-serializable end-to-end.
+ */
+export type CheckReadResult = {
+  safeTxHash: Hex
+  /** The Safenet chain the Consensus contract lives on — the config chain id. */
+  chainId: string
+  /** All decoded lifecycle events, sorted ascending by (blockNumber, logIndex). */
+  events: NormalizedCheckEvent[]
+  /** Chain head observed at read time (a decimal string). */
+  headBlock: string
+  /** The oracle generation that drove this check, once a sentinel event is seen. */
+  generation: OracleGeneration | null
+  /** The oracle request id (equals the oracle-proposal hash), once proposed. */
+  requestId: Hex | null
+  epoch: string | null
+  oracle: string | null
+  /** Block the check times out at (V1 `deadline` / V2 `revealDeadline`). */
+  deadlineBlock: string | null
+}
+
+export type SafenetReaderConfig = {
+  /** Pinned Gnosis endpoints, rotated on failure. */
+  rpcUrls: string[]
+  /** Feeds BOTH the provider network AND the EIP-712 request-id domain. */
+  chainId: string
+  consensus: string
+  /** FROSTCoordinator override; `null` discovers it via `getCoordinator()`. */
+  coordinator: string | null
+  /** Allowlisted sentinel-oracle addresses. Empty = the oracle path is skipped. */
+  oracles: string[]
+}
+
+/** Build a reader config from the dual-env constants (the production default). */
+export const readerConfigFromEnv = (): SafenetReaderConfig => ({
+  rpcUrls: SAFENET_RPC_URLS,
+  chainId: SAFENET_CHAIN_ID,
+  consensus: SAFENET_CONSENSUS_ADDRESS,
+  coordinator: SAFENET_COORDINATOR_ADDRESS,
+  oracles: SAFENET_ORACLE_ADDRESSES,
+})
+
+const IS_DEV = process.env.NODE_ENV !== 'production'
+
+const isProposed = (event: NormalizedCheckEvent): event is OracleProposedEvent =>
+  event.type === CheckEventType.ORACLE_PROPOSED
+
+/** Sort a copy of the events ascending by (blockNumber, logIndex). */
+const sortEvents = (events: NormalizedCheckEvent[]): NormalizedCheckEvent[] =>
+  [...events].sort((a, b) => a.blockNumber - b.blockNumber || a.logIndex - b.logIndex)
+
+/** Inclusive [from, to] block ranges of at most `size` blocks each. */
+const chunkRanges = (from: number, to: number, size: number): Array<[number, number]> => {
+  const ranges: Array<[number, number]> = []
+  for (let start = from; start <= to; start += size) {
+    ranges.push([start, Math.min(start + size - 1, to)])
+  }
+  return ranges
+}
+
+/** Map an ethers `Log` onto the decoder's `RawLog` shape (`.index` → `logIndex`). */
+const toRawLog = (log: Log): RawLog => ({
+  address: log.address,
+  topics: [...log.topics],
+  data: log.data,
+  blockNumber: log.blockNumber,
+  logIndex: log.index,
+  transactionHash: log.transactionHash,
+})
+
+/** Highest `deadlineBlock` across the check's request events, as a string or null. */
+const maxDeadline = (events: NormalizedCheckEvent[]): string | null => {
+  let max: bigint | null = null
+  for (const event of events) {
+    if (event.type === CheckEventType.REQUEST_CREATED) {
+      const value = BigInt(event.deadlineBlock)
+      if (max === null || value > max) max = value
+    }
+  }
+  return max === null ? null : max.toString()
+}
+
+/**
+ * Chain reader for a check's Safenet lifecycle. Owns a pinned-endpoint provider
+ * (rotated on failure), a per-epoch group-key cache, and a per-signature
+ * verification cache. Construct with {@link readerConfigFromEnv} in production;
+ * pass an explicit config in tests.
+ */
+export class SafenetReader {
+  private readonly rpcUrls: string[]
+  private readonly chainId: string
+  private readonly consensus: string
+  private readonly coordinator: string | null
+  private readonly oracles: readonly string[]
+
+  private urlIndex = 0
+  private currentProvider: JsonRpcProvider | null = null
+  private chainIdChecked = false
+  private coordinatorPromise: Promise<string> | null = null
+  private readonly groupKeyCache = new Map<string, { x: string; y: string }>()
+  private readonly verificationCache = new Map<string, AttestationVerification>()
+
+  constructor(config: SafenetReaderConfig) {
+    this.rpcUrls = config.rpcUrls
+    this.chainId = config.chainId
+    this.consensus = config.consensus
+    this.coordinator = config.coordinator
+    this.oracles = config.oracles.map((address) => address.toLowerCase())
+  }
+
+  /** True when an oracle address is on the configured allowlist. */
+  private isAllowedOracle(oracle: string): boolean {
+    return this.oracles.includes(oracle.toLowerCase())
+  }
+
+  private provider(): JsonRpcProvider {
+    if (!this.currentProvider) {
+      const url = this.rpcUrls[this.urlIndex]
+      if (!url) throw new Error('Safenet reader: no RPC URLs configured (set SAFENET_RPC_URLS)')
+      this.currentProvider = new JsonRpcProvider(url, Number(this.chainId), {
+        staticNetwork: true,
+        batchMaxCount: PROVIDER_BATCH_MAX_COUNT,
+      })
+    }
+    return this.currentProvider
+  }
+
+  private rotate(): void {
+    this.currentProvider?.destroy()
+    this.currentProvider = null
+    if (this.rpcUrls.length > 0) this.urlIndex = (this.urlIndex + 1) % this.rpcUrls.length
+  }
+
+  /** Run an op against the current endpoint, rotating through the URL list on failure. */
+  private async withProvider<T>(op: (provider: JsonRpcProvider) => Promise<T>): Promise<T> {
+    const attempts = Math.max(1, this.rpcUrls.length)
+    let lastError: unknown
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      try {
+        return await op(this.provider())
+      } catch (error) {
+        lastError = error
+        this.rotate()
+      }
+    }
+    throw lastError
+  }
+
+  /** Dev-only, one-shot: warn loudly if the RPC's chain id disagrees with config. */
+  private async assertChainId(provider: JsonRpcProvider): Promise<void> {
+    if (this.chainIdChecked || !IS_DEV) return
+    this.chainIdChecked = true
+    try {
+      const actual = Number(await provider.send('eth_chainId', []))
+      if (actual !== Number(this.chainId)) {
+        console.error(
+          `[safenet-reader] chain id mismatch: SAFENET_CHAIN_ID=${this.chainId} but the RPC ` +
+            `reports ${actual}. Request ids derive from SAFENET_CHAIN_ID, so they will be WRONG ` +
+            `and every check will appear stuck at SUBMITTED. Fix SAFENET_CHAIN_ID / SAFENET_RPC_URLS.`,
+        )
+      }
+    } catch {
+      // The assertion is a development aid, never a hard gate on the read path.
+    }
+  }
+
+  private async getLogsChunked(
+    provider: JsonRpcProvider,
+    filter: { address?: string; topics: Array<string | string[]>; fromBlock: number; toBlock: number },
+  ): Promise<RawLog[]> {
+    const ranges = chunkRanges(filter.fromBlock, filter.toBlock, GETLOGS_CHUNK_BLOCKS)
+    // Issued concurrently so the pinned provider coalesces them into one batched
+    // HTTP request (bounded by PROVIDER_BATCH_MAX_COUNT).
+    const chunks = await Promise.all(
+      ranges.map(([fromBlock, toBlock]) =>
+        provider.getLogs({ address: filter.address, topics: filter.topics, fromBlock, toBlock }),
+      ),
+    )
+    return chunks.flat().map(toRawLog)
+  }
+
+  /**
+   * Choose the block range to read.
+   *
+   * With a transaction timestamp: a narrow window centred on the matching block,
+   * so a two-year-old check costs the same as a two-minute-old one. Without one:
+   * the head-relative scan, which only sees the last {@link MAX_LOOKBACK_BLOCKS}.
+   */
+  private async readRange(
+    provider: JsonRpcProvider,
+    timestampMs: number | null | undefined,
+    head: { number: number; timestamp: number },
+  ): Promise<{ fromBlock: number; toBlock: number }> {
+    if (timestampMs == null || !Number.isFinite(timestampMs)) {
+      return { fromBlock: Math.max(0, head.number - MAX_LOOKBACK_BLOCKS + 1), toBlock: head.number }
+    }
+    const centre = await this.estimateBlockAt(provider, Math.floor(timestampMs / 1000), head)
+    // Exactly one chunk wide, so a targeted read is always a single getLogs.
+    const fromBlock = Math.max(0, centre - TARGETED_WINDOW_HALF_BLOCKS)
+    return { fromBlock, toBlock: Math.min(head.number, fromBlock + GETLOGS_CHUNK_BLOCKS - 1) }
+  }
+
+  /**
+   * Estimate the block nearest a unix timestamp, using the nominal block time and
+   * refining against real block timestamps to absorb drift.
+   *
+   * Costs one RPC call per refinement round (at most
+   * {@link BLOCK_ESTIMATE_MAX_REFINEMENTS}), and stops early once within
+   * {@link BLOCK_ESTIMATE_TOLERANCE_SECONDS}.
+   */
+  private async estimateBlockAt(
+    provider: JsonRpcProvider,
+    targetSeconds: number,
+    head: { number: number; timestamp: number },
+  ): Promise<number> {
+    const clamp = (block: number) => Math.min(head.number, Math.max(0, block))
+    let guess = clamp(head.number - Math.floor((head.timestamp - targetSeconds) / BLOCK_TIME_SECONDS))
+
+    for (let round = 0; round < BLOCK_ESTIMATE_MAX_REFINEMENTS; round++) {
+      const block = await provider.getBlock(guess)
+      if (!block) break
+      const drift = block.timestamp - targetSeconds
+      if (Math.abs(drift) <= BLOCK_ESTIMATE_TOLERANCE_SECONDS) break
+      const next = clamp(guess - Math.round(drift / BLOCK_TIME_SECONDS))
+      if (next === guess) break
+      guess = next
+    }
+    return guess
+  }
+
+  /**
+   * Read a check's full lifecycle: Consensus logs keyed by `safeTxHash`, then —
+   * once a `Proposed` event pins the epoch/oracle — the sentinel/oracle logs keyed
+   * by the derived `requestId`. Returns the sorted event set plus the derived
+   * correlation fields; FROST verification and the status machine live above this.
+   *
+   * @param safeTxHash - the Safe transaction hash to read.
+   * @param options.timestampMs - when the Safe transaction happened. Given this,
+   *   the read targets a narrow window around the matching block instead of
+   *   walking back {@link MAX_LOOKBACK_BLOCKS} from the head, so cost stays
+   *   constant however old the check is. Falls back to the head-relative scan
+   *   when omitted.
+   */
+  async fetchCheckState(safeTxHash: string, options: { timestampMs?: number | null } = {}): Promise<CheckReadResult> {
+    return this.withProvider(async (provider) => {
+      await this.assertChainId(provider)
+
+      const latest = await provider.getBlock('latest')
+      if (!latest) throw new Error('Safenet reader: could not read the chain head')
+      const head = latest.number
+
+      const range = await this.readRange(provider, options.timestampMs, {
+        number: head,
+        timestamp: latest.timestamp,
+      })
+
+      const consensusLogs = await this.getLogsChunked(provider, {
+        address: this.consensus,
+        topics: [[...CONSENSUS_TOPIC0S], safeTxHash],
+        fromBlock: range.fromBlock,
+        toBlock: range.toBlock,
+      })
+      const consensusEvents = decodeLogs(consensusLogs)
+
+      // Only a proposal naming an ALLOWLISTED oracle may drive the oracle read.
+      // `proposeOracleTransaction` is permissionless and the oracle address is a
+      // caller argument, so an unfiltered `find` would let anyone point us at
+      // their own contract and feed us a fabricated `OracleResult`.
+      const proposed = consensusEvents.find(
+        (event): event is OracleProposedEvent => isProposed(event) && this.isAllowedOracle(event.oracle),
+      )
+
+      let requestId: Hex | null = null
+      let oracleEvents: NormalizedCheckEvent[] = []
+      if (proposed) {
+        requestId = oracleProposalHash({
+          chainId: this.chainId,
+          consensus: this.consensus,
+          epoch: proposed.epoch,
+          oracle: proposed.oracle,
+          safeTxHash: safeTxHash as Hex,
+        })
+        const oracleLogs = await this.getLogsChunked(provider, {
+          address: proposed.oracle,
+          topics: [[...SENTINEL_TOPIC0S], requestId],
+          fromBlock: range.fromBlock,
+          toBlock: range.toBlock,
+        })
+        oracleEvents = decodeLogs(oracleLogs)
+      }
+
+      const events = sortEvents([...consensusEvents, ...oracleEvents])
+      const generation = events.find((event) => event.generation !== OracleGeneration.STABLE)?.generation ?? null
+
+      return {
+        safeTxHash: safeTxHash as Hex,
+        chainId: this.chainId,
+        events,
+        headBlock: head.toString(),
+        generation,
+        requestId,
+        epoch: proposed?.epoch ?? null,
+        oracle: proposed?.oracle ?? null,
+        deadlineBlock: maxDeadline(events),
+      }
+    })
+  }
+
+  private async resolveCoordinator(provider: JsonRpcProvider): Promise<string> {
+    if (this.coordinator) return this.coordinator
+    if (!this.coordinatorPromise) {
+      const consensus = new Contract(this.consensus, [...CONSENSUS_READ_ABI], provider)
+      this.coordinatorPromise = (consensus.getCoordinator() as Promise<string>).catch((error) => {
+        // Never cache a failed discovery — the next call retries.
+        this.coordinatorPromise = null
+        throw error
+      })
+    }
+    return this.coordinatorPromise
+  }
+
+  /**
+   * Resolve an epoch's FROST group public key: `getEpochGroupId(epoch)` →
+   * `coordinator.groupKey(groupId)`. Cached by group id. Throws on RPC failure so
+   * {@link verifyAttestation} can treat it as retryable (`PENDING`).
+   */
+  async loadGroupKey(epoch: string): Promise<{ x: string; y: string }> {
+    return this.withProvider(async (provider) => {
+      const consensus = new Contract(this.consensus, [...CONSENSUS_READ_ABI], provider)
+      const groupId: string = await consensus.getEpochGroupId(BigInt(epoch))
+
+      const cached = this.groupKeyCache.get(groupId)
+      if (cached) return cached
+
+      const coordinatorAddress = await this.resolveCoordinator(provider)
+      const coordinator = new Contract(coordinatorAddress, [...COORDINATOR_READ_ABI], provider)
+      const key = await coordinator.groupKey(groupId)
+      const point = { x: key.x.toString(), y: key.y.toString() }
+      this.groupKeyCache.set(groupId, point)
+      return point
+    })
+  }
+
+  /**
+   * Verify an attested event's FROST signature against its epoch group key.
+   * Cached (terminal outcomes only) by `signatureId`. A group-key fetch failure is
+   * retryable (`PENDING`, not cached); a signature that does not verify is terminal
+   * (`INVALID`) and must never render as BENIGN.
+   */
+  async verifyAttestation(attested: OracleAttestedEvent | PlainAttestedEvent): Promise<AttestationVerification> {
+    // The two paths sign different EIP-712 preimages. Deriving it here, from the
+    // event we actually decoded, is the only place that knows which is which —
+    // callers cannot pair the wrong hash with the wrong attestation.
+    const message =
+      attested.type === CheckEventType.ORACLE_ATTESTED
+        ? oracleProposalHash({
+            chainId: this.chainId,
+            consensus: this.consensus,
+            epoch: attested.epoch,
+            oracle: attested.oracle,
+            safeTxHash: attested.safeTxHash,
+          })
+        : plainProposalHash({
+            chainId: this.chainId,
+            consensus: this.consensus,
+            epoch: attested.epoch,
+            safeTxHash: attested.safeTxHash,
+          })
+
+    const signatureId = attested.signatureId
+    const cached = this.verificationCache.get(signatureId)
+    if (cached) return cached
+
+    let groupKey: { x: string; y: string }
+    try {
+      groupKey = await this.loadGroupKey(attested.epoch)
+    } catch {
+      return { status: AttestationVerificationStatus.PENDING, signatureId, message }
+    }
+
+    const verified = verifyFrostAttestation({ groupKey, attestation: attested.attestation, message })
+    const result: AttestationVerification = {
+      status: verified ? AttestationVerificationStatus.VERIFIED : AttestationVerificationStatus.INVALID,
+      signatureId,
+      message,
+    }
+    this.verificationCache.set(signatureId, result)
+    return result
+  }
+}
+
+let defaultReader: SafenetReader | null = null
+
+/** The process-wide pinned-provider reader singleton (built from env constants). */
+export const getSafenetReader = (): SafenetReader => (defaultReader ??= new SafenetReader(readerConfigFromEnv()))
+
+/** Drop the singleton so the next {@link getSafenetReader} rebuilds it (tests). */
+export const resetSafenetReader = (): void => {
+  defaultReader = null
+}

--- a/packages/utils/src/features/safenet-checks/utils/index.ts
+++ b/packages/utils/src/features/safenet-checks/utils/index.ts
@@ -1,0 +1,6 @@
+export * from './decodeLogs'
+export * from './deriveCheckState'
+export * from './mergeMonotonic'
+export * from './computePollingInterval'
+export * from './oracleProposalHash'
+export * from './frost'


### PR DESCRIPTION
## What it solves

Resolves: part 4 of 5 replacing #8368 (closed — 4.2k lines was too large to review).

> **Stacked on the status PR.** Merge order: #8369 → decode → status → **this** → wiring.

This PR answers one question: **is the chain access correct and safe?**

It is the only PR in the stack that talks to a node. Everything below it is pure functions; everything above it is wiring.

## How this PR fixes it

`SafenetReader` locates a check's logs on Gnosis Chain, verifies its attestation, and hands the events to the status machine.

### Reads are aimed, not scanned

The block window is derived from the Safe transaction's timestamp, so cost stays constant however old the check is. A head-relative scan remains as the fallback when no timestamp is available. `eth_getLogs` is chunked, and providers rotate on failure.

### Two security properties — the reason this PR is on its own

**1. The EIP-712 preimage is derived from the event that was decoded**, never from a proposal located separately. An earlier version correlated proposal and attestation by "first found", which meant a stranger's proposal could be paired with a valid attestation, verify against the wrong preimage, and pin the check at a terminal verification failure. The oracle and non-oracle preimages (#8369) are never crossed.

**2. Sentinel-oracle logs are read only for a proposal naming an allowlisted oracle.** `proposeOracleTransaction` is permissionless and the oracle address is a *caller argument*. Sourcing oracle logs from the address in the event would let anyone deploy a contract, emit a fabricated `OracleResult(approved=false)`, and permanently mark any Safe transaction malicious. `SAFENET_ORACLE_ADDRESSES` (added in the status PR) is a client-side allowlist and is **empty by default**, which skips the oracle path entirely — matching beta today, which runs attesters only.

### One more distinction worth checking

An unknown epoch surfaces as retryable `PENDING`, not terminal `INVALID`. `groupKey` *reverts* for an epoch the coordinator hasn't seen, which is a different thing from a signature that failed to verify. Collapsing the two would permanently mark a valid check unverifiable because of a transient read.

## How to test it

```bash
yarn workspace @safe-global/utils test --testPathPattern 'safenet-checks'
yarn workspace @safe-global/utils type-check
```

109 tests, 9 suites (cumulative). Tests use MSW against real JSON-RPC shapes rather than mocking ethers, so provider behaviour is exercised rather than stubbed.

Optional, against a live network:

```bash
make devnet-up   # workspace repo
SAFENET_IT_RPC=http://127.0.0.1:8547 SAFENET_IT_CHAIN_ID=31337 \
  yarn workspace @safe-global/utils test:integration
```

## Affected flows

None. Nothing constructs a `SafenetReader` yet — that happens in the wiring PR.

## Blast radius

- **New files** under `packages/utils/src/features/safenet-checks/services/`, plus the `utils/` barrel.
- **`packages/utils/jest.config.js`** — `*.integration.test.ts` added to `testPathIgnorePatterns`. Worth a look: this is the mechanism that keeps a live-network spec out of the default run and out of turbo. The spec self-skips with instructions when `SAFENET_IT_RPC` is unset, so it is green either way.
- **`packages/utils/package.json`** — adds a `test:integration` script.
- **Mobile**: shared package, nothing calls it.
- **No network calls in the default configuration** — nothing constructs the reader, and the oracle allowlist is empty.
- No persistence, no migrations, no routes.

## Risks / not checked

- **`estimateBlockAt` never checks convergence.** It refines twice and returns whatever it has. Probed as safe at Gnosis' current ~5.2s block time (error ≈ −389 blocks at 1 year), but there is no margin: it fails at 5.5s/1yr, 7s/30d, and 10s at any age. A miss reads as `UNAVAILABLE` with no signal. **Known and deliberately not fixed here** — the fix is to return the residual drift and fall back to the head-relative scan when it exceeds the targeted window. Happy to do it in this PR if you'd rather not merge without it.
- **RPC failover is effectively untested in practice** — the default config ships a single RPC URL, so rotation is a no-op wrapper. The rotation logic itself has unit coverage.
- **Not exercised against a Safe transaction older than the targeted window** on live beta.
- **The dev-only chain-id assertion is deliberate**: ethers does *not* catch a chain-id mismatch even with `staticNetwork`, which I verified. Reading Safenet events off the wrong chain would silently return nothing.
- **Not tested on mobile.**

## Visual summary

```mermaid
flowchart TB
  IN["safeTxHash + tx timestamp"] --> W{"timestamp<br/>available?"}
  W -->|yes| AIM["estimateBlockAt<br/>→ targeted window<br/>cost independent of age"]
  W -->|no| SCAN["head-relative scan<br/>(fallback)"]
  AIM --> GL["getLogsChunked<br/>provider rotates on failure"]
  SCAN --> GL
  GL --> DEC["decodeLogs"]

  DEC --> AL{"proposal names an<br/>ALLOWLISTED oracle?"}
  AL -->|"no — DEFAULT<br/>(allowlist empty)"| SKIP["oracle path skipped entirely"]
  AL -->|yes| OL["read sentinel + oracle logs<br/>keyed by derived requestId"]

  DEC --> PRE["derive preimage FROM<br/>THE DECODED EVENT<br/>oracle and plain never crossed"]
  PRE --> GK["groupKey(epoch)<br/>from FROSTCoordinator"]
  GK -->|reverts: unknown epoch| PEND["PENDING — retryable"]
  GK -->|ok| VER["FROST verify (#8369)"]
  VER --> OUT["events + verification<br/>→ deriveCheckState"]
  SKIP --> OUT
  OL --> OUT
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — n/a, no mobile code path reaches this yet
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
