### PR TITLE
fix(web): add directly deployed Safes to the active workspace

### DIFF
--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.test.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.test.tsx
@@ -11,6 +11,8 @@ import { act, fireEvent, screen } from '@testing-library/react'
 import { LATEST_SAFE_VERSION } from '@safe-global/utils/config/constants'
 import { type SafeVersion } from '@safe-global/types-kit'
 import * as cfServices from '@/features/counterfactual/services'
+import * as spaceServices from '@/features/spaces/services'
+import * as useIsWrongChain from '@/hooks/useIsWrongChain'
 import * as multichain from '@/features/multichain'
 import * as createLogic from '@/components/new-safe/create/logic'
 import * as web3 from '@/hooks/wallets/web3'
@@ -258,5 +260,91 @@ describe('ReviewStep', () => {
     expect(persistSpy).toHaveBeenCalledWith(
       expect.objectContaining({ payMethod: PayMethod.PayLater, isUserAuthenticated: true }),
     )
+  })
+
+  describe('direct deployment (pay now)', () => {
+    const SPACE_UUID = '11111111-1111-1111-1111-111111111111'
+    const PREDICTED_ADDRESS = '0x0000000000000000000000000000000000000001'
+
+    const spaceAuthReduxState = {
+      auth: { ...authReduxState.auth, lastUsedSpace: SPACE_UUID },
+    }
+
+    const buildSingleChainData = (): NewSafeFormData => ({
+      name: 'Test',
+      networks: [{ ...mockChain, features: [] } as Chain],
+      threshold: 1,
+      owners: [{ name: '', address: '0x1' }],
+      saltNonce: 0,
+      safeVersion: LATEST_SAFE_VERSION as SafeVersion,
+    })
+
+    /** Drives the non-counterfactual branch: counterfactual off => the Safe is deployed directly. */
+    const renderAndDeploy = async (reduxState: object) => {
+      const mockData = buildSingleChainData()
+
+      jest.spyOn(useChains, 'useHasFeature').mockReturnValue(false)
+      jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(mockData.networks[0])
+      jest.spyOn(useWallet, 'default').mockReturnValue({ provider: {} } as unknown as ConnectedWallet)
+      // Explicit: earlier tests in this file leave a `true` spy behind (clearAllMocks
+      // keeps implementations), which would route creation through the relay path.
+      jest.spyOn(relay, 'hasRemainingRelays').mockReturnValue(false)
+      // The direct path blocks submission behind the wrong-network warning.
+      jest.spyOn(useIsWrongChain, 'default').mockReturnValue(false)
+      jest
+        .spyOn(createLogic, 'createNewUndeployedSafeWithoutSalt')
+        .mockReturnValue({ safeAccountConfig: { owners: ['0x1'], threshold: 1 } } as unknown as ReplayedSafeProps)
+      jest.spyOn(web3, 'createWeb3ReadOnly').mockReturnValue({} as ReturnType<typeof web3.createWeb3ReadOnly>)
+      jest.spyOn(multichain, 'predictAddressBasedOnReplayData').mockResolvedValue(PREDICTED_ADDRESS)
+      // Invoke the onSubmit callback as a real deployment would once the tx is broadcast.
+      jest
+        .spyOn(createLogic, 'createNewSafe')
+        .mockImplementation(async (_provider, _props, _chain, _options, onSubmit) => {
+          onSubmit?.('0xTxHash')
+          return undefined as never
+        })
+
+      render(<ReviewStep data={mockData} onSubmit={jest.fn()} onBack={jest.fn()} setStep={jest.fn()} />, {
+        initialReduxState: reduxState,
+      })
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('review-step-next-btn'))
+      })
+    }
+
+    it('adds the deployed Safe to the active workspace', async () => {
+      const addSpy = jest.spyOn(spaceServices, 'addSafeToSpace').mockResolvedValue({ status: 'added' })
+
+      await renderAndDeploy(spaceAuthReduxState)
+
+      expect(addSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ chainId: '100', safeAddress: PREDICTED_ADDRESS, spaceId: SPACE_UUID }),
+      )
+    })
+
+    it('does not touch the backend when the user has no SIWE session', async () => {
+      const addSpy = jest.spyOn(spaceServices, 'addSafeToSpace').mockResolvedValue({ status: 'added' })
+
+      await renderAndDeploy({})
+
+      // The Safe is still deployed — only the workspace call is skipped.
+      expect(createLogic.createNewSafe).toHaveBeenCalledTimes(1)
+      expect(addSpy).not.toHaveBeenCalled()
+    })
+
+    it('still completes creation when the workspace add fails', async () => {
+      const addSpy = jest.spyOn(spaceServices, 'addSafeToSpace').mockResolvedValue({
+        status: 'failed',
+        error: new Error('Failed to add Safe account to workspace'),
+        isLimitRejection: false,
+      })
+
+      await renderAndDeploy(spaceAuthReduxState)
+
+      expect(addSpy).toHaveBeenCalledTimes(1)
+      // The transaction is already broadcast, so creation must not be reported as failed.
+      expect(screen.queryByText(/Error creating the Safe account/)).not.toBeInTheDocument()
+    })
   })
 })

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -66,6 +66,8 @@ import uniq from 'lodash/uniq'
 import { selectRpc } from '@/store/settingsSlice'
 import { isAuthenticated, lastUsedSpace } from '@/store/authSlice'
 import { useIsAdmin, useSpaceSafeCount } from '@/features/spaces'
