### PR TITLE
Updates to settings and team pages

### DIFF
--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -33,7 +33,7 @@ const badgeVariants = cva(
         destructive:
           'bg-destructive/10 [a]:hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 text-destructive dark:bg-destructive/20',
         outline: 'border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground',
-        warning: 'bg-yellow-50 text-yellow-800',
+        warning: 'bg-warning-subtle text-warning-strong',
         success: 'bg-success-subtle text-success-strong',
         ghost: 'hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50',
         link: 'text-primary underline-offset-4 hover:underline',

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -34,6 +34,7 @@ const badgeVariants = cva(
           'bg-destructive/10 [a]:hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 text-destructive dark:bg-destructive/20',
         outline: 'border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground',
         warning: 'bg-yellow-50 text-yellow-800',
+        success: 'bg-primary/10 text-primary',
         ghost: 'hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50',
         link: 'text-primary underline-offset-4 hover:underline',
       },

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -34,7 +34,7 @@ const badgeVariants = cva(
           'bg-destructive/10 [a]:hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 text-destructive dark:bg-destructive/20',
         outline: 'border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground',
         warning: 'bg-yellow-50 text-yellow-800',
-        success: 'bg-primary/10 text-primary',
+        success: 'bg-success-subtle text-success-strong',
         ghost: 'hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50',
         link: 'text-primary underline-offset-4 hover:underline',
       },

--- a/apps/web/src/features/oidc-auth/components/MemberTwoFactorBadge/__tests__/index.test.tsx
+++ b/apps/web/src/features/oidc-auth/components/MemberTwoFactorBadge/__tests__/index.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@/tests/test-utils'
+import { memberBuilder, memberUserBuilder } from '@/tests/builders/member'
+import MemberTwoFactorBadge from '../index'
+
+describe('MemberTwoFactorBadge', () => {
+  it('shows an active badge for a member signed in with email or Google', () => {
+    const member = memberBuilder()
+      .with({ status: 'ACTIVE', user: memberUserBuilder().with({ email: 'alice@example.com' }).build() })
+      .build()
+
+    render(<MemberTwoFactorBadge member={member} />)
+
+    expect(screen.getByTestId('member-2fa-badge')).toHaveTextContent('Active')
+  })
+
+  it('shows a wallet sign-in badge for a member without an email', () => {
+    const member = memberBuilder()
+      .with({ status: 'ACTIVE', user: memberUserBuilder().with({ email: null }).build() })
+      .build()
+
+    render(<MemberTwoFactorBadge member={member} />)
+
+    expect(screen.getByTestId('member-2fa-badge')).toHaveTextContent('Wallet sign-in')
+  })
+
+  it('shows a pending badge for an invited member', () => {
+    const member = memberBuilder()
+      .with({
+        status: 'INVITED',
+        user: memberUserBuilder().with({ status: 'PENDING', email: 'bob@example.com' }).build(),
+      })
+      .build()
+
+    render(<MemberTwoFactorBadge member={member} />)
+
+    expect(screen.getByTestId('member-2fa-badge')).toHaveTextContent('Invite pending')
+  })
+
+  it('renders nothing for a declined invite', () => {
+    const member = memberBuilder()
+      .with({ status: 'DECLINED', user: memberUserBuilder().with({ status: 'PENDING' }).build() })
+      .build()
+
+    const { container } = render(<MemberTwoFactorBadge member={member} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/apps/web/src/features/oidc-auth/components/MemberTwoFactorBadge/index.stories.tsx
+++ b/apps/web/src/features/oidc-auth/components/MemberTwoFactorBadge/index.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import type { MemberDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import MemberTwoFactorBadge from './index'
+
+const member = (overrides: Omit<Partial<MemberDto>, 'user'> & { user?: Partial<MemberDto['user']> }): MemberDto => ({
+  id: 1,
+  role: 'MEMBER',
+  status: 'ACTIVE',
+  name: 'Member',
+  alias: null,
+  invitedBy: null,
+  createdAt: '2026-04-22T00:00:00.000Z',
+  updatedAt: '2026-04-22T00:00:00.000Z',
+  ...overrides,
+  user: { id: 99, status: 'ACTIVE', email: null, ...overrides.user },
+})
+
+const meta = {
+  title: 'Features/OidcAuth/MemberTwoFactorBadge',
+  component: MemberTwoFactorBadge,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof MemberTwoFactorBadge>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Active: Story = {
+  args: { member: member({ user: { email: 'alice@example.com' } }) },
+}
+
+export const WalletSignIn: Story = {
+  args: { member: member({ user: { email: null } }) },
+}
+
+export const InvitePending: Story = {
+  args: { member: member({ status: 'INVITED', user: { status: 'PENDING', email: 'bob@example.com' } }) },
+}

--- a/apps/web/src/features/oidc-auth/components/MemberTwoFactorBadge/index.tsx
+++ b/apps/web/src/features/oidc-auth/components/MemberTwoFactorBadge/index.tsx
@@ -1,0 +1,36 @@
+import { ShieldCheck, Wallet, type LucideIcon } from 'lucide-react'
+import type { MemberDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { Badge } from '@/components/ui/badge'
+import { getMemberTwoFactorStatus, MemberTwoFactorStatus } from '../../utils/twoFactor'
+
+const BADGE_BY_STATUS: Record<
+  MemberTwoFactorStatus,
+  { label: string; variant: 'success' | 'secondary'; icon?: LucideIcon }
+> = {
+  [MemberTwoFactorStatus.ACTIVE]: { label: 'Active', variant: 'success', icon: ShieldCheck },
+  [MemberTwoFactorStatus.WALLET_SIGN_IN]: { label: 'Wallet sign-in', variant: 'secondary', icon: Wallet },
+  [MemberTwoFactorStatus.INVITE_PENDING]: { label: 'Invite pending', variant: 'secondary' },
+}
+
+/**
+ * 2FA status of a single workspace member, as shown in the Team table.
+ * Renders nothing for declined invites, which have no 2FA state.
+ */
+const MemberTwoFactorBadge = ({ member }: { member: MemberDto }) => {
+  const status = getMemberTwoFactorStatus(member)
+
+  if (!status) {
+    return null
+  }
+
+  const { label, variant, icon: Icon } = BADGE_BY_STATUS[status]
+
+  return (
+    <Badge variant={variant} data-testid="member-2fa-badge">
+      {Icon && <Icon />}
+      {label}
+    </Badge>
+  )
+}
+
+export default MemberTwoFactorBadge

--- a/apps/web/src/features/oidc-auth/components/SwitchAuthenticatorSection/__tests__/index.test.tsx
+++ b/apps/web/src/features/oidc-auth/components/SwitchAuthenticatorSection/__tests__/index.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@/tests/test-utils'
+import SwitchAuthenticatorSection from '../index'
+
+const mockUseHasFeature = jest.fn(() => true)
+const mockUseAuthenticators = jest.fn()
+
+jest.mock('@/hooks/useChains', () => ({
+  useHasFeature: () => mockUseHasFeature(),
+}))
+
+jest.mock('../../../hooks/useAuthenticators', () => ({
+  useAuthenticators: () => mockUseAuthenticators(),
+}))
+
+describe('SwitchAuthenticatorSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseHasFeature.mockReturnValue(true)
+    mockUseAuthenticators.mockReturnValue({
+      isOidcSession: true,
+      authenticators: [{ id: '1', type: 'totp', createdAt: '2026-04-22T00:00:00.000Z' }],
+      error: undefined,
+      enrollNewAuthenticator: jest.fn(),
+    })
+  })
+
+  it('renders nothing for a non-OIDC session', () => {
+    mockUseAuthenticators.mockReturnValue({ isOidcSession: false, authenticators: undefined })
+
+    const { container } = render(<SwitchAuthenticatorSection />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when the switch-authenticator feature is disabled', () => {
+    mockUseHasFeature.mockReturnValue(false)
+
+    const { container } = render(<SwitchAuthenticatorSection />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('marks 2FA as active when an authenticator is enrolled', () => {
+    render(<SwitchAuthenticatorSection />)
+
+    expect(screen.getByText('Active')).toBeInTheDocument()
+    expect(screen.getByTestId('authenticator-row')).toBeInTheDocument()
+  })
+
+  it('offers to add an authenticator when none is enrolled', () => {
+    mockUseAuthenticators.mockReturnValue({
+      isOidcSession: true,
+      authenticators: [],
+      error: undefined,
+      enrollNewAuthenticator: jest.fn(),
+    })
+
+    render(<SwitchAuthenticatorSection />)
+
+    expect(screen.queryByText('Active')).not.toBeInTheDocument()
+    expect(screen.getByTestId('add-authenticator-btn')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/oidc-auth/components/SwitchAuthenticatorSection/index.tsx
+++ b/apps/web/src/features/oidc-auth/components/SwitchAuthenticatorSection/index.tsx
@@ -1,5 +1,6 @@
 import { Plus, ShieldCheck, Smartphone } from 'lucide-react'
 import { FEATURES } from '@safe-global/utils/utils/chains'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Typography } from '@/components/ui/typography'
@@ -44,10 +45,10 @@ const SwitchAuthenticatorSection = () => {
           Two-factor authentication
         </Typography>
         {authenticator && (
-          <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">
-            <ShieldCheck className="h-3.5 w-3.5" />
+          <Badge variant="success">
+            <ShieldCheck />
             Active
-          </span>
+          </Badge>
         )}
       </div>
       <Typography variant="paragraph-small" color="muted" className="mb-4 block max-w-[560px]">

--- a/apps/web/src/features/oidc-auth/components/WalletTwoFactorSection/__tests__/index.test.tsx
+++ b/apps/web/src/features/oidc-auth/components/WalletTwoFactorSection/__tests__/index.test.tsx
@@ -42,4 +42,10 @@ describe('WalletTwoFactorSection', () => {
     expect(screen.getByText('Two-factor authentication')).toBeInTheDocument()
     expect(screen.getByText('Not active for wallet sign-in')).toBeInTheDocument()
   })
+
+  it('tells wallet users to create a new email or Google account, not to sign in with one', () => {
+    render(<WalletTwoFactorSection />)
+
+    expect(screen.getByText(/create a new email or Google account instead/)).toBeInTheDocument()
+  })
 })

--- a/apps/web/src/features/oidc-auth/components/WalletTwoFactorSection/index.tsx
+++ b/apps/web/src/features/oidc-auth/components/WalletTwoFactorSection/index.tsx
@@ -37,7 +37,7 @@ const WalletTwoFactorSection = () => {
 
       <Typography variant="paragraph-small" color="muted" className="block max-w-[560px]">
         You&apos;re signed in with your wallet — your signature is your key. 2FA currently protects email and Google
-        sign-ins. If you want 2FA today, sign in with a Google or email account instead.
+        sign-ins. If you want 2FA today, create a new email or Google account instead.
       </Typography>
     </section>
   )

--- a/apps/web/src/features/oidc-auth/components/WorkspaceTwoFactorSection/__tests__/index.test.tsx
+++ b/apps/web/src/features/oidc-auth/components/WorkspaceTwoFactorSection/__tests__/index.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@/tests/test-utils'
+import { memberBuilder, memberUserBuilder } from '@/tests/builders/member'
+import WorkspaceTwoFactorSection from '../index'
+
+const mockUseHasFeature = jest.fn(() => true)
+
+jest.mock('@/hooks/useChains', () => ({
+  useHasFeature: () => mockUseHasFeature(),
+}))
+
+const oidcMember = (id: number) =>
+  memberBuilder()
+    .with({
+      id,
+      status: 'ACTIVE',
+      user: memberUserBuilder()
+        .with({ id, email: `user${id}@example.com` })
+        .build(),
+    })
+    .build()
+
+const walletMember = (id: number) =>
+  memberBuilder()
+    .with({ id, status: 'ACTIVE', user: memberUserBuilder().with({ id, email: null }).build() })
+    .build()
+
+describe('WorkspaceTwoFactorSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseHasFeature.mockReturnValue(true)
+  })
+
+  it('renders nothing when the switch-authenticator feature is disabled', () => {
+    mockUseHasFeature.mockReturnValue(false)
+
+    const { container } = render(<WorkspaceTwoFactorSection members={[oidcMember(1)]} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('states that 2FA is required for everyone', () => {
+    render(<WorkspaceTwoFactorSection members={[oidcMember(1)]} />)
+
+    expect(screen.getByText('Two-factor authentication')).toBeInTheDocument()
+    expect(screen.getByText('Required for everyone')).toBeInTheDocument()
+  })
+
+  it('counts wallet members as not covered', () => {
+    render(<WorkspaceTwoFactorSection members={[oidcMember(1), oidcMember(2), walletMember(3)]} />)
+
+    expect(screen.getByTestId('workspace-2fa-count')).toHaveTextContent('2/3 users have 2FA enabled')
+  })
+
+  it('handles a workspace with no members', () => {
+    render(<WorkspaceTwoFactorSection members={[]} />)
+
+    expect(screen.getByTestId('workspace-2fa-count')).toHaveTextContent('0/0 users have 2FA enabled')
+  })
+
+  it('links to the team page of the current space', () => {
+    render(<WorkspaceTwoFactorSection members={[oidcMember(1)]} spaceId="space-uuid" />)
+
+    expect(screen.getByTestId('workspace-2fa-manage-members')).toHaveAttribute(
+      'href',
+      '/spaces/members?spaceId=space-uuid',
+    )
+  })
+})

--- a/apps/web/src/features/oidc-auth/components/WorkspaceTwoFactorSection/__tests__/index.test.tsx
+++ b/apps/web/src/features/oidc-auth/components/WorkspaceTwoFactorSection/__tests__/index.test.tsx
@@ -65,4 +65,16 @@ describe('WorkspaceTwoFactorSection', () => {
       '/spaces/members?spaceId=space-uuid',
     )
   })
+
+  it('offers to manage members to an admin', () => {
+    render(<WorkspaceTwoFactorSection members={[oidcMember(1)]} isAdmin />)
+
+    expect(screen.getByTestId('workspace-2fa-manage-members')).toHaveTextContent('Manage members')
+  })
+
+  it('only offers to see members to a non-admin, who cannot manage anyone', () => {
+    render(<WorkspaceTwoFactorSection members={[oidcMember(1)]} isAdmin={false} />)
+
+    expect(screen.getByTestId('workspace-2fa-manage-members')).toHaveTextContent('See members')
+  })
 })

--- a/apps/web/src/features/oidc-auth/components/WorkspaceTwoFactorSection/index.stories.tsx
+++ b/apps/web/src/features/oidc-auth/components/WorkspaceTwoFactorSection/index.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { mswLoader } from 'msw-storybook-addon'
+import type { MemberDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { createMockStory } from '@/stories/mocks'
+import WorkspaceTwoFactorSection from './index'
+
+const member = (id: number, email: string | null): MemberDto => ({
+  id,
+  role: 'MEMBER',
+  status: 'ACTIVE',
+  name: `Member ${id}`,
+  alias: null,
+  invitedBy: null,
+  createdAt: '2026-04-22T00:00:00.000Z',
+  updatedAt: '2026-04-22T00:00:00.000Z',
+  user: { id, status: 'ACTIVE', email },
+})
+
+const defaultSetup = createMockStory({
+  features: { spaces: true, oidcAuth: true, switchAuthenticator: true },
+  pathname: '/spaces/settings/general',
+  query: { spaceId: '1' },
+  shadcn: true,
+})
+
+const meta = {
+  title: 'Features/OidcAuth/WorkspaceTwoFactorSection',
+  component: WorkspaceTwoFactorSection,
+  loaders: [mswLoader],
+  decorators: [defaultSetup.decorator],
+  parameters: {
+    layout: 'padded',
+    ...defaultSetup.parameters,
+  },
+} satisfies Meta<typeof WorkspaceTwoFactorSection>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const FullCoverage: Story = {
+  args: {
+    spaceId: '1',
+    members: [member(1, 'admin@example.com'), member(2, 'alice@example.com')],
+  },
+}
+
+export const PartialCoverage: Story = {
+  args: {
+    spaceId: '1',
+    members: [member(1, 'admin@example.com'), member(2, 'alice@example.com'), member(3, null)],
+  },
+}
+
+export const NoMembers: Story = {
+  args: { spaceId: '1', members: [] },
+}

--- a/apps/web/src/features/oidc-auth/components/WorkspaceTwoFactorSection/index.stories.tsx
+++ b/apps/web/src/features/oidc-auth/components/WorkspaceTwoFactorSection/index.stories.tsx
@@ -40,6 +40,7 @@ type Story = StoryObj<typeof meta>
 export const FullCoverage: Story = {
   args: {
     spaceId: '1',
+    isAdmin: true,
     members: [member(1, 'admin@example.com'), member(2, 'alice@example.com')],
   },
 }
@@ -47,10 +48,20 @@ export const FullCoverage: Story = {
 export const PartialCoverage: Story = {
   args: {
     spaceId: '1',
+    isAdmin: true,
+    members: [member(1, 'admin@example.com'), member(2, 'alice@example.com'), member(3, null)],
+  },
+}
+
+// A plain member can't manage anyone, so the CTA only offers to see the team
+export const AsNonAdmin: Story = {
+  args: {
+    spaceId: '1',
+    isAdmin: false,
     members: [member(1, 'admin@example.com'), member(2, 'alice@example.com'), member(3, null)],
   },
 }
 
 export const NoMembers: Story = {
-  args: { spaceId: '1', members: [] },
+  args: { spaceId: '1', isAdmin: true, members: [] },
 }

--- a/apps/web/src/features/oidc-auth/components/WorkspaceTwoFactorSection/index.tsx
+++ b/apps/web/src/features/oidc-auth/components/WorkspaceTwoFactorSection/index.tsx
@@ -1,0 +1,64 @@
+import { ShieldCheck } from 'lucide-react'
+import NextLink from 'next/link'
+import type { MemberDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import { AppRoutes } from '@/config/routes'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Typography } from '@/components/ui/typography'
+import { useHasFeature } from '@/hooks/useChains'
+import { getTwoFactorCoverage } from '../../utils/twoFactor'
+
+/**
+ * Two-factor authentication card on the workspace settings page. States the
+ * always-on 2FA policy and how much of the workspace it covers, and points
+ * admins at the Team page to manage the members it doesn't.
+ *
+ * Gated behind the SWITCH_AUTHENTICATOR feature, like the account-level 2FA cards.
+ */
+const WorkspaceTwoFactorSection = ({ members, spaceId }: { members: MemberDto[]; spaceId?: string }) => {
+  const isSwitchAuthenticatorEnabled = useHasFeature(FEATURES.SWITCH_AUTHENTICATOR)
+
+  if (!isSwitchAuthenticatorEnabled) {
+    return null
+  }
+
+  const { enabled, total } = getTwoFactorCoverage(members)
+
+  return (
+    <section className="bg-card rounded-2xl p-6 mb-3" data-testid="settings-workspace-2fa">
+      <div className="flex items-center gap-3 mb-2">
+        <Typography variant="paragraph-bold" className="block tracking-tight">
+          Two-factor authentication
+        </Typography>
+        <Badge variant="success">
+          <ShieldCheck />
+          Required for everyone
+        </Badge>
+      </div>
+
+      <Typography variant="paragraph-small" color="muted" className="block max-w-[560px]">
+        Everyone who signs in with email or Google needs a 6-digit code from their authenticator app. This can&apos;t be
+        turned off.
+      </Typography>
+
+      <div className="border-border mt-6 flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+        <Typography variant="paragraph-small-bold" data-testid="workspace-2fa-count">
+          {enabled}/{total} users have 2FA enabled
+        </Typography>
+
+        <Button
+          variant="outline"
+          size="sm"
+          data-testid="workspace-2fa-manage-members"
+          nativeButton={false}
+          render={<NextLink href={{ pathname: AppRoutes.spaces.members, query: spaceId ? { spaceId } : undefined }} />}
+        >
+          Manage members
+        </Button>
+      </div>
+    </section>
+  )
+}
+
+export default WorkspaceTwoFactorSection

--- a/apps/web/src/features/oidc-auth/components/WorkspaceTwoFactorSection/index.tsx
+++ b/apps/web/src/features/oidc-auth/components/WorkspaceTwoFactorSection/index.tsx
@@ -11,12 +11,21 @@ import { getTwoFactorCoverage } from '../../utils/twoFactor'
 
 /**
  * Two-factor authentication card on the workspace settings page. States the
- * always-on 2FA policy and how much of the workspace it covers, and points
- * admins at the Team page to manage the members it doesn't.
+ * always-on 2FA policy and how much of the workspace it covers, and points at
+ * the Team page — to manage the members it doesn't cover, or just to see them
+ * when the viewer isn't an admin.
  *
  * Gated behind the SWITCH_AUTHENTICATOR feature, like the account-level 2FA cards.
  */
-const WorkspaceTwoFactorSection = ({ members, spaceId }: { members: MemberDto[]; spaceId?: string }) => {
+const WorkspaceTwoFactorSection = ({
+  members,
+  spaceId,
+  isAdmin,
+}: {
+  members: MemberDto[]
+  spaceId?: string
+  isAdmin?: boolean
+}) => {
   const isSwitchAuthenticatorEnabled = useHasFeature(FEATURES.SWITCH_AUTHENTICATOR)
 
   if (!isSwitchAuthenticatorEnabled) {
@@ -54,7 +63,7 @@ const WorkspaceTwoFactorSection = ({ members, spaceId }: { members: MemberDto[];
           nativeButton={false}
           render={<NextLink href={{ pathname: AppRoutes.spaces.members, query: spaceId ? { spaceId } : undefined }} />}
         >
-          Manage members
+          {isAdmin ? 'Manage members' : 'See members'}
         </Button>
       </div>
     </section>

--- a/apps/web/src/features/oidc-auth/index.ts
+++ b/apps/web/src/features/oidc-auth/index.ts
@@ -44,3 +44,11 @@ export { useAuthenticators } from './hooks/useAuthenticators'
 // handle does not apply there.
 export { default as SwitchAuthenticatorSection } from './components/SwitchAuthenticatorSection'
 export { default as WalletTwoFactorSection } from './components/WalletTwoFactorSection'
+export { default as WorkspaceTwoFactorSection } from './components/WorkspaceTwoFactorSection'
+export { default as MemberTwoFactorBadge } from './components/MemberTwoFactorBadge'
+
+// ─────────────────────────────────────────────────────────────────
+// 2FA STATUS DERIVATION (shared with the spaces Team page)
+// ─────────────────────────────────────────────────────────────────
+
+export { getMemberTwoFactorStatus, getTwoFactorCoverage, MemberTwoFactorStatus } from './utils/twoFactor'

--- a/apps/web/src/features/oidc-auth/utils/__tests__/twoFactor.test.ts
+++ b/apps/web/src/features/oidc-auth/utils/__tests__/twoFactor.test.ts
@@ -1,0 +1,68 @@
+import { memberBuilder, memberUserBuilder } from '@/tests/builders/member'
+import { getMemberTwoFactorStatus, getTwoFactorCoverage, MemberTwoFactorStatus } from '../twoFactor'
+
+const oidcMember = (id: number) =>
+  memberBuilder()
+    .with({
+      id,
+      status: 'ACTIVE',
+      user: memberUserBuilder()
+        .with({ id, email: `user${id}@example.com` })
+        .build(),
+    })
+    .build()
+
+const walletMember = (id: number) =>
+  memberBuilder()
+    .with({ id, status: 'ACTIVE', user: memberUserBuilder().with({ id, email: null }).build() })
+    .build()
+
+const invitedMember = (id: number) =>
+  memberBuilder()
+    .with({
+      id,
+      status: 'INVITED',
+      user: memberUserBuilder()
+        .with({ id, status: 'PENDING', email: `invited${id}@example.com` })
+        .build(),
+    })
+    .build()
+
+const declinedMember = (id: number) =>
+  memberBuilder()
+    .with({ id, status: 'DECLINED', user: memberUserBuilder().with({ id, status: 'PENDING' }).build() })
+    .build()
+
+describe('getMemberTwoFactorStatus', () => {
+  it('reports active 2FA for an active member with an email (Google/email sign-in)', () => {
+    expect(getMemberTwoFactorStatus(oidcMember(1))).toBe(MemberTwoFactorStatus.ACTIVE)
+  })
+
+  it('reports a wallet sign-in for an active member without an email (SIWE)', () => {
+    expect(getMemberTwoFactorStatus(walletMember(1))).toBe(MemberTwoFactorStatus.WALLET_SIGN_IN)
+  })
+
+  it('reports a pending invite regardless of the invitee having an email', () => {
+    expect(getMemberTwoFactorStatus(invitedMember(1))).toBe(MemberTwoFactorStatus.INVITE_PENDING)
+  })
+
+  it('reports no status for a declined invite', () => {
+    expect(getMemberTwoFactorStatus(declinedMember(1))).toBeUndefined()
+  })
+})
+
+describe('getTwoFactorCoverage', () => {
+  it('counts only active members, and only email/Google ones as enabled', () => {
+    const members = [oidcMember(1), oidcMember(2), walletMember(3), invitedMember(4), declinedMember(5)]
+
+    expect(getTwoFactorCoverage(members)).toEqual({ enabled: 2, total: 3 })
+  })
+
+  it('reports full coverage when every active member signs in with email or Google', () => {
+    expect(getTwoFactorCoverage([oidcMember(1), oidcMember(2)])).toEqual({ enabled: 2, total: 2 })
+  })
+
+  it('reports zero coverage for an empty member list', () => {
+    expect(getTwoFactorCoverage([])).toEqual({ enabled: 0, total: 0 })
+  })
+})

--- a/apps/web/src/features/oidc-auth/utils/twoFactor.ts
+++ b/apps/web/src/features/oidc-auth/utils/twoFactor.ts
@@ -1,0 +1,33 @@
+import type { MemberDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+
+/**
+ * Workspace members enrol in 2FA implicitly: email and Google sign-ins are always
+ * forced through an authenticator, wallet (SIWE) sign-ins never are. CGW exposes no
+ * per-user enrolment status, so the presence of an email on the member's user record
+ * is what tells the two apart. This holds only while the "OIDC always enrols" policy
+ * does — real enrolment status would need Management API plumbing.
+ */
+export enum MemberTwoFactorStatus {
+  ACTIVE = 'ACTIVE',
+  WALLET_SIGN_IN = 'WALLET_SIGN_IN',
+  INVITE_PENDING = 'INVITE_PENDING',
+}
+
+type TwoFactorMember = Pick<MemberDto, 'status' | 'user'>
+
+/** Declined invitees have no meaningful 2FA state, hence `undefined`. */
+export const getMemberTwoFactorStatus = (member: TwoFactorMember): MemberTwoFactorStatus | undefined => {
+  if (member.status === 'DECLINED') return undefined
+  if (member.status === 'INVITED') return MemberTwoFactorStatus.INVITE_PENDING
+  return member.user.email ? MemberTwoFactorStatus.ACTIVE : MemberTwoFactorStatus.WALLET_SIGN_IN
+}
+
+/** Coverage across members who have actually joined; pending and declined invites don't count. */
+export const getTwoFactorCoverage = (members: TwoFactorMember[]): { enabled: number; total: number } => {
+  const activeMembers = members.filter((member) => member.status === 'ACTIVE')
+
+  return {
+    enabled: activeMembers.filter((member) => getMemberTwoFactorStatus(member) === MemberTwoFactorStatus.ACTIVE).length,
+    total: activeMembers.length,
+  }
+}

--- a/apps/web/src/features/spaces/components/MembersList/MembersList.stories.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/MembersList.stories.tsx
@@ -24,7 +24,7 @@ const member = (overrides: Omit<Partial<MemberDto>, 'user'> & { user?: Partial<M
 const defaultSetup = createMockStory({
   scenario: 'efSafe',
   wallet: 'owner',
-  features: { spaces: true },
+  features: { spaces: true, switchAuthenticator: true },
   pathname: '/spaces/members',
   query: { spaceId: '1' },
   shadcn: true,

--- a/apps/web/src/features/spaces/components/MembersList/index.test.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/index.test.tsx
@@ -31,6 +31,9 @@ jest.mock('./MemberRowActionsMenu', () => ({
 const mockUseIsMobile = jest.fn(() => false)
 jest.mock('@/hooks/use-mobile', () => ({ useIsMobile: () => mockUseIsMobile() }))
 
+const mockUseHasFeature = jest.fn(() => true)
+jest.mock('@/hooks/useChains', () => ({ useHasFeature: () => mockUseHasFeature() }))
+
 jest.mock('@/components/common/Track', () => ({
   __esModule: true,
   default: ({ children }: { children: ReactNode }) => <>{children}</>,
@@ -56,6 +59,7 @@ jest.mock('@/features/spaces', () => ({
 describe('MembersList', () => {
   beforeEach(() => {
     mockUseIsMobile.mockReturnValue(false)
+    mockUseHasFeature.mockReturnValue(true)
   })
 
   it('renders member email and leaves empty email cells blank', () => {
@@ -219,5 +223,60 @@ describe('MembersList', () => {
 
     const nameCell = screen.getByTestId('table-cell-name')
     expect(within(nameCell).getByText('alice@example.com')).toBeInTheDocument()
+  })
+
+  describe('2FA column', () => {
+    const twoFactorMembers = [
+      // Email/Google sign-in — always enrolled
+      memberBuilder()
+        .with({ id: 1, name: 'Alice', user: memberUserBuilder().with({ email: 'alice@example.com' }).build() })
+        .build(),
+      // Wallet (SIWE) sign-in — never enrolled
+      memberBuilder()
+        .with({ id: 2, name: 'Bob', user: memberUserBuilder().with({ id: 12, email: null }).build() })
+        .build(),
+      // Pending invite — no 2FA state yet, even with an email
+      memberBuilder()
+        .with({
+          id: 3,
+          status: 'INVITED',
+          name: 'Carol',
+          user: memberUserBuilder().with({ id: 13, status: 'PENDING', email: 'carol@example.com' }).build(),
+        })
+        .build(),
+      // Declined invite — no badge at all
+      memberBuilder()
+        .with({
+          id: 4,
+          status: 'DECLINED',
+          name: 'Dave',
+          user: memberUserBuilder().with({ id: 14, status: 'PENDING' }).build(),
+        })
+        .build(),
+    ]
+
+    it('renders a 2FA status per member', () => {
+      render(<MembersList members={twoFactorMembers} />)
+
+      expect(screen.getByText('2FA')).toBeInTheDocument()
+
+      const cells = screen.getAllByTestId('table-cell-2fa')
+      expect(cells).toHaveLength(4)
+      expect(within(cells[0]!).getByText('Active')).toBeInTheDocument()
+      expect(within(cells[1]!).getByText('Wallet sign-in')).toBeInTheDocument()
+      expect(within(cells[2]!).getByText('Invite pending')).toBeInTheDocument()
+      expect(within(cells[3]!).queryByTestId('member-2fa-badge')).not.toBeInTheDocument()
+    })
+
+    it('hides the column when the feature is disabled', () => {
+      mockUseHasFeature.mockReturnValue(false)
+
+      render(<MembersList members={twoFactorMembers} />)
+
+      expect(screen.queryByText('2FA')).not.toBeInTheDocument()
+      expect(screen.queryAllByTestId('table-cell-2fa')).toHaveLength(0)
+      // The other columns still render
+      expect(screen.getByText('Email')).toBeInTheDocument()
+    })
   })
 })

--- a/apps/web/src/features/spaces/components/MembersList/index.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/index.tsx
@@ -27,6 +27,9 @@ import EditMemberDialog from './EditMemberDialog'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
 import Track from '@/components/common/Track'
 import PaginatedDataTable, { type DataTableColumn } from '../PaginatedDataTable'
+import { getMemberTwoFactorStatus, MemberTwoFactorBadge } from '@/features/oidc-auth'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import { useHasFeature } from '@/hooks/useChains'
 
 const EditButton = ({ member, disabled }: { member: MemberDto; disabled: boolean }) => {
   const [open, setOpen] = useState(false)
@@ -96,6 +99,7 @@ const MembersList = ({ members }: { members: MemberDto[] }) => {
   const isMobile = useIsMobile()
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const { currentData: currentUser } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
+  const isTwoFactorEnabled = useHasFeature(FEATURES.SWITCH_AUTHENTICATOR)
 
   if (!members.length) {
     return null
@@ -119,11 +123,22 @@ const MembersList = ({ members }: { members: MemberDto[] }) => {
     return { isDeclined, isExpired, isInvite, isDisabled, editDisabled, canRenew, memberEmail }
   }
 
+  // The 2FA column takes its share from name and email so the widths still total 100%
+  const twoFactorColumn: DataTableColumn<MemberDto> = {
+    id: 'twoFactor',
+    header: '2FA',
+    width: '15%',
+    minWidth: 130,
+    cellTestId: 'table-cell-2fa',
+    sortValue: (m) => getMemberTwoFactorStatus(m),
+    cell: (member) => <MemberTwoFactorBadge member={member} />,
+  }
+
   const columns: DataTableColumn<MemberDto>[] = [
     {
       id: 'name',
       header: 'Name',
-      width: '40%',
+      width: isTwoFactorEnabled ? '35%' : '40%',
       sticky: true,
       minWidth: 200,
       cellTestId: 'table-cell-name',
@@ -148,7 +163,7 @@ const MembersList = ({ members }: { members: MemberDto[] }) => {
     {
       id: 'email',
       header: 'Email',
-      width: '30%',
+      width: isTwoFactorEnabled ? '20%' : '30%',
       priority: 'secondary',
       minWidth: 180,
       cellTestId: 'table-cell-email',
@@ -161,6 +176,7 @@ const MembersList = ({ members }: { members: MemberDto[] }) => {
           </Tooltip>
         ) : null,
     },
+    ...(isTwoFactorEnabled ? [twoFactorColumn] : []),
     {
       id: 'role',
       header: 'Role',

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/GeneralPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/GeneralPage.tsx
@@ -1,6 +1,7 @@
 import { useAppSelector } from '@/store'
 import { isAuthenticated } from '@/store/authSlice'
-import { useCurrentSpaceId } from '@/features/spaces'
+import { useCurrentSpaceId, useSpaceMembersByStatus } from '@/features/spaces'
+import { WorkspaceTwoFactorSection } from '@/features/oidc-auth'
 import { useSpacesGetOneV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import IdentitySection from '../sections/IdentitySection'
 import AppearanceSection from '../sections/AppearanceSection'
@@ -10,10 +11,12 @@ const GeneralPage = () => {
   const spaceId = useCurrentSpaceId()
   const isSignedIn = useAppSelector(isAuthenticated)
   const { currentData: space } = useSpacesGetOneV1Query({ id: spaceId ?? '' }, { skip: !isSignedIn || !spaceId })
+  const { activeMembers } = useSpaceMembersByStatus()
 
   return (
     <div data-testid="settings-general-page">
       <IdentitySection space={space} />
+      <WorkspaceTwoFactorSection members={activeMembers} spaceId={spaceId ?? undefined} />
       <AppearanceSection />
       <DangerZoneSection space={space} />
     </div>

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/GeneralPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/GeneralPage.tsx
@@ -1,6 +1,6 @@
 import { useAppSelector } from '@/store'
 import { isAuthenticated } from '@/store/authSlice'
-import { useCurrentSpaceId, useSpaceMembersByStatus } from '@/features/spaces'
+import { useCurrentSpaceId, useIsAdmin, useSpaceMembersByStatus } from '@/features/spaces'
 import { WorkspaceTwoFactorSection } from '@/features/oidc-auth'
 import { useSpacesGetOneV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import IdentitySection from '../sections/IdentitySection'
@@ -12,11 +12,12 @@ const GeneralPage = () => {
   const isSignedIn = useAppSelector(isAuthenticated)
   const { currentData: space } = useSpacesGetOneV1Query({ id: spaceId ?? '' }, { skip: !isSignedIn || !spaceId })
   const { activeMembers } = useSpaceMembersByStatus()
+  const isAdmin = useIsAdmin()
 
   return (
     <div data-testid="settings-general-page">
       <IdentitySection space={space} />
-      <WorkspaceTwoFactorSection members={activeMembers} spaceId={spaceId ?? undefined} />
+      <WorkspaceTwoFactorSection members={activeMembers} spaceId={spaceId ?? undefined} isAdmin={isAdmin} />
       <AppearanceSection />
       <DangerZoneSection space={space} />
     </div>

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/__tests__/GeneralPage.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/__tests__/GeneralPage.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@/tests/test-utils'
+import GeneralPage from '../GeneralPage'
+
+const mockUseSpaceMembersByStatus = jest.fn()
+
+jest.mock('@/features/spaces', () => ({
+  useCurrentSpaceId: () => 'space-uuid',
+  useSpaceMembersByStatus: () => mockUseSpaceMembersByStatus(),
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
+  useSpacesGetOneV1Query: () => ({ currentData: undefined }),
+}))
+
+jest.mock('../../sections/IdentitySection', () => ({
+  __esModule: true,
+  default: () => <div data-testid="identity-section" />,
+}))
+
+jest.mock('../../sections/AppearanceSection', () => ({
+  __esModule: true,
+  default: () => <div data-testid="appearance-section" />,
+}))
+
+jest.mock('../../sections/DangerZoneSection', () => ({
+  __esModule: true,
+  default: () => <div data-testid="danger-zone-section" />,
+}))
+
+jest.mock('@/features/oidc-auth', () => ({
+  WorkspaceTwoFactorSection: ({ members, spaceId }: { members: { id: number }[]; spaceId?: string }) => (
+    <div data-testid="workspace-2fa-section">{`${members.length}:${spaceId}`}</div>
+  ),
+}))
+
+describe('GeneralPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseSpaceMembersByStatus.mockReturnValue({ activeMembers: [{ id: 1 }, { id: 2 }], invitedMembers: [] })
+  })
+
+  it('renders the workspace 2FA section with the active members of the current space', () => {
+    render(<GeneralPage />)
+
+    expect(screen.getByTestId('workspace-2fa-section')).toHaveTextContent('2:space-uuid')
+  })
+
+  it('keeps the 2FA section between identity and appearance', () => {
+    render(<GeneralPage />)
+
+    const sections = screen.getByTestId('settings-general-page').children
+
+    expect(Array.from(sections).map((section) => section.getAttribute('data-testid'))).toEqual([
+      'identity-section',
+      'workspace-2fa-section',
+      'appearance-section',
+      'danger-zone-section',
+    ])
+  })
+})

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/__tests__/GeneralPage.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/__tests__/GeneralPage.test.tsx
@@ -2,10 +2,12 @@ import { render, screen } from '@/tests/test-utils'
 import GeneralPage from '../GeneralPage'
 
 const mockUseSpaceMembersByStatus = jest.fn()
+const mockUseIsAdmin = jest.fn()
 
 jest.mock('@/features/spaces', () => ({
   useCurrentSpaceId: () => 'space-uuid',
   useSpaceMembersByStatus: () => mockUseSpaceMembersByStatus(),
+  useIsAdmin: () => mockUseIsAdmin(),
 }))
 
 jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
@@ -28,21 +30,36 @@ jest.mock('../../sections/DangerZoneSection', () => ({
 }))
 
 jest.mock('@/features/oidc-auth', () => ({
-  WorkspaceTwoFactorSection: ({ members, spaceId }: { members: { id: number }[]; spaceId?: string }) => (
-    <div data-testid="workspace-2fa-section">{`${members.length}:${spaceId}`}</div>
-  ),
+  WorkspaceTwoFactorSection: ({
+    members,
+    spaceId,
+    isAdmin,
+  }: {
+    members: { id: number }[]
+    spaceId?: string
+    isAdmin?: boolean
+  }) => <div data-testid="workspace-2fa-section">{`${members.length}:${spaceId}:${isAdmin}`}</div>,
 }))
 
 describe('GeneralPage', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockUseSpaceMembersByStatus.mockReturnValue({ activeMembers: [{ id: 1 }, { id: 2 }], invitedMembers: [] })
+    mockUseIsAdmin.mockReturnValue(true)
   })
 
   it('renders the workspace 2FA section with the active members of the current space', () => {
     render(<GeneralPage />)
 
-    expect(screen.getByTestId('workspace-2fa-section')).toHaveTextContent('2:space-uuid')
+    expect(screen.getByTestId('workspace-2fa-section')).toHaveTextContent('2:space-uuid:true')
+  })
+
+  it("passes the viewer's admin status through, so the CTA can adapt", () => {
+    mockUseIsAdmin.mockReturnValue(false)
+
+    render(<GeneralPage />)
+
+    expect(screen.getByTestId('workspace-2fa-section')).toHaveTextContent('2:space-uuid:false')
   })
 
   it('keeps the 2FA section between identity and appearance', () => {

--- a/apps/web/src/stories/mocks/chains.ts
+++ b/apps/web/src/stories/mocks/chains.ts
@@ -16,6 +16,7 @@ export const DEFAULT_FEATURES: Required<FeatureFlags> = {
   earn: false,
   spaces: false,
   oidcAuth: false,
+  switchAuthenticator: false,
 }
 
 /**
@@ -30,6 +31,7 @@ const FEATURE_MAP: Record<keyof FeatureFlags, string> = {
   earn: 'EARN',
   spaces: 'SPACES',
   oidcAuth: 'OIDC_AUTH',
+  switchAuthenticator: 'SWITCH_AUTHENTICATOR',
 }
 
 /**

--- a/apps/web/src/stories/mocks/handlers.ts
+++ b/apps/web/src/stories/mocks/handlers.ts
@@ -711,6 +711,7 @@ export function createHandlers(config: MockStoryConfig = {}): RequestHandler[] {
     earn: features.earn ?? false,
     spaces: features.spaces ?? false,
     oidcAuth: features.oidcAuth ?? false,
+    switchAuthenticator: features.switchAuthenticator ?? false,
   }
 
   // Build handlers array

--- a/apps/web/src/stories/mocks/types.ts
+++ b/apps/web/src/stories/mocks/types.ts
@@ -37,6 +37,8 @@ export interface FeatureFlags {
   spaces?: boolean
   /** OIDC_AUTH - OIDC-based login for email and Google (default: false) */
   oidcAuth?: boolean
+  /** SWITCH_AUTHENTICATOR - 2FA management surfaces (default: false) */
+  switchAuthenticator?: boolean
 }
 
 /**

--- a/apps/web/src/styles/shadcn.css
+++ b/apps/web/src/styles/shadcn.css
@@ -143,6 +143,9 @@
   --color-success-subtle: var(--color-success-background);
   --color-success-muted: var(--color-success-light);
   --color-success-strong: var(--color-success-dark);
+  /* Amber badge pairing. `warning1` is the amber scale; `warning` proper is the coral alert colour. */
+  --color-warning-subtle: var(--color-warning1-main);
+  --color-warning-strong: var(--color-warning1-text);
   --radius-2xs: 0.25rem;
   --radius-xs: 0.5rem;
   --radius-sm: 0.5rem;


### PR DESCRIPTION
Fixes:
- https://linear.app/safe-global/issue/WA-2964/wallet-monorepo-give-2fa-its-own-section-on-the-workspace-settings
- https://linear.app/safe-global/issue/WA-2878/wallet-monorepo-show-2fa-status-column-on-the-team-page

## Team page

<img width="1959" height="763" alt="Screenshot 2026-07-31 at 09 27 34" src="https://github.com/user-attachments/assets/6d14e30f-8dc3-43e7-9fe2-7d2cb4b6029c" />

## Workspace settings

### As a member

(note how it says "See members")

<img width="1288" height="665" alt="Screenshot 2026-07-31 at 09 40 25" src="https://github.com/user-attachments/assets/ffcf36e0-f567-40fe-9b5b-012513cbb810" />

### As an admin

<img width="1272" height="590" alt="Screenshot 2026-07-31 at 09 44 45" src="https://github.com/user-attachments/assets/e5041694-1949-4eda-aee9-75212a26b431" />

## User settings as SIWE

We clarified the explanation text ("You have to create a new account")

<img width="1041" height="417" alt="Screenshot 2026-07-31 at 09 40 35" src="https://github.com/user-attachments/assets/c42a0aa7-9ceb-4634-90e8-7f4c77b2217c" />


## Feature flags

I have put all of this also behind SWITCH_AUTHENTICATOR, which I should probably rename at one point to something more descriptive (e.g. 2FA_WORKSPACES)

