### PR TITLE
fix: drop expected targeted-messaging 404s from RUM

### DIFF
--- a/apps/web/src/services/observability/providers/__tests__/datadog.test.ts
+++ b/apps/web/src/services/observability/providers/__tests__/datadog.test.ts
@@ -238,6 +238,44 @@ describe('DatadogProvider', () => {
       expect(filterRumEvent({ type: 'resource' } as any, {} as any)).toBe(true)
     })
 
+    const buildResourceEvent = (url: string, status_code: number): any => ({
+      type: 'resource',
+      resource: { url, status_code },
+    })
+
+    it('drops expected 404s from the targeted-messaging outreaches endpoint', async () => {
+      const { filterRumEvent } = await import('../datadog')
+      const event = buildResourceEvent(
+        'https://safe-client.safe.global/v1/targeted-messaging/outreaches/5/chains/1/safes/0xabc',
+        404,
+      )
+      expect(filterRumEvent(event, {} as any)).toBe(false)
+    })
+
+    it('keeps genuine failures (429, 500) on the same endpoint', async () => {
+      const { filterRumEvent } = await import('../datadog')
+      const base = 'https://safe-client.safe.global/v1/targeted-messaging/outreaches/5/chains/1/safes/0xabc'
+      expect(filterRumEvent(buildResourceEvent(base, 429), {} as any)).toBe(true)
+      expect(filterRumEvent(buildResourceEvent(base, 500), {} as any)).toBe(true)
+    })
+
+    it('keeps 404s from other endpoints', async () => {
+      const { filterRumEvent } = await import('../datadog')
+      const event = buildResourceEvent('https://safe-client.safe.global/v1/chains/1/safes/0xabc', 404)
+      expect(filterRumEvent(event, {} as any)).toBe(true)
+    })
+
+    it('keeps resource events missing url or status_code', async () => {
+      const { filterRumEvent } = await import('../datadog')
+      expect(filterRumEvent({ type: 'resource', resource: {} } as any, {} as any)).toBe(true)
+      expect(
+        filterRumEvent(
+          { type: 'resource', resource: { url: '/v1/targeted-messaging/outreaches/x' } } as any,
+          {} as any,
+        ),
+      ).toBe(true)
+    })
+
     it('keeps application errors', async () => {
       const { filterRumEvent } = await import('../datadog')
       const event = buildErrorEvent({

--- a/apps/web/src/services/observability/providers/__tests__/datadog.test.ts
+++ b/apps/web/src/services/observability/providers/__tests__/datadog.test.ts
@@ -1,4 +1,5 @@
 import type * as ConstantsModule from '@/config/constants'
+import type { RumResourceEvent, RumEventDomainContext } from '@datadog/browser-rum'
 import type { ObservedError } from '../../types'
 
 const mockAddAction = jest.fn()
@@ -238,42 +239,42 @@ describe('DatadogProvider', () => {
       expect(filterRumEvent({ type: 'resource' } as any, {} as any)).toBe(true)
     })
 
-    const buildResourceEvent = (url: string, status_code: number): any => ({
-      type: 'resource',
-      resource: { url, status_code },
-    })
+    const resourceContext = {} as RumEventDomainContext
+
+    const buildResourceEvent = (url: string, status_code: number): RumResourceEvent =>
+      ({ type: 'resource', resource: { url, status_code } }) as unknown as RumResourceEvent
+
+    const OUTREACH_BASE = 'https://safe-client.safe.global/v1/targeted-messaging/outreaches/5/chains/1/safes/0xabc'
 
     it('drops expected 404s from the targeted-messaging outreaches endpoint', async () => {
       const { filterRumEvent } = await import('../datadog')
-      const event = buildResourceEvent(
-        'https://safe-client.safe.global/v1/targeted-messaging/outreaches/5/chains/1/safes/0xabc',
-        404,
-      )
-      expect(filterRumEvent(event, {} as any)).toBe(false)
+      expect(filterRumEvent(buildResourceEvent(OUTREACH_BASE, 404), resourceContext)).toBe(false)
     })
 
     it('keeps genuine failures (429, 500) on the same endpoint', async () => {
       const { filterRumEvent } = await import('../datadog')
-      const base = 'https://safe-client.safe.global/v1/targeted-messaging/outreaches/5/chains/1/safes/0xabc'
-      expect(filterRumEvent(buildResourceEvent(base, 429), {} as any)).toBe(true)
-      expect(filterRumEvent(buildResourceEvent(base, 500), {} as any)).toBe(true)
+      expect(filterRumEvent(buildResourceEvent(OUTREACH_BASE, 429), resourceContext)).toBe(true)
+      expect(filterRumEvent(buildResourceEvent(OUTREACH_BASE, 500), resourceContext)).toBe(true)
+    })
+
+    it('keeps 404s on sibling outreaches operations (e.g. signer submissions)', async () => {
+      const { filterRumEvent } = await import('../datadog')
+      const url = 'https://safe-client.safe.global/v1/targeted-messaging/outreaches/5/signers/0xabc/submissions'
+      expect(filterRumEvent(buildResourceEvent(url, 404), resourceContext)).toBe(true)
     })
 
     it('keeps 404s from other endpoints', async () => {
       const { filterRumEvent } = await import('../datadog')
       const event = buildResourceEvent('https://safe-client.safe.global/v1/chains/1/safes/0xabc', 404)
-      expect(filterRumEvent(event, {} as any)).toBe(true)
+      expect(filterRumEvent(event, resourceContext)).toBe(true)
     })
 
     it('keeps resource events missing url or status_code', async () => {
       const { filterRumEvent } = await import('../datadog')
-      expect(filterRumEvent({ type: 'resource', resource: {} } as any, {} as any)).toBe(true)
-      expect(
-        filterRumEvent(
-          { type: 'resource', resource: { url: '/v1/targeted-messaging/outreaches/x' } } as any,
-          {} as any,
-        ),
-      ).toBe(true)
+      const noResource = { type: 'resource', resource: {} } as unknown as RumResourceEvent
+      const noStatus = buildResourceEvent(OUTREACH_BASE, undefined as unknown as number)
+      expect(filterRumEvent(noResource, resourceContext)).toBe(true)
+      expect(filterRumEvent(noStatus, resourceContext)).toBe(true)
     })
 
     it('keeps application errors', async () => {

--- a/apps/web/src/services/observability/providers/datadog.ts
+++ b/apps/web/src/services/observability/providers/datadog.ts
@@ -3,6 +3,7 @@ import {
   datadogRum,
   type RumEvent,
   type RumErrorEvent,
+  type RumResourceEvent,
   type RumEventDomainContext,
   type RumErrorEventDomainContext,
 } from '@datadog/browser-rum'
@@ -69,9 +70,32 @@ const isKnownNoise = (message: string | undefined): boolean => {
 const NON_USER_IMPACTING_SOURCES = new Set(['console', 'report'])
 
 /**
+ * Resource requests whose non-2xx responses are an expected part of normal
+ * operation, not failures. Dropped before dispatch to keep RUM ingestion and
+ * the Resource explorer free of predictable noise. Matched on the raw request
+ * URL (the `@resource.url_path_group` facet is computed by Datadog and is not
+ * available client-side) plus the status code.
+ */
+const EXPECTED_RESOURCE_FAILURES: { urlIncludes: string; statuses: Set<number> }[] = [
+  // CGW returns 404 when the current user is not targeted for an outreach —
+  // polled on nearly every Safe load, so this dominates RUM resource volume.
+  { urlIncludes: '/v1/targeted-messaging/outreaches/', statuses: new Set([404]) },
+]
+
+const isExpectedResourceFailure = (event: RumResourceEvent): boolean => {
+  const { url, status_code: status } = event.resource ?? {}
+  if (!url || status === undefined) return false
+  return EXPECTED_RESOURCE_FAILURES.some(
+    ({ urlIncludes, statuses }) => url.includes(urlIncludes) && statuses.has(status),
+  )
+}
+
+/**
  * Drop RUM error events that are demonstrably not caused by user-impacting
- * failures so the Error-Free Views SLO reflects real breakage. Non-error events
- * (views, actions, resources) pass through untouched.
+ * failures so the Error-Free Views SLO reflects real breakage, plus resource
+ * events for endpoints whose non-2xx responses are expected (see
+ * `EXPECTED_RESOURCE_FAILURES`). Views, actions and other resources pass
+ * through untouched.
  *
  * Sources we drop:
  * - `console`: the RUM SDK auto-instruments `console.error` via
@@ -89,6 +113,7 @@ const NON_USER_IMPACTING_SOURCES = new Set(['console', 'report'])
  * network failures (`network`).
  */
 export const filterRumEvent = (event: RumEvent, context: RumEventDomainContext): boolean => {
+  if (event.type === 'resource') return !isExpectedResourceFailure(event as RumResourceEvent)
   if (event.type !== 'error') return true
 
   const errorEvent = event as RumErrorEvent

--- a/apps/web/src/services/observability/providers/datadog.ts
+++ b/apps/web/src/services/observability/providers/datadog.ts
@@ -76,18 +76,21 @@ const NON_USER_IMPACTING_SOURCES = new Set(['console', 'report'])
  * URL (the `@resource.url_path_group` facet is computed by Datadog and is not
  * available client-side) plus the status code.
  */
-const EXPECTED_RESOURCE_FAILURES: { urlIncludes: string; statuses: Set<number> }[] = [
-  // CGW returns 404 when the current user is not targeted for an outreach —
-  // polled on nearly every Safe load, so this dominates RUM resource volume.
-  { urlIncludes: '/v1/targeted-messaging/outreaches/', statuses: new Set([404]) },
+const EXPECTED_RESOURCE_FAILURES: { urlPattern: RegExp; statuses: Set<number> }[] = [
+  // CGW returns 404 from the "is this user targeted?" check when no outreach
+  // exists for the Safe — polled on nearly every Safe load, so this dominates
+  // RUM resource volume. Scoped to the exact outreaches/chains/safes route so
+  // sibling operations (e.g. /signers/{address}/submissions) keep reporting 404.
+  {
+    urlPattern: /\/v1\/targeted-messaging\/outreaches\/[^/]+\/chains\/[^/]+\/safes\/[^/?#]+/,
+    statuses: new Set([404]),
+  },
 ]
 
 const isExpectedResourceFailure = (event: RumResourceEvent): boolean => {
   const { url, status_code: status } = event.resource ?? {}
   if (!url || status === undefined) return false
-  return EXPECTED_RESOURCE_FAILURES.some(
-    ({ urlIncludes, statuses }) => url.includes(urlIncludes) && statuses.has(status),
-  )
+  return EXPECTED_RESOURCE_FAILURES.some(({ urlPattern, statuses }) => urlPattern.test(url) && statuses.has(status))
 }
 
 /**


### PR DESCRIPTION
## What it solves

The CGW targeted-messaging endpoint returns 404 when the current user isn't targeted (~30k/week). These flood RUM as failed resources — pure noise and ingestion cost.

## How this PR fixes it

Extends the existing RUM `beforeSend` filter to drop `@type:resource` events matching a configured (URL substring + status) list — currently `/v1/targeted-messaging/outreaches/` + `404`. These are resource events, not errors, so they never affected the Error-Free Views SLO; this is noise/cost reduction only. Genuine failures (429, 500) still flow through. Matching is on the raw request URL since the `url_path_group` facet is Datadog-computed and unavailable client-side.

## How to test it

1. `yarn workspace @safe-global/web test src/services/observability/providers/__tests__/datadog.test.ts --watchman=false`
2. Run the app, load a Safe, and confirm the 404 `outreaches` calls no longer appear in the Datadog RUM Resource explorer while 4xx/5xx from other endpoints still do.

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).