### PR TITLE
fix: repair web3-onboard ENS resolution (resolver + RPC)

### DIFF
--- a/.yarn/patches/@web3-onboard-core-npm-2.24.1-56d6bba493.patch
+++ b/.yarn/patches/@web3-onboard-core-npm-2.24.1-56d6bba493.patch
@@ -1,0 +1,12 @@
+diff --git a/dist/index-6ae5acf7.js b/dist/index-6ae5acf7.js
+index 2a629f8f1fa428c0d475551b706be3fdcf7594d3..8d483466e2bd65cd2829105220e8869997a79342 100644
+--- a/dist/index-6ae5acf7.js
++++ b/dist/index-6ae5acf7.js
+@@ -2951,6 +2951,7 @@ function trackWallet(provider, label) {
+     });
+ }
+ async function getEns(address, chain) {
++    return null; // disabled: the app resolves ENS via useAddressResolver
+     // chain we don't recognize and don't have a rpcUrl for requests
+     if (!chain)
+         return null;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -91,7 +91,7 @@
     "@walletconnect/core": "^2.21.10",
     "@walletconnect/utils": "^2.21.10",
     "@web3-onboard/coinbase": "^2.4.2",
-    "@web3-onboard/core": "^2.24.1",
+    "@web3-onboard/core": "patch:@web3-onboard/core@npm%3A2.24.1#~/.yarn/patches/@web3-onboard-core-npm-2.24.1-56d6bba493.patch",
     "@web3-onboard/hw-common": "^2.3.3",
     "@web3-onboard/injected-wallets": "^2.11.3",
     "@web3-onboard/walletconnect": "2.6.2",

--- a/apps/web/src/components/common/Header/Topbar/index.tsx
+++ b/apps/web/src/components/common/Header/Topbar/index.tsx
@@ -15,6 +15,7 @@ import { useTheme } from '@mui/material/styles'
 import { useAppDispatch, useAppSelector } from '@/store'
 import { selectNotifications } from '@/store/notificationsSlice'
 import { openGlobalSearch } from '@/features/global-search/store'
+import { useWalletName } from '@/hooks/wallets/useWalletName'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
@@ -50,6 +51,7 @@ const Topbar = ({ onMenuToggle, onBatchToggle }: TopbarProps): ReactElement => {
     handleClick: handleWalletClick,
     handleClose: handleWalletClose,
   } = useWalletPopover()
+  const walletName = useWalletName(wallet)
   const { WalletPopover } = useLoadFeature(WalletFeature)
   const { GlobalSearchModal, GlobalSearchInput } = useLoadFeature(GlobalSearchFeature)
   const { WalletConnectWidget } = useLoadFeature(WalletConnectFeature)
@@ -145,7 +147,7 @@ const Topbar = ({ onMenuToggle, onBatchToggle }: TopbarProps): ReactElement => {
 
           <HeaderNavigation
             walletAddress={wallet?.address ?? ''}
-            walletEns={wallet?.ens}
+            walletEns={walletName}
             isConnected={Boolean(wallet)}
             walletIcon={wallet?.icon}
             walletLabel={wallet?.label}

--- a/apps/web/src/components/common/WalletInfo/index.tsx
+++ b/apps/web/src/components/common/WalletInfo/index.tsx
@@ -10,6 +10,7 @@ import { useChain } from '@/hooks/useChains'
 import madProps from '@/utils/mad-props'
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew'
 import useChainId from '@/hooks/useChainId'
+import { useWalletName } from '@/hooks/wallets/useWalletName'
 import { getNativeTokenDisplay, NATIVE_TOKEN_DISPLAY_DEFAULT } from '@safe-global/utils/utils/chains'
 
 type WalletInfoProps = {
@@ -35,6 +36,7 @@ export const WalletInfo = ({
 }: WalletInfoProps) => {
   const chainInfo = useChain(wallet.chainId)
   const prefix = chainInfo?.shortName
+  const walletName = useWalletName(wallet)
   const { showWalletBalance } = chainInfo ? getNativeTokenDisplay(chainInfo) : NATIVE_TOKEN_DISPLAY_DEFAULT
 
   const handleSwitchWallet = () => {
@@ -61,7 +63,7 @@ export const WalletInfo = ({
         <Typography variant="body2" className={css.address} component="div">
           <EthHashInfo
             address={wallet.address}
-            name={addressBook[wallet.address] || wallet.ens || wallet.label}
+            name={addressBook[wallet.address] || walletName || wallet.label}
             showAvatar={false}
             showPrefix={false}
             hasExplorer

--- a/apps/web/src/components/common/WalletOverview/index.tsx
+++ b/apps/web/src/components/common/WalletOverview/index.tsx
@@ -7,6 +7,7 @@ import EthHashInfo from '@/components/common/EthHashInfo'
 import WalletIcon from '@/components/common/WalletIcon'
 import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import { useChain } from '@/hooks/useChains'
+import { useWalletName } from '@/hooks/wallets/useWalletName'
 import WalletBalance from '@/components/common/WalletBalance'
 import { getNativeTokenDisplay, NATIVE_TOKEN_DISPLAY_DEFAULT } from '@safe-global/utils/utils/chains'
 
@@ -35,8 +36,8 @@ const WalletOverview = ({
   showBalance?: boolean
 }): ReactElement => {
   const walletChain = useChain(wallet.chainId)
-  const prefix = walletChain?.shortName
   const { showWalletBalance } = walletChain ? getNativeTokenDisplay(walletChain) : NATIVE_TOKEN_DISPLAY_DEFAULT
+  const ens = useWalletName(wallet)
 
   return (
     <Box className={css.container}>
@@ -44,11 +45,11 @@ const WalletOverview = ({
 
       <Box className={css.walletDetails}>
         <Typography variant="body2" component="div">
-          {wallet.ens ? (
-            <div>{wallet.ens}</div>
+          {ens ? (
+            <div>{ens}</div>
           ) : (
             <EthHashInfo
-              prefix={prefix || ''}
+              prefix={walletChain?.shortName || ''}
               address={wallet.address}
               showName={false}
               showAvatar={false}

--- a/apps/web/src/hooks/wallets/__tests__/useWalletName.test.ts
+++ b/apps/web/src/hooks/wallets/__tests__/useWalletName.test.ts
@@ -1,0 +1,70 @@
+import { renderHook, waitFor } from '@/tests/test-utils'
+import type { Eip1193Provider, JsonRpcProvider } from 'ethers'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import { useWalletName } from '@/hooks/wallets/useWalletName'
+import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
+import * as useChains from '@/hooks/useChains'
+import * as ens from '@/services/ens'
+import * as web3 from '@/hooks/wallets/web3'
+
+const VITALIK = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
+
+const createWallet = (chainId = '1'): ConnectedWallet => ({
+  label: 'MetaMask',
+  chainId,
+  address: VITALIK,
+  provider: { request: jest.fn() } as unknown as Eip1193Provider,
+})
+
+const createChain = (features: FEATURES[]): Chain => ({ chainId: '1', shortName: 'eth', features }) as unknown as Chain
+
+describe('useWalletName', () => {
+  const mockProvider = { destroy: jest.fn() } as unknown as JsonRpcProvider
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    jest.spyOn(web3, 'createWeb3ReadOnly').mockReturnValue(mockProvider)
+  })
+
+  it("resolves the wallet's ENS name on the wallet's chain", async () => {
+    jest.spyOn(useChains, 'useChain').mockReturnValue(createChain([FEATURES.DOMAIN_LOOKUP]))
+    const lookup = jest.spyOn(ens, 'lookupAddress').mockResolvedValue('vitalik.eth')
+
+    const { result } = renderHook(() => useWalletName(createWallet('1')))
+
+    await waitFor(() => expect(result.current).toBe('vitalik.eth'))
+    expect(lookup).toHaveBeenCalledWith(mockProvider, VITALIK)
+    expect(mockProvider.destroy).toHaveBeenCalled()
+  })
+
+  it('does not resolve when domain lookup is unsupported on the chain', async () => {
+    jest.spyOn(useChains, 'useChain').mockReturnValue(createChain([]))
+    const lookup = jest.spyOn(ens, 'lookupAddress').mockResolvedValue('vitalik.eth')
+
+    const { result } = renderHook(() => useWalletName(createWallet('1')))
+
+    await waitFor(() => expect(result.current).toBeUndefined())
+    expect(lookup).not.toHaveBeenCalled()
+  })
+
+  it('returns undefined when the chain config is not found', async () => {
+    jest.spyOn(useChains, 'useChain').mockReturnValue(undefined)
+    const lookup = jest.spyOn(ens, 'lookupAddress').mockResolvedValue('vitalik.eth')
+
+    const { result } = renderHook(() => useWalletName(createWallet('1')))
+
+    await waitFor(() => expect(result.current).toBeUndefined())
+    expect(lookup).not.toHaveBeenCalled()
+  })
+
+  it('returns undefined when no wallet is connected', async () => {
+    jest.spyOn(useChains, 'useChain').mockReturnValue(createChain([FEATURES.DOMAIN_LOOKUP]))
+    const lookup = jest.spyOn(ens, 'lookupAddress').mockResolvedValue('vitalik.eth')
+
+    const { result } = renderHook(() => useWalletName(null))
+
+    await waitFor(() => expect(result.current).toBeUndefined())
+    expect(lookup).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/hooks/wallets/useWalletName.ts
+++ b/apps/web/src/hooks/wallets/useWalletName.ts
@@ -1,0 +1,43 @@
+import useAsync from '@safe-global/utils/hooks/useAsync'
+import { FEATURES, hasFeature } from '@safe-global/utils/utils/chains'
+import { useChain } from '@/hooks/useChains'
+import { useAppSelector } from '@/store'
+import { selectRpc } from '@/store/settingsSlice'
+import { lookupAddress } from '@/services/ens'
+import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
+
+// ENS primary names live on Ethereum mainnet, so the connected wallet's name always resolves there
+// regardless of which chain the wallet or the currently viewed Safe is on.
+const ENS_CHAIN_ID = '1'
+
+/**
+ * Resolves the connected wallet's ENS name against Ethereum mainnet.
+ *
+ * Unlike `useAddressResolver`, this does not depend on the currently viewed Safe/route (the wallet
+ * chip renders even when no Safe is open) nor on the wallet's connected chain (a testnet/L2 wallet
+ * still has its primary name on mainnet). Returns `undefined` when mainnet has no domain lookup or
+ * resolution fails (handled by `lookupAddress`).
+ */
+export const useWalletName = (wallet?: ConnectedWallet | null): string | undefined => {
+  const chain = useChain(ENS_CHAIN_ID)
+  const customRpc = useAppSelector(selectRpc)
+  const address = wallet?.address
+  const canResolve = !!chain && !!address && hasFeature(chain, FEATURES.DOMAIN_LOOKUP)
+
+  const [ens] = useAsync<string | undefined>(async () => {
+    if (!canResolve || !chain || !address) return undefined
+
+    // Dynamic import to keep ethers out of the main bundle
+    const { createWeb3ReadOnly } = await import('@/hooks/wallets/web3')
+    const provider = createWeb3ReadOnly(chain, customRpc?.[chain.chainId])
+    if (!provider) return undefined
+
+    try {
+      return await lookupAddress(provider, address)
+    } finally {
+      provider.destroy()
+    }
+  }, [canResolve, chain, customRpc, address])
+
+  return ens
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13903,7 +13903,7 @@ __metadata:
     "@walletconnect/core": "npm:^2.21.10"
     "@walletconnect/utils": "npm:^2.21.10"
     "@web3-onboard/coinbase": "npm:^2.4.2"
-    "@web3-onboard/core": "npm:^2.24.1"
+    "@web3-onboard/core": "patch:@web3-onboard/core@npm%3A2.24.1#~/.yarn/patches/@web3-onboard-core-npm-2.24.1-56d6bba493.patch"
     "@web3-onboard/hw-common": "npm:^2.3.3"
     "@web3-onboard/injected-wallets": "npm:^2.11.3"
     "@web3-onboard/walletconnect": "npm:2.6.2"
@@ -21023,7 +21023,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@web3-onboard/core@npm:^2.24.1":
+"@web3-onboard/core@npm:2.24.1":
   version: 2.24.1
   resolution: "@web3-onboard/core@npm:2.24.1"
   dependencies:
@@ -21040,6 +21040,26 @@ __metadata:
     svelte-i18n: "npm:^4.0.1"
     viem: "npm:2.12.0"
   checksum: 10/ce3808b2884574049b82a223cebfd8da0d31010a36fa139ce1c97db4b068224c6d1f3999792fd575191d4c3e12a89d4e18b9ac1f43a17573c35c72861f78b0b6
+  languageName: node
+  linkType: hard
+
+"@web3-onboard/core@patch:@web3-onboard/core@npm%3A2.24.1#~/.yarn/patches/@web3-onboard-core-npm-2.24.1-56d6bba493.patch":
+  version: 2.24.1
+  resolution: "@web3-onboard/core@patch:@web3-onboard/core@npm%3A2.24.1#~/.yarn/patches/@web3-onboard-core-npm-2.24.1-56d6bba493.patch::version=2.24.1&hash=5071c5"
+  dependencies:
+    "@web3-onboard/common": "npm:^2.4.1"
+    bnc-sdk: "npm:^4.6.7"
+    bowser: "npm:^2.11.0"
+    eventemitter3: "npm:^4.0.7"
+    joi: "npm:17.9.1"
+    lodash.merge: "npm:^4.6.2"
+    lodash.partition: "npm:^4.6.0"
+    nanoid: "npm:^4.0.0"
+    rxjs: "npm:^7.5.5"
+    svelte: "npm:^3.49.0"
+    svelte-i18n: "npm:^4.0.1"
+    viem: "npm:2.12.0"
+  checksum: 10/b10439fd2bc951dd8bb5ecffe00611cedd8bf50034bfc6983b0c7cb72d993256c7c41f7844bd81ee23377de79f16ec588f4c444f9400c10ee785051b18755bc1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR is basically a follow up for this: https://github.com/safe-global/safe-wallet-monorepo/pull/8185 - the original PR couldn't be merged, because it didn't have signed commits. Also upon testing I found out that it doesn't directly work in our repo, because of a viem version mismatch. 

web3-onboard@2.24.1 inlines viem 2.12.0 chain defs (stale ENS UniversalResolver 0xce01f8…) but resolves viem 2.52.2 at runtime, whose getEnsName calls reverseWithGateways — reverting on every connect. 

Also its bundled Sepolia default RPC (rpc.sepolia.org) is dead. Patch getProvider to source chain defs from the runtime viem (viem/chains) and to use the app-configured RPC.

## What it solves
An error in the console. There was no visible user error, but the console error was miles long

Resolves: https://github.com/safe-global/safe-wallet-monorepo/issues/6989
