### PR TITLE
chore: Release hotfix 1.96.2

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,7 +2,7 @@
   "name": "@safe-global/web",
   "homepage": "https://github.com/safe-global/safe-wallet-web",
   "license": "GPL-3.0",
-  "version": "1.96.1",
+  "version": "1.96.2",
   "type": "module",
   "scripts": {
     "pw:test": "npx playwright test --config=e2e/playwright.config.ts --project=chromium",


### PR DESCRIPTION
## 🚀 Release web-v1.96.2

Hotfix re-cut of 1.96.1. The 1.96.1 release job failed at "Create a git tag"
(the `web-v1.96.1` tag already existed from an earlier partial run), so the
build, S3 upload, GitHub release, and deploy never ran — even though the fixes
landed on `main`. This bumps the patch version so the release pipeline runs
cleanly and ships the fixes already in `main`.

### Fixes
- fix(web): stop URL-derived safe address breaking hydration (React #418) (#8376)
- fix: Nested `<a>`

---

## 📋 QA Checklist
- [ ] Regression testing completed
- [ ] New features tested
- [ ] Bug fixes verified
- [ ] Cross-browser testing done
- [ ] Performance checked

## 📝 Next Steps
1. ✅ PR created - **YOU ARE HERE**
2. ⏳ QA team reviews and tests
3. ⏳ **Merge PR to main WITHOUT SQUASHING** (after QA approval)
4. ⏳ Auto: Tag, release, build, upload to S3 & back-merge PR

---

## ⚠️ IMPORTANT: How to Merge

**Do NOT use GitHub's merge button!**

Merge commits are disabled in this repo. Use the command line: