### PR TITLE
fix(web): stop execute-flow review step remounting in a loop when wor…

### DIFF
--- a/apps/web/src/components/tx-flow/flows/ConfirmTx/ConfirmProposedTx.test.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmTx/ConfirmProposedTx.test.tsx
@@ -1,0 +1,61 @@
+import { render } from '@/tests/test-utils'
+import { createExistingTx } from '@/services/tx/tx-sender'
+import { SafeTxContext, type SafeTxContextParams } from '@/components/tx-flow/SafeTxProvider'
+import { TxFlowContext, initialContext } from '@/components/tx-flow/TxFlowProvider'
+import ConfirmProposedTx from './ConfirmProposedTx'
+
+jest.mock('@/services/tx/tx-sender', () => ({
+  createExistingTx: jest.fn(() => Promise.resolve({})),
+}))
+
+jest.mock('@/components/tx/ReviewTransactionV2', () => ({
+  __esModule: true,
+  default: ({ children }: { children?: React.ReactNode }) => <div data-testid="review-tx">{children}</div>,
+}))
+
+const mockCreateExistingTx = createExistingTx as jest.MockedFunction<typeof createExistingTx>
+
+const TX_ID = 'multisig_0x1000000000000000000000000000000000000001_0xabc'
+
+const renderWithContexts = (safeTxContext: Partial<SafeTxContextParams>) => {
+  const txFlowValue = { ...initialContext, txId: TX_ID, txNonce: 7 }
+  const safeTxValue: SafeTxContextParams = {
+    setSafeTx: jest.fn(),
+    setSafeMessage: jest.fn(),
+    setSafeMessageHash: jest.fn(),
+    setSafeTxError: jest.fn(),
+    setNonce: jest.fn(),
+    setNonceNeeded: jest.fn(),
+    setSafeTxGas: jest.fn(),
+    setTxOrigin: jest.fn(),
+    isReadOnly: false,
+    gtfPaymentMode: 'safe',
+    setGtfPaymentMode: jest.fn(),
+    setGtfSelectedGasToken: jest.fn(),
+    ...safeTxContext,
+  }
+
+  const result = render(
+    <TxFlowContext.Provider value={txFlowValue}>
+      <SafeTxContext.Provider value={safeTxValue}>
+        <ConfirmProposedTx onSubmit={jest.fn()} />
+      </SafeTxContext.Provider>
+    </TxFlowContext.Provider>,
+  )
+
+  return { ...result, safeTxValue, txFlowValue }
+}
+
+describe('ConfirmProposedTx', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('sets the nonce from TxFlowContext and creates the existing tx from its txId', () => {
+    const { safeTxValue } = renderWithContexts({})
+
+    expect(safeTxValue.setNonce).toHaveBeenCalledWith(7)
+    expect(mockCreateExistingTx).toHaveBeenCalledTimes(1)
+    expect(mockCreateExistingTx).toHaveBeenCalledWith(expect.any(String), TX_ID)
+  })
+})

--- a/apps/web/src/components/tx-flow/flows/ConfirmTx/ConfirmProposedTx.test.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmTx/ConfirmProposedTx.test.tsx
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker'
 import { render } from '@/tests/test-utils'
 import { createExistingTx } from '@/services/tx/tx-sender'
 import { SafeTxContext, type SafeTxContextParams } from '@/components/tx-flow/SafeTxProvider'
