### PR TITLE
chore(deps): bump transitive brace-expansion 5.x to 5.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "resolutions": {
     "axios": "1.18.1",
     "protobufjs": "7.6.5",
+    "brace-expansion@^5.0.2": "^5.0.8",
     "motion": "12.34.0",
     "@ledgerhq/context-module/ethers": "6.17.0",
     "@gnosis.pm/zodiac/ethers": "6.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23113,12 +23113,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.2":
-  version: 5.0.6
-  resolution: "brace-expansion@npm:5.0.6"
+"brace-expansion@npm:^5.0.8":
+  version: 5.0.8
+  resolution: "brace-expansion@npm:5.0.8"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10/a7acf120fefa79e9d7c9c92898114f57c07596a3920197f3c5917e6a628b04220a5f7f9618c30bdd973a6576a32113b99f9c3f1c8245ccc399dd2a9a718d81d8
+  checksum: 10/75d2d2ebc8f5f65156d16706216d23e48f499a1164e4b045e0ca4045d3ce6b16ced11ea2e4c76e3670b6c38454123213f43d23127df8fc6840980aea9a35e061
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What it solves

Clears the Dependabot alerts on the **brace-expansion 5.x** transitive copy (pulled in via `minimatch` 10.x). Two published DoS advisories affect the installed `5.0.6`:

- exponential-time expansion of consecutive `{}` groups — fixed in `5.0.7`
- unbounded expansion length causing OOM — fixed in `5.0.8`

`brace-expansion` is never a direct dependency here; it is a pure leaf pulled **only** through `minimatch` (glob matching in build/test/lint tooling), so there is no runtime app surface.

## How this PR fixes it

Adds a single scoped `resolutions` entry forcing the `^5.0.2` line to `^5.0.8`. No source changes; the lockfile diff is exactly one resolution (`5.0.6 → 5.0.8`, `balanced-match` unchanged).

```json
"brace-expansion@^5.0.2": "^5.0.8",
```

The `1.x` (`1.1.16`) and `2.x` (`2.0.1`) copies still need `1.1.17` / `2.1.3`. Those fixes are <7 days old and currently quarantined by our `npmMinimalAgeGate`, so they'll land in a follow-up bump once they clear the gate (Aug 4–5).

## How to test it

- `yarn install` resolves cleanly (no quarantine).
- `grep -A1 '"brace-expansion@npm:\^5' yarn.lock` shows `5.0.8`.
- `1.1.16` and `2.0.1` remain unchanged (intentional — follow-up).

## Visual summary

```mermaid
flowchart LR
  M10[minimatch 10.x] -->|^5.0.2| BE5["brace-expansion 5.0.6 (vulnerable)"]
  M10 -->|resolution ^5.0.8| BE58["brace-expansion 5.0.8 (patched)"]
  M3[minimatch 3.x] -->|^1.1.7| BE1["brace-expansion 1.1.16 (follow-up)"]
  M5[minimatch 5.x / 9.x] -->|^2.0.1| BE2["brace-expansion 2.0.1 (follow-up)"]
```

## Checklist

- [x] I've tested it and it works as expected
- [x] The change is scoped and minimal (lockfile + one resolution line)
- [x] No source code changes; transitive-only dependency
