### PR TITLE
feat(safenet): read a check's lifecycle from Gnosis Chain

### DIFF
--- a/packages/utils/src/features/safenet-checks/constants.ts
+++ b/packages/utils/src/features/safenet-checks/constants.ts
@@ -1,0 +1,49 @@
+/**
+ * Configuration for the Safenet read layer. Shared web+mobile, so every value
+ * reads the `NEXT_PUBLIC_*` variable first and falls back to `EXPO_PUBLIC_*`.
+ *
+ * These MUST be referenced statically (`process.env.NEXT_PUBLIC_…`). The web
+ * (webpack/Next) and mobile (Expo/Babel) bundlers only inline literal
+ * `process.env.<PREFIX>_*` reads — a dynamic `process.env[…]` lookup is left
+ * untouched and resolves to `undefined` in the browser, silently leaving the
+ * reader with no RPC URLs.
+ */
+
+const parseCsv = (value: string | undefined): string[] =>
+  value
+    ? value
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+    : []
+
+/**
+ * The Safenet chain id — feeds BOTH the reader's provider network AND the
+ * EIP-712 domain used to derive request ids. A wrong value silently derives
+ * wrong request ids (checks stuck at SUBMITTED), so the reader asserts it
+ * against `eth_chainId` in development.
+ */
+export const SAFENET_CHAIN_ID =
+  process.env.NEXT_PUBLIC_SAFENET_CHAIN_ID || process.env.EXPO_PUBLIC_SAFENET_CHAIN_ID || '100'
+
+/** Pinned Gnosis RPC endpoints for the read layer (csv). Rotated on failure. */
+export const SAFENET_RPC_URLS = parseCsv(
+  process.env.NEXT_PUBLIC_SAFENET_RPC_URLS || process.env.EXPO_PUBLIC_SAFENET_RPC_URLS || 'https://rpc.gnosischain.com',
+)
+
+/** Safenet Consensus contract. Default: Gnosis beta deployment. */
+export const SAFENET_CONSENSUS_ADDRESS =
+  process.env.NEXT_PUBLIC_SAFENET_CONSENSUS_ADDRESS ||
+  process.env.EXPO_PUBLIC_SAFENET_CONSENSUS_ADDRESS ||
+  '0x223624cBF099e5a8f8cD5aF22aFa424a1d1acEE9'
+
+// --- Lookback tuning ------------------------------------------------------
+
+/** Hard cap on how far back the reader scans for a check's first event. */
+export const MAX_LOOKBACK_BLOCKS = 30_000
+
+/** Max block span per `getLogs` call (Gnosis public RPC ceiling). */
+export const GETLOGS_CHUNK_BLOCKS = 10_000
+
+/** Max JSON-RPC calls batched into a single HTTP request by the provider. */
+export const PROVIDER_BATCH_MAX_COUNT = 3

