### PR TITLE
fix(web): show clear message when spending limit module is not deployed on a chain

### DIFF
--- a/apps/web/src/features/spending-limits/components/CreateSpendingLimit/SpendingLimitNotSupported.stories.tsx
+++ b/apps/web/src/features/spending-limits/components/CreateSpendingLimit/SpendingLimitNotSupported.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { createMockStory } from '@/stories/mocks'
+import SpendingLimitNotSupported from './SpendingLimitNotSupported'
+
+const meta: Meta<typeof SpendingLimitNotSupported> = {
+  title: 'Components/Settings/SpendingLimits/SpendingLimitNotSupported',
+  component: SpendingLimitNotSupported,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const setup = createMockStory({ layout: 'paper' })
+
+/**
+ * Shown in the New spending limit flow when the AllowanceModule is not deployed on the current chain.
+ */
+export const Default: Story = {
+  parameters: setup.parameters,
+  decorators: [setup.decorator],
+}

--- a/apps/web/src/features/spending-limits/components/CreateSpendingLimit/SpendingLimitNotSupported.tsx
+++ b/apps/web/src/features/spending-limits/components/CreateSpendingLimit/SpendingLimitNotSupported.tsx
@@ -1,0 +1,27 @@
+import { Typography } from '@mui/material'
+
+import TxCard from '@/components/tx-flow/common/TxCard'
+import ErrorMessage from '@/components/tx/ErrorMessage'
+import ExternalLink from '@/components/common/ExternalLink'
+import { useCurrentChain } from '@/hooks/useChains'
+import { HELP_CENTER_URL } from '@safe-global/utils/config/constants'
+
+const SpendingLimitNotSupported = () => {
+  const chain = useCurrentChain()
+  const chainName = chain?.chainName ?? 'this network'
+
+  return (
+    <TxCard>
+      <ErrorMessage>
+        <Typography fontWeight={700}>Spending limits aren&apos;t available on {chainName} yet</Typography>
+        <Typography mt={1}>
+          The spending limit module hasn&apos;t been deployed on this network. Once it&apos;s available you&apos;ll be
+          able to set up spending limits here. <ExternalLink href={HELP_CENTER_URL}>Contact us</ExternalLink> to request
+          support for {chainName}.
+        </Typography>
+      </ErrorMessage>
+    </TxCard>
+  )
+}
+
+export default SpendingLimitNotSupported

--- a/apps/web/src/features/spending-limits/components/CreateSpendingLimit/index.tsx
+++ b/apps/web/src/features/spending-limits/components/CreateSpendingLimit/index.tsx
@@ -15,6 +15,8 @@ import TokenAmountInput from '@/components/common/TokenAmountInput'
 import { validateAmount, validateDecimalLength } from '@safe-global/utils/utils/validation'
 import { TxFlowContext, type TxFlowContextType } from '@/components/tx-flow/TxFlowProvider'
 import { SpendingLimitFields, type NewSpendingLimitFlowProps } from '../../types'
+import useIsSpendingLimitSupported from '../../hooks/useIsSpendingLimitSupported'
+import SpendingLimitNotSupported from './SpendingLimitNotSupported'
 
 export const _validateSpendingLimit = (val: string, decimals?: number | null) => {
   // Allowance amount is uint96 https://github.com/safe-global/safe-modules/blob/main/modules/allowances/contracts/AllowanceModule.sol#L52
@@ -28,6 +30,7 @@ export const _validateSpendingLimit = (val: string, decimals?: number | null) =>
 
 const CreateSpendingLimit = () => {
   const chainId = useChainId()
+  const isSupported = useIsSpendingLimitSupported()
   const { balances } = useVisibleBalances()
   const { onNext, data } = useContext<TxFlowContextType<NewSpendingLimitFlowProps>>(TxFlowContext)
 
@@ -59,6 +62,10 @@ const CreateSpendingLimit = () => {
     },
     [selectedToken?.tokenInfo.decimals],
   )
+
+  if (!isSupported) {
+    return <SpendingLimitNotSupported />
+  }
 
   return (
     <TxCard>

--- a/apps/web/src/features/spending-limits/components/SpendingLimitsSettings/index.tsx
+++ b/apps/web/src/features/spending-limits/components/SpendingLimitsSettings/index.tsx
@@ -11,10 +11,12 @@ import { TxModalContext } from '@/components/tx-flow'
 import { FEATURES } from '@safe-global/utils/utils/chains'
 import { useAppSelector } from '@/store'
 import { selectSpendingLimits, selectSpendingLimitsLoading } from '../../store/spendingLimitsSlice'
+import useIsSpendingLimitSupported from '../../hooks/useIsSpendingLimitSupported'
 
 const SpendingLimitsSettings = () => {
   const { setTxFlow } = useContext(TxModalContext)
   const isEnabled = useHasFeature(FEATURES.SPENDING_LIMIT)
+  const isSupported = useIsSpendingLimitSupported()
 
   // Read data from store (loaded on app start via SpendingLimitsLoader)
   const spendingLimits = useAppSelector(selectSpendingLimits)
@@ -49,22 +51,29 @@ const SpendingLimitsSettings = () => {
                 collect all signatures.
               </Typography>
 
-              <CheckWallet>
-                {(isOk) => (
-                  <Track {...SETTINGS_EVENTS.SPENDING_LIMIT.NEW_LIMIT}>
-                    <Button
-                      data-testid="new-spending-limit"
-                      onClick={() => setTxFlow(<NewSpendingLimitFlow />)}
-                      sx={{ mt: 2, mb: 2 }}
-                      variant="contained"
-                      disabled={!isOk}
-                      size="small"
-                    >
-                      New spending limit
-                    </Button>
-                  </Track>
-                )}
-              </CheckWallet>
+              {isSupported ? (
+                <CheckWallet>
+                  {(isOk) => (
+                    <Track {...SETTINGS_EVENTS.SPENDING_LIMIT.NEW_LIMIT}>
+                      <Button
+                        data-testid="new-spending-limit"
+                        onClick={() => setTxFlow(<NewSpendingLimitFlow />)}
+                        sx={{ mt: 2, mb: 2 }}
+                        variant="contained"
+                        disabled={!isOk}
+                        size="small"
+                      >
+                        New spending limit
+                      </Button>
+                    </Track>
+                  )}
+                </CheckWallet>
+              ) : (
+                <Typography sx={{ mt: 2 }}>
+                  The spending limit module isn&apos;t deployed on this chain yet, so new spending limits can&apos;t be
+                  created here.
+                </Typography>
+              )}
 
               {!spendingLimits.length && !spendingLimitsLoading && <NoSpendingLimits />}
               {spendingLimits.length > 0 && (

--- a/apps/web/src/features/spending-limits/components/SpendingLimitsSettings/index.tsx
+++ b/apps/web/src/features/spending-limits/components/SpendingLimitsSettings/index.tsx
@@ -75,7 +75,7 @@ const SpendingLimitsSettings = () => {
                 </Typography>
               )}
 
-              {!spendingLimits.length && !spendingLimitsLoading && <NoSpendingLimits />}
+              {isSupported && !spendingLimits.length && !spendingLimitsLoading && <NoSpendingLimits />}
               {spendingLimits.length > 0 && (
                 <SpendingLimitsTable isLoading={spendingLimitsLoading} spendingLimits={spendingLimits} />
               )}

--- a/apps/web/src/features/spending-limits/hooks/__tests__/useIsSpendingLimitSupported.test.ts
+++ b/apps/web/src/features/spending-limits/hooks/__tests__/useIsSpendingLimitSupported.test.ts
@@ -3,6 +3,7 @@ import { faker } from '@faker-js/faker'
 import { getAllowanceModuleDeployment } from '@safe-global/safe-modules-deployments'
 import * as useSafeInfo from '@/hooks/useSafeInfo'
 import * as useChainId from '@/hooks/useChainId'
+import { addressExBuilder, extendedSafeInfoBuilder } from '@/tests/builders/safe'
 import useIsSpendingLimitSupported from '../useIsSpendingLimitSupported'
 
 // A chain that has the AllowanceModule registered in @safe-global/safe-modules-deployments
@@ -17,27 +18,27 @@ const FALLBACK_MODULE_ADDRESS = Object.values(
 
 const mockSafeInfo = ({
   chainId,
-  modules,
+  moduleAddresses = null,
   deployed = true,
 }: {
   chainId: string
-  modules: Array<{ value: string }> | null
+  moduleAddresses?: string[] | null
   deployed?: boolean
 }) => {
   jest.spyOn(useChainId, 'default').mockReturnValue(chainId)
-  jest.spyOn(useSafeInfo, 'default').mockReturnValue({
-    safe: {
-      address: { value: faker.finance.ethereumAddress() },
-      chainId,
-      modules,
-      deployed,
-      txHistoryTag: '0',
-    },
-    safeAddress: faker.finance.ethereumAddress(),
+
+  const modules = moduleAddresses?.map((value) => addressExBuilder().with({ value }).build()) ?? null
+  const safe = extendedSafeInfoBuilder().with({ chainId, modules, deployed }).build()
+
+  const safeInfo: ReturnType<typeof useSafeInfo.default> = {
+    safe,
+    safeAddress: safe.address.value,
     safeLoaded: true,
     safeLoading: false,
     safeError: undefined,
-  } as any)
+  }
+
+  jest.spyOn(useSafeInfo, 'default').mockReturnValue(safeInfo)
 }
 
 describe('useIsSpendingLimitSupported', () => {
@@ -46,7 +47,7 @@ describe('useIsSpendingLimitSupported', () => {
   })
 
   it('returns true on a chain with a registered deployment', () => {
-    mockSafeInfo({ chainId: SUPPORTED_CHAIN_ID, modules: null })
+    mockSafeInfo({ chainId: SUPPORTED_CHAIN_ID })
 
     const { result } = renderHook(() => useIsSpendingLimitSupported())
 
@@ -54,7 +55,7 @@ describe('useIsSpendingLimitSupported', () => {
   })
 
   it('returns false on a chain without a registered deployment and no enabled module', () => {
-    mockSafeInfo({ chainId: UNSUPPORTED_CHAIN_ID, modules: null })
+    mockSafeInfo({ chainId: UNSUPPORTED_CHAIN_ID })
 
     const { result } = renderHook(() => useIsSpendingLimitSupported())
 
@@ -62,7 +63,7 @@ describe('useIsSpendingLimitSupported', () => {
   })
 
   it('returns false when an unrelated module is enabled on an unsupported chain', () => {
-    mockSafeInfo({ chainId: UNSUPPORTED_CHAIN_ID, modules: [{ value: faker.finance.ethereumAddress() }] })
+    mockSafeInfo({ chainId: UNSUPPORTED_CHAIN_ID, moduleAddresses: [faker.finance.ethereumAddress()] })
 
     const { result } = renderHook(() => useIsSpendingLimitSupported())
 
@@ -70,7 +71,7 @@ describe('useIsSpendingLimitSupported', () => {
   })
 
   it('returns true when the AllowanceModule is already enabled on an unsupported chain', () => {
-    mockSafeInfo({ chainId: UNSUPPORTED_CHAIN_ID, modules: [{ value: FALLBACK_MODULE_ADDRESS }] })
+    mockSafeInfo({ chainId: UNSUPPORTED_CHAIN_ID, moduleAddresses: [FALLBACK_MODULE_ADDRESS] })
 
     const { result } = renderHook(() => useIsSpendingLimitSupported())
 

--- a/apps/web/src/features/spending-limits/hooks/__tests__/useIsSpendingLimitSupported.test.ts
+++ b/apps/web/src/features/spending-limits/hooks/__tests__/useIsSpendingLimitSupported.test.ts
@@ -1,0 +1,79 @@
+import { renderHook } from '@/tests/test-utils'
+import { faker } from '@faker-js/faker'
+import { getAllowanceModuleDeployment } from '@safe-global/safe-modules-deployments'
+import * as useSafeInfo from '@/hooks/useSafeInfo'
+import * as useChainId from '@/hooks/useChainId'
+import useIsSpendingLimitSupported from '../useIsSpendingLimitSupported'
+
+// A chain that has the AllowanceModule registered in @safe-global/safe-modules-deployments
+const SUPPORTED_CHAIN_ID = '11155111' // Sepolia
+// A chain that does NOT have the AllowanceModule registered yet
+const UNSUPPORTED_CHAIN_ID = '42161' // Arbitrum One
+
+// The CREATE2 address the deployment package falls back to for unregistered chains
+const FALLBACK_MODULE_ADDRESS = Object.values(
+  getAllowanceModuleDeployment({ version: '0.1.0' })!.networkAddresses,
+)[0] as string
+
+const mockSafeInfo = ({
+  chainId,
+  modules,
+  deployed = true,
+}: {
+  chainId: string
+  modules: Array<{ value: string }> | null
+  deployed?: boolean
+}) => {
+  jest.spyOn(useChainId, 'default').mockReturnValue(chainId)
+  jest.spyOn(useSafeInfo, 'default').mockReturnValue({
+    safe: {
+      address: { value: faker.finance.ethereumAddress() },
+      chainId,
+      modules,
+      deployed,
+      txHistoryTag: '0',
+    },
+    safeAddress: faker.finance.ethereumAddress(),
+    safeLoaded: true,
+    safeLoading: false,
+    safeError: undefined,
+  } as any)
+}
+
+describe('useIsSpendingLimitSupported', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns true on a chain with a registered deployment', () => {
+    mockSafeInfo({ chainId: SUPPORTED_CHAIN_ID, modules: null })
+
+    const { result } = renderHook(() => useIsSpendingLimitSupported())
+
+    expect(result.current).toBe(true)
+  })
+
+  it('returns false on a chain without a registered deployment and no enabled module', () => {
+    mockSafeInfo({ chainId: UNSUPPORTED_CHAIN_ID, modules: null })
+
+    const { result } = renderHook(() => useIsSpendingLimitSupported())
+
+    expect(result.current).toBe(false)
+  })
+
+  it('returns false when an unrelated module is enabled on an unsupported chain', () => {
+    mockSafeInfo({ chainId: UNSUPPORTED_CHAIN_ID, modules: [{ value: faker.finance.ethereumAddress() }] })
+
+    const { result } = renderHook(() => useIsSpendingLimitSupported())
+
+    expect(result.current).toBe(false)
+  })
+
+  it('returns true when the AllowanceModule is already enabled on an unsupported chain', () => {
+    mockSafeInfo({ chainId: UNSUPPORTED_CHAIN_ID, modules: [{ value: FALLBACK_MODULE_ADDRESS }] })
+
+    const { result } = renderHook(() => useIsSpendingLimitSupported())
+
+    expect(result.current).toBe(true)
+  })
+})

--- a/apps/web/src/features/spending-limits/hooks/useIsSpendingLimitSupported.ts
+++ b/apps/web/src/features/spending-limits/hooks/useIsSpendingLimitSupported.ts
@@ -1,0 +1,27 @@
+import useChainId from '@/hooks/useChainId'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import {
+  getDeployedSpendingLimitModuleAddress,
+  getLatestSpendingLimitAddress,
+} from '../services/spendingLimitDeployments'
+
+/**
+ * Whether a new spending limit can be created on the current chain.
+ *
+ * Returns true when the AllowanceModule is already enabled on the Safe (resolvable
+ * via the CREATE2 fallback), or when a deployment address is registered for the chain
+ * so the module can be enabled. Otherwise the module cannot be used here and the flow
+ * would otherwise stall — the config-service feature flag can be on for a chain the
+ * deployment package doesn't cover yet.
+ */
+const useIsSpendingLimitSupported = (): boolean => {
+  const chainId = useChainId()
+  const { safe } = useSafeInfo()
+
+  const alreadyEnabled = safe.deployed && !!getDeployedSpendingLimitModuleAddress(chainId, safe.modules)
+  const canEnable = !!getLatestSpendingLimitAddress(chainId)
+
+  return alreadyEnabled || canEnable
+}
+
+export default useIsSpendingLimitSupported


### PR DESCRIPTION
## What it solves

On networks where the `SPENDING_LIMIT` feature flag is enabled but the AllowanceModule contract isn't in `@safe-global/safe-modules-deployments` (e.g. Arbitrum), the spending-limit setup transaction hangs on an infinite loading spinner with no explanation.

Resolves: https://linear.app/safe-global/issue/WA-2955

## How this PR fixes it

The Review step builds the tx via `createNewSpendingLimitTx`, which silently `return`s `undefined` when no module address resolves for the chain. That resolves `setSafeTx(undefined)` without ever calling `setSafeTxError`, so `ReviewTransaction` renders its skeleton forever (`!safeTx && !safeTxError`).

Rather than surface an error on the Review step (that component assumes a valid built tx), the fix detects the unsupported chain up front via a new `useIsSpendingLimitSupported` hook — true when the module is already enabled on the Safe (CREATE2 fallback) **or** a deployment address is registered for the chain. The create step then shows an explanatory message with a "contact us" link, and the settings button is hidden on unsupported chains.

Note: the deeper cause is that the Config Service flag and the deployments package are independent sources of truth; this reconciles them client-side. The durable fix is to not enable the flag until the module is deployed.

## How to test it

1. Point the app at a Safe on a chain where `SPENDING_LIMIT` is on but the AllowanceModule isn't deployed (Arbitrum).
2. Go to Settings → Spending limits — the "New spending limit" button is replaced by an explanatory note.
3. On a supported chain (e.g. Sepolia/mainnet), confirm the form and flow still work normally.
4. On a Safe that already has the module enabled, confirm spending limits still work.

## Screenshots

N/A — replaces an infinite spinner with an inline message; screenshot can be added after review.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
