### PR TITLE
chore(deps): resolve single protocol-kit 8.0.4 / safe-deployments 1.37.60

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -35,7 +35,7 @@
     "ts-node": "^10.9.2"
   },
   "peerDependencies": {
-    "@safe-global/protocol-kit": "^7.1.x",
+    "@safe-global/protocol-kit": "^8.0.4",
     "@safe-global/store": "*",
     "@safe-global/types-kit": "^3.1.x"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13615,28 +13615,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@safe-global/protocol-kit@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "@safe-global/protocol-kit@npm:8.0.1"
-  dependencies:
-    "@noble/curves": "npm:^1.6.0"
-    "@peculiar/asn1-schema": "npm:^2.3.13"
-    "@safe-global/safe-deployments": "npm:^1.37.57"
-    "@safe-global/safe-modules-deployments": "npm:^3.0.4"
-    "@safe-global/types-kit": "npm:^4.0.1"
-    abitype: "npm:^1.2.3"
-    semver: "npm:^7.8.0"
-    viem: "npm:^2.52.2"
-  dependenciesMeta:
-    "@noble/curves":
-      optional: true
-    "@peculiar/asn1-schema":
-      optional: true
-  checksum: 10/aaee5ec701a62c5a1afcf486dc69de789ac9cb28989920edc7d5cdd492a3e939a7079a0ae683a1b1d46c48d4dc02fa140cb045c9c6acfa472398aab6f3b98d30
-  languageName: node
-  linkType: hard
-
-"@safe-global/protocol-kit@npm:^8.0.4":
+"@safe-global/protocol-kit@npm:^8.0.1, @safe-global/protocol-kit@npm:^8.0.4":
   version: 8.0.4
   resolution: "@safe-global/protocol-kit@npm:8.0.4"
   dependencies:
@@ -13688,15 +13667,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@safe-global/safe-deployments@npm:^1.37.57":
-  version: 1.37.57
-  resolution: "@safe-global/safe-deployments@npm:1.37.57"
-  dependencies:
-    semver: "npm:^7.6.2"
-  checksum: 10/6188f703b786e4bfe10dae59fc251afa1f125486579aebe8c824e8c539aac009abae0dd1cd97f33aaa3e89e06d3a2c4f2cb0e70e7a6dd62f93e330d6092eb24c
-  languageName: node
-  linkType: hard
-
 "@safe-global/safe-deployments@npm:^1.37.60":
   version: 1.37.60
   resolution: "@safe-global/safe-deployments@npm:1.37.60"
@@ -13717,13 +13687,6 @@ __metadata:
   version: 3.22.4
   resolution: "@safe-global/safe-gateway-typescript-sdk@npm:3.22.4"
   checksum: 10/5b088499a01a0d0190b4ab6828bfb2df779b603bbcee7645c23ad8e420670aab4ce7ca39b858fc62ee03fded77b322c3f8a9b0203f41ecb779d08f47bd4bfe0c
-  languageName: node
-  linkType: hard
-
-"@safe-global/safe-modules-deployments@npm:^3.0.4":
-  version: 3.0.5
-  resolution: "@safe-global/safe-modules-deployments@npm:3.0.5"
-  checksum: 10/b0362d5ba1d75840f5a7710c5413e65da37b19d1e987b0d3a89a095716c21617bccf2755af0426357e7626e6892d06e0b90a5fb88500a6009d92b7f5c22d84ab
   languageName: node
   linkType: hard
 
@@ -13917,7 +13880,7 @@ __metadata:
     typescript: "npm:~5.9.2"
     typescript-eslint: "npm:^8.31.1"
   peerDependencies:
-    "@safe-global/protocol-kit": ^7.1.x
+    "@safe-global/protocol-kit": ^8.0.4
     "@safe-global/store": "*"
     "@safe-global/types-kit": ^3.1.x
   languageName: unknown


### PR DESCRIPTION
## What it solves

Resolves: WA-2859 — fragmented resolution of Safe contract deployment data (part of the Safe contracts v1.5.0 support effort).

First-round dependency housekeeping so the monorepo resolves Safe contracts **v1.5.0** (addresses + ABIs) from a single, up-to-date `@safe-global/safe-deployments` copy on every registered chain.

The hoisted `@safe-global/safe-deployments` was already **1.37.60** (the latest release, which ships the full v1.5.0 assets), but two inconsistencies remained:

- `@safe-global/api-kit` carried a nested duplicate `@safe-global/protocol-kit@8.0.1` with its own stale `@safe-global/safe-deployments@1.37.57`, so parts of the tree resolved deployment data from an older copy.
- `@safe-global/utils` still declared a `^7.1.x` peer range for protocol-kit, contradicting the installed 8.x major.

## How this PR fixes it

- `yarn.lock`: dedupe `@safe-global/protocol-kit` to a single **8.0.4** and `@safe-global/safe-deployments` to a single **1.37.60**, removing the orphaned lockfile entries only referenced by the old nested copy (incl. the unused `safe-modules-deployments@3.0.5` entry — the version in use stays 3.0.8).
- `packages/utils/package.json`: fix the `@safe-global/protocol-kit` peer range `^7.1.x` → `^8.0.4`.

**No package is upgraded to a version that was not already in the tree** — the dedupe merges the nested copies into the already-installed versions within their declared semver ranges. protocol-kit 8.0.2–8.0.4 are patch releases whose only content is refreshed deployment data (per upstream changelog).

Deliberately out of scope (follow-up tickets): adding `1.5.0` to any version allow-list / recognition path, and any protocol-kit or safe-modules-deployments upgrades.

## How to test it

```bash
# single resolution across the workspace
yarn why @safe-global/protocol-kit      # only 8.0.4
yarn why @safe-global/safe-deployments  # only 1.37.60

# v1.5.0 deployments resolve with the canonical addresses (e.g. Sepolia)
node -e "
const { getSafeSingletonDeployment, getSafeL2SingletonDeployment } = require('@safe-global/safe-deployments');
console.log(
  getSafeSingletonDeployment({ version: '1.5.0', network: '11155111' })?.networkAddresses['11155111'],
  getSafeL2SingletonDeployment({ version: '1.5.0', network: '11155111' })?.networkAddresses['11155111'],
);"
# expect: 0xFf51A5898e281Db6DfC7855790607438dF2ca44b 0xEdd160fEBBD92E350D4D398fb636302fccd67C7e
```

Verified locally: `@safe-global/utils` jest suite (68 suites / 1083 tests) ✅, `@safe-global/web` `type-check` ✅ and `lint` ✅, `generate-types` regenerates cleanly incl. the `v1.5.0` factories (generated output is git-ignored, hence not in the diff).

## Affected flows

- None intentionally — this PR changes dependency resolution only; no source code, feature, or user journey changes.

## Blast radius

- **`@safe-global/api-kit` consumers (apps/web)**: api-kit now runs against protocol-kit 8.0.4 instead of its nested 8.0.1 (patch-only delta: deployment-data refresh) and reads deployment data from safe-deployments 1.37.60 instead of 1.37.57.
- **Contract address/ABI resolution everywhere** (`packages/utils` deployments helpers, typechain factories): now guaranteed to come from a single safe-deployments 1.37.60 copy.
- **Peer-dependency contract**: `@safe-global/utils` now correctly advertises protocol-kit `^8.0.4`; any consumer already satisfies it (web and mobile both declare `^8.0.4`).
- **Mobile**: no resolution change — mobile already used the hoisted protocol-kit 8.0.4 / safe-deployments 1.37.60.
- No RTK Query endpoints, feature flags, persistence, or routes touched.

## Risks / not checked

- Did not run the `apps/web` full jest suite or Cypress e2e locally (CI covers them).
- Did not run the `apps/mobile` test suite (no resolution change for mobile, but not empirically verified).
- Did not manually exercise api-kit runtime flows (e.g. transaction-service calls) against the deduped protocol-kit 8.0.4 beyond unit-test coverage.

## Visual summary

```mermaid
graph LR
  subgraph Before
    webA["apps/web"] -->|"^8.0.4"| pkA["protocol-kit 8.0.4"]
    pkA -->|"^1.37.60"| sdA["safe-deployments 1.37.60"]
    webA --> akA["api-kit 5.0.1"]
    akA -->|"^8.0.1"| pkOld["protocol-kit 8.0.1 (nested)"]
    pkOld -->|"^1.37.57"| sdOld["safe-deployments 1.37.57 (nested)"]
  end
  subgraph After
    webB["apps/web"] -->|"^8.0.4"| pkB["protocol-kit 8.0.4"]
    pkB -->|"^1.37.60"| sdB["safe-deployments 1.37.60"]
    webB --> akB["api-kit 5.0.1"]
    akB -->|"^8.0.1 → deduped"| pkB
  end
  style pkOld fill:#fdd,stroke:#c66
  style sdOld fill:#fdd,stroke:#c66
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — n/a, lockfile/manifest-only change
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)