--- a/packages/utils/src/features/safenet-checks/services/__tests__/rpcEndpoint.ts
+++ b/packages/utils/src/features/safenet-checks/services/__tests__/rpcEndpoint.ts
@@ -1,0 +1,111 @@
+import { http, HttpResponse } from 'msw'
+import type { RawLog } from '../../utils/decodeLogs'
+
+/**
+ * Fake JSON-RPC endpoint for reader tests (msw). Answers real JSON-RPC shapes —
+ * single and batched bodies — so the reader is exercised through an actual
+ * ethers `JsonRpcProvider`, not a mocked one.
+ *
+ * Not a test file: `testMatch` only picks `*.test.ts`.
+ */
+
+export type GetLogsFilter = { address?: string; topics: unknown[]; fromBlock: number; toBlock: number }
+
+export type RpcConfig = {
+  url: string
+  chainId?: string
+  head?: number
+  headTimestamp?: number
+  logs?: RawLog[]
+  failEverything?: boolean
+}
+
+const hexToNum = (value: string): number => Number(BigInt(value))
+
+const filterLogs = (logs: RawLog[], filter: GetLogsFilter): RawLog[] => {
+  const topic0s = (Array.isArray(filter.topics[0]) ? filter.topics[0] : [filter.topics[0]]) as string[]
+  const topic1s =
+    filter.topics[1] == null
+      ? null
+      : ((Array.isArray(filter.topics[1]) ? filter.topics[1] : [filter.topics[1]]) as string[])
+  return logs.filter((log) => {
+    if (filter.address && (log.address ?? '').toLowerCase() !== filter.address.toLowerCase()) return false
+    if (!topic0s.includes(log.topics[0])) return false
+    if (topic1s && !topic1s.includes(log.topics[1])) return false
+    return log.blockNumber >= filter.fromBlock && log.blockNumber <= filter.toBlock
+  })
+}
+
+/** One JSON-RPC endpoint recorder + responder. Handles single and batched bodies. */
+export const makeEndpoint = (config: RpcConfig) => {
+  const getLogsCalls: GetLogsFilter[] = []
+  const methods: string[] = []
+
+  const respondOne = (req: { id: number; method: string; params: unknown[] }) => {
+    methods.push(req.method)
+    if (config.failEverything) {
+      return { jsonrpc: '2.0', id: req.id, error: { code: -32000, message: 'endpoint down' } }
+    }
+    const ok = (result: unknown) => ({ jsonrpc: '2.0', id: req.id, result })
+    const err = (message: string) => ({ jsonrpc: '2.0', id: req.id, error: { code: 3, message } })
+
+    switch (req.method) {
+      case 'eth_chainId':
+        return ok('0x' + Number(config.chainId ?? '100').toString(16))
+      // The reader only ever asks for 'latest' in this slice.
+      case 'eth_getBlockByNumber': {
+        const number = config.head ?? 0
+        return ok({
+          number: '0x' + number.toString(16),
+          timestamp: '0x' + (config.headTimestamp ?? 1_000_000).toString(16),
+          hash: '0x' + '22'.repeat(32),
+          parentHash: '0x' + '33'.repeat(32),
+          nonce: '0x0000000000000000',
+          difficulty: '0x0',
+          gasLimit: '0x1c9c380',
+          gasUsed: '0x0',
+          miner: '0x' + '00'.repeat(20),
+          extraData: '0x',
+          baseFeePerGas: '0x7',
+          transactions: [],
+        })
+      }
+      case 'eth_getLogs': {
+        const raw = req.params[0] as { address?: string; topics: unknown[]; fromBlock: string; toBlock: string }
+        const filter: GetLogsFilter = {
+          address: raw.address,
+          topics: raw.topics,
+          fromBlock: hexToNum(raw.fromBlock),
+          toBlock: hexToNum(raw.toBlock),
+        }
+        getLogsCalls.push(filter)
+        // Onto the wire shape ethers parses back into `Log`s.
+        return ok(
+          filterLogs(config.logs ?? [], filter).map((log) => ({
+            address: log.address ?? '0x' + 'aa'.repeat(20),
+            topics: log.topics,
+            data: log.data,
+            blockNumber: '0x' + log.blockNumber.toString(16),
+            transactionHash: log.transactionHash,
+            transactionIndex: '0x0',
+            blockHash: '0x' + '11'.repeat(32),
+            logIndex: '0x' + log.logIndex.toString(16),
+            removed: false,
+          })),
+        )
+      }
+      default:
+        return err(`unhandled ${req.method}`)
+    }
+  }
+
+  const handler = http.post(config.url, async ({ request }) => {
+    const body = (await request.json()) as
+      | { id: number; method: string; params: unknown[] }
+      | Array<{ id: number; method: string; params: unknown[] }>
+    const response = Array.isArray(body) ? body.map(respondOne) : respondOne(body)
+    return HttpResponse.json(response)
+  })
+
+  return { handler, getLogsCalls, methods }
+}

