### PR TITLE
feat(safenet): add event fragments, topic0 dispatch, and event types

### DIFF
--- a/packages/utils/src/features/safenet-checks/__tests__/abi.test.ts
+++ b/packages/utils/src/features/safenet-checks/__tests__/abi.test.ts
@@ -1,0 +1,58 @@
+import {
+  CONSENSUS_EVENT_FRAGMENTS,
+  CONSENSUS_PLAIN_EVENT_FRAGMENTS,
+  consensusPlainInterface,
+  EVENT_DISPATCH,
+  SHARED_ORACLE_EVENT_FRAGMENTS,
+  TOPICS,
+  V1_SENTINEL_EVENT_FRAGMENTS,
+  V2_SENTINEL_EVENT_FRAGMENTS,
+  topicHashOf,
+  v1SentinelInterface,
+  v2SentinelInterface,
+} from '../abi'
+
+describe('safenet-checks abi', () => {
+  it('assigns a unique topic0 to every dispatched event (no collisions)', () => {
+    const topics = EVENT_DISPATCH.map(topicHashOf)
+    const unique = new Set(topics)
+    expect(unique.size).toBe(EVENT_DISPATCH.length)
+    // Every dispatch descriptor is reachable in the topic0 map.
+    expect(Object.keys(TOPICS)).toHaveLength(EVENT_DISPATCH.length)
+  })
+
+  it('gives V1 and V2 NewRequest distinct topic0s (the disambiguation invariant)', () => {
+    const v1 = v1SentinelInterface.getEvent('NewRequest')!.topicHash
+    const v2 = v2SentinelInterface.getEvent('NewRequest')!.topicHash
+    expect(v1).not.toBe(v2)
+  })
+
+  it('gives V1 and V2 Committed distinct topic0s', () => {
+    const v1 = v1SentinelInterface.getEvent('Committed')!.topicHash
+    const v2 = v2SentinelInterface.getEvent('Committed')!.topicHash
+    expect(v1).not.toBe(v2)
+  })
+
+  it('covers every declared fragment across all five interfaces', () => {
+    const totalFragments =
+      CONSENSUS_EVENT_FRAGMENTS.length +
+      CONSENSUS_PLAIN_EVENT_FRAGMENTS.length +
+      V1_SENTINEL_EVENT_FRAGMENTS.length +
+      V2_SENTINEL_EVENT_FRAGMENTS.length +
+      SHARED_ORACLE_EVENT_FRAGMENTS.length
+    expect(EVENT_DISPATCH).toHaveLength(totalFragments)
+  })
+
+  // Regression guard: these four topic0s were read off the live Gnosis beta
+  // Consensus on 2026-07-28. The oracle pair is what repo HEAD emits; the plain
+  // pair is what beta actually emits while the sentinels are not yet live.
+  // Reading the wrong family silently yields "no events found".
+  it('matches the topic0s observed on the deployed Gnosis beta Consensus', () => {
+    expect(consensusPlainInterface.getEvent('TransactionProposed')!.topicHash).toBe(
+      '0xe7427c304b80147290ec649ec1d8881f5fa455e85ba79ecb7dbfc58a56ea0906',
+    )
+    expect(consensusPlainInterface.getEvent('TransactionAttested')!.topicHash).toBe(
+      '0x72272729e643703db011cc155474c30d652f1a68712d921cc263a881efd7bce6',
+    )
+  })
+})

