### PR TITLE
fix: render global search sections as components to keep hook order stable

### DIFF
--- a/apps/web/src/features/global-search/components/SearchSection/SearchSection.tsx
+++ b/apps/web/src/features/global-search/components/SearchSection/SearchSection.tsx
@@ -16,7 +16,7 @@ const SectionEntry = ({ item, query }: { item: SectionItem; query: string }) => 
 
   if (!isActive) return null
 
-  return <>{item.renderItem({ query, label: item.label })}</>
+  return <item.Component query={query} label={item.label} />
 }
 
 const SearchSectionContent = ({ query }: SearchSectionProps) => {

--- a/apps/web/src/features/global-search/components/SearchSection/__tests__/SearchSection.test.tsx
+++ b/apps/web/src/features/global-search/components/SearchSection/__tests__/SearchSection.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@/tests/test-utils'
+import SearchSection from '../SearchSection'
+
+// `useIsQualifiedSafe` resolves asynchronously in the app: it is false until the space
+// and space-safes queries settle, then flips to true when the Safe belongs to a space.
+let mockIsQualifiedSafe = false
+
+jest.mock('@/hooks/wallets/useWallet')
+
+jest.mock('@/features/swap', () => ({
+  useIsSwapFeatureEnabled: () => true,
+}))
+
+jest.mock('@/features/spaces', () => ({
+  useIsQualifiedSafe: () => mockIsQualifiedSafe,
+  useCurrentSpaceId: () => null,
+  useSpaceSafes: () => ({
+    allSafes: [
+      {
+        chainId: '1',
+        address: '0x1111111111111111111111111111111111111111',
+        isReadOnly: false,
+        isPinned: false,
+        lastVisited: 0,
+        name: 'Space safe',
+      },
+    ],
+    isLoading: false,
+  }),
+  SafeCardReadOnly: () => null,
+}))
+
+jest.mock('@/hooks/safes', () => ({
+  useAllSafesGrouped: () => ({
+    allMultiChainSafes: [],
+    allSingleSafes: [
+      {
+        chainId: '1',
+        address: '0x2222222222222222222222222222222222222222',
+        isReadOnly: false,
+        isPinned: true,
+        lastVisited: 0,
+        name: 'Pinned safe',
+      },
+    ],
+  }),
+  isMultiChainSafeItem: () => false,
+  flattenSafeItems: (items: unknown[]) => items,
+}))
+
+describe('SearchSection', () => {
+  beforeEach(() => {
+    mockIsQualifiedSafe = false
+  })
+
+  it('renders the always-active section', () => {
+    render(<SearchSection query="" />)
+
+    expect(screen.getByText('Navigate to')).toBeInTheDocument()
+  })
+
+  it('swaps sections when the Safe is resolved as part of a space', () => {
+    const { rerender } = render(<SearchSection query="" />)
+
+    expect(screen.getByText('My accounts')).toBeInTheDocument()
+    expect(screen.queryByText('Safe accounts')).not.toBeInTheDocument()
+
+    mockIsQualifiedSafe = true
+    rerender(<SearchSection query="" />)
+
+    expect(screen.getByText('Safe accounts')).toBeInTheDocument()
+    expect(screen.queryByText('My accounts')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/global-search/components/SearchSection/sectionItems.ts
+++ b/apps/web/src/features/global-search/components/SearchSection/sectionItems.ts
@@ -1,3 +1,4 @@
+import type { ComponentType } from 'react'
 import { useIsSpaceRoute } from '@/hooks/useIsSpaceRoute'
 import { AccountsSection } from './sections/Accounts'
 import { NavigateToSection } from './sections/NavigateTo'
@@ -12,7 +13,7 @@ export interface SectionItemProps {
 export interface SectionItem {
   label: string
   useActivate: () => boolean
-  renderItem: (props: SectionItemProps) => React.ReactNode
+  Component: ComponentType<SectionItemProps>
 }
 
 const useAlwaysActive = () => true
@@ -33,16 +34,16 @@ export const sectionItems: SectionItem[] = [
   {
     label: 'Navigate to',
     useActivate: useAlwaysActive,
-    renderItem: NavigateToSection,
+    Component: NavigateToSection,
   },
   {
     label: 'Safe accounts',
     useActivate: useIsInSpace,
-    renderItem: AccountsSection,
+    Component: AccountsSection,
   },
   {
     label: 'My accounts',
     useActivate: useNotInSpace,
-    renderItem: TrustedSafesSection,
+    Component: TrustedSafesSection,
   },
 ]


### PR DESCRIPTION
## What it solves

Opening the global search crashed with `Rendered more hooks than during the previous render.` (surfacing at `useCurrentSpaceId.ts:14`) whenever the current Safe belongs to a space. Safes outside a space were unaffected.

## How this PR fixes it

**Root cause:** `SectionEntry` called each section as a plain function — `item.renderItem({ query, label })` — instead of rendering it as an element. A called component's hooks run in the *caller's* fiber, so every section's hooks lived inside `SectionEntry`, behind its `if (!isActive) return null` guard.

`useIsQualifiedSafe()` is async (it waits on `useSpacesGetOneV1Query` / `useSpaceSafesGetV1Query`). For a Safe in a space it resolves `false → true`, which flips `useActivate()` for two entries:

- **Safe accounts** (`useIsInSpace`): `false → true` → `AccountsSection`'s hooks start running → *more hooks* 💥
- **My accounts** (`useNotInSpace`): `true → false` → `TrustedSafesSection`'s hooks stop running → *fewer hooks*

The reported line is `useCurrentSpaceId.ts:14` because `AccountsSection` → `useSpaceSafes()` → `useCurrentSpaceId()` and `useAppSelector(lastUsedSpace)` is its first hook that occupies a slot (`useRouter` above it is `useContext`, which doesn't allocate one).

Outside a space `useIsQualifiedSafe()` stays `false` forever, nothing flips, and the hook count never changes — hence "works on the safe level".

**Fix:** render the section as an element (`<item.Component … />`) so it gets its own fiber. `SectionItem.renderItem` is renamed to `Component: ComponentType<SectionItemProps>` to make the contract explicit and prevent the same mistake.

## How to test it

1. Sign in with SIWE and open a Safe that is part of a space.
2. Click the global search icon in the topbar.
3. The modal opens with the **Safe accounts** section and no runtime error.
4. Open the global search on a Safe that is *not* in a space — the **My accounts** section still shows.

## Affected flows

- Global search opened from the topbar on a Safe route where the Safe belongs to a space (the crash).
- Global search opened from the topbar on a Safe route where the Safe is not in a space (previously working; must stay working).
- Global search on space routes, where `GlobalSearchInput` is rendered inline.
- Section activation/deactivation as `useIsQualifiedSafe` resolves, plus `AccountsSection`'s loading → loaded skeleton transition.

## Blast radius

- `SearchSection.tsx` / `sectionItems.ts` — both local to `features/global-search`; `SectionItem` has no consumers outside this folder (verified by grep on `renderItem` / `sectionItems`).
- The three section components (`NavigateToSection`, `AccountsSection`, `TrustedSafesSection`) each get their own fiber now. Their hook state — including the `useId` inside `useGlobalSearchFilter` used as the `SectionVisibilityContext` key — is no longer shared with `SectionEntry`. Visibility reporting and the `No results found` fallback still behave correctly (covered by the existing `useGlobalSearchFilter` and `GlobalSearchModal` tests).
- No changes to shared hooks, selectors, slices, RTK Query endpoints, feature flags, routes, or persisted state. No mobile/shared-package impact.

## Risks / not checked

- No live-browser reproduction with a real SIWE session and a space (needs auth + backend). The async `false → true` flip is modelled in the new unit test, which fails with the exact production error before the fix.
- Did not audit other features for the same call-a-component-as-a-function pattern beyond this folder.
- `yarn workspace @safe-global/web type-check` reports 3 pre-existing errors in `features/swap/components/SwapWidget/index.tsx` from the CoW widget upgrade (932bd5d64). Unrelated to this PR and untouched here; no other type errors.
- Not tested on mobile (web-only feature).

## Visual summary

```mermaid
flowchart TB
  subgraph Before["Before — section hooks live in SectionEntry's fiber"]
    A1["SectionEntry fiber"] --> B1["useActivate()"]
    B1 --> C1{"isActive?"}
    C1 -->|"false — first render"| D1["return null<br/>hook count = N"]
    C1 -->|"true — after queries settle"| E1["renderItem() called as a function<br/>AccountsSection hooks run here<br/>hook count = N + M"]
    E1 --> F1["React: Rendered more hooks<br/>than during the previous render"]
  end

  subgraph After["After — each section owns its fiber"]
    A2["SectionEntry fiber"] --> B2["useActivate()"]
    B2 --> C2{"isActive?"}
    C2 -->|false| D2["return null<br/>hook count = N"]
    C2 -->|true| E2["&lt;item.Component /&gt;"]
    E2 --> G2["AccountsSection fiber<br/>its own hook list"]
    D2 --> H2["SectionEntry hook count<br/>is always N"]
    E2 --> H2
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics change
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
