### PR TITLE
fix: stop sending RUM events from localhost

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -11,6 +11,11 @@ inputs:
     description: 'Production build flag'
     required: false
 
+  skip_datadog:
+    description: 'Withhold Datadog RUM credentials and skip the sourcemap upload (for E2E test builds)'
+    required: false
+    default: 'false'
+
 runs:
   using: 'composite'
 
@@ -25,6 +30,7 @@ runs:
       shell: bash
       env:
         SECRETS_JSON: ${{ inputs.secrets }}
+        SKIP_DATADOG: ${{ inputs.skip_datadog }}
       run: |
         set -euo pipefail
 
@@ -32,9 +38,12 @@ runs:
         # New secrets with this prefix are picked up automatically.
         # Uses per-key heredoc delimiters to safely handle multi-line values
         # (e.g. NEXT_PUBLIC_FIREBASE_OPTIONS_* are JSON strings).
-        EXPORTED=$(echo "$SECRETS_JSON" | jq -r '
+        # NEXT_PUBLIC_DATADOG_* is withheld when skip_datadog is set, so E2E
+        # builds cannot ship RUM events from localhost.
+        EXPORTED=$(echo "$SECRETS_JSON" | jq -r --arg skipDatadog "$SKIP_DATADOG" '
           to_entries[]
           | select(.key | startswith("NEXT_PUBLIC_"))
+          | select($skipDatadog != "true" or (.key | startswith("NEXT_PUBLIC_DATADOG_") | not))
           | select(.value != null and .value != "")
           | "\(.key)<<EOF_\(.key)\n\(.value)\nEOF_\(.key)"
         ')
@@ -58,15 +67,17 @@ runs:
         # Datadog RUM env:
         # - can be overridden by setting NEXT_PUBLIC_DATADOG_RUM_ENV in repo secrets
         # - otherwise set to "production" or "development" based on prod flag
-        DATADOG_RUM_ENV="${{ fromJSON(inputs.secrets).NEXT_PUBLIC_DATADOG_RUM_ENV }}"
-        if [ -z "$DATADOG_RUM_ENV" ]; then
-          if [ "${{ inputs.prod }}" = "true" ]; then
-            DATADOG_RUM_ENV="production"
-          else
-            DATADOG_RUM_ENV="development"
+        if [ "${{ inputs.skip_datadog }}" != "true" ]; then
+          DATADOG_RUM_ENV="${{ fromJSON(inputs.secrets).NEXT_PUBLIC_DATADOG_RUM_ENV }}"
+          if [ -z "$DATADOG_RUM_ENV" ]; then
+            if [ "${{ inputs.prod }}" = "true" ]; then
+              DATADOG_RUM_ENV="production"
+            else
+              DATADOG_RUM_ENV="development"
+            fi
           fi
+          echo "NEXT_PUBLIC_DATADOG_RUM_ENV=$DATADOG_RUM_ENV" >> $GITHUB_ENV
         fi
-        echo "NEXT_PUBLIC_DATADOG_RUM_ENV=$DATADOG_RUM_ENV" >> $GITHUB_ENV
 
         if [ "${{ inputs.prod }}" = "true" ]; then
           echo "NEXT_PUBLIC_INFURA_TOKEN=${{ fromJSON(inputs.secrets).NEXT_PUBLIC_INFURA_TOKEN }}" >> $GITHUB_ENV
@@ -83,7 +94,10 @@ runs:
         NEXT_PUBLIC_IS_PRODUCTION: ${{ inputs.prod }}
 
     - name: Upload source maps to Datadog
-      if: ${{ fromJSON(inputs.secrets).DATADOG_API_KEY }}
+      # Skipped for E2E builds: they share the deploy build's service and
+      # release-version (commit SHA), so uploading would overwrite the
+      # sourcemaps that real production errors are symbolicated against.
+      if: ${{ inputs.skip_datadog != 'true' && fromJSON(inputs.secrets).DATADOG_API_KEY }}
       shell: bash
       working-directory: apps/web
       run: |

--- a/.github/actions/cypress/action.yml
+++ b/.github/actions/cypress/action.yml
@@ -56,6 +56,9 @@ runs:
     - uses: ./.github/actions/build
       with:
         secrets: ${{ inputs.secrets }}
+        # E2E runs are served from localhost; without RUM credentials the app
+        # falls back to the no-op observability provider.
+        skip_datadog: 'true'
       env:
         NODE_ENV: cypress
         # `next build` overrides NODE_ENV to 'production' in client bundles, so

--- a/apps/web/src/services/observability/providers/__tests__/datadog.localhost.test.ts
+++ b/apps/web/src/services/observability/providers/__tests__/datadog.localhost.test.ts
@@ -1,0 +1,65 @@
+/**
+ * E2E runs (`yarn serve` on :8080) and dev servers must never reach RUM, even
+ * when the credentials are present in the bundle.
+ *
+ * @jest-environment-options {"url": "http://localhost:8080/balances?safe=eth:0xb3b83bf204C458B461de9B0CD2739DB152b4fa5A"}
+ */
+
+import type * as ConstantsModule from '@/config/constants'
+
+const mockInit = jest.fn()
+const mockAddError = jest.fn()
+const mockGetInitConfiguration = jest.fn()
+
+jest.mock('@datadog/browser-rum', () => ({
+  datadogRum: {
+    init: (...args: unknown[]) => mockInit(...args),
+    addAction: jest.fn(),
+    addError: (...args: unknown[]) => mockAddError(...args),
+    getInitConfiguration: (...args: unknown[]) => mockGetInitConfiguration(...args),
+  },
+}))
+
+interface DatadogProviderInstance {
+  init: () => Promise<void>
+  captureError: (error: { error: Error; isUserFacing: boolean }) => void
+}
+
+type DatadogProviderConstructor = new () => DatadogProviderInstance
+
+describe('DatadogProvider on a local hostname', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    jest.clearAllMocks()
+
+    jest.doMock('@/config/constants', () => ({
+      ...jest.requireActual<typeof ConstantsModule>('@/config/constants'),
+      DATADOG_RUM_APPLICATION_ID: 'test-app-id',
+      DATADOG_RUM_CLIENT_TOKEN: 'test-client-token',
+    }))
+
+    mockGetInitConfiguration.mockReturnValue(undefined)
+  })
+
+  const createProvider = async (): Promise<DatadogProviderInstance> => {
+    const { DatadogProvider } = await import('../datadog')
+    return new (DatadogProvider as unknown as DatadogProviderConstructor)()
+  }
+
+  it('does not initialize the RUM SDK even though the credentials are present', async () => {
+    const provider = await createProvider()
+
+    await provider.init()
+
+    expect(mockInit).not.toHaveBeenCalled()
+  })
+
+  it('reports no errors after a skipped initialization', async () => {
+    const provider = await createProvider()
+    await provider.init()
+
+    provider.captureError({ error: new Error('local failure'), isUserFacing: true })
+
+    expect(mockAddError).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/services/observability/providers/__tests__/datadog.test.ts
+++ b/apps/web/src/services/observability/providers/__tests__/datadog.test.ts
@@ -1,3 +1,11 @@
+/**
+ * RUM never initializes on a local hostname, and the default jsdom URL is
+ * http://localhost/. These specs therefore run against a deployed-looking
+ * origin; the localhost bail-out is covered in datadog.localhost.test.ts.
+ *
+ * @jest-environment-options {"url": "https://app.safe.global/balances?safe=eth:0xb3b83bf204C458B461de9B0CD2739DB152b4fa5A"}
+ */
+
 import type * as ConstantsModule from '@/config/constants'
 import type { RumResourceEvent, RumEventDomainContext } from '@datadog/browser-rum'
 import type { ObservedError } from '../../types'
@@ -223,6 +231,27 @@ describe('DatadogProvider', () => {
       provider.captureError({ error, isUserFacing: false, tags: { code: 601 } })
 
       expect(mockAddError).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('isLocalHostname', () => {
+    it.each(['localhost', '127.0.0.1', '0.0.0.0', '[::1]', '::1', 'app.localhost'])(
+      'treats %s as local',
+      async (hostname) => {
+        const { isLocalHostname } = await import('../datadog')
+        expect(isLocalHostname(hostname)).toBe(true)
+      },
+    )
+
+    it.each([
+      'app.safe.global',
+      'safe-wallet-web.staging.5afe.dev',
+      'release--walletweb.review.5afe.dev',
+      'notlocalhost.com',
+      'localhost.attacker.com',
+    ])('treats %s as remote', async (hostname) => {
+      const { isLocalHostname } = await import('../datadog')
+      expect(isLocalHostname(hostname)).toBe(false)
     })
   })
 

--- a/apps/web/src/services/observability/providers/datadog.ts
+++ b/apps/web/src/services/observability/providers/datadog.ts
@@ -36,6 +36,19 @@ type DatadogSite =
 
 export const isDatadogEnabled = Boolean(DATADOG_RUM_APPLICATION_ID) && Boolean(DATADOG_RUM_CLIENT_TOKEN)
 
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '[::1]', '::1'])
+
+/**
+ * Local origins must never reach RUM. E2E runs (`yarn serve` on :8080) and dev
+ * servers report as `@session.type:user` and are indistinguishable from real
+ * traffic in the Error Explorer and the Error-Free Views SLO, while also
+ * consuming session quota. Withholding the credentials in CI is the first line
+ * of defence; this guard also covers a developer who copies deployed env vars
+ * into a local `.env`.
+ */
+export const isLocalHostname = (hostname: string): boolean =>
+  LOCAL_HOSTNAMES.has(hostname) || hostname.endsWith('.localhost')
+
 const EXTENSION_URL_PATTERNS = [
   'chrome-extension://',
   'moz-extension://',
@@ -139,6 +152,10 @@ export class DatadogProvider implements IObservabilityProvider {
   async init(): Promise<void> {
     const isClient = typeof window !== 'undefined'
     if (!isClient || !isDatadogEnabled || this.isInitialized) {
+      return
+    }
+
+    if (isLocalHostname(window.location.hostname)) {
       return
     }
 


### PR DESCRIPTION
## What it solves

Resolves: RUM ingestion from localhost.

Datadog is receiving events from local origins. Over the last 30 days, RUM events whose `@view.url_host` is `localhost`:

| Event type | Events | Sessions |
| --- | --- | --- |
| resource | 459,167 | 2,682 |
| view | 7,683 | 5,772 |
| error | **3,696** | 2,925 |
| long_task | 1,469 | 877 |
| action | 328 | 13 |

Split by port: **8080 → 468,491 events (3,666 errors)**; ports 3001/3002/4003 → ~100 events total. Port 8080 is not a dev server — it's the E2E static server (`apps/web/package.json` `serve`, wired up by `.github/actions/cypress/action.yml` and `apps/web/e2e/playwright.config.ts`). So essentially all of this volume is Cypress / Argos / Playwright CI, not developer laptops.

Why it matters:

- These sessions report as `@session.type:user` with `env:development` — indistinguishable from real traffic in the Error Explorer, and they consume session quota.
- A single E2E-only hydration mismatch (`Minified React error #418`) contributed **3,531** of the 3,696 localhost errors — ~10% of the whole `app.safe.global` error count (37,471) in noise.
- 10 error events came from `localhost` tagged `env:production`, i.e. a production-configured build run locally.

Root cause: `isDatadogEnabled` gates only on token presence (since #7315), and the Cypress action passes the entire secrets JSON into `actions/build`, which auto-exports every `NEXT_PUBLIC_*` secret — including the RUM app ID and client token — into the E2E bundle.

## How this PR fixes it

Two independent gates, so neither is a single point of failure:

1. **Withhold the credentials in CI.** `actions/build` gains a `skip_datadog` input (default `false`, so deploy builds are untouched) that filters `NEXT_PUBLIC_DATADOG_*` out of the exported secrets. `actions/cypress` sets it to `'true'`, so E2E builds have no tokens and fall back to `NoOpProvider`.
2. **Guard the client.** `DatadogProvider.init()` returns early when `window.location.hostname` is local (`localhost`, `127.0.0.1`, `0.0.0.0`, `[::1]`, `*.localhost`). This covers a developer who copies deployed env vars into a local `.env`, which the CI-side change cannot.

Also skips the **Datadog sourcemap upload** for E2E builds. E2E and deploy builds upload under the same `service` and `release-version` (commit short SHA), so the E2E upload can overwrite the sourcemaps that real production errors are symbolicated against.

Deliberately not used: the existing `IS_TEST_E2E` constant. It's currently dead (defined in `apps/web/src/config/constants.ts`, zero consumers) and it depends on a `NEXT_PUBLIC_` flag surviving the build — the exact fragility the comment in `actions/cypress/action.yml` documents. The hostname check is unconditional and covers local Playwright runs on :3000 too.

## How to test it

Client guard:

```bash
yarn workspace @safe-global/web test --testPathPattern "observability"
```

`datadog.localhost.test.ts` runs under a `http://localhost:8080/` jsdom URL with the RUM credentials mocked as present, and asserts `datadogRum.init` is never called. I confirmed both of its assertions fail when the guard is removed, so the test is load-bearing.

Manual: put real `NEXT_PUBLIC_DATADOG_RUM_APPLICATION_ID` / `_CLIENT_TOKEN` in `apps/web/.env`, run `yarn workspace @safe-global/web dev`, and check the Network tab — there should be no requests to `browser-intake-datadoghq.eu`.

CI side, after this branch builds:

- Any E2E job log → the "Export NEXT_PUBLIC secrets to env" step must not list `Exported: NEXT_PUBLIC_DATADOG_*`, and "Upload source maps to Datadog" must be skipped.
- `web-deploy-dev` → must still list the Datadog keys and still run the sourcemap upload.

I validated the `jq` filter locally against a sample secrets JSON both ways (`skip_datadog=false` keeps all three `NEXT_PUBLIC_DATADOG_*` keys; `skip_datadog=true` drops exactly those and keeps the rest, including the multi-line `NEXT_PUBLIC_FIREBASE_OPTIONS_*` values). Both action files parse as valid YAML.

## Affected flows

- Local development and E2E test runs: RUM no longer initializes, and the app uses the no-op observability provider.
- Production / staging / review-app deploys: unchanged — RUM initializes exactly as before.
- Datadog sourcemap upload: unchanged for deploy builds, skipped for E2E builds.

## Blast radius

- **`DatadogProvider.init()`** — the single gate for all RUM ingestion. Called from `apps/web/src/pages/_app.tsx` with `new DatadogProvider()` directly, bypassing `factory.ts`, so this is the effective decision point. `isDatadogEnabled` and `filterRumEvent` are unchanged.
- **`.github/actions/build/action.yml`** — shared by `web-deploy-dev`, `web-tag-release`, `web-nextjs-bundle-analysis`, and `actions/cypress`. The new input defaults to `'false'`, so only the Cypress path changes behaviour.
- **`.github/actions/cypress/action.yml`** — used by `web-e2e-smoke`, `web-argos-e2e`, `web-e2e-full-ondemand`, `web-e2e-hp-ondemand`.
- **`MixpanelTracingProvider`** — shares `initObservability` but initializes independently; unaffected.
- **Mobile** — untouched. Mobile Datadog lives in `apps/mobile/src/services/analytics/datadogAnalytics.ts` and no shared package is modified.
- **Unit tests** — jsdom runs at `http://localhost/…` (`apps/web/jest.config.cjs`), so `datadog.test.ts` now sets a deployed-looking origin via `@jest-environment-options`; otherwise every "after initialization" spec would silently hit the new guard.
- No RTK Query endpoints, selectors, slices, feature flags, routes, or persisted state involved.

## Risks / not checked

- **CI YAML is not executable locally.** The `jq` filter and the YAML both check out, but the actual GitHub Actions behaviour is only verifiable from this PR's own run. Please eyeball the E2E and deploy build logs before merging.
- **No post-merge Datadog confirmation yet** — that needs ~24h of data. Expect `@view.url_host:localhost` to go to zero.
- **Sourcemap overwrite is inferred, not proven.** Both builds demonstrably upload under the same service + commit SHA; I did not prove that an E2E upload has actually degraded symbolication in practice.
- **Did not test on mobile** — no mobile code path touched.
- **Did not add an opt-in escape hatch** for testing RUM against a local build. Anyone who needs that must temporarily bypass the guard; say the word if you'd rather have an explicit env flag.
- The ~19 error events on port 4003 come from something not present in this repo. The hostname guard covers them, but I didn't identify the source.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    B1[actions/cypress] -->|full secrets JSON| B2[actions/build]
    B2 -->|NEXT_PUBLIC_DATADOG_* in bundle| B3[serve out -p 8080]
    B3 --> B4[Cypress / Argos run]
    B4 -->|"env:development<br/>session.type:user"| B5[(Datadog RUM<br/>3,666 errors / 30d)]
    B2 -->|sourcemaps @ commit SHA| B5
  end
  subgraph After
    A1[actions/cypress] -->|"secrets + skip_datadog: true"| A2[actions/build]
    A2 -->|"NEXT_PUBLIC_DATADOG_* filtered out<br/>sourcemap upload skipped"| A3[serve out -p 8080]
    A3 --> A4[Cypress / Argos run]
    A4 --> A5{isDatadogEnabled?}
    A5 -->|no tokens| A6[NoOpProvider]
    D1[Dev with tokens in .env] --> D2{"isLocalHostname<br/>(location.hostname)?"}
    D2 -->|yes| D3[init returns early]
    P1[Deploy build<br/>app.safe.global] --> P2{"isLocalHostname?"}
    P2 -->|no| P3[(Datadog RUM<br/>real users only)]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — n/a, no mobile code path touched
- [x] I've documented how it affects the analytics (if at all) 📊 — removes ~470k/month of E2E events from RUM; Mixpanel unaffected
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