--- a/packages/utils/src/features/safenet-checks/services/__tests__/safenetReader.test.ts
+++ b/packages/utils/src/features/safenet-checks/services/__tests__/safenetReader.test.ts
@@ -1,0 +1,189 @@
+import { setupServer, type SetupServerApi } from 'msw/node'
+import { SafenetReader, type SafenetReaderConfig } from '../safenetReader'
+import {
+  resetLogCounter,
+  buildOracleProposedLog,
+  buildOracleAttestedLog,
+  buildPlainProposedLog,
+  buildPlainAttestedLog,
+} from '../../builders/rawLogs'
+import type { RawLog } from '../../utils/decodeLogs'
+import { CheckEventType, type Hex } from '../../types'
+import { makeEndpoint } from './rpcEndpoint'
+
+// Mirrors the fixed addresses the raw-log builders encode (see builders/rawLogs.ts).
+const CONSENSUS = '0x223624cBF099e5a8f8cD5aF22aFa424a1d1acEE9'
+const ORACLE = '0x00000000000000000000000000000000000000AA'
+const CHAIN_ID = '100'
+
+const makeReader = (over: Partial<SafenetReaderConfig> = {}, url = 'http://rpc.test/1') =>
+  new SafenetReader({
+    rpcUrls: [url],
+    chainId: CHAIN_ID,
+    consensus: CONSENSUS,
+    ...over,
+  })
+
+/**
+ * The plain (non-oracle) pair — the only lifecycle live beta emits. Built with
+ * OUT-OF-ORDER metas so the reader's (blockNumber, logIndex) sort has teeth:
+ * the harness replays logs in insertion order.
+ */
+const plainPairFor = (safeTxHash: Hex): RawLog[] => {
+  resetLogCounter()
+  return [
+    buildPlainAttestedLog({ safeTxHash, epoch: 7n }, { blockNumber: 200, logIndex: 0 }),
+    buildPlainProposedLog({ safeTxHash, epoch: 7n }, { blockNumber: 100, logIndex: 5 }),
+  ]
+}
+
+const SAFE_TX_HASH = ('0x' + 'ab'.repeat(32)) as Hex
+
+let server: SetupServerApi
+afterEach(() => server?.close())
+
+describe('SafenetReader.fetchCheckState', () => {
+  it('bootstraps from the chain head and returns the sorted, decoded plain pair', async () => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs: plainPairFor(SAFE_TX_HASH) })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader().fetchCheckState(SAFE_TX_HASH)
+
+    expect(endpoint.methods).toContain('eth_getBlockByNumber')
+    expect(result.headBlock).toBe('25000')
+    expect(result.safeTxHash).toBe(SAFE_TX_HASH)
+    expect(result.events.map((e) => e.type)).toEqual([CheckEventType.PLAIN_PROPOSED, CheckEventType.PLAIN_ATTESTED])
+    // Sorted ascending by (blockNumber, logIndex).
+    const keys = result.events.map((e) => e.blockNumber * 1e6 + e.logIndex)
+    expect(keys).toEqual([...keys].sort((a, b) => a - b))
+  })
+
+  it('decodes the oracle-path Consensus events too (proposed + attested)', async () => {
+    resetLogCounter()
+    const logs = [
+      buildOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: ORACLE }),
+      buildOracleAttestedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: ORACLE }),
+    ]
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader().fetchCheckState(SAFE_TX_HASH)
+
+    expect(result.events.map((e) => e.type)).toEqual([CheckEventType.ORACLE_PROPOSED, CheckEventType.ORACLE_ATTESTED])
+    // Only the Consensus address is read — sentinel-oracle correlation is the
+    // next slice's job.
+    for (const call of endpoint.getLogsCalls) {
+      expect(call.address?.toLowerCase()).toBe(CONSENSUS.toLowerCase())
+    }
+  })
+
+  it('rejects a malformed safeTxHash before touching any endpoint', async () => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await expect(makeReader().fetchCheckState('0xnot-a-hash')).rejects.toThrow('invalid safeTxHash')
+    expect(endpoint.methods).toHaveLength(0)
+  })
+
+  it('chunks the lookback window into ≤10k-block getLogs calls', async () => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs: plainPairFor(SAFE_TX_HASH) })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader().fetchCheckState(SAFE_TX_HASH)
+
+    expect(endpoint.getLogsCalls.map((c) => [c.fromBlock, c.toBlock])).toEqual([
+      [0, 9999],
+      [10_000, 19_999],
+      [20_000, 25_000],
+    ])
+  })
+
+  it('caps the scan at exactly 30k blocks — 3 whole chunks, no degenerate 4th', async () => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 45_000, logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader().fetchCheckState(SAFE_TX_HASH)
+
+    expect(endpoint.getLogsCalls[0].fromBlock).toBe(15_001)
+    expect(endpoint.getLogsCalls).toHaveLength(3)
+  })
+
+  it('propagates the failure when every RPC endpoint is down', async () => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', failEverything: true })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await expect(makeReader().fetchCheckState(SAFE_TX_HASH)).rejects.toBeDefined()
+    // The endpoint was actually touched — the rejection is not a config error.
+    expect(endpoint.methods.length).toBeGreaterThan(0)
+  })
+
+  it('rotates to the next endpoint when the first one fails', async () => {
+    const down = makeEndpoint({ url: 'http://rpc.test/1', failEverything: true })
+    const up = makeEndpoint({ url: 'http://rpc.test/2', head: 25_000, logs: plainPairFor(SAFE_TX_HASH) })
+    server = setupServer(down.handler, up.handler)
+    server.listen()
+
+    const reader = new SafenetReader({
+      rpcUrls: ['http://rpc.test/1', 'http://rpc.test/2'],
+      chainId: CHAIN_ID,
+      consensus: CONSENSUS,
+    })
+    const result = await reader.fetchCheckState(SAFE_TX_HASH)
+    expect(result.headBlock).toBe('25000')
+    expect(up.methods.length).toBeGreaterThan(0)
+  })
+
+  it('survives concurrent reads racing failing endpoints — rotation is not double-applied', async () => {
+    // Two dead endpoints + one healthy: an unguarded double-rotation strands a
+    // retry on a dead URL and the read fails; the generation guard cannot.
+    const down1 = makeEndpoint({ url: 'http://rpc.test/1', failEverything: true })
+    const down2 = makeEndpoint({ url: 'http://rpc.test/2', failEverything: true })
+    const up = makeEndpoint({ url: 'http://rpc.test/3', head: 25_000, logs: plainPairFor(SAFE_TX_HASH) })
+    server = setupServer(down1.handler, down2.handler, up.handler)
+    server.listen()
+
+    const reader = new SafenetReader({
+      rpcUrls: ['http://rpc.test/1', 'http://rpc.test/2', 'http://rpc.test/3'],
+      chainId: CHAIN_ID,
+      consensus: CONSENSUS,
+    })
+    const results = await Promise.all([
+      reader.fetchCheckState(SAFE_TX_HASH),
+      reader.fetchCheckState(SAFE_TX_HASH),
+      reader.fetchCheckState(SAFE_TX_HASH),
+    ])
+    for (const result of results) expect(result.headBlock).toBe('25000')
+  })
+})
+
+describe('SafenetReader chain-id assertion (dev-only, one-shot)', () => {
+  it('logs a loud error when the RPC chain id disagrees with SAFENET_CHAIN_ID', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', chainId: '31337', head: 10, logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader({ chainId: '100' }).fetchCheckState(SAFE_TX_HASH)
+
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('chain id mismatch'))
+    spy.mockRestore()
+  })
+
+  it('stays silent when the RPC chain id matches', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', chainId: '100', head: 10, logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader({ chainId: '100' }).fetchCheckState(SAFE_TX_HASH)
+
+    expect(spy).not.toHaveBeenCalled()
+    spy.mockRestore()
+  })
+})