--- a/packages/utils/src/features/safenet-checks/abi.ts
+++ b/packages/utils/src/features/safenet-checks/abi.ts
@@ -1,0 +1,183 @@
+import { Interface } from 'ethers'
+import { CheckEventType, OracleGeneration } from './types'
+
+/**
+ * Event fragments copied verbatim (field names + types) from the protocol repo:
+ *   - Consensus: `explorer/src/lib/consensus/abi.ts` + `validator/src/types/abis.ts`
+ *   - V1 sentinel: `contracts/src/libraries/{SentinelOracleRequests,SentinelOracleCommitments}.sol`
+ *   - V2 sentinel: `contracts/src/libraries/{SentinelOracleRequestsV2,SentinelOracleCommitmentsV2}.sol`
+ *   - Shared: `contracts/src/interfaces/IOracle.sol` + `SentinelOracle(V2).sol`
+ *
+ * The two generations' `NewRequest`/`Committed` have genuinely different
+ * signatures (and therefore different topic0s), which is what lets a single
+ * topic0→generation map disambiguate them. `DisputeResolved` and `OracleResult`
+ * are identical across generations, so they live in one shared bucket (defining
+ * them per-generation would collide on topic0).
+ */
+
+const TX_TUPLE =
+  '(uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce)'
+const FROST_SIG_TUPLE = '((uint256 x, uint256 y) r, uint256 z)'
+
+export const CONSENSUS_EVENT_FRAGMENTS = [
+  `event OracleTransactionProposed(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, address oracle, ${TX_TUPLE} transaction)`,
+  `event OracleTransactionAttested(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, address oracle, bytes32 signatureId, ${FROST_SIG_TUPLE} attestation)`,
+] as const
+
+/**
+ * The **non-oracle** Consensus events: same shape as the oracle pair minus the
+ * `oracle` field, so they hash to different topic0s. Confirmed 2026-07-28 as
+ * what the live Gnosis beta actually emits — in a 10k-block sample the deployed
+ * Consensus emitted ~3k `TransactionProposed` / ~2.9k `TransactionAttested` and
+ * zero `OracleTransaction*`. The validator set runs its own deterministic checks
+ * on this path and attests the result; the sentinel oracle adds richer checks
+ * later. Both resolve to `BENIGN` once the FROST signature verifies.
+ */
+export const CONSENSUS_PLAIN_EVENT_FRAGMENTS = [
+  `event TransactionProposed(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, ${TX_TUPLE} transaction)`,
+  `event TransactionAttested(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, bytes32 signatureId, ${FROST_SIG_TUPLE} attestation)`,
+] as const
+
+export const V1_SENTINEL_EVENT_FRAGMENTS = [
+  'event NewRequest(bytes32 indexed requestId, address indexed proposer, uint256 fee, uint256 bondTarget, uint256 deadline)',
+  'event Committed(bytes32 indexed requestId, address indexed sentinel, bool approved, uint256 bondAmount, uint256 position)',
+] as const
+
+export const V2_SENTINEL_EVENT_FRAGMENTS = [
+  'event NewRequest(bytes32 indexed requestId, address indexed proposer, uint256 fee, uint256 bondTarget, uint256 commitDeadline, uint256 revealDeadline)',
+  'event Committed(bytes32 indexed requestId, address indexed sentinel, uint256 bondAmount)',
+  'event Revealed(bytes32 indexed requestId, address indexed sentinel, bool approved, uint256 bondAmount, string reason)',
+] as const
+
+export const SHARED_ORACLE_EVENT_FRAGMENTS = [
+  'event OracleResult(bytes32 indexed requestId, address indexed proposer, bytes result, bool approved)',
+  'event DisputeResolved(bytes32 indexed requestId, uint8 outcome, uint256 slashed)',
+] as const
+
+/**
+ * Read (view) functions the reader calls with `ethers.Contract`. Copied from the
+ * protocol explorer's `consensus`/`coordinator` ABIs. `getEpochGroupId` maps an
+ * epoch to its FROST group id; `groupKey` returns that group's public key;
+ * `getCoordinator` discovers the FROSTCoordinator when no override is configured.
+ */
+export const CONSENSUS_READ_ABI = [
+  'function getCoordinator() view returns (address)',
+  'function getEpochGroupId(uint64 epoch) view returns (bytes32 groupId)',
+] as const
+
+export const COORDINATOR_READ_ABI = [
+  'function groupKey(bytes32 gid) view returns ((uint256 x, uint256 y) key)',
+] as const
+
+export const consensusInterface = new Interface(CONSENSUS_EVENT_FRAGMENTS)
+export const consensusPlainInterface = new Interface(CONSENSUS_PLAIN_EVENT_FRAGMENTS)
+export const v1SentinelInterface = new Interface(V1_SENTINEL_EVENT_FRAGMENTS)
+export const v2SentinelInterface = new Interface(V2_SENTINEL_EVENT_FRAGMENTS)
+export const sharedOracleInterface = new Interface(SHARED_ORACLE_EVENT_FRAGMENTS)
+
+export type TopicDispatch = {
+  iface: Interface
+  eventName: string
+  type: CheckEventType
+  generation: OracleGeneration
+}
+
+/** One descriptor per decodable event; the source of truth for {@link TOPICS}. */
+export const EVENT_DISPATCH: readonly TopicDispatch[] = [
+  {
+    iface: consensusInterface,
+    eventName: 'OracleTransactionProposed',
+    type: CheckEventType.ORACLE_PROPOSED,
+    generation: OracleGeneration.STABLE,
+  },
+  {
+    iface: consensusInterface,
+    eventName: 'OracleTransactionAttested',
+    type: CheckEventType.ORACLE_ATTESTED,
+    generation: OracleGeneration.STABLE,
+  },
+  {
+    iface: consensusPlainInterface,
+    eventName: 'TransactionProposed',
+    type: CheckEventType.PLAIN_PROPOSED,
+    generation: OracleGeneration.STABLE,
+  },
+  {
+    iface: consensusPlainInterface,
+    eventName: 'TransactionAttested',
+    type: CheckEventType.PLAIN_ATTESTED,
+    generation: OracleGeneration.STABLE,
+  },
+  {
+    iface: v1SentinelInterface,
+    eventName: 'NewRequest',
+    type: CheckEventType.REQUEST_CREATED,
+    generation: OracleGeneration.V1,
+  },
+  {
+    iface: v1SentinelInterface,
+    eventName: 'Committed',
+    type: CheckEventType.SENTINEL_COMMITTED,
+    generation: OracleGeneration.V1,
+  },
+  {
+    iface: v2SentinelInterface,
+    eventName: 'NewRequest',
+    type: CheckEventType.REQUEST_CREATED,
+    generation: OracleGeneration.V2,
+  },
+  {
+    iface: v2SentinelInterface,
+    eventName: 'Committed',
+    type: CheckEventType.SENTINEL_COMMITTED,
+    generation: OracleGeneration.V2,
+  },
+  {
+    iface: v2SentinelInterface,
+    eventName: 'Revealed',
+    type: CheckEventType.SENTINEL_REVEALED,
+    generation: OracleGeneration.V2,
+  },
+  {
+    iface: sharedOracleInterface,
+    eventName: 'OracleResult',
+    type: CheckEventType.ORACLE_RESULT,
+    generation: OracleGeneration.STABLE,
+  },
+  {
+    iface: sharedOracleInterface,
+    eventName: 'DisputeResolved',
+    type: CheckEventType.DISPUTE_RESOLVED,
+    generation: OracleGeneration.STABLE,
+  },
+]
+
+/** Compute an event's topic0 from its interface + name. */
+export const topicHashOf = (dispatch: Pick<TopicDispatch, 'iface' | 'eventName'>): string => {
+  const fragment = dispatch.iface.getEvent(dispatch.eventName)
+  if (!fragment) throw new Error(`unknown event ${dispatch.eventName}`)
+  return fragment.topicHash
+}
+
+/** topic0 → dispatch descriptor. Uniqueness is asserted by the abi guard test. */
+export const TOPICS: Readonly<Record<string, TopicDispatch>> = Object.freeze(
+  Object.fromEntries(EVENT_DISPATCH.map((dispatch) => [topicHashOf(dispatch), dispatch])),
+)
+
+/**
+ * The two Consensus event topic0s (`OracleTransactionProposed` /
+ * `OracleTransactionAttested`) — indexed by `safeTxHash` (topic1). Used as the
+ * topic0 filter for the first `getLogs`.
+ */
+export const CONSENSUS_TOPIC0S: readonly string[] = EVENT_DISPATCH.filter(
+  (dispatch) => dispatch.iface === consensusInterface || dispatch.iface === consensusPlainInterface,
+).map(topicHashOf)
+
+/**
+ * Every sentinel/oracle event topic0 (V1 + V2 `NewRequest`/`Committed`/
+ * `Revealed`, plus the shared `OracleResult`/`DisputeResolved`) — all indexed by
+ * `requestId` (topic1). Used as the topic0 filter for the second `getLogs`.
+ */
+export const SENTINEL_TOPIC0S: readonly string[] = EVENT_DISPATCH.filter(
+  (dispatch) => dispatch.iface !== consensusInterface && dispatch.iface !== consensusPlainInterface,
+).map(topicHashOf)

