### PR TITLE
chore(deps): dedupe transitive postcss to patched 8.5.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "resolutions": {
     "axios": "1.18.1",
     "protobufjs": "7.6.5",
-    "postcss": "^8.5.18",
+    "postcss": "8.5.23",
     "motion": "12.34.0",
     "@ledgerhq/context-module/ethers": "6.17.0",
     "@gnosis.pm/zodiac/ethers": "6.17.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "resolutions": {
     "axios": "1.18.1",
     "protobufjs": "7.6.5",
+    "postcss": "^8.5.18",
     "motion": "12.34.0",
     "@ledgerhq/context-module/ethers": "6.17.0",
     "@gnosis.pm/zodiac/ethers": "6.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36665,7 +36665,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.12":
+"nanoid@npm:^3.3.16":
   version: 3.3.16
   resolution: "nanoid@npm:3.3.16"
   bin:
@@ -38932,14 +38932,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.18":
-  version: 8.5.18
-  resolution: "postcss@npm:8.5.18"
+"postcss@npm:8.5.23":
+  version: 8.5.23
+  resolution: "postcss@npm:8.5.23"
   dependencies:
-    nanoid: "npm:^3.3.12"
+    nanoid: "npm:^3.3.16"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10/b43f2d2493d82dc43fa50d21cf184bf3b66229e7f53fa1dedc7b8a7c4cecd7ac8ee18fad099f47570da7f78bbf46997a4c6e6c87d8d8ece683dc1f32cda6db3b
+  checksum: 10/8387f421216696bf62a13e5a270e9fefdafc81e196903c0f8d7653f8bab315367cc2261b3c22cf197e492cb075f31bdfc07fd9c3be1cb165ff3cabe14c5a039a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -36647,7 +36647,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.1, nanoid@npm:^3.3.6, nanoid@npm:^3.3.7":
+"nanoid@npm:^3.3.1":
   version: 3.3.8
   resolution: "nanoid@npm:3.3.8"
   bin:
@@ -36665,7 +36665,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.12, nanoid@npm:^3.3.16":
+"nanoid@npm:^3.3.12":
   version: 3.3.16
   resolution: "nanoid@npm:3.3.16"
   bin:
@@ -38932,39 +38932,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.4.31":
-  version: 8.4.31
-  resolution: "postcss@npm:8.4.31"
-  dependencies:
-    nanoid: "npm:^3.3.6"
-    picocolors: "npm:^1.0.0"
-    source-map-js: "npm:^1.0.2"
-  checksum: 10/1a6653e72105907377f9d4f2cd341d8d90e3fde823a5ddea1e2237aaa56933ea07853f0f2758c28892a1d70c53bbaca200eb8b80f8ed55f13093003dbec5afa0
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.0.0, postcss@npm:^8.2.14, postcss@npm:^8.4.21, postcss@npm:^8.4.33, postcss@npm:^8.4.38, postcss@npm:~8.4.32":
-  version: 8.4.49
-  resolution: "postcss@npm:8.4.49"
-  dependencies:
-    nanoid: "npm:^3.3.7"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10/28fe1005b1339870e0a5006375ba5ac1213fd69800f79e7db09c398e074421ba6e162898e94f64942fed554037fd292db3811d87835d25ab5ef7f3c9daacb6ca
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.15":
-  version: 8.5.25
-  resolution: "postcss@npm:8.5.25"
-  dependencies:
-    nanoid: "npm:^3.3.16"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10/68aaeb314a1b2407e11e926acc0462b01b3e911d3d9e755d06adc5b2ececdefe8432dc3c3c93eacc07138952e17997d4674529061b8e3a338a7ac4c1accfdf98
-  languageName: node
-  linkType: hard
-
 "postcss@npm:^8.5.18":
   version: 8.5.18
   resolution: "postcss@npm:8.5.18"
@@ -38973,17 +38940,6 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10/b43f2d2493d82dc43fa50d21cf184bf3b66229e7f53fa1dedc7b8a7c4cecd7ac8ee18fad099f47570da7f78bbf46997a4c6e6c87d8d8ece683dc1f32cda6db3b
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.6":
-  version: 8.5.6
-  resolution: "postcss@npm:8.5.6"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10/9e4fbe97574091e9736d0e82a591e29aa100a0bf60276a926308f8c57249698935f35c5d2f4e80de778d0cbb8dcffab4f383d85fd50c5649aca421c3df729b86
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What it solves

Clears the open Dependabot alerts on the transitive **postcss** dependency by moving every copy onto a patched, hardened `8.5.x` version.

`postcss` is never a direct dependency here — it's pulled only through build/dev tooling (Next, Storybook, css-loader, `@expo/metro-config`, `resolve-url-loader`, `typescript-plugin-css-modules`, shadcn) and Vite. No shipped-runtime surface.

## How this PR fixes it

Adds a single `resolutions` entry:

```json
"postcss": "8.5.23",
```

This collapses the previously-installed copies (`8.4.31`, `8.4.49`, `8.5.6`, `8.5.18`, `8.5.25`) into one `8.5.23`. Lockfile-only change; no source edits.

`8.5.23` is chosen deliberately:
- clears both open alerts (patched line),
- keeps the "do not load source map without `opts.from`" hardening added in 8.5.23 (so the Vite copies that were on 8.5.25 are **not** regressed — the pin sits above that hardening, not below it),
- is the newest version past our 7-day supply-chain age gate (8.5.24/8.5.25 are still quarantined).

postcss is backward-compatible within major 8, so all consumers keep working.

## How to test it

- `yarn install --immutable` passes (lockfile consistent).
- `yarn why postcss` shows a single resolved copy at `8.5.23`.
- CI build (web + mobile) exercises the actual CSS pipeline.

## Visual summary

```mermaid
flowchart LR
  subgraph Before
    N1[next] --> A[postcss 8.4.31]
    T1[css-loader / storybook / metro / shadcn] --> B[postcss 8.4.49 / 8.5.6]
    V1[vite] --> C[postcss 8.5.25]
  end
  subgraph After
    N2[next] --> P[postcss 8.5.23]
    T2[css-loader / storybook / metro / shadcn] --> P
    V2[vite] --> P
  end
```

## Checklist

- [x] I've tested it and it works as expected
- [x] Scoped and minimal (one resolution line + lockfile dedupe)
- [x] No source code changes; transitive-only dependency