--- a/packages/utils/src/features/safenet-checks/services/safenetReader.ts
+++ b/packages/utils/src/features/safenet-checks/services/safenetReader.ts
@@ -1,0 +1,207 @@
+import { JsonRpcProvider } from 'ethers'
+import { CONSENSUS_TOPIC0S } from '../abi'
+import {
+  GETLOGS_CHUNK_BLOCKS,
+  MAX_LOOKBACK_BLOCKS,
+  PROVIDER_BATCH_MAX_COUNT,
+  SAFENET_CHAIN_ID,
+  SAFENET_CONSENSUS_ADDRESS,
+  SAFENET_RPC_URLS,
+} from '../constants'
+import type { Hex, NormalizedCheckEvent } from '../types'
+import { decodeLogs, type RawLog } from '../utils/decodeLogs'
+
+/**
+ * Everything one poll reads off-chain for a single check, before the query layer
+ * folds in FROST verification and the monotonic merge. Numeric values are decimal
+ * strings so the result is Redux-serializable end-to-end.
+ */
+export type CheckReadResult = {
+  safeTxHash: Hex
+  /** The Safenet chain the Consensus contract lives on — the config chain id. */
+  chainId: string
+  /** All decoded lifecycle events, sorted ascending by (blockNumber, logIndex). */
+  events: NormalizedCheckEvent[]
+  /** Chain head observed at read time (a decimal string). */
+  headBlock: string
+}
+
+export type SafenetReaderConfig = {
+  /** Pinned Gnosis endpoints, rotated on failure. */
+  rpcUrls: string[]
+  /** Feeds the provider network; the EIP-712 request-id domain in later slices. */
+  chainId: string
+  consensus: string
+}
+
+/** Build a reader config from the dual-env constants (the production default). */
+export const readerConfigFromEnv = (): SafenetReaderConfig => ({
+  rpcUrls: SAFENET_RPC_URLS,
+  chainId: SAFENET_CHAIN_ID,
+  consensus: SAFENET_CONSENSUS_ADDRESS,
+})
+
+const IS_DEV = process.env.NODE_ENV !== 'production'
+
+/** Inclusive [from, to] block ranges of at most `size` blocks each. */
+const chunkRanges = (from: number, to: number, size: number): Array<[number, number]> => {
+  const ranges: Array<[number, number]> = []
+  for (let start = from; start <= to; start += size) {
+    ranges.push([start, Math.min(start + size - 1, to)])
+  }
+  return ranges
+}
+
+/**
+ * Chain reader for a check's Safenet lifecycle. Owns a pinned-endpoint provider,
+ * rotated on failure. Construct with
+ * {@link readerConfigFromEnv} in production; pass an explicit config in tests.
+ */
+export class SafenetReader {
+  private readonly rpcUrls: string[]
+  private readonly chainId: string
+  private readonly consensus: string
+
+  private urlIndex = 0
+  private currentProvider: JsonRpcProvider | null = null
+  private chainIdChecked = false
+
+  constructor(config: SafenetReaderConfig) {
+    this.rpcUrls = config.rpcUrls
+    this.chainId = config.chainId
+    this.consensus = config.consensus
+  }
+
+  private provider(): JsonRpcProvider {
+    if (!this.currentProvider) {
+      const url = this.rpcUrls[this.urlIndex]
+      if (!url) throw new Error('Safenet reader: no RPC URLs configured (set SAFENET_RPC_URLS)')
+      this.currentProvider = new JsonRpcProvider(url, Number(this.chainId), {
+        staticNetwork: true,
+        batchMaxCount: PROVIDER_BATCH_MAX_COUNT,
+      })
+    }
+    return this.currentProvider
+  }
+
+  /**
+   * Advance to the next endpoint — but only if `failed` is still the current
+   * provider. Concurrent reads share the pinned provider; without this guard a
+   * read cancelled by a sibling's rotation would rotate AGAIN, skipping over
+   * (or cycling back to) endpoints and burning its retry budget on the same
+   * dead URL.
+   */
+  private rotate(failed: JsonRpcProvider): void {
+    if (this.currentProvider !== failed) return
+    failed.destroy()
+    this.currentProvider = null
+    this.urlIndex = (this.urlIndex + 1) % this.rpcUrls.length
+  }
+
+  /** Run an op against the current endpoint, rotating through the URL list on failure. */
+  private async withProvider<T>(op: (provider: JsonRpcProvider) => Promise<T>): Promise<T> {
+    const attempts = Math.max(1, this.rpcUrls.length)
+    let lastError: unknown
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      const provider = this.provider()
+      try {
+        return await op(provider)
+      } catch (error) {
+        lastError = error
+        this.rotate(provider)
+      }
+    }
+    throw lastError
+  }
+
+  /** Dev-only, one-shot: warn loudly if the RPC's chain id disagrees with config. */
+  private async assertChainId(provider: JsonRpcProvider): Promise<void> {
+    if (this.chainIdChecked || !IS_DEV) return
+    try {
+      const actual = Number(await provider.send('eth_chainId', []))
+      // One-shot only after a SUCCESSFUL probe — a dead first endpoint must not
+      // consume the check before rotation reaches the endpoint actually used.
+      this.chainIdChecked = true
+      if (actual !== Number(this.chainId)) {
+        console.error(
+          `[safenet-reader] chain id mismatch: SAFENET_CHAIN_ID=${this.chainId} but the RPC ` +
+            `reports ${actual}. Request ids derive from SAFENET_CHAIN_ID, so they will be WRONG ` +
+            `and every check will appear stuck at SUBMITTED. Fix SAFENET_CHAIN_ID / SAFENET_RPC_URLS.`,
+        )
+      }
+    } catch {
+      // The assertion is a development aid, never a hard gate on the read path.
+    }
+  }
+
+  private async getLogsChunked(
+    provider: JsonRpcProvider,
+    filter: { address?: string; topics: Array<string | string[]>; fromBlock: number; toBlock: number },
+  ): Promise<RawLog[]> {
+    const ranges = chunkRanges(filter.fromBlock, filter.toBlock, GETLOGS_CHUNK_BLOCKS)
+    // Issued concurrently so the pinned provider coalesces them into one batched
+    // HTTP request (bounded by PROVIDER_BATCH_MAX_COUNT).
+    const chunks = await Promise.all(
+      ranges.map(([fromBlock, toBlock]) =>
+        provider.getLogs({ address: filter.address, topics: filter.topics, fromBlock, toBlock }),
+      ),
+    )
+    // Onto the decoder's `RawLog` shape — ethers names the log index `.index`.
+    return chunks.flat().map((log) => ({
+      address: log.address,
+      topics: [...log.topics],
+      data: log.data,
+      blockNumber: log.blockNumber,
+      logIndex: log.index,
+      transactionHash: log.transactionHash,
+    }))
+  }
+
+  /**
+   * Read a check's lifecycle: Consensus logs keyed by `safeTxHash` — both the
+   * plain pair (all live beta emits) and the oracle-path Consensus events.
+   * Returns the sorted event set; sentinel-oracle log correlation, FROST
+   * verification, and the status machine live above this.
+   */
+  async fetchCheckState(safeTxHash: string): Promise<CheckReadResult> {
+    // Validated up front: a malformed hash is a caller bug, not an endpoint
+    // failure — it must not burn a rotation through the URL list.
+    if (!/^0x[0-9a-f]{64}$/i.test(safeTxHash)) {
+      throw new Error(`Safenet reader: invalid safeTxHash '${safeTxHash}'`)
+    }
+    return this.withProvider(async (provider) => {
+      await this.assertChainId(provider)
+
+      const latest = await provider.getBlock('latest')
+      if (!latest) throw new Error('Safenet reader: could not read the chain head')
+      const head = latest.number
+
+      // Head-relative scan — sees the last MAX_LOOKBACK_BLOCKS (~42h on Gnosis).
+      // Timestamp-aimed windows (constant cost at any age) arrive in the next slice.
+      const range = { fromBlock: Math.max(0, head - MAX_LOOKBACK_BLOCKS + 1), toBlock: head }
+
+      const consensusLogs = await this.getLogsChunked(provider, {
+        address: this.consensus,
+        topics: [[...CONSENSUS_TOPIC0S], safeTxHash],
+        fromBlock: range.fromBlock,
+        toBlock: range.toBlock,
+      })
+      const consensusEvents = decodeLogs(consensusLogs)
+
+      // Ascending by (blockNumber, logIndex), so downstream folds see chain order.
+      const events = [...consensusEvents].sort((a, b) => a.blockNumber - b.blockNumber || a.logIndex - b.logIndex)
+
+      return {
+        safeTxHash: safeTxHash as Hex,
+        chainId: this.chainId,
+        events,
+        headBlock: head.toString(),
+      }
+    })
+  }
+}
+
+let defaultReader: SafenetReader | null = null
+
+/** The process-wide pinned-provider reader singleton (built from env constants). */
+export const getSafenetReader = (): SafenetReader => (defaultReader ??= new SafenetReader(readerConfigFromEnv()))