--- a/packages/utils/src/features/safenet-checks/types/events.ts
+++ b/packages/utils/src/features/safenet-checks/types/events.ts
@@ -1,11 +1,168 @@
 /**
- * Shared primitives for the Safenet read layer. Onchain integers are carried as
- * decimal strings so the tree stays Redux-serializable; the event types that
- * rely on that land with the decoder.
+ * Normalized Safenet lifecycle events.
+ *
+ * Every onchain value that is a `uint256`/`uint64`/`uint` is carried as a
+ * decimal `string` so the whole tree is Redux-serializable (no bigints ever
+ * cross the decode boundary). Point coordinates and scalars (FROST `r`/`z`) are
+ * likewise strings.
  *
  * `Hex` is the Safe SDK's own (`@safe-global/types-kit`, already a dependency
  * of this package) — re-exported so feature code keeps importing from
  * `../types`.
  */
 
-export type { Hex } from '@safe-global/types-kit'
+import type { Hex } from '@safe-global/types-kit'
+
+export type { Hex }
+
+/**
+ * Which sentinel-oracle generation produced an event. Consensus events and the
+ * shared `OracleResult`/`DisputeResolved` are generation-agnostic (`STABLE`).
+ */
+export enum OracleGeneration {
+  V1 = 'V1',
+  V2 = 'V2',
+  STABLE = 'STABLE',
+}
+
+export enum CheckEventType {
+  /** Consensus `OracleTransactionProposed` — the check enters existence. */
+  ORACLE_PROPOSED = 'ORACLE_PROPOSED',
+  /** Consensus `OracleTransactionAttested` — carries the FROST signature. */
+  ORACLE_ATTESTED = 'ORACLE_ATTESTED',
+  /**
+   * Consensus `TransactionProposed` — the **non-oracle** path: the validator set
+   * is asked to attest a Safe transaction with no sentinel oracle in the loop.
+   * No fee, no bond, no verdict. This is what live beta traffic overwhelmingly
+   * uses today.
+   */
+  PLAIN_PROPOSED = 'PLAIN_PROPOSED',
+  /**
+   * Consensus `TransactionAttested` — the non-oracle attestation. Proves the
+   * validator set signed the transaction; proves **nothing** about whether it is
+   * safe, because no security check ran.
+   */
+  PLAIN_ATTESTED = 'PLAIN_ATTESTED',
+  /** Sentinel `NewRequest` — carries the per-check deadline block. */
+  REQUEST_CREATED = 'REQUEST_CREATED',
+  /** Sentinel `Committed` — V1 carries the verdict, V2 is activity-only. */
+  SENTINEL_COMMITTED = 'SENTINEL_COMMITTED',
+  /** Sentinel `Revealed` (V2 only) — carries the per-sentinel verdict. */
+  SENTINEL_REVEALED = 'SENTINEL_REVEALED',
+  /** `OracleResult` — the oracle's final approved flag. */
+  ORACLE_RESULT = 'ORACLE_RESULT',
+  /** `DisputeResolved` — a frozen/contested request was resolved. */
+  DISPUTE_RESOLVED = 'DISPUTE_RESOLVED',
+}
+
+/** Fields present on every decoded event; used for ordering and de-duplication. */
+export type CheckEventBase = {
+  blockNumber: number
+  logIndex: number
+  transactionHash: string
+  generation: OracleGeneration
+}
+
+export type OracleProposedEvent = CheckEventBase & {
+  type: CheckEventType.ORACLE_PROPOSED
+  safeTxHash: Hex
+  chainId: string
+  safe: string
+  epoch: string
+  oracle: string
+}
+
+export type FrostSignature = {
+  r: { x: string; y: string }
+  z: string
+}
+
+export type OracleAttestedEvent = CheckEventBase & {
+  type: CheckEventType.ORACLE_ATTESTED
+  safeTxHash: Hex
+  chainId: string
+  safe: string
+  epoch: string
+  oracle: string
+  signatureId: Hex
+  attestation: FrostSignature
+}
+
+export type PlainProposedEvent = CheckEventBase & {
+  type: CheckEventType.PLAIN_PROPOSED
+  safeTxHash: Hex
+  chainId: string
+  safe: string
+  epoch: string
+}
+
+export type PlainAttestedEvent = CheckEventBase & {
+  type: CheckEventType.PLAIN_ATTESTED
+  safeTxHash: Hex
+  chainId: string
+  safe: string
+  epoch: string
+  signatureId: Hex
+  attestation: FrostSignature
+}
+
+export type RequestCreatedEvent = CheckEventBase & {
+  type: CheckEventType.REQUEST_CREATED
+  requestId: Hex
+  proposer: string
+  fee: string
+  bondTarget: string
+  /**
+   * The block the check times out at. Normalized across generations: V1's
+   * single `deadline`, or V2's `revealDeadline` (the last block a verdict can
+   * still land). V2's earlier `commitDeadline` is kept separately.
+   */
+  deadlineBlock: string
+  commitDeadlineBlock: string | null
+}
+
+export type SentinelCommittedEvent = CheckEventBase & {
+  type: CheckEventType.SENTINEL_COMMITTED
+  requestId: Hex
+  sentinel: string
+  bondAmount: string
+  /** Present in V1 only — V1 commits carry the verdict directly. */
+  approved: boolean | null
+  /** Present in V1 only. */
+  position: string | null
+}
+
+export type SentinelRevealedEvent = CheckEventBase & {
+  type: CheckEventType.SENTINEL_REVEALED
+  requestId: Hex
+  sentinel: string
+  approved: boolean
+  bondAmount: string
+  reason: string
+}
+
+export type OracleResultEvent = CheckEventBase & {
+  type: CheckEventType.ORACLE_RESULT
+  requestId: Hex
+  proposer: string
+  approved: boolean
+  result: Hex
+}
+
+export type DisputeResolvedEvent = CheckEventBase & {
+  type: CheckEventType.DISPUTE_RESOLVED
+  requestId: Hex
+  outcome: number
+  slashed: string
+}
+
+export type NormalizedCheckEvent =
+  | OracleProposedEvent
+  | OracleAttestedEvent
+  | PlainProposedEvent
+  | PlainAttestedEvent
+  | RequestCreatedEvent
+  | SentinelCommittedEvent
+  | SentinelRevealedEvent
+  | OracleResultEvent
+  | DisputeResolvedEvent


