### PR TITLE
feat: add environment-aware robots.txt generation

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -23,5 +23,6 @@ storybook-static
 # Generated build-time data
 src/config/__generated__/
 public/version.json
+public/robots.txt
 
 docs/superpowers/

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,7 @@
     "dev": "cross-env USE_RSPACK=1 next dev",
     "dev:full": "cross-env USE_RSPACK=0 ENABLE_PWA=1 ENABLE_EXPERIMENTAL_OPTIMIZATIONS=1 next dev",
     "start": "next dev",
-    "build": "node scripts/generate-version.mjs && next build",
+    "build": "node scripts/generate-version.mjs && node scripts/generate-robots.mjs && next build",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "type-check": "tsc --noEmit",

--- a/apps/web/scripts/generate-robots.mjs
+++ b/apps/web/scripts/generate-robots.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const webRoot = resolve(here, '..')
+
+// Default-deny: only production allows crawlers; staging/previews/misconfig disallow.
+const isProduction = process.env.NEXT_PUBLIC_IS_PRODUCTION === 'true'
+
+const robots = isProduction ? 'User-agent: *\nAllow: /\n' : 'User-agent: *\nDisallow: /\n'
+
+const outPath = resolve(webRoot, 'public', 'robots.txt')
+writeFileSync(outPath, robots)
+console.log(`Wrote ${outPath} (${isProduction ? 'production: allow' : 'non-production: disallow'})`)


### PR DESCRIPTION
## What it solves

Resolves: [WA-1603](https://linear.app/safe-global/issue/WA-1603/add-environment-aware-robotstxt-to-block-staging-indexing)

Staging domain being indexable/crawlable by search engines. Staging should be blocked from indexing while production stays crawlable.

## How this PR fixes it

The web app is a static export (`output: 'export'`) with no runtime server, so a per-request controller isn't possible — but staging and production are separate builds with different env vars. A build-time script (`scripts/generate-robots.mjs`) generates `public/robots.txt` from `NEXT_PUBLIC_IS_PRODUCTION`: production emits `Allow: /`, everything else (staging, previews, misconfig) emits `Disallow: /` (default-deny). Wired into the `build` script alongside `generate-version.mjs`; the generated file is gitignored like `public/version.json`.

## How to test it

- `NEXT_PUBLIC_IS_PRODUCTION=true node scripts/generate-robots.mjs` → `public/robots.txt` contains `Allow: /`
- `node scripts/generate-robots.mjs` (unset) → `public/robots.txt` contains `Disallow: /`

## Affected flows

- Search-engine crawling of the staging vs production web deployments.

## Blast radius

- Build pipeline only: adds one step to the web `build` script. No app/runtime code, no shared hooks/components/selectors/slices/endpoints, no mobile impact.
- New generated artifact `public/robots.txt` (gitignored).

## Risks / not checked

- Did not verify the actual deployed staging/prod env-var values — correctness depends on `NEXT_PUBLIC_IS_PRODUCTION` being set correctly per environment.

## Visual summary

```mermaid
flowchart LR
  A[yarn build] --> B[generate-robots.mjs]
  B --> C{NEXT_PUBLIC_IS_PRODUCTION === 'true'?}
  C -->|Yes| D["robots.txt: Allow: /"]
  C -->|No| E["robots.txt: Disallow: /"]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