+import { addSafeToSpace } from '@/features/spaces/services'
+import { showNotification } from '@/store/notificationsSlice'
 import { normalizeSpaceId } from '@/utils/spaces'
 import { AppRoutes } from '@/config/routes'
 import type { CreateSafeResult, ReplayedSafeProps } from '@safe-global/utils/features/counterfactual/store/types'
@@ -396,6 +398,32 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
         trackEvent({ ...OVERVIEW_EVENTS.PROCEED_WITH_TX, label: 'deployment', category: CREATE_SAFE_CATEGORY })
 
         onSubmit(data)
+
+        // Attach to the active workspace, same as the counterfactual path does.
+        // Runs last so it never delays the status screen: the transaction is
+        // already broadcast, so a failure here cannot abort creation — the user
+        // is warned and keeps the Safe.
+        if (isUserAuthenticated) {
+          const spaceResult = await addSafeToSpace({
+            chainId: chain.chainId,
+            safeAddress,
+            spaceId,
+            isAdminOfActiveSpace,
+            spaceSafeCount,
+            dispatch,
+          })
+
+          // Limit rejections already notify the user inside the service.
+          if (spaceResult.status === 'failed' && !spaceResult.isLimitRejection) {
+            dispatch(
+              showNotification({
+                variant: 'warning',
+                groupKey: 'safe-space-add-error',
+                message: `Safe created, but it couldn't be added to the workspace: ${spaceResult.error.message}`,
+              }),
+            )
+          }
+        }
       }
 
       if (willRelay) {

--- a/apps/web/src/features/counterfactual/services/__tests__/persistCounterfactualSafe.test.ts
+++ b/apps/web/src/features/counterfactual/services/__tests__/persistCounterfactualSafe.test.ts
@@ -193,6 +193,33 @@ describe('persistCounterfactualSafe', () => {
     if (!result.ok) expect(result.error.message).toMatch(/space/i)
   })
 
+  it('keeps the safe and succeeds when the space already contains it (no rollback)', async () => {
+    const dispatch = jest.fn((action) => {
+      if (action.type === 'space-create-thunk') {
+        return {
+          error: {
+            status: 409,
+            data: { message: 'A SpaceSafe with the same chainId and address already exists' },
+          },
+        }
+      }
+      return action
+    }) as unknown as AppDispatch
+
+    const result = await persistCounterfactualSafe({
+      ...baseArgs,
+      spaceId: MOCK_SPACE_UUID,
+      isUserAuthenticated: true,
+      dispatch,
+    })
+
+    // The safe is in the space already — deleting it would destroy a good record.
+    expect(userDeleteInitiate).not.toHaveBeenCalled()
+    expect(replayImpl).toHaveBeenCalled()
+    expect(showNotificationImpl).not.toHaveBeenCalled()
+    expect(result).toEqual({ ok: true })
+  })
+
   it('keeps the user-level safe and shows the backend message as a toast when the space POST fails with a 400 (stale-snapshot limit)', async () => {
     const backendMessage = 'This space only allows a maximum of 40 safe accounts'
     const dispatch = jest.fn((action) => {

--- a/apps/web/src/features/counterfactual/services/persistCounterfactualSafe.ts
+++ b/apps/web/src/features/counterfactual/services/persistCounterfactualSafe.ts
@@ -2,13 +2,10 @@ import type { AppDispatch } from '@/store'
 import type { PayMethod } from '@safe-global/utils/features/counterfactual/types'
 import type { ReplayedSafeProps } from '@safe-global/utils/features/counterfactual/store/types'
 import { cgwApi as counterfactualSafesApi } from '@safe-global/store/gateway/AUTO_GENERATED/counterfactual-safes'
-import { cgwApi as spacesApi } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { toBackendDto } from './counterfactualSafeMapper'
 import { replayCounterfactualSafeDeployment } from './safeDeployment'
 import { enqueuePendingCfDelete } from '../store/pendingCfDeletesSlice'
-import { showNotification } from '@/store/notificationsSlice'
-import { normalizeSpaceId } from '@/utils/spaces'
-import { SAFE_ACCOUNTS_LIMIT } from '@/features/spaces/constants'
+import { addSafeToSpace } from '@/features/spaces/services'
 
 type PersistArgs = {
   chainId: string
@@ -78,82 +75,39 @@ export const persistCounterfactualSafe = async ({
       return { ok: false, error: toPersistError(userResult.error) }
     }
 
-    // Guard against persisted/legacy lastUsedSpace values that are empty or
-    // whitespace-only — pass any non-empty string through unchanged.
-    const resolvedSpaceId = normalizeSpaceId(spaceId)
-    if (resolvedSpaceId !== null) {
-      if (!isAdminOfActiveSpace) {
-        // Backend gates this endpoint on admin role and would 403. Inform the
-        // user — the safe is still persisted at the user level above.
-        dispatch(
-          showNotification({
-            variant: 'info',
-            groupKey: 'cf-safe-space-skipped',
-            message: 'Safe added to your accounts — ask an admin to add it to the workspace',
+    const spaceResult = await addSafeToSpace({
+      chainId,
+      safeAddress,
+      spaceId,
+      isAdminOfActiveSpace,
+      spaceSafeCount,
+      dispatch,
+    })
+
+    if (spaceResult.status === 'failed') {
+      // A limit rejection means another admin filled the space in the meantime.
+      // The Safe itself was still created, so a single-chain creation keeps it
+      // and succeeds (the user has already been warned). In a multi-chain batch
+      // the safe genuinely wasn't attached on this chain, so roll back and
+      // report failure — otherwise the caller records this chain as created.
+      const shouldRollBack = !spaceResult.isLimitRejection || isMultiChainCreation === true
+
+      if (shouldRollBack) {
+        // Roll back the user-level entry so the backend doesn't end up with a
+        // safe that the user "created" but failed to associate with their
+        // active space.
+        const rollbackResult = await dispatch(
+          counterfactualSafesApi.endpoints.counterfactualSafesDeleteV1.initiate({
+            deleteCounterfactualSafesDto: { safes: [{ chainId, address: safeAddress }] },
           }),
         )
-      } else if (spaceSafeCount !== undefined && spaceSafeCount >= SAFE_ACCOUNTS_LIMIT) {
-        // Space is full — the backend would reject the add. Skip it and keep the
-        // user-level safe so creation still succeeds, but tell the user it
-        // wasn't added to the workspace.
-        dispatch(
-          showNotification({
-            variant: 'info',
-            groupKey: 'cf-safe-space-limit',
-            message: `Safe created. This workspace is full (${SAFE_ACCOUNTS_LIMIT} Safes), so it wasn't added — switch to another workspace to add it there`,
-          }),
-        )
-      } else {
-        const spaceResult = await dispatch(
-          spacesApi.endpoints.spaceSafesCreateV1.initiate({
-            spaceId: resolvedSpaceId,
-            createSpaceSafesDto: { safes: [{ chainId, address: safeAddress }] },
-          }),
-        )
-        if ('error' in spaceResult) {
-          // Use case: another admin added Safes to the same workspace in the meantime.
-          // The cached count was stale and the backend returned 400.
-          // The Safe itself was still created, so keep it and show the warning.
-          if (isLimitRejection(spaceResult.error)) {
-            dispatch(
-              showNotification({
-                variant: 'info',
-                groupKey: 'cf-safe-space-limit',
-                message: toSpaceError(spaceResult.error).message,
-              }),
-            )
-            // In a multi-chain batch the safe genuinely wasn't attached on this
-            // chain. Roll back the user-level entry and report failure so the
-            // caller doesn't record this chain as successfully created.
-            if (isMultiChainCreation) {
-              const rollbackResult = await dispatch(
-                counterfactualSafesApi.endpoints.counterfactualSafesDeleteV1.initiate({
-                  deleteCounterfactualSafesDto: { safes: [{ chainId, address: safeAddress }] },
-                }),
-              )
-              if ('error' in rollbackResult) {
-                dispatch(enqueuePendingCfDelete({ chainId, address: safeAddress }))
-              }
-              return { ok: false, error: toSpaceError(spaceResult.error) }
-            }
-          } else {
-            // Roll back the user-level entry so the backend doesn't end up with
-            // a safe that the user "created" but failed to associate with their
-            // active space.
-            const rollbackResult = await dispatch(
-              counterfactualSafesApi.endpoints.counterfactualSafesDeleteV1.initiate({
-                deleteCounterfactualSafesDto: { safes: [{ chainId, address: safeAddress }] },
-              }),
-            )
-            if ('error' in rollbackResult) {
-              // Rollback also failed — orphan now exists server-side. Queue the
-              // cleanup so the next sign-in's sync flushes it, otherwise the GET
-              // would re-surface the orphan locally as "Not activated".
-              dispatch(enqueuePendingCfDelete({ chainId, address: safeAddress }))
-            }
-            return { ok: false, error: toSpaceError(spaceResult.error) }
-          }
+        if ('error' in rollbackResult) {
+          // Rollback also failed — orphan now exists server-side. Queue the
+          // cleanup so the next sign-in's sync flushes it, otherwise the GET
+          // would re-surface the orphan locally as "Not activated".
+          dispatch(enqueuePendingCfDelete({ chainId, address: safeAddress }))
         }
+        return { ok: false, error: spaceResult.error }
       }
     }
   }
@@ -169,17 +123,6 @@ const CONFLICT_MESSAGE =
   'A counterfactual Safe with these parameters already exists on this chain. Please contact support if this is unexpected.'
 
 type BackendError = { status?: number; data?: { message?: string } }
-
-function toSpaceError(error: unknown): Error {
-  return new Error((error as BackendError)?.data?.message || 'Failed to add Safe account to workspace')
-}
-
-/** Matches the CGW limit message, e.g. "This space only allows a maximum of 40 safe accounts...".
- *  Other 400s (validation, malformed payload) must keep the rollback path. */
-function isLimitRejection(error: unknown): boolean {
-  const { status, data } = (error as BackendError) ?? {}
-  return status === 400 && typeof data?.message === 'string' && /maximum of \d+/i.test(data.message)
-}
 
 function toPersistError(error: unknown): Error {
   if ((error as BackendError)?.status === 409) {

--- a/apps/web/src/features/spaces/services/__tests__/addSafeToSpace.test.ts
+++ b/apps/web/src/features/spaces/services/__tests__/addSafeToSpace.test.ts
@@ -132,6 +132,30 @@ describe('addSafeToSpace', () => {
     )
   })
 
+  // The Safe already being in the space is the end state we wanted, so it must not
+  // surface as an error — and must never trigger the caller's rollback.
+  it.each([
+    [
+      'the CGW duplicate-key message',
+      {
+        status: 409,
+        data: {
+          message:
+            'A SpaceSafe with the same chainId and address already exists: Key (chain_id, address_index, space_id)=(11155111, pBOVCziYoTCLdLXj2sLEMOZhzts9AuWXWZLa-7UGtvY, 131) already exists.',
+        },
+      },
+    ],
+    ['a bare 409', { status: 409 }],
+    ['a duplicate reported as a 500', { status: 500, data: { message: 'SpaceSafe already exists' } }],
+  ])('treats %s as success', async (_label, error) => {
+    const dispatch = jest.fn(() => ({ error })) as unknown as AppDispatch
+
+    const result = await addSafeToSpace({ ...baseArgs, spaceId: MOCK_SPACE_UUID, dispatch })
+
+    expect(result).toEqual({ status: 'added' })
+    expect(showNotificationImpl).not.toHaveBeenCalled()
+  })
+
   it('reports other failures without notifying, leaving the caller to decide', async () => {
     const dispatch = jest.fn(() => ({ error: { status: 500 } })) as unknown as AppDispatch
 

--- a/apps/web/src/features/spaces/services/__tests__/addSafeToSpace.test.ts
+++ b/apps/web/src/features/spaces/services/__tests__/addSafeToSpace.test.ts
@@ -1,0 +1,161 @@
+import { addSafeToSpace } from '../addSafeToSpace'
+import { SAFE_ACCOUNTS_LIMIT } from '../../constants'
+import type { AppDispatch } from '@/store'
+import { faker } from '@faker-js/faker'
+
+const MOCK_SPACE_UUID = faker.string.uuid()
+
+const spaceInitiate = jest.fn()
+const showNotificationImpl = jest.fn()
+
+jest.mock('@/store/notificationsSlice', () => ({
+  showNotification: (payload: unknown) => {
+    showNotificationImpl(payload)
+    return { type: 'showNotification', payload }
+  },
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
+  cgwApi: {
+    endpoints: {
+      spaceSafesCreateV1: {
+        initiate: (...args: unknown[]) => {
+          spaceInitiate(...args)
+          return { type: 'space-create-thunk' }
+        },
+      },
+    },
+  },
+}))
+
+const baseArgs = {
+  chainId: '100',
+  safeAddress: '0xSafe',
+  isAdminOfActiveSpace: true,
+}
+
+describe('addSafeToSpace', () => {
+  beforeEach(() => {
+    spaceInitiate.mockClear()
+    showNotificationImpl.mockClear()
+  })
+
+  it('POSTs the safe to the space and reports it as added', async () => {
+    const dispatch = jest.fn(() => ({ data: undefined })) as unknown as AppDispatch
+
+    const result = await addSafeToSpace({ ...baseArgs, spaceId: MOCK_SPACE_UUID, dispatch })
+
+    expect(result).toEqual({ status: 'added' })
+    expect(spaceInitiate).toHaveBeenCalledWith({
+      spaceId: MOCK_SPACE_UUID,
+      createSpaceSafesDto: { safes: [{ chainId: '100', address: '0xSafe' }] },
+    })
+    expect(showNotificationImpl).not.toHaveBeenCalled()
+  })
+
+  it.each([null, '', '   '])('skips the call when there is no usable space id (%p)', async (spaceId) => {
+    const dispatch = jest.fn(() => ({ data: undefined })) as unknown as AppDispatch
+
+    const result = await addSafeToSpace({ ...baseArgs, spaceId, dispatch })
+
+    expect(result).toEqual({ status: 'skipped', reason: 'no-space' })
+    expect(spaceInitiate).not.toHaveBeenCalled()
+    expect(showNotificationImpl).not.toHaveBeenCalled()
+  })
+
+  it('skips the call and informs the user when they are not an admin', async () => {
+    const dispatch = jest.fn(() => ({ data: undefined })) as unknown as AppDispatch
+
+    const result = await addSafeToSpace({
+      ...baseArgs,
+      spaceId: MOCK_SPACE_UUID,
+      isAdminOfActiveSpace: false,
+      dispatch,
+    })
+
+    expect(result).toEqual({ status: 'skipped', reason: 'not-admin' })
+    expect(spaceInitiate).not.toHaveBeenCalled()
+    expect(showNotificationImpl).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'info', groupKey: 'cf-safe-space-skipped' }),
+    )
+  })
+
+  it('skips the call and informs the user when the space is already full', async () => {
+    const dispatch = jest.fn(() => ({ data: undefined })) as unknown as AppDispatch
+
+    const result = await addSafeToSpace({
+      ...baseArgs,
+      spaceId: MOCK_SPACE_UUID,
+      spaceSafeCount: SAFE_ACCOUNTS_LIMIT,
+      dispatch,
+    })
+
+    expect(result).toEqual({ status: 'skipped', reason: 'space-full' })
+    expect(spaceInitiate).not.toHaveBeenCalled()
+    expect(showNotificationImpl).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'info', groupKey: 'cf-safe-space-limit' }),
+    )
+  })
+
+  it('still POSTs when the cached count is below the limit', async () => {
+    const dispatch = jest.fn(() => ({ data: undefined })) as unknown as AppDispatch
+
+    const result = await addSafeToSpace({
+      ...baseArgs,
+      spaceId: MOCK_SPACE_UUID,
+      spaceSafeCount: SAFE_ACCOUNTS_LIMIT - 1,
+      dispatch,
+    })
+
+    expect(result).toEqual({ status: 'added' })
+    expect(spaceInitiate).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a limit rejection separately and informs the user with the backend message', async () => {
+    const dispatch = jest.fn(() => ({
+      error: { status: 400, data: { message: 'This space only allows a maximum of 40 safe accounts' } },
+    })) as unknown as AppDispatch
+
+    const result = await addSafeToSpace({ ...baseArgs, spaceId: MOCK_SPACE_UUID, dispatch })
+
+    expect(result).toEqual({
+      status: 'failed',
+      isLimitRejection: true,
+      error: new Error('This space only allows a maximum of 40 safe accounts'),
+    })
+    expect(showNotificationImpl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: 'info',
+        groupKey: 'cf-safe-space-limit',
+        message: 'This space only allows a maximum of 40 safe accounts',
+      }),
+    )
+  })
+
+  it('reports other failures without notifying, leaving the caller to decide', async () => {
+    const dispatch = jest.fn(() => ({ error: { status: 500 } })) as unknown as AppDispatch
+
+    const result = await addSafeToSpace({ ...baseArgs, spaceId: MOCK_SPACE_UUID, dispatch })
+
+    expect(result).toEqual({
+      status: 'failed',
+      isLimitRejection: false,
+      error: new Error('Failed to add Safe account to workspace'),
+    })
+    expect(showNotificationImpl).not.toHaveBeenCalled()
+  })
+
+  it('treats a 400 without a limit message as an ordinary failure', async () => {
+    const dispatch = jest.fn(() => ({
+      error: { status: 400, data: { message: 'Invalid address' } },
+    })) as unknown as AppDispatch
+
+    const result = await addSafeToSpace({ ...baseArgs, spaceId: MOCK_SPACE_UUID, dispatch })
+
+    expect(result).toEqual({
+      status: 'failed',
+      isLimitRejection: false,
+      error: new Error('Invalid address'),
+    })
+  })
+})

--- a/apps/web/src/features/spaces/services/addSafeToSpace.ts
+++ b/apps/web/src/features/spaces/services/addSafeToSpace.ts
@@ -84,6 +84,14 @@ export const addSafeToSpace = async ({
   if ('error' in spaceResult) {
     const error = toSpaceError(spaceResult.error)
 
+    // The Safe is already in this space (e.g. a leftover counterfactual record at
+    // the same predicted address, a retry, or a co-admin adding it concurrently).
+    // That is the end state we wanted, so report success — surfacing an error here
+    // would also make the counterfactual caller roll back a perfectly good Safe.
+    if (isDuplicateRejection(spaceResult.error)) {
+      return { status: 'added' }
+    }
+
     // Use case: another admin added Safes to the same workspace in the meantime.
     // The cached count was stale and the backend returned 400.
     if (isLimitRejection(spaceResult.error)) {
@@ -107,6 +115,14 @@ type BackendError = { status?: number; data?: { message?: string } }
 
 function toSpaceError(error: unknown): Error {
   return new Error((error as BackendError)?.data?.message || 'Failed to add Safe account to workspace')
+}
+
+/** True when the backend rejected the add because the Safe is already in the space.
+ *  CGW answers 409, but a duplicate-key violation can also surface as a 5xx with the
+ *  constraint text, so the message is matched independently of the status code. */
+function isDuplicateRejection(error: unknown): boolean {
+  const { status, data } = (error as BackendError) ?? {}
+  return status === 409 || (typeof data?.message === 'string' && /already exists/i.test(data.message))
 }
 
 /** Matches the CGW limit message, e.g. "This space only allows a maximum of 40 safe accounts...".

--- a/apps/web/src/features/spaces/services/addSafeToSpace.ts
+++ b/apps/web/src/features/spaces/services/addSafeToSpace.ts
@@ -1,0 +1,117 @@
+import type { AppDispatch } from '@/store'
+import { cgwApi as spacesApi } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { showNotification } from '@/store/notificationsSlice'
+import { normalizeSpaceId } from '@/utils/spaces'
+import { SAFE_ACCOUNTS_LIMIT } from '../constants'
+
+type AddSafeToSpaceArgs = {
+  chainId: string
+  safeAddress: string
+  /** Active space id (string from auth state), or null if the user has none. */
+  spaceId: string | null
+  /** Whether the user is an active admin of the active space. When false the
+   *  backend would reject the call with 403, so it is skipped. */
+  isAdminOfActiveSpace: boolean
+  /** Number of safes already in the active space, when known. */
+  spaceSafeCount?: number
+  dispatch: AppDispatch
+}
+
+export type AddSafeToSpaceResult =
+  | { status: 'added' }
+  | { status: 'skipped'; reason: 'no-space' | 'not-admin' | 'space-full' }
+  /** `isLimitRejection` distinguishes "the space is full" (the safe itself is
+   *  fine, the user has been informed) from a genuine write failure. */
+  | { status: 'failed'; error: Error; isLimitRejection: boolean }
+
+/**
+ * Attaches an existing Safe address to the user's active space. Shared by the
+ * counterfactual and the direct-deployment creation paths so both land the new
+ * Safe in the same workspace.
+ *
+ * Never throws: every outcome is reported so the caller can decide whether it
+ * is fatal. The counterfactual path rolls back and aborts on failure; the
+ * deployment path cannot (the transaction is already broadcast) and only warns.
+ */
+export const addSafeToSpace = async ({
+  chainId,
+  safeAddress,
+  spaceId,
+  isAdminOfActiveSpace,
+  spaceSafeCount,
+  dispatch,
+}: AddSafeToSpaceArgs): Promise<AddSafeToSpaceResult> => {
+  // Guard against persisted/legacy lastUsedSpace values that are empty or
+  // whitespace-only — pass any non-empty string through unchanged.
+  const resolvedSpaceId = normalizeSpaceId(spaceId)
+  if (resolvedSpaceId === null) {
+    return { status: 'skipped', reason: 'no-space' }
+  }
+
+  if (!isAdminOfActiveSpace) {
+    // Backend gates this endpoint on admin role and would 403. Inform the user —
+    // the safe itself is unaffected.
+    dispatch(
+      showNotification({
+        variant: 'info',
+        groupKey: 'cf-safe-space-skipped',
+        message: 'Safe added to your accounts — ask an admin to add it to the workspace',
+      }),
+    )
+    return { status: 'skipped', reason: 'not-admin' }
+  }
+
+  if (spaceSafeCount !== undefined && spaceSafeCount >= SAFE_ACCOUNTS_LIMIT) {
+    // Space is full — the backend would reject the add. Skip it so creation
+    // still succeeds, but tell the user it wasn't added to the workspace.
+    dispatch(
+      showNotification({
+        variant: 'info',
+        groupKey: 'cf-safe-space-limit',
+        message: `Safe created. This workspace is full (${SAFE_ACCOUNTS_LIMIT} Safes), so it wasn't added — switch to another workspace to add it there`,
+      }),
+    )
+    return { status: 'skipped', reason: 'space-full' }
+  }
+
+  const spaceResult = await dispatch(
+    spacesApi.endpoints.spaceSafesCreateV1.initiate({
+      spaceId: resolvedSpaceId,
+      createSpaceSafesDto: { safes: [{ chainId, address: safeAddress }] },
+    }),
+  )
+
+  if ('error' in spaceResult) {
+    const error = toSpaceError(spaceResult.error)
+
+    // Use case: another admin added Safes to the same workspace in the meantime.
+    // The cached count was stale and the backend returned 400.
+    if (isLimitRejection(spaceResult.error)) {
+      dispatch(
+        showNotification({
+          variant: 'info',
+          groupKey: 'cf-safe-space-limit',
+          message: error.message,
+        }),
+      )
+      return { status: 'failed', error, isLimitRejection: true }
+    }
+
+    return { status: 'failed', error, isLimitRejection: false }
+  }
+
+  return { status: 'added' }
+}
+
+type BackendError = { status?: number; data?: { message?: string } }
+
+function toSpaceError(error: unknown): Error {
+  return new Error((error as BackendError)?.data?.message || 'Failed to add Safe account to workspace')
+}
+
+/** Matches the CGW limit message, e.g. "This space only allows a maximum of 40 safe accounts...".
+ *  Other 400s (validation, malformed payload) must keep the rollback path. */
+function isLimitRejection(error: unknown): boolean {
+  const { status, data } = (error as BackendError) ?? {}
+  return status === 400 && typeof data?.message === 'string' && /maximum of \d+/i.test(data.message)
+}

--- a/apps/web/src/features/spaces/services/index.ts
+++ b/apps/web/src/features/spaces/services/index.ts
@@ -1,0 +1,2 @@
+export { addSafeToSpace } from './addSafeToSpace'
+export type { AddSafeToSpaceResult } from './addSafeToSpace'


### PR DESCRIPTION
## What it solves

Resolves: [WA-2917](https://linear.app/safe-global/issue/WA-2917/counterfactual-safe-workspace-flow-fails-to-save-account) (partial — Case 1)

A Safe created with **"pay now"** was never added to the workspace it was created from — only the counterfactual branch called the space endpoint.

That also disabled **"Add network"**: the space chain selector derives its chains from the workspace's safes, so an unattached Safe produced an empty list, which `useSafeCreationData` misreported as _"outdated mastercopy"_. The 40-Safe limit was never involved.

## How this PR fixes it

1. **`refactor`** — extract the workspace-attach block out of `persistCounterfactualSafe` into a shared `addSafeToSpace` service returning a typed outcome (`added` / `skipped` / `failed`). Behaviour-preserving: existing tests pass untouched.
2. **`fix`** — call it from the deploy branch in `ReviewStep`, after the status events. The tx is already broadcast, so a failure warns instead of rolling back.
3. **`fix`** — treat "already in this workspace" as success. Previously it surfaced a raw DB constraint error, and on the counterfactual path it **rolled back**, deleting a good record and aborting creation.

## How to test it

1. Create a workspace → create a Safe from it with **"Pay now"**.
2. Safe appears in the workspace; **"Add network"** is enabled.
3. **"Pay later"** — unchanged.

## Affected flows

- Safe creation, pay-now — now attaches to the active workspace
- Safe creation, pay-later, and "Add another network" — unchanged, same extracted code path
- Add-network availability for a workspace Safe — fixed as a consequence

## Blast radius

- **New** `features/spaces/services/addSafeToSpace.ts` — consumers: `persistCounterfactualSafe`, `ReviewStep`
- `spaceSafesCreateV1` gains one caller; each call invalidates the coarse `'spaces'` RTK tag, refetching every mounted space query
- No shared-package, mobile, persistence, or route changes

## Risks / not checked

- **Unverified: that CGW accepts `spaceSafesCreateV1` for an address whose deployment tx is still pending.** Inferred from the counterfactual path already posting undeployed addresses. Worth a staging check — the fix rests on it.
- Multi-chain direct deployment now issues one space POST per chain, slightly worsening the Case 2 429s. The DTO takes an array; batching is the follow-up.
- Not tested on mobile (web-only) or end-to-end in a real workspace.
- **Cases 2 and 3 are not addressed.** Commit 3 fixes the symptom of a repeat address, not the cause: salt-nonce selection still ignores workspace membership.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1[ReviewStep] -->|Pay later| B1[persistCounterfactualSafe]
    B1 --> C1[CF record + workspace attach]
    A1 -->|Pay now| D1[createNewSafe]
    D1 --> E1["local Redux only — never in the workspace"]
  end
  subgraph After
    A2[ReviewStep] -->|Pay later| B2[persistCounterfactualSafe]
    A2 -->|Pay now| D2[createNewSafe]
    B2 --> S[addSafeToSpace]
    D2 --> S
    S --> F["in the workspace (duplicate = success)"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 <!-- web-only change -->
- [x] I've documented how it affects the analytics (if at all) 📊 <!-- no analytics change -->
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 <!-- 20 new tests; 190 suites / 1691 tests green -->
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
