### PR TITLE
chore: update the wording for the slow network status

### DIFF
--- a/apps/web/src/features/spaces/components/Sidebar/SidebarIndexingStatus/SidebarIndexingStatus.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarIndexingStatus/SidebarIndexingStatus.tsx
@@ -14,7 +14,7 @@ type Status = 'synced' | 'slow' | 'outOfSync'
 
 const STATUS_LABEL: Record<Status, string> = {
   synced: 'Synced',
-  slow: 'Slow network',
+  slow: 'Network delays',
   outOfSync: 'Out of sync',
 }
 


### PR DESCRIPTION
## What it solves

Resolves: [WA-1562](https://linear.app/safe-global/issue/WA-1562/change-the-language-around-slow-network-indicator)
Sidebar indexing-status label reads "Slow network", which was requested to be reworded.

## How this PR fixes it

Renames the `slow` status label in `SidebarIndexingStatus` from "Slow network" to "Network delays" (sentence case per repo UI-copy convention).

## How to test it

Trigger a slow blockchain sync (or mock `getStatus` → `slow`) and hover the sidebar indexing-status icon — the accessible label reads "Indexing status: Network delays".

## Affected flows

- Sidebar → blockchain indexing status indicator (tooltip / aria-label copy only)

## Blast radius

- Single module-private `STATUS_LABEL` map in `SidebarIndexingStatus.tsx`. No shared hooks, selectors, endpoints, or status keys changed — only the display string. No mobile impact.

## Risks / not checked

- Copy-only change; no functional logic touched.
- Did not run a live slow-sync scenario; verified via code path only.

## Visual summary

_UI copy change only._ Sidebar status label: `Slow network` → `Network delays`.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯


---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