### PR DESCRIPTION
Part 5 of the Safenet read-layer sequence — after #8369 (FROST verifier), #8381 (event vocabulary), #8398 (decoder), #8400 (status derivation). First slice that talks to a node, and the first of three reader slices:

1. **this PR** — basic chain access: is it correct and safe?
2. *next* — timestamp-aimed read windows + allowlist-gated sentinel-oracle correlation
3. *then* — FROST verification against the coordinator group key + polling policy

### What's here (+556: 207 source, 300 tests/harness, 49 config)

- `services/safenetReader.ts` — a pinned-endpoint provider pool for the deployed beta Consensus ([`0x223624cB…`](https://gnosisscan.io/address/0x223624cBF099e5a8f8cD5aF22aFa424a1d1acEE9), unverified on Gnosisscan — shapes were probed live, see #8398):
  - **generation-guarded rotation**: concurrent reads share the pinned provider; a read cancelled by a sibling's rotation must not rotate *again* past a healthy endpoint. Covered by a 2-dead+1-healthy concurrency test.
  - **one-shot dev-only chain-id assertion** — `SAFENET_CHAIN_ID` feeds the EIP-712 request-id domain in the next slices, so a mismatched RPC would silently derive wrong ids; the assertion is consumed only after a *successful* probe so a dead first endpoint can't eat it.
  - `eth_getLogs` chunked to the 10k-block Gnosis public-RPC ceiling; 30k-block head-relative scan (~42h — constant-cost aimed windows are the next slice).
  - reads BOTH Consensus event families (the plain pair — everything live beta emits — and the oracle-path events), decoded through the #8398 decoder; `safeTxHash` shape-validated up front so a malformed input can't burn a rotation cycle.
- `constants.ts` — dual-env (`NEXT_PUBLIC_`/`EXPO_PUBLIC_`) config: chain id, pinned RPC csv, Consensus address, lookback tuning. Values must be referenced statically — both bundlers only inline literal reads.

### Tests

MSW against real JSON-RPC wire shapes (single **and** batched bodies) through an actual `JsonRpcProvider` — ethers is not mocked. Fixtures are built with deliberately out-of-order block metas so the sort contract has teeth. The endpoint-down test asserts the endpoint was actually touched.

### Deliberate scope notes

- `getSafenetReader` singleton ships here unconsumed — its consumer is the wiring slice (RTK Query layer), same shape as the previously-reviewed stack.
- No correlation fields / deadline / verification on `CheckReadResult` yet: each arrives in the slice that makes it derivable (sentinel logs / coordinator reads).
- Dead code until the wiring slice lands, like the previous four PRs.

The full three-slice stack (not just this commit) was validated against live Gnosis beta: the reference check (`0x3fb727ef…`, epoch 32947, >30k blocks old) located via timestamp targeting and FROST-VERIFIED, plus 25/25 fresh attestations VERIFIED.