### PR TITLE
chore(deps): pin axios to 1.18.1 via resolution to dedupe transitive …

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "postinstall": "husky"
   },
   "resolutions": {
+    "axios": "1.18.1",
     "motion": "12.34.0",
     "@ledgerhq/context-module/ethers": "6.17.0",
     "@gnosis.pm/zodiac/ethers": "6.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22392,40 +22392,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.8.2":
-  version: 1.8.2
-  resolution: "axios@npm:1.8.2"
-  dependencies:
-    follow-redirects: "npm:^1.15.6"
-    form-data: "npm:^4.0.0"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10/d4328758128d0602cc809a8e7627622cb7839b379eae5e4d6b9d603dd4d5fb89159985630243ec107cf5c675cd8825dba737a319dff9499f3b7688d9a69ec9ed
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.12.2, axios@npm:^1.13.5":
-  version: 1.13.6
-  resolution: "axios@npm:1.13.6"
-  dependencies:
-    follow-redirects: "npm:^1.15.11"
-    form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10/a7ed83c2af3ef21d64609df0f85e76893a915a864c5934df69241001d0578082d6521a0c730bf37518ee458821b5695957cb10db9fc705f2a8996c8686ea7a89
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.13.2, axios@npm:^1.6.1":
-  version: 1.13.2
-  resolution: "axios@npm:1.13.2"
-  dependencies:
-    follow-redirects: "npm:^1.15.6"
-    form-data: "npm:^4.0.4"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10/ae4e06dcd18289f2fd18179256d550d27f9a53ecb2f9c59f2ccc4efd1d7151839ba8c3e0fb533dac793e4a59a576ca8689a19244dce5c396680837674a47a867
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.18.1":
+"axios@npm:1.18.1":
   version: 1.18.1
   resolution: "axios@npm:1.18.1"
   dependencies:
@@ -22434,17 +22401,6 @@ __metadata:
     https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
   checksum: 10/c4cdced3ee0a9bf7dcae189fbc74a124aa079d4f04dbd995e602d39c1419476e8d021f87ee39ac8d8398e5a55e6d0b986238b3645f0d9177ac80de87c2a73f18
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.6.8":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
-  dependencies:
-    follow-redirects: "npm:^1.15.11"
-    form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^2.1.0"
-  checksum: 10/d39a2c0ebc7ff4739401b282e726cc2673377949d6c46d60eb619458f8d7a2f7eadbcada7097f4dbc7d5c59abb4d3bf6fac33d474412bc3415d3f5aa7ed45530
   languageName: node
   linkType: hard
 
@@ -29368,7 +29324,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.11, follow-redirects@npm:^1.15.6, follow-redirects@npm:^1.16.0":
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.16.0":
   version: 1.16.0
   resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:


### PR DESCRIPTION
## What it solves

The lockfile was resolving five separate axios copies (`1.8.2`, `1.13.2`, `1.13.6`, `1.15.0`, `1.18.1`) pulled in by different transitive dependencies. This consolidates them onto a single up-to-date 1.18.1 and clears the outstanding Dependabot dependency alerts.

Resolves: N/A (no Linear issue)

## How this PR fixes it

Adds a single global `axios: "1.18.1"` entry to the root `package.json` `resolutions` block — the same mechanism the repo already uses for `viem`, `webpack`, and `isows`.

Notes for reviewers:
- Our only direct axios dependency (`apps/tx-builder`, `^1.18.1`) was already on 1.18.1; every other copy was transitive.
- Five of the six consumers declare caret ranges (`^1.6.1`, `^1.6.8`, `^1.12.2`, `^1.13.2`, `^1.13.5`), so 1.18.1 is already within their own declared compatibility. The only exact-pin overridden is `@ledgerhq/*` (`1.8.2`); Ledger uses axios for a plain authenticated GET and dropped axios entirely in their v2 line, so the override is low-risk.
- 1.19.0 (latest) is intentionally **not** used: it's within the repo's 7-day supply-chain age gate (`.yarnrc.yml`) and is quarantined. Can revisit once it ages out.

## How to test it

1. `yarn install` — confirm the lockfile resolves a single `axios@npm:1.18.1` (`grep '^"axios@' yarn.lock` returns one entry).
2. `yarn verify:web` and mobile `type-check` pass.
3. On a deploy preview, smoke-test the network-facing integrations that used the overridden copies: Ledger connect/sign, Trezor connect, and a CoW swap/bridge quote.

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