@@ -15,10 +16,11 @@ jest.mock('@/components/tx/ReviewTransactionV2', () => ({
 
 const mockCreateExistingTx = createExistingTx as jest.MockedFunction<typeof createExistingTx>
 
-const TX_ID = 'multisig_0x1000000000000000000000000000000000000001_0xabc'
+const TX_ID = `multisig_${faker.finance.ethereumAddress()}_${faker.string.hexadecimal({ length: 8 })}`
+const TX_NONCE = faker.number.int({ min: 1, max: 100000 })
 
 const renderWithContexts = (safeTxContext: Partial<SafeTxContextParams>) => {
-  const txFlowValue = { ...initialContext, txId: TX_ID, txNonce: 7 }
+  const txFlowValue = { ...initialContext, txId: TX_ID, txNonce: TX_NONCE }
   const safeTxValue: SafeTxContextParams = {
     setSafeTx: jest.fn(),
     setSafeMessage: jest.fn(),
@@ -54,7 +56,7 @@ describe('ConfirmProposedTx', () => {
   it('sets the nonce from TxFlowContext and creates the existing tx from its txId', () => {
     const { safeTxValue } = renderWithContexts({})
 
-    expect(safeTxValue.setNonce).toHaveBeenCalledWith(7)
+    expect(safeTxValue.setNonce).toHaveBeenCalledWith(TX_NONCE)
     expect(mockCreateExistingTx).toHaveBeenCalledTimes(1)
     expect(mockCreateExistingTx).toHaveBeenCalledWith(expect.any(String), TX_ID)
   })

--- a/apps/web/src/components/tx-flow/flows/ConfirmTx/ConfirmProposedTx.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmTx/ConfirmProposedTx.tsx
@@ -1,21 +1,19 @@
-import { type PropsWithChildren, type ReactElement, useContext, useEffect } from 'react'
+import { type ReactElement, useContext, useEffect } from 'react'
 import useChainId from '@/hooks/useChainId'
 import { createExistingTx } from '@/services/tx/tx-sender'
 import ReviewTransaction from '@/components/tx/ReviewTransactionV2'
-import type { ReviewTransactionContentProps } from '@/components/tx/ReviewTransactionV2/ReviewTransactionContent'
+import type { ReviewTransactionProps } from '@/components/tx/ReviewTransactionV2'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { TxFlowContext } from '@/components/tx-flow/TxFlowProvider'
 
-type ConfirmProposedTxProps = PropsWithChildren<
-  {
-    txNonce: number | undefined
-  } & ReviewTransactionContentProps
->
-
-const ConfirmProposedTx = ({ txNonce, children, ...props }: ConfirmProposedTxProps): ReactElement => {
+// Reads txNonce/txId from TxFlowContext (like RejectTx) so ConfirmTxFlow can pass this component
+// to TxFlow by reference. An inline wrapper would change component identity on every render,
+// remounting the whole review step — re-running the effects below (tx-details fetch + setSafeTx)
+// and every mount-time estimation/scan in the subtree, in a loop.
+const ConfirmProposedTx = ({ children, ...props }: ReviewTransactionProps): ReactElement => {
   const chainId = useChainId()
   const { setSafeTx, setSafeTxError, setNonce } = useContext(SafeTxContext)
-  const { txId } = useContext(TxFlowContext)
+  const { txId, txNonce } = useContext(TxFlowContext)
 
   useEffect(() => {
     if (txNonce !== undefined) {

--- a/apps/web/src/components/tx-flow/flows/ConfirmTx/ConfirmProposedTx.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmTx/ConfirmProposedTx.tsx
@@ -6,10 +6,6 @@ import type { ReviewTransactionProps } from '@/components/tx/ReviewTransactionV2
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { TxFlowContext } from '@/components/tx-flow/TxFlowProvider'
 
-// Reads txNonce/txId from TxFlowContext (like RejectTx) so ConfirmTxFlow can pass this component
-// to TxFlow by reference. An inline wrapper would change component identity on every render,
-// remounting the whole review step — re-running the effects below (tx-details fetch + setSafeTx)
-// and every mount-time estimation/scan in the subtree, in a loop.
 const ConfirmProposedTx = ({ children, ...props }: ReviewTransactionProps): ReactElement => {
   const chainId = useChainId()
   const { setSafeTx, setSafeTxError, setNonce } = useContext(SafeTxContext)

--- a/apps/web/src/components/tx-flow/flows/ConfirmTx/index.test.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmTx/index.test.tsx
@@ -1,0 +1,73 @@
+import type { Transaction } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import {
+  DetailedExecutionInfoType,
+  TransactionInfoType,
+  TransactionStatus,
+  TransactionTokenType,
+  TransferDirection,
+} from '@safe-global/store/gateway/types'
+
+import { render } from '@/tests/test-utils'
+import ConfirmTxFlow from './index'
+import ConfirmProposedTx from './ConfirmProposedTx'
+import { TxFlow } from '../../TxFlow'
+
+jest.mock('../../TxFlow', () => ({
+  TxFlow: jest.fn(() => null),
+}))
+
+const mockTxFlow = TxFlow as jest.MockedFunction<typeof TxFlow>
+
+const buildTxSummary = (): Transaction =>
+  ({
+    id: 'multisig_0x1000000000000000000000000000000000000001_0xabc',
+    timestamp: Date.now(),
+    executionInfo: {
+      type: DetailedExecutionInfoType.MULTISIG,
+      nonce: 7,
+      confirmationsRequired: 2,
+      confirmationsSubmitted: 1,
+      missingSigners: [{ value: '0x6a5602335a878ADDCa4BF63a050E34946B56B5bC' }],
+    },
+    txInfo: {
+      type: TransactionInfoType.TRANSFER,
+      direction: TransferDirection.OUTGOING,
+      transferInfo: {
+        value: '1000000',
+        type: TransactionTokenType.NATIVE_COIN,
+      },
+    },
+    txStatus: TransactionStatus.AWAITING_CONFIRMATIONS,
+  }) as unknown as Transaction
+
+describe('ConfirmTxFlow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('passes a referentially stable ReviewTransactionComponent to TxFlow across re-renders', () => {
+    // Regression test: an inline `(props) => <ConfirmProposedTx ... />` wrapper changes component
+    // identity on every render, so React remounts the whole review step. Each remount re-runs
+    // ConfirmProposedTx's effects (tx-details fetch + setSafeTx) and every mount-time gas
+    // estimation/scan in the subtree — an infinite refetch/rerender loop once anything (e.g. the
+    // space address book when signed in to a workspace) re-renders ConfirmTxFlow.
+    const { rerender } = render(<ConfirmTxFlow txSummary={buildTxSummary()} />)
+    // A fresh txSummary object forces a genuine re-render of ConfirmTxFlow
+    rerender(<ConfirmTxFlow txSummary={buildTxSummary()} />)
+
+    expect(mockTxFlow.mock.calls.length).toBeGreaterThanOrEqual(2)
+    const firstProps = mockTxFlow.mock.calls[0][0]
+    const lastProps = mockTxFlow.mock.calls[mockTxFlow.mock.calls.length - 1][0]
+
+    expect(firstProps.ReviewTransactionComponent).toBe(ConfirmProposedTx)
+    expect(lastProps.ReviewTransactionComponent).toBe(firstProps.ReviewTransactionComponent)
+  })
+
+  it('forwards txId and txNonce so ConfirmProposedTx can read them from TxFlowContext', () => {
+    render(<ConfirmTxFlow txSummary={buildTxSummary()} />)
+
+    const props = mockTxFlow.mock.calls[0][0]
+    expect(props.txId).toBe('multisig_0x1000000000000000000000000000000000000001_0xabc')
+    expect(props.txNonce).toBe(7)
+  })
+})

--- a/apps/web/src/components/tx-flow/flows/ConfirmTx/index.test.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmTx/index.test.tsx
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker'
 import type { Transaction } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import {
   DetailedExecutionInfoType,
@@ -18,22 +19,25 @@ jest.mock('../../TxFlow', () => ({
 
 const mockTxFlow = TxFlow as jest.MockedFunction<typeof TxFlow>
 
+const TX_ID = `multisig_${faker.finance.ethereumAddress()}_${faker.string.hexadecimal({ length: 8 })}`
+const TX_NONCE = faker.number.int({ min: 1, max: 100000 })
+
 const buildTxSummary = (): Transaction =>
   ({
-    id: 'multisig_0x1000000000000000000000000000000000000001_0xabc',
+    id: TX_ID,
     timestamp: Date.now(),
     executionInfo: {
       type: DetailedExecutionInfoType.MULTISIG,
-      nonce: 7,
+      nonce: TX_NONCE,
       confirmationsRequired: 2,
       confirmationsSubmitted: 1,
-      missingSigners: [{ value: '0x6a5602335a878ADDCa4BF63a050E34946B56B5bC' }],
+      missingSigners: [{ value: faker.finance.ethereumAddress() }],
     },
     txInfo: {
       type: TransactionInfoType.TRANSFER,
       direction: TransferDirection.OUTGOING,
       transferInfo: {
-        value: '1000000',
+        value: faker.string.numeric(7),
         type: TransactionTokenType.NATIVE_COIN,
       },
     },
@@ -46,13 +50,7 @@ describe('ConfirmTxFlow', () => {
   })
 
   it('passes a referentially stable ReviewTransactionComponent to TxFlow across re-renders', () => {
-    // Regression test: an inline `(props) => <ConfirmProposedTx ... />` wrapper changes component
-    // identity on every render, so React remounts the whole review step. Each remount re-runs
-    // ConfirmProposedTx's effects (tx-details fetch + setSafeTx) and every mount-time gas
-    // estimation/scan in the subtree — an infinite refetch/rerender loop once anything (e.g. the
-    // space address book when signed in to a workspace) re-renders ConfirmTxFlow.
     const { rerender } = render(<ConfirmTxFlow txSummary={buildTxSummary()} />)
-    // A fresh txSummary object forces a genuine re-render of ConfirmTxFlow
     rerender(<ConfirmTxFlow txSummary={buildTxSummary()} />)
 
     expect(mockTxFlow.mock.calls.length).toBeGreaterThanOrEqual(2)
@@ -67,7 +65,7 @@ describe('ConfirmTxFlow', () => {
     render(<ConfirmTxFlow txSummary={buildTxSummary()} />)
 
     const props = mockTxFlow.mock.calls[0][0]
-    expect(props.txId).toBe('multisig_0x1000000000000000000000000000000000000001_0xabc')
-    expect(props.txNonce).toBe(7)
+    expect(props.txId).toBe(TX_ID)
+    expect(props.txNonce).toBe(TX_NONCE)
   })
 })

--- a/apps/web/src/components/tx-flow/flows/ConfirmTx/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmTx/index.tsx
@@ -31,8 +31,6 @@ const ConfirmTxFlow = ({ txSummary }: { txSummary: Transaction }) => {
       onlyExecute={!canSign}
       isRejection={isRejection}
       txSummary={txSummary}
-      // Must be a stable reference: TxFlow renders it as an element type, so a new identity per
-      // render would remount the review step (ConfirmProposedTx reads txNonce from TxFlowContext).
       ReviewTransactionComponent={ConfirmProposedTx}
       eventCategory={TxFlowType.CONFIRM_TX}
     />

--- a/apps/web/src/components/tx-flow/flows/ConfirmTx/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmTx/index.tsx
@@ -26,11 +26,14 @@ const ConfirmTxFlow = ({ txSummary }: { txSummary: Transaction }) => {
       icon={isSwapOrder ? SwapIcon : undefined}
       subtitle={<>{text}&nbsp;</>}
       txId={txId}
+      txNonce={txNonce}
       isExecutable={canExecute}
       onlyExecute={!canSign}
       isRejection={isRejection}
       txSummary={txSummary}
-      ReviewTransactionComponent={(props) => <ConfirmProposedTx txNonce={txNonce} {...props} />}
+      // Must be a stable reference: TxFlow renders it as an element type, so a new identity per
+      // render would remount the review step (ConfirmProposedTx reads txNonce from TxFlowContext).
+      ReviewTransactionComponent={ConfirmProposedTx}
       eventCategory={TxFlowType.CONFIRM_TX}
     />
   )

--- a/apps/web/src/features/spaces/hooks/useGetSpaceAddressBook.ts
+++ b/apps/web/src/features/spaces/hooks/useGetSpaceAddressBook.ts
@@ -7,8 +7,6 @@ import {
 } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { SPACE_REFRESH_OPTIONS } from './refreshOptions'
 
-// Stable reference: `|| []` would mint a new array per render for every consumer (useAddressBook is
-// mounted per address row), invalidating the memo chains built on top of it.
 const EMPTY_ADDRESS_BOOK: SpaceAddressBookItemDto[] = []
 
 const useGetSpaceAddressBook = (): SpaceAddressBookItemDto[] => {

--- a/apps/web/src/features/spaces/hooks/useGetSpaceAddressBook.ts
+++ b/apps/web/src/features/spaces/hooks/useGetSpaceAddressBook.ts
@@ -1,10 +1,17 @@
 import { useCurrentSpaceId } from './useCurrentSpaceId'
 import { useAppSelector } from '@/store'
 import { isAuthenticated } from '@/store/authSlice'
-import { useAddressBooksGetAddressBookItemsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import {
+  useAddressBooksGetAddressBookItemsV1Query,
+  type SpaceAddressBookItemDto,
+} from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { SPACE_REFRESH_OPTIONS } from './refreshOptions'
 
-const useGetSpaceAddressBook = () => {
+// Stable reference: `|| []` would mint a new array per render for every consumer (useAddressBook is
+// mounted per address row), invalidating the memo chains built on top of it.
+const EMPTY_ADDRESS_BOOK: SpaceAddressBookItemDto[] = []
+
+const useGetSpaceAddressBook = (): SpaceAddressBookItemDto[] => {
   const spaceId = useCurrentSpaceId()
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const { currentData: addressBook } = useAddressBooksGetAddressBookItemsV1Query(
@@ -12,7 +19,7 @@ const useGetSpaceAddressBook = () => {
     { skip: !isUserSignedIn || !spaceId, ...SPACE_REFRESH_OPTIONS },
   )
 
-  return addressBook?.data || []
+  return addressBook?.data ?? EMPTY_ADDRESS_BOOK
 }
 
 export default useGetSpaceAddressBook


### PR DESCRIPTION
## What it solves

Resolves: infinite rerender/refetch loop on the transaction execution page (`ConfirmTxFlow`) when the user is signed in to a workspace. Every element on the page kept re-rendering while `/v1/chains/{chainId}/transactions/multisig_*`, the space address-book endpoint, and RPC (Infura) requests replayed in a loop. Signed out, the page was stable.

## How this PR fixes it

`ConfirmTxFlow` passed an **inline arrow component** as `ReviewTransactionComponent` to `TxFlow`. `TxFlow` renders that prop as an element type, so every re-render of `ConfirmTxFlow` handed React a new component type, which unmounted and **remounted the entire review step**. Each remount re-ran `ConfirmProposedTx`'s mount effect (tx-details fetch + `setSafeTx`) and every mount-time estimation/simulation/scan in the subtree (the RPC storm).

Workspace sign-in supplied the re-render driver that made this self-sustaining: each `useAddressBook` consumer holds its own space address-book subscription (`refetchOnFocus` + refetch-on-mount), and refetched data flows into `useTransactionType(txSummary)` inside `ConfirmTxFlow` → re-render → new component type → remount → refetch → ∞. Signed out, the address book is stable local Redux state, so the cycle never sustained.

Changes:

- `ConfirmTx/index.tsx`: pass `ReviewTransactionComponent={ConfirmProposedTx}` by reference and thread `txNonce` through `TxFlow` → `TxFlowContext` (same pattern as `RejectTx`)
- `ConfirmProposedTx.tsx`: read `txNonce` from `TxFlowContext` instead of props (single consumer)
- `useGetSpaceAddressBook.ts`: return a stable empty array instead of minting `[]` per render (identity-churn hardening for every `useAddressBook` consumer)

Measured with a Playwright harness against the dev server (25 forced address-book-driven re-renders with the execute flow open): **before: 22 repeated tx-details requests, after: 0**.

## How to test it

1. Sign in to a workspace (Spaces) whose safe has a queued transaction, with your wallet connected.
2. Open the transaction and click **Execute** (or Confirm) to enter the review step.
3. Watch the Network tab: `/v1/chains/{chainId}/transactions/multisig_*`, `/v1/spaces/{id}/address-book`, and RPC calls must each fire once — no repeats while idling on the step.
4. Rename an address-book entry while the flow is open: the review step must not flash/remount, and no tx-details refetch should fire.
5. Sign/execute still works: nonce shown matches the queued tx (nonce now flows via `TxFlowContext`).

## Affected flows

- Owner confirms or executes a queued transaction via the Confirm transaction flow (`ConfirmTxFlow` → review step → receipt)

## Blast radius

- `TxFlow` / `TxFlowContext`: API unchanged; `ConfirmTxFlow` now passes `txNonce` (already consumed the same way by `RejectTx`, `ReplaceTx`)
- `ConfirmProposedTx`: prop signature changed (`txNonce` prop removed) — only consumer is `ConfirmTx/index.tsx`
- `useGetSpaceAddressBook`: consumed by `useMergedAddressBooks` → `useAddressBook` (app-wide address name resolution) and space address-book surfaces; change only affects the no-data identity (stable `[]`), not data content
- All other flows pass module-scope `ReviewTransactionComponent`s already — `ConfirmTx` was the only inline one
- No API contract, feature flag, persistence, or mobile impact

## Risks / not checked

- Did not execute a transaction on-chain end-to-end (verified up to the Execute step UI with a throwaway key)
- Did not manually exercise the execute-through-role or counterfactual variants of the flow (unchanged code paths, covered by existing tests)
- Loop cadence in other environments depends on what drives `ConfirmTxFlow` re-renders (address-book refetch, focus events); the fix removes the remount trigger they all funnel through

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1[ConfirmTxFlow re-renders<br/>space address-book refetch → new data ref] --> B1["ReviewTransactionComponent = (props) => ...<br/>new component type every render"]
    B1 --> C1[React remounts review step]
    C1 --> D1[mount effect: tx-details fetch + setSafeTx<br/>+ gas estimation, scans, simulations RPC]
    D1 --> E1[address-book resubscribe/refetch<br/>new data → useTransactionType]
    E1 --> A1
  end
  subgraph After
    A2[ConfirmTxFlow re-renders] --> B2["ReviewTransactionComponent = ConfirmProposedTx<br/>stable reference, txNonce via TxFlowContext"]
    B2 --> C2[review step reconciles in place<br/>effects run once]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics changes
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — regression test pins `ReviewTransactionComponent` identity stability; `ConfirmProposedTx` context-nonce test
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).