### PR TITLE
fix: keep search focus in account list dropdown

### DIFF
--- a/apps/web/src/components/common/SpaceSafeBar/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.tsx
@@ -218,11 +218,12 @@ function SpaceSafeBar() {
 
   // Manual sort turns the active tab's list into a drag-to-reorder list. The order persists to the
   // same scope the welcome/workspace tables use — trusted for My accounts, this space for the
-  // workspace tab — so every surface stays in sync. Disabled while searching (a drop would persist a
-  // partial order). The Workspace tab has no scope outside a space, so it isn't reorderable there.
+  // workspace tab — so every surface stays in sync. The Workspace tab has no scope outside a space,
+  // so it isn't reorderable there. Kept defined while searching so the dropdown doesn't swap the list
+  // component (which steals focus from the search input); dragging is disabled there instead.
   const reorderScope = activeTab === 'local' ? TRUSTED_ORDER_SCOPE : spaceId ? getSpaceOrderScope(spaceId) : undefined
   const handleReorder =
-    orderBy === OrderByOption.MANUAL && !search.trim() && reorderScope
+    orderBy === OrderByOption.MANUAL && reorderScope
       ? (order: string[]) => dispatch(setManualOrder({ scope: reorderScope, order }))
       : undefined
 

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/ReorderableSafeList.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/ReorderableSafeList.tsx
@@ -16,6 +16,12 @@ interface ReorderableSafeListProps {
   onRename?: (target: SafeRenameTarget) => void
   /** Fired on drop with the reordered top-level addresses, in display order. */
   onReorder: (orderedAddresses: string[]) => void
+  /**
+   * Disables dragging and hides the grips — used while a search query is active, where a drop would
+   * persist a partial (filtered) order. The list stays mounted so filtering never swaps it out for a
+   * different component (which would remount the base-ui rows and steal focus from the search input).
+   */
+  isDragDisabled?: boolean
 }
 
 /**
@@ -28,7 +34,14 @@ interface ReorderableSafeListProps {
  * Auto-scroll works within the dropdown's scroll container, so lists longer than the fold reorder too.
  * The dragged row is portaled to <body> so the Select popup's positioning transform can't offset it.
  */
-const ReorderableSafeList = ({ items, selectedItemId, onSelect, onRename, onReorder }: ReorderableSafeListProps) => {
+const ReorderableSafeList = ({
+  items,
+  selectedItemId,
+  onSelect,
+  onRename,
+  onReorder,
+  isDragDisabled = false,
+}: ReorderableSafeListProps) => {
   const handleDragEnd = ({ source, destination }: DropResult) => {
     if (!destination || destination.index === source.index) return
     onReorder(reorderByKey(items, source.index, destination.index, (item) => item.address))
@@ -40,10 +53,14 @@ const ReorderableSafeList = ({ items, selectedItemId, onSelect, onRename, onReor
         {(dropProvided) => (
           <div ref={dropProvided.innerRef} {...dropProvided.droppableProps} data-testid="safe-selector-reorder-list">
             {items.map((item, index) => (
-              <Draggable key={item.address} draggableId={item.address} index={index}>
+              <Draggable key={item.address} draggableId={item.address} index={index} isDragDisabled={isDragDisabled}>
                 {(dragProvided, snapshot) => {
                   const isCurrent = item.id === selectedItemId
-                  const dragHandle = <DragHandle dragHandleProps={dragProvided.dragHandleProps} />
+                  // No grip while dragging is disabled (search) — dnd allows a missing handle only when
+                  // the draggable is disabled, and an inert grip would wrongly signal "draggable".
+                  const dragHandle = isDragDisabled ? null : (
+                    <DragHandle dragHandleProps={dragProvided.dragHandleProps} />
+                  )
                   // Multi-chain groups keep their expand/collapse behaviour (grip lives in the summary row);
                   // single-chain rows stay a flat, click-to-navigate row.
                   const row =

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -163,9 +163,11 @@ const SafeDropdownContainer = ({
       )
     }
 
-    // Manual sort turns the list into a drag-to-reorder list (never while searching — a drop would
-    // persist a partial order). Selecting a row navigates and closes, mirroring the Select rows.
-    if (onReorder && !query) {
+    // Manual sort turns the list into a drag-to-reorder list. It stays mounted while searching (with
+    // dragging disabled, since a drop would persist a partial order) rather than swapping to the
+    // plain Select list — the swap would remount the base-ui rows and pull focus off the search input.
+    // Selecting a row navigates and closes, mirroring the Select rows.
+    if (onReorder) {
       return (
         <ReorderableSafeList
           items={filteredItems}
@@ -176,6 +178,7 @@ const SafeDropdownContainer = ({
           }}
           onRename={handleRename}
           onReorder={onReorder}
+          isDragDisabled={Boolean(query)}
         />
       )
     }

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/ReorderableSafeList.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/ReorderableSafeList.test.tsx
@@ -78,6 +78,25 @@ describe('ReorderableSafeList', () => {
 
     expect(row).toHaveFocus()
   })
+
+  it('hides the grips but keeps click-to-navigate rows while dragging is disabled (search)', () => {
+    const onSelect = jest.fn()
+    render(
+      <ReorderableSafeList
+        items={[item(ADDR_A, 'A'), item(ADDR_B, 'B')]}
+        selectedItemId={`1:${ADDR_B}`}
+        onSelect={onSelect}
+        onReorder={jest.fn()}
+        isDragDisabled
+      />,
+    )
+
+    expect(screen.getAllByTestId('reorder-safe-row')).toHaveLength(2)
+    expect(screen.queryByTestId('safe-drag-handle')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getAllByTestId('reorder-safe-row')[0])
+    expect(onSelect).toHaveBeenCalledWith(`1:${ADDR_A}`)
+  })
 })
 
 describe('ReorderableSafeList multi-chain items', () => {

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeDropdownContainer.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeDropdownContainer.test.tsx
@@ -460,7 +460,7 @@ describe('SafeDropdownContainer', () => {
       expect(screen.getAllByTestId('select-item')).toHaveLength(2)
     })
 
-    it('falls back to the normal list while a search is active (never persists a partial order)', () => {
+    it('keeps the reorder list mounted while searching but disables dragging (no partial-order drop)', () => {
       render(
         <SafeDropdownContainer
           items={[itemA, itemB]}
@@ -472,8 +472,46 @@ describe('SafeDropdownContainer', () => {
         />,
       )
 
-      expect(screen.queryByTestId('safe-selector-reorder-list')).not.toBeInTheDocument()
-      expect(screen.getByTestId('select-item')).toBeInTheDocument()
+      // The list component stays the same across search (no swap to plain Select rows), so the base-ui
+      // rows aren't remounted and focus stays in the search input.
+      expect(screen.getByTestId('safe-selector-reorder-list')).toBeInTheDocument()
+      expect(screen.queryByTestId('select-item')).not.toBeInTheDocument()
+      // Only the match is shown, and its grip is hidden (dragging disabled while searching).
+      expect(screen.getByText('Alpha')).toBeInTheDocument()
+      expect(screen.queryByText('Beta')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('safe-drag-handle')).not.toBeInTheDocument()
+    })
+
+    it('does not swap the list component when a search transitions from empty to non-empty', () => {
+      const { rerender } = render(
+        <SafeDropdownContainer
+          items={[itemA, itemB]}
+          onItemSelect={jest.fn()}
+          closeDropdown={jest.fn()}
+          onReorder={jest.fn()}
+          searchValue=""
+          onSearchValueChange={jest.fn()}
+        />,
+      )
+
+      expect(screen.getByTestId('safe-selector-reorder-list')).toBeInTheDocument()
+      expect(screen.getAllByTestId('safe-drag-handle')).toHaveLength(2)
+
+      rerender(
+        <SafeDropdownContainer
+          items={[itemA, itemB]}
+          onItemSelect={jest.fn()}
+          closeDropdown={jest.fn()}
+          onReorder={jest.fn()}
+          searchValue="alpha"
+          onSearchValueChange={jest.fn()}
+        />,
+      )
+
+      // Same list component, just filtered + grips hidden — never the plain Select-item fallback.
+      expect(screen.getByTestId('safe-selector-reorder-list')).toBeInTheDocument()
+      expect(screen.queryByTestId('select-item')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('safe-drag-handle')).not.toBeInTheDocument()
     })
 
     it('navigates and closes the dropdown when a reorder row is clicked', () => {


### PR DESCRIPTION
## What it solves

Typing in the account-list search (Manual sort) lost input focus after the first character, forcing a re-click. Clearing the field back to empty lost focus too.

Resolves: https://linear.app/safe-global/issue/WA-2979/search-input-loses-focus-in-account-list

## How this PR fixes it

The first keystroke swapped the list between the drag-to-reorder list and the plain list (reorder is disabled while searching), remounting the base-ui rows inside the open popup — base-ui then moved focus onto an option. The list now stays mounted across search; dragging is just disabled while a query is active. Appeared "multi-chain only" because a multi-chain current safe reliably survives filtering, keeping an option mounted to steal focus.

## How to test it

1. Open a workspace with a multi-chain Safe as the current Safe; set the account list to Manual sort.
2. Open the account dropdown and type in the search box.
3. Focus stays in the input across every character and when clearing it.
4. With no query, drag-to-reorder still works.

## Screenshots

N/A - no visual changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
EOF