### PR DESCRIPTION
## What it solves

Part 2 of the Safenet read-layer sequence — sized per review feedback (≤500 LOC): the former decode PR (#8371, 1,144 lines, closed) is now two slices; this is the first.

> **Sequence:** #8369 FROST verification (merged) → **this: the event vocabulary** → the decoder (branch `safenet-decode`, opens when this merges) → status derivation → reader → wiring. One PR open at a time.

This PR answers one question: **is the event vocabulary right?**

## How this PR fixes it

Three files, no behavior — fragments, dispatch, and types the decoder (next PR) will consume:

- **`abi.ts`** — event fragments copied verbatim from the protocol repo: [`IConsensus.sol`](https://github.com/safe-research/safenet/blob/main/contracts/src/interfaces/IConsensus.sol) (both attestation pairs), the V1 [`SentinelOracleRequests`](https://github.com/safe-research/safenet/blob/main/contracts/src/libraries/SentinelOracleRequests.sol)/[`Commitments`](https://github.com/safe-research/safenet/blob/main/contracts/src/libraries/SentinelOracleCommitments.sol) and V2 [`RequestsV2`](https://github.com/safe-research/safenet/blob/main/contracts/src/libraries/SentinelOracleRequestsV2.sol)/[`CommitmentsV2`](https://github.com/safe-research/safenet/blob/main/contracts/src/libraries/SentinelOracleCommitmentsV2.sol) libraries, and the shared [`IOracle`](https://github.com/safe-research/safenet/blob/main/contracts/src/interfaces/IOracle.sol) events — plus the topic0 dispatch table mapping every fragment to a normalized event type and oracle generation.
- **`types/events.ts`** — the normalized event shapes. Every `uint` is carried as a decimal `string` so the tree stays Redux-serializable. `Hex` re-exported from `@safe-global/types-kit` (per review on #8369).
- **`__tests__/abi.test.ts`** — the guard test: topic0 uniqueness across all fragments (the V1/V2 disambiguation invariant — the two generations' `NewRequest`/`Committed` differ in arity, so topic0 alone selects the decode path), full dispatch coverage, and **pins the two topic0s read off the deployed Gnosis beta Consensus** (`0xe7427c30…`/`0x72272729…`). Reading the wrong event family silently yields "no events found" — that pin is what catches it.

## How to test it

```bash
yarn workspace @safe-global/utils test --testPathPattern 'safenet-checks'
yarn workspace @safe-global/utils type-check
```

## Affected flows

None — dead code until the decoder lands (next PR). Nothing imports these modules yet.

## Blast radius

- New files only under `packages/utils/src/features/safenet-checks/`; `types/events.ts` grows on top of #8369's version.
- `packages/utils` is shared with mobile; nothing calls this code there.
- No dependencies added (`Hex` comes from `@safe-global/types-kit`, already a direct dependency).

## Risks / not checked

- The oracle-pair and sentinel fragments are verified against the protocol repo source, not against live traffic — the deployed beta emits only the non-oracle pair (whose topic0s are pinned to live observations). Live-byte validation of the decode itself lands with the decoder PR.

## Checklist

- [ ] I've tested the branch on mobile 📱 — n/a, nothing imports this yet
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
