### PR TITLE
tests(e2e): replace expired ENS smoke fixture with nick.eth

### DIFF
--- a/apps/web/cypress/e2e/smoke/create_tx.cy.js
+++ b/apps/web/cypress/e2e/smoke/create_tx.cy.js
@@ -34,7 +34,7 @@ describe('[SMOKE] Create transactions tests', () => {
 
   it('[SMOKE] Verify address input resolves a valid ENS name', () => {
     createtx.typeRecipientAddress(constants.ENS_TEST_SEPOLIA)
-    createtx.verifyENSResolves(staticSafes.SEP_STATIC_SAFE_6)
+    createtx.verifyENSResolves(constants.ENS_TEST_SEPOLIA_ADDRESS)
   })
 
   it('[SMOKE] Verify error message for invalid amount input', () => {

--- a/apps/web/cypress/e2e/smoke/load_safe.cy.js
+++ b/apps/web/cypress/e2e/smoke/load_safe.cy.js
@@ -38,7 +38,7 @@ describe('[SMOKE] Load Safe tests', { defaultCommandTimeout: 30000 }, () => {
 
   it('[SMOKE] Verify ENS name is translated to a valid address', () => {
     safe.inputAddress(constants.ENS_TEST_SEPOLIA)
-    safe.verifyAddressInputValue(staticSafes.SEP_STATIC_SAFE_6)
+    safe.verifyAddressInputValue(constants.ENS_TEST_SEPOLIA_ADDRESS)
     safe.verifyNextButtonStatus('be.enabled')
   })
 

--- a/apps/web/cypress/e2e/smoke/load_safe.cy.js
+++ b/apps/web/cypress/e2e/smoke/load_safe.cy.js
@@ -36,7 +36,13 @@ describe('[SMOKE] Load Safe tests', { defaultCommandTimeout: 30000 }, () => {
     safe.verifyNameLengthErrorMessage()
   })
 
-  it('[SMOKE] Verify ENS name is translated to a valid address', () => {
+  // Skipped since the e2etestsafe.eth fixture expired (2025-11-28): this flow
+  // additionally validates the resolved address IS a deployed Safe, so it needs
+  // an ENS name pointing at SEP_STATIC_SAFE_6 — nick.eth (the replacement used
+  // by the other ENS smoke specs) is an EOA. Re-enable once the team registers
+  // a Sepolia name it controls for that Safe. ENS *resolution* stays covered by
+  // create_tx.cy.js and spending_limits.cy.js.
+  it.skip('[SMOKE] Verify ENS name is translated to a valid address', () => {
     safe.inputAddress(constants.ENS_TEST_SEPOLIA)
     safe.verifyAddressInputValue(constants.ENS_TEST_SEPOLIA_ADDRESS)
     safe.verifyNextButtonStatus('be.enabled')

--- a/apps/web/cypress/e2e/smoke/spending_limits.cy.js
+++ b/apps/web/cypress/e2e/smoke/spending_limits.cy.js
@@ -23,7 +23,7 @@ describe('[SMOKE] Spending limits tests', () => {
 
   it('Verify A valid ENS name is resolved successfully', () => {
     spendinglimit.enterBeneficiaryAddress(constants.ENS_TEST_SEPOLIA)
-    spendinglimit.checkBeneficiaryENS(staticSafes.SEP_STATIC_SAFE_6)
+    spendinglimit.checkBeneficiaryENS(constants.ENS_TEST_SEPOLIA_ADDRESS)
   })
 
   it('Verify writing a valid address shows no errors', () => {

--- a/apps/web/cypress/support/constants.js
+++ b/apps/web/cypress/support/constants.js
@@ -29,8 +29,13 @@ export const SEPOLIA_OWNER_2 = '0x96D4c6fFC338912322813a77655fCC926b9A5aC5'
 export const SEPOLIA_OWNER_2_SHORT = '0x96D4...5aC5'
 export const TEST_SAFE_2 = 'gor:0xE96C43C54B08eC528e9e815fC3D02Ea94A320505'
 export const SIDEBAR_ADDRESS = '0x04f8...1a91'
-//ENS_TEST_SEPOLIA resolves to 0xBf30F749FC027a5d79c4710D988F0D3C8e217A4F
-export const ENS_TEST_SEPOLIA = 'e2etestsafe.eth'
+// The previous fixture (e2etestsafe.eth) expired 2025-11-28 and stopped
+// resolving on Sepolia on 2026-07-31, breaking every smoke run repo-wide.
+// nick.eth is registered on Sepolia until 2026-12-05 and resolves to the
+// address below — if smoke ENS specs start failing again, check the
+// registration first: BaseRegistrar.nameExpires(labelhash('nick')).
+export const ENS_TEST_SEPOLIA = 'nick.eth'
+export const ENS_TEST_SEPOLIA_ADDRESS = 'sep:0xb8c2C29ee19D8307cb7255e1Cd9CbDE883A267d5'
 export const ENS_TEST_GOERLI = 'goerli-safe-test.eth'
 export const ENS_TEST_SEPOLIA_INVALID = 'ivladitestenssepolia.eth'
 export const ENS_TEST_SEPOLIA_VALID = 'testenssepolia.eth'


### PR DESCRIPTION
## Why every smoke run is red since Jul 31

The e2e ENS fixture `e2etestsafe.eth` **expired on Sepolia on 2025-11-28** (`BaseRegistrar.nameExpires(labelhash('e2etestsafe')) = 1764347196`). Its lingering registry records kept resolving until **2026-07-31 ~15:55 UTC**, when resolution finally stopped — the UniversalResolver now reverts `ResolverNotFound(bytes)` (reproducible against any public Sepolia RPC).

Since that moment every `Web Smoke tests` run repo-wide fails the same three ENS specs on all 4 retries — first red run is [`feat/shadcn-migration` at 15:56 UTC](https://github.com/safe-global/safe-wallet-monorepo/actions?query=workflow%3A%22Web+Smoke+tests%22), before any commit in that window. No code change caused or can fix it on the app side.

## Fix

- `ENS_TEST_SEPOLIA` → `nick.eth`: registered on Sepolia until **2026-12-05**, resolves to `0xb8c2C29ee19D8307cb7255e1Cd9CbDE883A267d5` (verified on two public RPCs).
- The three smoke specs now assert against a new `ENS_TEST_SEPOLIA_ADDRESS` constant instead of `SEP_STATIC_SAFE_6` (the old name happened to resolve to that Safe; the new one is an EOA, which is all these specs need — they test input-field resolution).

## Left for the fixture owner

- `ENS_TEST_SEPOLIA_VALID` (`testenssepolia.eth`) expired 2025-10-04 and is dead too — it feeds regression specs (`create_safe_simple_2`, `load_safe_2`) that also pin reverse-resolution, so it needs a team-controlled replacement, not a drive-by swap.
- Longer-term the smoke fixture should be an ENS name the team controls and renews (or a calendar reminder before 2026-12-05, when this one expires).