### PR TITLE
fix: stop initialising Datadog RUM in E2E builds

### DIFF
--- a/apps/web/src/services/observability/providers/__tests__/datadog.test.ts
+++ b/apps/web/src/services/observability/providers/__tests__/datadog.test.ts
@@ -66,6 +66,19 @@ describe('DatadogProvider', () => {
     })
   }
 
+  const mockE2EDatadogConstants = (): void => {
+    jest.doMock('@/config/constants', () => {
+      const actualConstants = jest.requireActual<typeof ConstantsModule>('@/config/constants')
+
+      return {
+        ...actualConstants,
+        DATADOG_RUM_APPLICATION_ID: 'test-app-id',
+        DATADOG_RUM_CLIENT_TOKEN: 'test-client-token',
+        IS_TEST_E2E: true,
+      }
+    })
+  }
+
   const importProvider = async () => {
     const { DatadogProvider } = await import('../datadog')
     return DatadogProvider as unknown as DatadogProviderConstructor
@@ -165,6 +178,39 @@ describe('DatadogProvider', () => {
     const tags = { componentStack: 'test' }
 
     expect(() => provider.captureError({ error, isUserFacing: true, tags })).not.toThrow()
+  })
+
+  describe('E2E test builds', () => {
+    it('should report Datadog as disabled even when credentials are present', async () => {
+      mockE2EDatadogConstants()
+      const { isDatadogEnabled } = await import('../datadog')
+
+      expect(isDatadogEnabled).toBe(false)
+    })
+
+    it('should not initialize the RUM SDK', async () => {
+      mockE2EDatadogConstants()
+      mockGetInitConfiguration.mockReturnValue(undefined)
+      const Provider = await importProvider()
+
+      await new Provider().init()
+
+      expect(mockInit).not.toHaveBeenCalled()
+    })
+
+    it('should not send events through the logger or captureError', async () => {
+      mockE2EDatadogConstants()
+      mockGetInitConfiguration.mockReturnValue(undefined)
+      const Provider = await importProvider()
+      const provider = new Provider()
+      await provider.init()
+
+      provider.getLogger().error('e2e error')
+      provider.captureError({ error: new Error('e2e error'), isUserFacing: true })
+
+      expect(mockAddError).not.toHaveBeenCalled()
+      expect(mockAddAction).not.toHaveBeenCalled()
+    })
   })
 
   describe('after initialization', () => {

--- a/apps/web/src/services/observability/providers/datadog.ts
+++ b/apps/web/src/services/observability/providers/datadog.ts
@@ -24,6 +24,7 @@ import {
   DATADOG_RUM_TRACING_ENABLED,
   GATEWAY_URL_PRODUCTION,
   GATEWAY_URL_STAGING,
+  IS_TEST_E2E,
 } from '@/config/constants'
 
 type DatadogSite =
@@ -34,7 +35,7 @@ type DatadogSite =
   | 'ddog-gov.com'
   | 'ap1.datadoghq.com'
 
-export const isDatadogEnabled = Boolean(DATADOG_RUM_APPLICATION_ID) && Boolean(DATADOG_RUM_CLIENT_TOKEN)
+export const isDatadogEnabled = Boolean(DATADOG_RUM_APPLICATION_ID) && Boolean(DATADOG_RUM_CLIENT_TOKEN) && !IS_TEST_E2E
 
 const EXTENSION_URL_PATTERNS = [
   'chrome-extension://',


### PR DESCRIPTION
## What it solves

Resolves: CI-generated RUM errors polluting the production error stream.

Cypress runs are served from `http://localhost:8080`, but they were initialising the Datadog RUM SDK with **real credentials**. Their errors landed in the normal RUM error stream as `env:development` sessions tagged `@session.type:user` — indistinguishable from real user breakage.

Between Jul 31 and Aug 3 this produced **15 errors** from `@view.url_host:localhost`, all HeadlessChrome/Linux from CI runners:

| Count | Error |
| --- | --- |
| 8 | `TypeError: Failed to fetch` (dev-server teardown mid-test) |
| 4 | `ChunkLoadError: Loading chunk NNNN failed` |
| 2 | `server response 403 Forbidden` — Sepolia Infura key rejected by project-ID settings |
| 1 | `TypeError: Cannot read properties of undefined (reading 'then')` |

## How this PR fixes it

`.github/actions/build` exports **every** `NEXT_PUBLIC_*` repo secret, so E2E builds inherited `NEXT_PUBLIC_DATADOG_RUM_APPLICATION_ID` and `_CLIENT_TOKEN`, making `isDatadogEnabled` true. Nothing in the runtime knew it was in CI.

This gates `isDatadogEnabled` on the existing `IS_TEST_E2E` flag, which `.github/actions/cypress/action.yml` already forwards as `NEXT_PUBLIC_IS_TEST_E2E: 'true'`. With Datadog disabled, `createObservabilityProvider()` falls back to the no-op provider, so all logger/`captureError` call sites stay safe.

No new env var or CI wiring needed — the flag and its plumbing already exist.

## How to test it

1. `yarn workspace @safe-global/web test src/services/observability` — the new `E2E test builds` block asserts the SDK is never initialised.
2. Locally: `NEXT_PUBLIC_IS_TEST_E2E=true` plus RUM credentials → no `/v1/rum` requests in the network tab; without the flag they reappear.
3. After merge: `@type:error @view.url_host:localhost` in RUM should stop accruing new events.

## Affected flows

- CI E2E runs (Cypress) — RUM SDK no longer initialises; app uses the no-op observability provider
- Real user sessions on prod/staging — unchanged, `IS_TEST_E2E` is false there

## Blast radius

- **`isDatadogEnabled`** (`providers/datadog.ts:38`) — single consumer, `createObservabilityProvider()` in `services/observability/factory.ts:6`
- **`DatadogProvider.init()`** — early-returns via the same flag, so `datadogRum.init` is never called
- **`IS_TEST_E2E`** (`config/constants.ts:14`) — pre-existing flag; this adds one more consumer. Already set by `APP_ENV === 'cypress'` or `NEXT_PUBLIC_IS_TEST_E2E`
- **No API contract, slice, endpoint, flag, route or persisted-state changes.** No mobile impact — `apps/web` only, no shared package touched
- Sourcemap upload is untouched: E2E builds share the deploy build's service and commit-SHA version, so they were already overwriting deploy sourcemaps. Not addressed here

## Risks / not checked

- **Type-check currently fails on `dev`** in `features/swap/components/SwapWidget/index.tsx` (`CowWidgetEventListeners` / `CowWidgetEvents` no longer exported after the CoW upgrade in 932bd5d64). Pre-existing and unrelated to this PR — but it means `yarn verify:web` is red on this branch too. Tests pass: 579 suites / 5107 tests
- **Local `yarn dev` still sends RUM** if a developer has credentials in `.env`. Only E2E builds are gated. A hostname-based guard would also cover that — deliberately out of scope here
- **Playwright**: no workflow currently builds/serves the app on `:8080`, so nothing to gate. If one is added it must forward `NEXT_PUBLIC_IS_TEST_E2E`
- Did not run the Cypress suite end-to-end to confirm nothing depended on the Datadog provider being live
- The two underlying bugs surfaced by these errors (the Infura 403 and the `.then` TypeError) are **not** fixed here — this only stops CI noise from masquerading as user errors

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1[E2E build on localhost:8080] --> B1[All NEXT_PUBLIC_* secrets exported]
    B1 --> C1["isDatadogEnabled = creds present ✓"]
    C1 --> D1[datadogRum.init]
    D1 --> E1[("RUM: env=development<br/>session.type=user")]
    E1 --> F1[15 CI errors mixed<br/>into real user errors]
  end
  subgraph After
    A2[E2E build on localhost:8080] --> B2[All NEXT_PUBLIC_* secrets exported]
    B2 --> C2["isDatadogEnabled = creds ✓ AND NOT IS_TEST_E2E"]
    C2 -->|false in E2E| D2[NoopProvider]
    D2 --> E2[No RUM events emitted]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — n/a, `apps/web` only
- [x] I've documented how it affects the analytics (if at all) 📊 — removes CI noise from RUM; no product analytics touched
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
