### PR TITLE
fix(tx-flow): show correct success screen for Safe-signed nested txs (WA-2891)

### DIFF
--- a/apps/web/src/components/common/WalletProvider/index.tsx
+++ b/apps/web/src/components/common/WalletProvider/index.tsx
@@ -52,10 +52,11 @@ const WalletProvider = ({ children }: { children: ReactNode }): ReactElement => 
   // A Safe connected directly (e.g. via WalletConnect) acts as its own signer. Resolve its Safe
   // info so the tx flow can treat it as a Safe signer (on-chain approveHash/execTransaction that
   // only queues) rather than an EOA. Returns undefined (404) for EOAs and non-Safe smart accounts.
+  // Gated on matching chains so a same-address Safe on a different chain can't be misdetected.
   const { currentData: connectedSafeInfo } = useSafesGetSafeV1Query(
     { chainId: currentChain?.chainId || '', safeAddress: wallet?.address || '' },
     {
-      skip: !wallet?.address || !currentChain,
+      skip: !wallet?.address || !currentChain || wallet.chainId !== currentChain.chainId,
     },
   )
 

--- a/apps/web/src/components/common/WalletProvider/index.tsx
+++ b/apps/web/src/components/common/WalletProvider/index.tsx
@@ -13,6 +13,9 @@ export type SignerWallet = {
   address: string
   chainId: string
   isSafe?: boolean
+  // Threshold of the nested (parent) Safe when `isSafe` is true; used to tell whether the
+  // parent executes an on-chain signature/execution immediately (threshold 1) or only queues it.
+  threshold?: number
 }
 
 export type WalletContextType = {

--- a/apps/web/src/components/common/WalletProvider/index.tsx
+++ b/apps/web/src/components/common/WalletProvider/index.tsx
@@ -12,9 +12,13 @@ export type SignerWallet = {
   provider: Eip1193Provider | null
   address: string
   chainId: string
+  // The signer is the in-app nested signer (a parent Safe picked from the signer dropdown, wrapped
+  // by getNestedWallet). It executes an on-chain signature/execution immediately at threshold 1.
   isSafe?: boolean
-  // Threshold of the nested (parent) Safe when `isSafe` is true; used to tell whether the
-  // parent executes an on-chain signature/execution immediately (threshold 1) or only queues it.
+  // The connected wallet is itself a Safe (e.g. connected via WalletConnect) acting as the signer.
+  // Such a Safe always returns a safeTxHash from eth_sendTransaction (never executes synchronously).
+  isConnectedSafe?: boolean
+  // Threshold of the signer Safe when `isSafe`/`isConnectedSafe` is true.
   threshold?: number
 }
 
@@ -45,6 +49,16 @@ const WalletProvider = ({ children }: { children: ReactNode }): ReactElement => 
     },
   )
 
+  // A Safe connected directly (e.g. via WalletConnect) acts as its own signer. Resolve its Safe
+  // info so the tx flow can treat it as a Safe signer (on-chain approveHash/execTransaction that
+  // only queues) rather than an EOA. Returns undefined (404) for EOAs and non-Safe smart accounts.
+  const { currentData: connectedSafeInfo } = useSafesGetSafeV1Query(
+    { chainId: currentChain?.chainId || '', safeAddress: wallet?.address || '' },
+    {
+      skip: !wallet?.address || !currentChain,
+    },
+  )
+
   useEffect(() => {
     if (!onboard) return
 
@@ -63,8 +77,11 @@ const WalletProvider = ({ children }: { children: ReactNode }): ReactElement => 
     if (wallet && nestedSafeInfo && web3ReadOnly) {
       return getNestedWallet(wallet, nestedSafeInfo, web3ReadOnly, router)
     }
+    if (wallet && connectedSafeInfo) {
+      return { ...wallet, isConnectedSafe: true as const, threshold: connectedSafeInfo.threshold }
+    }
     return wallet
-  }, [wallet, nestedSafeInfo, web3ReadOnly, router])
+  }, [wallet, nestedSafeInfo, connectedSafeInfo, web3ReadOnly, router])
 
   return (
     <WalletContext.Provider

--- a/apps/web/src/components/tx-flow/actions/Execute/ExecuteForm.tsx
+++ b/apps/web/src/components/tx-flow/actions/Execute/ExecuteForm.tsx
@@ -20,7 +20,7 @@ import { useNoFeeCampaignEligibility, useGasTooHigh, useIsNoFeeCampaignEnabled }
 import { hasRemainingRelays } from '@/utils/relaying'
 import type { SafeTransaction } from '@safe-global/types-kit'
 import { TxModalContext } from '@/components/tx-flow'
-import { SuccessScreenFlow } from '@/components/tx-flow/flows'
+import { SuccessScreenFlow, NestedTxSuccessScreenFlow } from '@/components/tx-flow/flows'
 import useGasLimit from '@/hooks/useGasLimit'
 import AdvancedParams, { useAdvancedParams } from '@/components/tx/AdvancedParams'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
@@ -70,6 +70,7 @@ export const ExecuteForm = ({
 }): ReactElement => {
   // Hooks
   const currentChain = useCurrentChain()
+  const signer = useSigner()
   const { executeTx } = txActions
   const { setTxFlow } = useContext(TxModalContext)
   const { needsRiskConfirmation, isRiskConfirmed } = txSecurity
@@ -175,15 +176,16 @@ export const ExecuteForm = ({
     onSubmit?.()
 
     let executedTxId: string
+    let isExecuted: boolean
     try {
-      executedTxId = await executeTx(
+      ;({ txId: executedTxId, isExecuted } = await executeTx(
         txOptions,
         safeTx,
         txId,
         origin,
         willRelay || willNoFeeCampaign,
         acceptUnverifiedSimulation,
-      )
+      ))
     } catch (_err) {
       const err = asError(_err)
       if (isWalletRejection(err)) {
@@ -199,9 +201,15 @@ export const ExecuteForm = ({
       return
     }
 
-    // On success
-    onSubmitSuccess?.({ txId: executedTxId, isExecuted: true })
-    setTxFlow(<SuccessScreenFlow txId={executedTxId} />, undefined, false)
+    // A smart-contract-wallet executor (nested Safe or a Safe connected via WalletConnect) that
+    // only queues the tx returns a safeTxHash rather than executing. Route those to the nested
+    // success screen instead of the processing screen (whose Etherscan link would be wrong).
+    onSubmitSuccess?.({ txId: executedTxId, isExecuted })
+    setTxFlow(
+      isExecuted ? <SuccessScreenFlow txId={executedTxId} /> : <NestedTxSuccessScreenFlow txId={executedTxId} />,
+      undefined,
+      false,
+    )
   }
 
   // On modal submit
@@ -220,7 +228,6 @@ export const ExecuteForm = ({
   // Parent Safe as executor cannot pay gas from the (child) Safe. The relay path doesn't
   // support this nested execution flow at this moment. Block Execute when both conditions hold so
   // the user can't submit a tx that would dead end at sign time.
-  const signer = useSigner()
   const blockSafePaysFromNestedExecutor = signer?.isSafe === true && !!requiresRelay
 
   const submitDisabled =

--- a/apps/web/src/components/tx-flow/actions/Execute/__tests__/ExecuteForm.test.tsx
+++ b/apps/web/src/components/tx-flow/actions/Execute/__tests__/ExecuteForm.test.tsx
@@ -172,7 +172,7 @@ describe('ExecuteForm', () => {
   })
 
   it('execute the tx when the submit button is clicked', async () => {
-    const mockExecuteTx = jest.fn()
+    const mockExecuteTx = jest.fn().mockResolvedValue({ txId: '0x123', isExecuted: true })
 
     const { getByText } = render(
       <ExecuteForm
@@ -278,7 +278,7 @@ describe('ExecuteForm', () => {
     const mockExecuteTx = jest
       .fn()
       .mockRejectedValueOnce(new RelaySimulationError('INDETERMINATE_SIMULATION', 'service down'))
-      .mockResolvedValueOnce('0xnewtx')
+      .mockResolvedValueOnce({ txId: '0xnewtx', isExecuted: true })
 
     const { getByText, getByTestId } = render(
       <ExecuteForm

--- a/apps/web/src/components/tx-flow/actions/Sign/SignForm.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/SignForm.tsx
@@ -12,7 +12,6 @@ import commonCss from '@/components/tx-flow/common/styles.module.css'
 import NonOwnerError from '@/components/tx/shared/errors/NonOwnerError'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
 import { isWalletRejection } from '@/utils/wallets'
-import { useSigner } from '@/hooks/wallets/useWallet'
 import { NestedTxSuccessScreenFlow } from '@/components/tx-flow/flows'
 import { TxFlowContext } from '@/components/tx-flow/TxFlowProvider'
 import { TxCardActions } from '@/components/tx-flow/common/TxCard'
@@ -51,7 +50,6 @@ export const SignForm = ({
     useContext(TxFlowContext)
   const { needsRiskConfirmation, isRiskConfirmed } = txSecurity
   const hasSigned = useAlreadySigned(safeTx)
-  const signer = useSigner()
 
   const handleOptionChange = (option: string) => {
     onChange?.(option)
@@ -70,8 +68,9 @@ export const SignForm = ({
     onSubmit?.()
 
     let resultTxId: string
+    let isNestedSigning: boolean
     try {
-      resultTxId = await signTx(safeTx, txId, origin)
+      ;({ txId: resultTxId, isNestedSigning } = await signTx(safeTx, txId, origin))
     } catch (_err) {
       const err = asError(_err)
       if (isWalletRejection(err)) {
@@ -87,7 +86,10 @@ export const SignForm = ({
     // On successful sign
     onSubmitSuccess?.({ txId: resultTxId })
 
-    if (signer?.isSafe) {
+    // A smart-account signer (nested Safe or a Safe connected via WalletConnect) creates an
+    // on-chain approveHash tx in its own Safe. Show the nested success screen so the user
+    // understands the signature still needs confirming there, rather than silently closing.
+    if (isNestedSigning) {
       setTxFlow(<NestedTxSuccessScreenFlow txId={resultTxId} />, undefined, false)
     } else {
       setTxFlow(undefined)

--- a/apps/web/src/components/tx-flow/actions/Sign/__tests__/SignForm.test.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/__tests__/SignForm.test.tsx
@@ -105,7 +105,7 @@ describe('SignForm', () => {
   })
 
   it('signs a transaction', async () => {
-    const mockSignTx = jest.fn()
+    const mockSignTx = jest.fn().mockResolvedValue({ txId: '0x123', isNestedSigning: false })
 
     const { getByText } = render(
       <SignForm

--- a/apps/web/src/components/tx-flow/flows/NestedTxSuccessScreen/index.test.tsx
+++ b/apps/web/src/components/tx-flow/flows/NestedTxSuccessScreen/index.test.tsx
@@ -1,0 +1,86 @@
+import { render } from '@/tests/test-utils'
+import { faker } from '@faker-js/faker'
+import { zeroPadValue } from 'ethers'
+import NestedTxSuccessScreen from '.'
+import { PendingStatus, type PendingTxsState } from '@/store/pendingTxsSlice'
+import * as useChainsHook from '@/hooks/useChains'
+import { chainBuilder } from '@/tests/builders/chains'
+
+const chain = chainBuilder()
+  .with({
+    chainId: '1',
+    blockExplorerUriTemplate: {
+      address: 'https://etherscan.io/address/{{address}}',
+      txHash: 'https://etherscan.io/tx/{{txHash}}',
+      api: 'https://api.etherscan.io/api',
+    },
+  })
+  .build()
+
+const TX_ID = 'multisig_0xchild_0xhash'
+const PARENT_SAFE = faker.finance.ethereumAddress()
+const CHILD_SAFE = faker.finance.ethereumAddress()
+
+const renderScreen = (executed: boolean, hash: string, method: 'approveHash' | 'execTransaction' = 'approveHash') => {
+  const pendingTxs: PendingTxsState = {
+    [TX_ID]: {
+      nonce: 1,
+      chainId: '1',
+      safeAddress: CHILD_SAFE,
+      status: PendingStatus.NESTED_SIGNING,
+      signerAddress: PARENT_SAFE,
+      txHashOrParentSafeTxHash: hash,
+      executed,
+      method,
+    },
+  }
+  return render(<NestedTxSuccessScreen txId={TX_ID} />, { initialReduxState: { pendingTxs } })
+}
+
+describe('NestedTxSuccessScreen', () => {
+  beforeEach(() => {
+    jest.spyOn(useChainsHook, 'useCurrentChain').mockReturnValue(chain)
+  })
+
+  it('links to the block explorer when the parent executed immediately', () => {
+    const onChainTxHash = zeroPadValue('0x01', 32)
+    const { getByText } = renderScreen(true, onChainTxHash)
+
+    expect(getByText(/executed this transaction on-chain/i)).toBeInTheDocument()
+
+    const link = getByText('Open the transaction').closest('a')
+    expect(link).toHaveAttribute('href', `https://etherscan.io/tx/${onChainTxHash}`)
+  })
+
+  it('deep-links to the parent transaction detail when the parent only queued the tx', () => {
+    const parentSafeTxHash = zeroPadValue('0x02', 32)
+    const { getByText } = renderScreen(false, parentSafeTxHash)
+
+    expect(getByText(/still need to confirm and execute/i)).toBeInTheDocument()
+
+    const link = getByText('Open the transaction').closest('a')
+    const href = link?.getAttribute('href') ?? ''
+    expect(href).toContain('/transactions/tx')
+    expect(href).toContain(`id=${encodeURIComponent(parentSafeTxHash)}`)
+    expect(href).not.toContain('etherscan.io')
+  })
+
+  it('labels the step approveHash and uses "confirm" copy for a nested signature', () => {
+    const { getByText } = renderScreen(false, zeroPadValue('0x03', 32), 'approveHash')
+
+    expect(getByText('approveHash')).toBeInTheDocument()
+    expect(getByText(/before it signs this Safe/i)).toBeInTheDocument()
+  })
+
+  it('labels the step execTransaction and uses "execute" copy for a nested execution', () => {
+    const { getByText } = renderScreen(false, zeroPadValue('0x04', 32), 'execTransaction')
+
+    expect(getByText('execTransaction')).toBeInTheDocument()
+    expect(getByText(/before this Safe's transaction runs/i)).toBeInTheDocument()
+  })
+
+  it('shows an error when there is no nested pending tx', () => {
+    const { getByText } = render(<NestedTxSuccessScreen txId="unknown" />, { initialReduxState: { pendingTxs: {} } })
+    expect(getByText('No transaction data found')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/tx-flow/flows/NestedTxSuccessScreen/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/NestedTxSuccessScreen/index.tsx
@@ -14,9 +14,8 @@ import { useAppSelector } from '@/store'
 import ExternalLink from '@/components/common/ExternalLink'
 import { MODALS_EVENTS } from '@/services/analytics'
 import Track from '@/components/common/Track'
-import useAsync from '@safe-global/utils/hooks/useAsync'
-import { getSafeTransaction } from '@/utils/transactions'
-import { isMultisigDetailedExecutionInfo } from '@/utils/transaction-guards'
+import { useCurrentChain } from '@/hooks/useChains'
+import { getExplorerLink } from '@safe-global/utils/utils/gateway'
 
 type Props = {
   txId: string
@@ -33,20 +32,16 @@ const NestedTxSuccessScreen = ({ txId }: Props) => {
     }
   }, [_pendingTx])
 
-  const [safeTx] = useAsync(() => {
-    if (cachedPendingTx?.status == PendingStatus.NESTED_SIGNING) {
-      return getSafeTransaction(
-        cachedPendingTx.txHashOrParentSafeTxHash,
-        cachedPendingTx.chainId,
-        cachedPendingTx.signerAddress,
-      )
-    }
-  }, [cachedPendingTx])
-  const isSafeTxHash =
-    cachedPendingTx?.status == PendingStatus.NESTED_SIGNING &&
-    !!safeTx &&
-    isMultisigDetailedExecutionInfo(safeTx.detailedExecutionInfo) &&
-    safeTx.detailedExecutionInfo.safeTxHash === cachedPendingTx.txHashOrParentSafeTxHash
+  const chain = useCurrentChain()
+
+  // When the parent executed immediately (threshold 1), `txHashOrParentSafeTxHash` is a real
+  // on-chain tx hash → link to the block explorer. Otherwise it is the parent's safeTxHash of a
+  // queued tx → deep-link to the parent's transaction detail so it can be confirmed.
+  const isExecuted = cachedPendingTx?.status === PendingStatus.NESTED_SIGNING && cachedPendingTx.executed
+  const explorerLink =
+    isExecuted && chain
+      ? getExplorerLink(cachedPendingTx.txHashOrParentSafeTxHash, chain.blockExplorerUriTemplate)
+      : undefined
 
   if (cachedPendingTx?.status !== PendingStatus.NESTED_SIGNING) {
     return <ErrorMessage>No transaction data found</ErrorMessage>
@@ -54,6 +49,7 @@ const NestedTxSuccessScreen = ({ txId }: Props) => {
 
   const currentSafeAddress = addressBook[cachedPendingTx.safeAddress]
   const parentSafeAddress = addressBook[cachedPendingTx.signerAddress]
+  const isExecTransaction = cachedPendingTx.method === 'execTransaction'
 
   return (
     <Container
@@ -70,10 +66,14 @@ const NestedTxSuccessScreen = ({ txId }: Props) => {
           <SvgIcon component={NestedSafeIcon} inheritViewBox fontSize="large" alt="Nested Safe" />
         </Box>
         <Typography data-testid="transaction-status" variant="h6" marginTop={2} fontWeight={700}>
-          A nested transaction was created
+          {isExecuted ? 'Transaction submitted' : 'One more step in the parent Safe'}
         </Typography>
         <Typography variant="body2" mb={3}>
-          Once confirmed and executed this signer transaction will confirm the child Safe&apos;s transaction.
+          {isExecuted
+            ? 'The parent Safe executed this transaction on-chain.'
+            : isExecTransaction
+              ? "Executing as the parent Safe created a transaction inside it. The parent Safe's owners still need to confirm and execute that transaction before this Safe's transaction runs."
+              : "Signing as the parent Safe created an approval transaction inside it. The parent Safe's owners still need to confirm and execute that transaction before it signs this Safe's transaction."}
         </Typography>
         <Stack spacing={2} width="70%">
           <Box display="flex" flexDirection="column" alignItems="start" gap={1}>
@@ -97,7 +97,7 @@ const NestedTxSuccessScreen = ({ txId }: Props) => {
                 whiteSpace: 'nowrap',
               }}
             >
-              approveHash
+              {cachedPendingTx.method}
             </Typography>
           </Stack>
           <Box display="flex" flexDirection="column" alignItems="start" gap={1}>
@@ -108,30 +108,26 @@ const NestedTxSuccessScreen = ({ txId }: Props) => {
           </Box>
         </Stack>
         <Track {...MODALS_EVENTS.OPEN_PARENT_TX}>
-          <Link
-            href={
-              isSafeTxHash
-                ? {
-                    pathname: AppRoutes.transactions.tx,
-                    query: {
-                      safe: cachedPendingTx.signerAddress,
-                      chainId: cachedPendingTx.chainId,
-                      id: cachedPendingTx.txHashOrParentSafeTxHash,
-                    },
-                  }
-                : {
-                    pathname: AppRoutes.transactions.queue,
-                    query: {
-                      safe: cachedPendingTx.signerAddress,
-                      chainId: cachedPendingTx.chainId,
-                    },
-                  }
-            }
-            passHref
-            legacyBehavior
-          >
-            <ExternalLink mode="button">Open the transaction</ExternalLink>
-          </Link>
+          {explorerLink ? (
+            <ExternalLink href={explorerLink.href} mode="button">
+              Open the transaction
+            </ExternalLink>
+          ) : (
+            <Link
+              href={{
+                pathname: AppRoutes.transactions.tx,
+                query: {
+                  safe: cachedPendingTx.signerAddress,
+                  chainId: cachedPendingTx.chainId,
+                  id: cachedPendingTx.txHashOrParentSafeTxHash,
+                },
+              }}
+              passHref
+              legacyBehavior
+            >
+              <ExternalLink mode="button">Open the transaction</ExternalLink>
+            </Link>
+          )}
         </Track>
       </Box>
     </Container>

--- a/apps/web/src/components/tx/shared/__tests__/hooks.test.ts
+++ b/apps/web/src/components/tx/shared/__tests__/hooks.test.ts
@@ -286,11 +286,11 @@ describe('SignOrExecute hooks', () => {
       const id = await signTx(createSafeTx())
       expect(signSpy).toHaveBeenCalled()
       expect(onchainSignSpy).not.toHaveBeenCalled()
-      expect(id).toBe('123')
+      expect(id.txId).toBe('123')
 
       const id2 = await signTx(createSafeTx(), '456')
       expect(signSpy).toHaveBeenCalled()
-      expect(id2).toBe('123')
+      expect(id2.txId).toBe('123')
     })
 
     it('should sign a tx on-chain', async () => {
@@ -322,7 +322,7 @@ describe('SignOrExecute hooks', () => {
 
       const id = await signTx(createSafeTx(), '456')
       expect(signSpy).toHaveBeenCalled()
-      expect(id).toBe('456')
+      expect(id.txId).toBe('456')
     })
 
     it('should execute a tx without a txId (immediate execution)', async () => {
@@ -355,7 +355,7 @@ describe('SignOrExecute hooks', () => {
       const id = await executeTx({ gasPrice: 1 }, createSafeTx())
       expect(proposeSpy).toHaveBeenCalled()
       expect(executeSpy).toHaveBeenCalled()
-      expect(id).toEqual('123')
+      expect(id.txId).toEqual('123')
     })
 
     it('should execute a tx with an id (existing tx)', async () => {
@@ -388,7 +388,7 @@ describe('SignOrExecute hooks', () => {
       const id = await executeTx({ gasPrice: 1 }, createSafeTx(), '455')
       expect(proposeSpy).not.toHaveBeenCalled()
       expect(executeSpy).toHaveBeenCalled()
-      expect(id).toEqual('455')
+      expect(id.txId).toEqual('455')
     })
 
     it('should throw an error if the tx is undefined', async () => {
@@ -454,7 +454,7 @@ describe('SignOrExecute hooks', () => {
       const id = await executeTx({ gasPrice: 1 }, tx, '123', 'origin.com', true)
       expect(proposeSpy).not.toHaveBeenCalled()
       expect(relaySpy).toHaveBeenCalled()
-      expect(id).toEqual('123')
+      expect(id.txId).toEqual('123')
     })
 
     it('should sign a not fully signed tx when relaying', async () => {
@@ -508,7 +508,7 @@ describe('SignOrExecute hooks', () => {
       expect(proposeSpy).toHaveBeenCalled()
       expect(signSpy).toHaveBeenCalled()
       expect(relaySpy).toHaveBeenCalled()
-      expect(id).toEqual('123')
+      expect(id.txId).toEqual('123')
     })
 
     it('should throw when relaying an unsigned tx as a smart contract wallet', async () => {

--- a/apps/web/src/components/tx/shared/hooks.ts
+++ b/apps/web/src/components/tx/shared/hooks.ts
@@ -35,9 +35,16 @@ import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { useAppDispatch, useAppSelector } from '@/store'
 import { selectCurrency } from '@/store/settingsSlice'
 
+// A smart-account signer creates an on-chain approveHash tx in its own Safe, so signing lands in
+// a "nested signing" state rather than adding an off-chain signature.
+type SignResult = { txId: string; isNestedSigning: boolean }
+// `isExecuted` is false when a smart-account executor only queued the tx in its own Safe (so the
+// returned hash is a safeTxHash, not an on-chain tx hash).
+type ExecuteResult = { txId: string; isExecuted: boolean }
+
 type TxActions = {
   addToBatch: (safeTx?: SafeTransaction, origin?: string) => Promise<string>
-  signTx: (safeTx?: SafeTransaction, txId?: string, origin?: string) => Promise<string>
+  signTx: (safeTx?: SafeTransaction, txId?: string, origin?: string) => Promise<SignResult>
   executeTx: (
     txOptions: TransactionOptions,
     safeTx?: SafeTransaction,
@@ -45,7 +52,7 @@ type TxActions = {
     origin?: string,
     isRelayed?: boolean,
     acceptUnverifiedSimulation?: boolean,
-  ) => Promise<string>
+  ) => Promise<ExecuteResult>
   signProposerTx: (safeTx?: SafeTransaction, origin?: string) => Promise<string>
   proposeTx: (safeTx: SafeTransaction, txId?: string, origin?: string) => Promise<TransactionDetails>
 }
@@ -131,28 +138,25 @@ export const useTxActions = (): TxActions => {
 
       safeTx = await withGtfFeeParams(safeTx)
 
-      // Smart contract wallets must sign via an on-chain tx
-      if (signer.isSafe || (await isSmartContractWallet(signer.chainId, signer.address))) {
+      // Smart contract wallets (nested Safe or a Safe connected via WalletConnect) must sign via
+      // an on-chain approveHash tx
+      const isSmartAccount = Boolean(signer.isSafe) || (await isSmartContractWallet(signer.chainId, signer.address))
+      if (isSmartAccount) {
         // If the first signature is a smart contract wallet, we have to propose w/o signatures
         // Otherwise the backend won't pick up the tx
         // The signature will be added once the on-chain signature is indexed
         const id = txId || (await _propose(signer.address, safeTx, txId, origin)).txId
-        await dispatchOnChainSigning(
-          safeTx,
-          id,
-          signer.provider,
-          chainId,
-          signer.address,
-          safeAddress,
-          Boolean(signer.isSafe),
-        )
-        return id
+        // The on-chain signature executes immediately only for the in-app nested signer with
+        // threshold 1; otherwise it is queued in the signer Safe and returns a safeTxHash.
+        const executed = Boolean(signer.isSafe) && signer.threshold === 1
+        await dispatchOnChainSigning(safeTx, id, signer.provider, chainId, signer.address, safeAddress, executed)
+        return { txId: id, isNestedSigning: true }
       }
 
       // Otherwise, sign off-chain
       const signedTx = await dispatchTxSigning(safeTx, signer.provider, txId)
       const tx = await _propose(signer.address, signedTx, txId, origin)
-      return tx.txId
+      return { txId: tx.txId, isNestedSigning: false }
     }
 
     const signProposerTx: TxActions['signProposerTx'] = async (safeTx, origin) => {
@@ -196,21 +200,30 @@ export const useTxActions = (): TxActions => {
       // Relay or execute the tx via connected wallet
       if (isRelayed) {
         await dispatchTxRelay(safeTx, safe, txId, chain, txOptions.gasLimit, acceptUnverifiedSimulation)
-      } else {
-        const isSmartAccount = await isSmartContractWallet(signer.chainId, signer.address)
-        await dispatchTxExecution(
-          safe.chainId,
-          safeTx,
-          txOptions,
-          txId,
-          signer.provider,
-          signer.address,
-          safeAddress,
-          isSmartAccount,
-        )
+        return { txId, isExecuted: true }
       }
 
-      return txId
+      const isSmartAccount = Boolean(signer.isSafe) || (await isSmartContractWallet(signer.chainId, signer.address))
+      // A smart-contract-wallet executor (nested Safe via the signer dropdown, or a Safe connected
+      // through WalletConnect) submits to its own Safe and gets back a safeTxHash, not an on-chain
+      // tx hash — UNLESS it's the in-app nested signer with threshold 1, which executes immediately
+      // and returns a real hash. In every other smart-account case the tx is only queued.
+      // Note: this assumes a smart-account executor is a Safe; a non-Safe smart account that
+      // executes immediately would be mislabelled as queued.
+      const executed = !isSmartAccount || (Boolean(signer.isSafe) && signer.threshold === 1)
+      await dispatchTxExecution(
+        safe.chainId,
+        safeTx,
+        txOptions,
+        txId,
+        signer.provider,
+        signer.address,
+        safeAddress,
+        isSmartAccount,
+        executed,
+      )
+
+      return { txId, isExecuted: executed }
     }
 
     return { addToBatch, signTx, executeTx, signProposerTx, proposeTx }
@@ -221,6 +234,7 @@ export const useTxActions = (): TxActions => {
     signer?.address,
     signer?.chainId,
     signer?.isSafe,
+    signer?.threshold,
     addTxToBatch,
     onboard,
     chain,

--- a/apps/web/src/components/tx/shared/hooks.ts
+++ b/apps/web/src/components/tx/shared/hooks.ts
@@ -34,6 +34,18 @@ import { mergeGtfFeeParams } from '@/features/gtf/services'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { useAppDispatch, useAppSelector } from '@/store'
 import { selectCurrency } from '@/store/settingsSlice'
+import type { SignerWallet } from '@/components/common/WalletProvider'
+
+// The signer is a Safe: either the in-app nested signer (`isSafe`) or a Safe connected directly,
+// e.g. via WalletConnect (`isConnectedSafe`). Such a signer creates an on-chain
+// approveHash/execTransaction in its own Safe instead of signing/executing directly.
+const isSafeSigner = (signer: SignerWallet): boolean => Boolean(signer.isSafe) || Boolean(signer.isConnectedSafe)
+
+// Whether the signer executes the on-chain tx immediately (returning a real tx hash) rather than
+// queuing it in its own Safe (returning a safeTxHash). True for EOAs and non-Safe smart accounts;
+// among Safe signers, only the in-app nested signer at threshold 1 executes synchronously.
+const executesImmediately = (signer: SignerWallet): boolean =>
+  !isSafeSigner(signer) || (Boolean(signer.isSafe) && signer.threshold === 1)
 
 // A smart-account signer creates an on-chain approveHash tx in its own Safe, so signing lands in
 // a "nested signing" state rather than adding an off-chain signature.
@@ -141,16 +153,13 @@ export const useTxActions = (): TxActions => {
       // Any smart contract wallet must sign via an on-chain approveHash tx (they can't sign
       // off-chain). Only a Safe signer (in-app nested or a Safe connected via WalletConnect) gets
       // the nested success screen; other smart accounts keep the plain flow.
-      const isSafeSigner = Boolean(signer.isSafe) || Boolean(signer.isConnectedSafe)
-      const isSmartAccount = isSafeSigner || (await isSmartContractWallet(signer.chainId, signer.address))
+      const viaSafe = isSafeSigner(signer)
+      const isSmartAccount = viaSafe || (await isSmartContractWallet(signer.chainId, signer.address))
       if (isSmartAccount) {
         // If the first signature is a smart contract wallet, we have to propose w/o signatures
         // Otherwise the backend won't pick up the tx
         // The signature will be added once the on-chain signature is indexed
         const id = txId || (await _propose(signer.address, safeTx, txId, origin)).txId
-        // Only the in-app nested signer executes the approveHash synchronously (threshold 1);
-        // a connected Safe always queues it and returns a safeTxHash.
-        const executed = Boolean(signer.isSafe) && signer.threshold === 1
         await dispatchOnChainSigning(
           safeTx,
           id,
@@ -158,10 +167,10 @@ export const useTxActions = (): TxActions => {
           chainId,
           signer.address,
           safeAddress,
-          isSafeSigner,
-          executed,
+          viaSafe,
+          executesImmediately(signer),
         )
-        return { txId: id, isNestedSigning: isSafeSigner }
+        return { txId: id, isNestedSigning: viaSafe }
       }
 
       // Otherwise, sign off-chain
@@ -214,13 +223,12 @@ export const useTxActions = (): TxActions => {
         return { txId, isExecuted: true }
       }
 
-      const isSafeSigner = Boolean(signer.isSafe) || Boolean(signer.isConnectedSafe)
-      const isSmartAccount = isSafeSigner || (await isSmartContractWallet(signer.chainId, signer.address))
+      const isSmartAccount = isSafeSigner(signer) || (await isSmartContractWallet(signer.chainId, signer.address))
       // A Safe executor submits to its own Safe and gets back a safeTxHash, not an on-chain tx hash
       // — UNLESS it's the in-app nested signer at threshold 1, which executes immediately and
       // returns a real hash. EOAs and non-Safe smart accounts execute directly (real hash / their
       // own semantics), so treat them as executed and keep the plain processing flow.
-      const executed = !isSafeSigner || (Boolean(signer.isSafe) && signer.threshold === 1)
+      const executed = executesImmediately(signer)
       await dispatchTxExecution(
         safe.chainId,
         safeTx,
@@ -240,12 +248,7 @@ export const useTxActions = (): TxActions => {
   }, [
     safe,
     wallet,
-    signer?.provider,
-    signer?.address,
-    signer?.chainId,
-    signer?.isSafe,
-    signer?.isConnectedSafe,
-    signer?.threshold,
+    signer,
     addTxToBatch,
     onboard,
     chain,

--- a/apps/web/src/components/tx/shared/hooks.ts
+++ b/apps/web/src/components/tx/shared/hooks.ts
@@ -138,19 +138,30 @@ export const useTxActions = (): TxActions => {
 
       safeTx = await withGtfFeeParams(safeTx)
 
-      // Smart contract wallets (nested Safe or a Safe connected via WalletConnect) must sign via
-      // an on-chain approveHash tx
-      const isSmartAccount = Boolean(signer.isSafe) || (await isSmartContractWallet(signer.chainId, signer.address))
+      // Any smart contract wallet must sign via an on-chain approveHash tx (they can't sign
+      // off-chain). Only a Safe signer (in-app nested or a Safe connected via WalletConnect) gets
+      // the nested success screen; other smart accounts keep the plain flow.
+      const isSafeSigner = Boolean(signer.isSafe) || Boolean(signer.isConnectedSafe)
+      const isSmartAccount = isSafeSigner || (await isSmartContractWallet(signer.chainId, signer.address))
       if (isSmartAccount) {
         // If the first signature is a smart contract wallet, we have to propose w/o signatures
         // Otherwise the backend won't pick up the tx
         // The signature will be added once the on-chain signature is indexed
         const id = txId || (await _propose(signer.address, safeTx, txId, origin)).txId
-        // The on-chain signature executes immediately only for the in-app nested signer with
-        // threshold 1; otherwise it is queued in the signer Safe and returns a safeTxHash.
+        // Only the in-app nested signer executes the approveHash synchronously (threshold 1);
+        // a connected Safe always queues it and returns a safeTxHash.
         const executed = Boolean(signer.isSafe) && signer.threshold === 1
-        await dispatchOnChainSigning(safeTx, id, signer.provider, chainId, signer.address, safeAddress, executed)
-        return { txId: id, isNestedSigning: true }
+        await dispatchOnChainSigning(
+          safeTx,
+          id,
+          signer.provider,
+          chainId,
+          signer.address,
+          safeAddress,
+          isSafeSigner,
+          executed,
+        )
+        return { txId: id, isNestedSigning: isSafeSigner }
       }
 
       // Otherwise, sign off-chain
@@ -203,14 +214,13 @@ export const useTxActions = (): TxActions => {
         return { txId, isExecuted: true }
       }
 
-      const isSmartAccount = Boolean(signer.isSafe) || (await isSmartContractWallet(signer.chainId, signer.address))
-      // A smart-contract-wallet executor (nested Safe via the signer dropdown, or a Safe connected
-      // through WalletConnect) submits to its own Safe and gets back a safeTxHash, not an on-chain
-      // tx hash — UNLESS it's the in-app nested signer with threshold 1, which executes immediately
-      // and returns a real hash. In every other smart-account case the tx is only queued.
-      // Note: this assumes a smart-account executor is a Safe; a non-Safe smart account that
-      // executes immediately would be mislabelled as queued.
-      const executed = !isSmartAccount || (Boolean(signer.isSafe) && signer.threshold === 1)
+      const isSafeSigner = Boolean(signer.isSafe) || Boolean(signer.isConnectedSafe)
+      const isSmartAccount = isSafeSigner || (await isSmartContractWallet(signer.chainId, signer.address))
+      // A Safe executor submits to its own Safe and gets back a safeTxHash, not an on-chain tx hash
+      // — UNLESS it's the in-app nested signer at threshold 1, which executes immediately and
+      // returns a real hash. EOAs and non-Safe smart accounts execute directly (real hash / their
+      // own semantics), so treat them as executed and keep the plain processing flow.
+      const executed = !isSafeSigner || (Boolean(signer.isSafe) && signer.threshold === 1)
       await dispatchTxExecution(
         safe.chainId,
         safeTx,
@@ -234,6 +244,7 @@ export const useTxActions = (): TxActions => {
     signer?.address,
     signer?.chainId,
     signer?.isSafe,
+    signer?.isConnectedSafe,
     signer?.threshold,
     addTxToBatch,
     onboard,

--- a/apps/web/src/hooks/useTxPendingStatuses.ts
+++ b/apps/web/src/hooks/useTxPendingStatuses.ts
@@ -255,6 +255,8 @@ const useTxPendingStatuses = (): void => {
           status: PendingStatus.NESTED_SIGNING,
           signerAddress: detail.parentSafeAddress,
           txHashOrParentSafeTxHash: detail.txHashOrParentSafeTxHash,
+          executed: detail.executed,
+          method: detail.method,
         }),
       )
     })

--- a/apps/web/src/services/tx/tx-sender/__tests__/ts-sender.test.ts
+++ b/apps/web/src/services/tx/tx-sender/__tests__/ts-sender.test.ts
@@ -8,12 +8,14 @@ import {
   createTx,
   createExistingTx,
   createRejectTx,
+  dispatchOnChainSigning,
   dispatchTxExecution,
   dispatchTxProposal,
   dispatchTxSigning,
   dispatchBatchExecutionRelay,
   dispatchTxRelay,
 } from '..'
+import * as sdk from '../sdk'
 import {
   BrowserProvider,
   type TransactionReceipt,
@@ -447,6 +449,7 @@ describe('txSender', () => {
         SIGNER_ADDRESS,
         safeAddress,
         false,
+        true,
       )
 
       expect(mockSafeSDK.executeTransaction).toHaveBeenCalled()
@@ -483,7 +486,7 @@ describe('txSender', () => {
       })
 
       await expect(
-        dispatchTxExecution('1', safeTx, {}, txId, MockEip1193Provider, '5', safeAddress, false),
+        dispatchTxExecution('1', safeTx, {}, txId, MockEip1193Provider, '5', safeAddress, false, true),
       ).rejects.toThrow('error')
 
       expect(mockSafeSDK.executeTransaction).toHaveBeenCalled()
@@ -509,7 +512,17 @@ describe('txSender', () => {
         nonce: 1,
       })
 
-      await dispatchTxExecution('1', safeTx, { nonce: 1 }, txId, MockEip1193Provider, SIGNER_ADDRESS, '0x123', false)
+      await dispatchTxExecution(
+        '1',
+        safeTx,
+        { nonce: 1 },
+        txId,
+        MockEip1193Provider,
+        SIGNER_ADDRESS,
+        '0x123',
+        false,
+        true,
+      )
 
       expect(mockSafeSDK.executeTransaction).toHaveBeenCalled()
       expect(txEvents.txDispatch).toHaveBeenCalledWith('EXECUTING', {
@@ -623,6 +636,83 @@ describe('txSender', () => {
         chainId: '5',
         safeAddress,
       })
+    })
+  })
+
+  describe('nested Safe signing/execution', () => {
+    const PARENT_SAFE = toBeHex('0xabc', 20)
+    const CHILD_SAFE = toBeHex('0xdef', 20)
+
+    it('dispatchOnChainSigning emits NESTED_SAFE_TX_CREATED with executed=false when the parent only queues the approveHash', async () => {
+      jest.spyOn(sdk, 'prepareApproveTxHash').mockResolvedValue('0xapprovehashdata')
+      const parentSafeTxHash = zeroPadValue('0x01', 32)
+      ;(MockEip1193Provider.request as jest.Mock).mockResolvedValue(parentSafeTxHash)
+
+      const safeTx = await createTx({ to: '0x123', value: '1', data: '0x0', nonce: 1 })
+
+      await dispatchOnChainSigning(safeTx, 'tx_id_123', MockEip1193Provider, '1', PARENT_SAFE, CHILD_SAFE, false)
+
+      expect(txEvents.txDispatch).toHaveBeenCalledWith(
+        'NESTED_SAFE_TX_CREATED',
+        expect.objectContaining({
+          txId: 'tx_id_123',
+          txHashOrParentSafeTxHash: parentSafeTxHash,
+          parentSafeAddress: PARENT_SAFE,
+          executed: false,
+          method: 'approveHash',
+        }),
+      )
+    })
+
+    it('dispatchOnChainSigning emits NESTED_SAFE_TX_CREATED with executed=true when the parent executes immediately', async () => {
+      jest.spyOn(sdk, 'prepareApproveTxHash').mockResolvedValue('0xapprovehashdata')
+      const onChainTxHash = zeroPadValue('0x02', 32)
+      ;(MockEip1193Provider.request as jest.Mock).mockResolvedValue(onChainTxHash)
+
+      const safeTx = await createTx({ to: '0x123', value: '1', data: '0x0', nonce: 1 })
+
+      await dispatchOnChainSigning(safeTx, 'tx_id_123', MockEip1193Provider, '1', PARENT_SAFE, CHILD_SAFE, true)
+
+      expect(txEvents.txDispatch).toHaveBeenCalledWith(
+        'NESTED_SAFE_TX_CREATED',
+        expect.objectContaining({
+          txHashOrParentSafeTxHash: onChainTxHash,
+          parentSafeAddress: PARENT_SAFE,
+          executed: true,
+        }),
+      )
+    })
+
+    it('dispatchTxExecution emits NESTED_SAFE_TX_CREATED instead of PROCESSING when a smart-account executor only queues the execTransaction', async () => {
+      jest.spyOn(sdk, 'prepareTxExecution').mockResolvedValue('0xexecdata')
+      const parentSafeTxHash = zeroPadValue('0x03', 32)
+      ;(MockEip1193Provider.request as jest.Mock).mockResolvedValue(parentSafeTxHash)
+
+      const safeTx = await createTx({ to: '0x123', value: '1', data: '0x0', nonce: 1 })
+
+      await dispatchTxExecution(
+        '1',
+        safeTx,
+        { nonce: 1 },
+        'tx_id_123',
+        MockEip1193Provider,
+        PARENT_SAFE,
+        CHILD_SAFE,
+        true, // isSmartAccount
+        false, // executed
+      )
+
+      expect(txEvents.txDispatch).toHaveBeenCalledWith(
+        'NESTED_SAFE_TX_CREATED',
+        expect.objectContaining({
+          txHashOrParentSafeTxHash: parentSafeTxHash,
+          parentSafeAddress: PARENT_SAFE,
+          executed: false,
+          method: 'execTransaction',
+        }),
+      )
+      expect(txEvents.txDispatch).not.toHaveBeenCalledWith('PROCESSING', expect.anything())
+      expect(txEvents.txDispatch).not.toHaveBeenCalledWith('EXECUTING', expect.anything())
     })
   })
 })

--- a/apps/web/src/services/tx/tx-sender/__tests__/ts-sender.test.ts
+++ b/apps/web/src/services/tx/tx-sender/__tests__/ts-sender.test.ts
@@ -650,7 +650,7 @@ describe('txSender', () => {
 
       const safeTx = await createTx({ to: '0x123', value: '1', data: '0x0', nonce: 1 })
 
-      await dispatchOnChainSigning(safeTx, 'tx_id_123', MockEip1193Provider, '1', PARENT_SAFE, CHILD_SAFE, false)
+      await dispatchOnChainSigning(safeTx, 'tx_id_123', MockEip1193Provider, '1', PARENT_SAFE, CHILD_SAFE, true, false)
 
       expect(txEvents.txDispatch).toHaveBeenCalledWith(
         'NESTED_SAFE_TX_CREATED',
@@ -671,7 +671,7 @@ describe('txSender', () => {
 
       const safeTx = await createTx({ to: '0x123', value: '1', data: '0x0', nonce: 1 })
 
-      await dispatchOnChainSigning(safeTx, 'tx_id_123', MockEip1193Provider, '1', PARENT_SAFE, CHILD_SAFE, true)
+      await dispatchOnChainSigning(safeTx, 'tx_id_123', MockEip1193Provider, '1', PARENT_SAFE, CHILD_SAFE, true, true)
 
       expect(txEvents.txDispatch).toHaveBeenCalledWith(
         'NESTED_SAFE_TX_CREATED',
@@ -681,6 +681,19 @@ describe('txSender', () => {
           executed: true,
         }),
       )
+    })
+
+    it('dispatchOnChainSigning does NOT emit NESTED_SAFE_TX_CREATED for a non-Safe smart-account signer', async () => {
+      jest.spyOn(sdk, 'prepareApproveTxHash').mockResolvedValue('0xapprovehashdata')
+      ;(MockEip1193Provider.request as jest.Mock).mockResolvedValue(zeroPadValue('0x05', 32))
+
+      const safeTx = await createTx({ to: '0x123', value: '1', data: '0x0', nonce: 1 })
+
+      // isSafeSigner = false → non-Safe smart account (e.g. Argent/AA): keeps the plain flow.
+      await dispatchOnChainSigning(safeTx, 'tx_id_123', MockEip1193Provider, '1', PARENT_SAFE, CHILD_SAFE, false, false)
+
+      expect(txEvents.txDispatch).toHaveBeenCalledWith('ONCHAIN_SIGNATURE_SUCCESS', expect.anything())
+      expect(txEvents.txDispatch).not.toHaveBeenCalledWith('NESTED_SAFE_TX_CREATED', expect.anything())
     })
 
     it('dispatchTxExecution emits NESTED_SAFE_TX_CREATED instead of PROCESSING when a smart-account executor only queues the execTransaction', async () => {

--- a/apps/web/src/services/tx/tx-sender/dispatch.ts
+++ b/apps/web/src/services/tx/tx-sender/dispatch.ts
@@ -142,6 +142,7 @@ export const dispatchOnChainSigning = async (
   chainId: SafeState['chainId'],
   signerAddress: string,
   safeAddress: string,
+  isSafeSigner: boolean,
   executed: boolean,
 ) => {
   const sdk = await getSafeSDKWithSigner(provider)
@@ -173,15 +174,17 @@ export const dispatchOnChainSigning = async (
 
   txDispatch(TxEvent.ONCHAIN_SIGNATURE_SUCCESS, eventParams)
 
-  // On-chain signing is only used by smart-account signers, and it always creates an approveHash
-  // tx in the signer Safe (executed immediately for a threshold-1 nested signer, otherwise queued).
-  txDispatch(TxEvent.NESTED_SAFE_TX_CREATED, {
-    ...eventParams,
-    txHashOrParentSafeTxHash,
-    parentSafeAddress: signerAddress,
-    executed,
-    method: 'approveHash',
-  })
+  // On-chain signing runs for any smart-account signer, but only a Safe signer creates an
+  // approveHash tx we can surface and deep-link to. Non-Safe smart accounts keep the plain flow.
+  if (isSafeSigner) {
+    txDispatch(TxEvent.NESTED_SAFE_TX_CREATED, {
+      ...eventParams,
+      txHashOrParentSafeTxHash,
+      parentSafeAddress: signerAddress,
+      executed,
+      method: 'approveHash',
+    })
+  }
 
   // Until the on-chain signature is/has been executed, the safeTx is not
   // signed so we don't return it

--- a/apps/web/src/services/tx/tx-sender/dispatch.ts
+++ b/apps/web/src/services/tx/tx-sender/dispatch.ts
@@ -142,7 +142,7 @@ export const dispatchOnChainSigning = async (
   chainId: SafeState['chainId'],
   signerAddress: string,
   safeAddress: string,
-  isNestedSafe: boolean,
+  executed: boolean,
 ) => {
   const sdk = await getSafeSDKWithSigner(provider)
   const safeTxHash = await sdk.getTransactionHash(safeTx)
@@ -173,13 +173,15 @@ export const dispatchOnChainSigning = async (
 
   txDispatch(TxEvent.ONCHAIN_SIGNATURE_SUCCESS, eventParams)
 
-  if (isNestedSafe) {
-    txDispatch(TxEvent.NESTED_SAFE_TX_CREATED, {
-      ...eventParams,
-      txHashOrParentSafeTxHash,
-      parentSafeAddress: signerAddress,
-    })
-  }
+  // On-chain signing is only used by smart-account signers, and it always creates an approveHash
+  // tx in the signer Safe (executed immediately for a threshold-1 nested signer, otherwise queued).
+  txDispatch(TxEvent.NESTED_SAFE_TX_CREATED, {
+    ...eventParams,
+    txHashOrParentSafeTxHash,
+    parentSafeAddress: signerAddress,
+    executed,
+    method: 'approveHash',
+  })
 
   // Until the on-chain signature is/has been executed, the safeTx is not
   // signed so we don't return it
@@ -290,6 +292,7 @@ export const dispatchTxExecution = async (
   signerAddress: string,
   safeAddress: string,
   isSmartAccount: boolean,
+  executed: boolean,
 ): Promise<string> => {
   const sdk = await getSafeSDKWithSigner(provider)
   const eventParams = { txId, nonce: safeTx.data.nonce, chainId, safeAddress }
@@ -314,11 +317,28 @@ export const dispatchTxExecution = async (
     } else {
       result = await sdk.executeTransaction(safeTx, txOptions)
     }
-    txDispatch(TxEvent.EXECUTING, { ...eventParams })
   } catch (error) {
     txDispatch(TxEvent.FAILED, { ...eventParams, error: asError(error) })
     throw error
   }
+
+  // A smart-contract-wallet executor (a nested parent Safe, or a Safe connected via WalletConnect)
+  // that doesn't execute immediately only queues the execTransaction in that Safe; nothing executes
+  // here yet, and `result.hash` is the executor Safe's safeTxHash, not an on-chain tx hash. Treat it
+  // like nested signing instead of a processing/executed tx.
+  if (isSmartAccount && !executed) {
+    txDispatch(TxEvent.NESTED_SAFE_TX_CREATED, {
+      ...eventParams,
+      txHashOrParentSafeTxHash: result.hash,
+      parentSafeAddress: signerAddress,
+      executed: false,
+      method: 'execTransaction',
+    })
+
+    return result.hash
+  }
+
+  txDispatch(TxEvent.EXECUTING, { ...eventParams })
 
   txDispatch(TxEvent.PROCESSING, {
     ...eventParams,

--- a/apps/web/src/services/tx/txEvents.ts
+++ b/apps/web/src/services/tx/txEvents.ts
@@ -45,6 +45,8 @@ interface TxEvents {
     SafeContext & {
       parentSafeAddress: string
       txHashOrParentSafeTxHash: string
+      executed: boolean
+      method: 'approveHash' | 'execTransaction'
     }
   [TxEvent.EXECUTING]: Id & SafeContext
   [TxEvent.PROCESSING]: Id &

--- a/apps/web/src/store/__tests__/txQueueSlice.test.ts
+++ b/apps/web/src/store/__tests__/txQueueSlice.test.ts
@@ -78,6 +78,8 @@ describe('txQueueSlice', () => {
           status: PendingStatus.NESTED_SIGNING,
           signerAddress: '0x456',
           txHashOrParentSafeTxHash: faker.string.hexadecimal({ length: 64 }),
+          executed: false,
+          method: 'approveHash',
         },
       } as PendingTxsState,
     } as RootState

--- a/apps/web/src/store/pendingTxsSlice.ts
+++ b/apps/web/src/store/pendingTxsSlice.ts
@@ -71,6 +71,11 @@ type PendingIndexingTx = PendingTxCommonProps & {
 type PendingNestedSigningTx = PendingTxCommonProps & {
   signerAddress: string
   txHashOrParentSafeTxHash: string
+  // true → executor Safe executed immediately, so `txHashOrParentSafeTxHash` is an on-chain tx hash
+  // false → the tx was only queued in the executor Safe, so it is that Safe's safeTxHash
+  executed: boolean
+  // Which Safe method the signer Safe was asked to run (drives the success-screen label)
+  method: 'approveHash' | 'execTransaction'
   status: PendingStatus.NESTED_SIGNING
 }
 

--- a/apps/web/src/utils/nested-safe-wallet.ts
+++ b/apps/web/src/utils/nested-safe-wallet.ts
@@ -19,6 +19,7 @@ export type NestedWallet = {
   chainId: string
   provider: Eip1193Provider | null
   isSafe: true
+  threshold: number
 }
 
 export const getNestedWallet = (
@@ -162,5 +163,6 @@ export const getNestedWallet = (
     address: safeInfo.address.value,
     chainId: safeInfo.chainId,
     isSafe: true,
+    threshold: safeInfo.threshold,
   }
 }


### PR DESCRIPTION
## What it solves

Resolves: WA-2891 (Nested Safe transaction hash retrieval)

When a Safe signs or executes another Safe's transaction — either the in-app **nested signer** (a parent Safe picked from the signer dropdown) or a **Safe connected via WalletConnect** — the on-chain call (`approveHash` for signing, `execTransaction` for executing) is submitted to that signer Safe. If the signer Safe doesn't execute immediately (threshold > 1, or any WalletConnect Safe), `eth_sendTransaction` returns a **`safeTxHash`, not an on-chain tx hash**.

Previously that `safeTxHash` was stored as `txHash` and rendered as an Etherscan link on the "Transaction is now processing" screen (broken link), and the flow implied the transaction had executed when it was only queued in the signer Safe. Signing via a WalletConnect Safe also closed the flow silently with no confirmation screen.

## How this PR fixes it

- The tx-sender layer computes an explicit **`executed`** flag (true only for EOA execution, or the in-app nested signer with threshold 1) and a **`method`** (`approveHash` | `execTransaction`).
- When a Safe signer/executor only queues the tx, dispatch emits `NESTED_SAFE_TX_CREATED` (pending status `NESTED_SIGNING`) instead of `PROCESSING`, so a `safeTxHash` is never rendered as an on-chain hash.
- `signTx`/`executeTx` now **return** the routing decision (`{ txId, isNestedSigning }` / `{ txId, isExecuted }`); the forms use it directly instead of reading the redux store — single source of truth, no store coupling.
- `NestedTxSuccessScreen` links to the signer (parent) Safe's queued transaction (or the block explorer when it truly executed) and labels the step with the method. Copy rewritten in plain language.
- **Routing is gated on "the signer is a Safe", not "is a smart contract".** `WalletProvider` resolves whether the connected wallet (e.g. a Safe via WalletConnect) is a Safe via `getSafe` and annotates the signer with `isConnectedSafe` + `threshold`. Non-Safe smart accounts (Argent / other AA wallets) keep their exact prior behaviour — no regression.

## How to test it

1. Open a child Safe whose owner is a parent Safe with threshold > 1 (connect the parent via WalletConnect, or pick it from the in-app signer dropdown).
2. Sign a transaction on the child. Expect the **"One more step in the parent Safe"** screen with a working link to the parent's queued `approveHash` transaction — not a broken Etherscan link, and not a silently-closed window.
3. Confirm + execute the `approveHash` in the parent; the child transaction gains its confirmation.
4. Execute the child transaction via the parent. Expect the same nested screen (labelled `execTransaction`), not the processing screen.
5. Regression: sign/execute as a plain EOA owner — unchanged normal success/processing screen with a real Etherscan link.

## Affected flows

- Sign a transaction as a Safe owner (nested dropdown or WalletConnect Safe) → nested success screen.
- Execute a transaction as a Safe owner → nested success screen when queued; normal processing when it executes on-chain (in-app nested, threshold 1).
- Sign/execute as an EOA owner → unchanged.

## Blast radius

- **`useTxActions` (`signTx`/`executeTx`)** — return type changed from `Promise<string>` to `Promise<{ txId, ... }>`. Consumers: only `SignForm` and `ExecuteForm` (both updated).
- **`dispatchOnChainSigning` / `dispatchTxExecution`** (`services/tx/tx-sender/dispatch.ts`) — `dispatchOnChainSigning` gates its nested event on a new `isSafeSigner` arg; `dispatchTxExecution` has a required `executed` param. Only caller is `useTxActions`.
- **`WalletProvider`** — adds a second `getSafe` (`useSafesGetSafeV1Query`) for the connected wallet address to detect a connected Safe. Skipped when no wallet is connected; cached by RTK Query. `signer` is consumed broadly, but the change is additive (`isConnectedSafe`/`threshold`); `isSafe` semantics (analytics `isNested` flag, safe-pays-relay block) are unchanged.
- **`TxEvent.NESTED_SAFE_TX_CREATED`** payload + **`PendingNestedSigningTx`** — added `executed` and `method`. Written in `useTxPendingStatuses`, read in `NestedTxSuccessScreen`.
- **`SignerWallet` / `NestedWallet`** — added `threshold` + `isConnectedSafe` (additive).
- No RTK Query endpoints changed, no feature flags, chain configs, routes, or persisted migrations touched.
- Shared `packages/**` not touched → no mobile impact.

## Risks / not checked

- **Non-Safe smart accounts** (Argent / other AA wallets) as owners are gated out of the nested routing and keep their exact prior behaviour — no regression. Their existing UX (a processing screen whose returned value may be a userOp hash, not a monitorable tx hash) is a pre-existing limitation, out of scope here.
- **Accepted minor — EOA `getSafe` round-trip:** the connected-wallet Safe lookup fires for every same-chain connected wallet, so EOAs incur one cached 404. Negligible; not gated behind a client-side contract check to keep the provider simple.
- **Accepted minor — load-window race:** if a WalletConnect-Safe user submits in the brief window before the connected-Safe lookup settles, `isConnectedSafe` isn't set yet and the tx would be treated as a plain execution. Narrow (the query resolves on connect, well before submit) and self-corrects on the next render; a submit-time loading guard was judged not worth the added coupling.
- Not tested on mobile (web-only tx-flow change; no shared package touched).
- WalletConnect-Safe path verified manually by the reporter; automated coverage is at the dispatch + screen level, not full E2E.

## Visual summary

```mermaid
flowchart TD
    A[Sign / Execute on child Safe] --> B{Signer kind?}
    B -->|EOA| C[Off-chain sig / real execution]
    C --> D[SuccessScreen: real tx hash + Etherscan link]
    B -->|"Non-Safe smart account (Argent/AA)"| P[Plain processing flow — unchanged, no regression]
    B -->|"Safe owner (in-app nested or WalletConnect)"| E[approveHash / execTransaction submitted to signer Safe]
    E --> F{executed?}
    F -->|"threshold 1 (in-app nested)"| G[SuccessScreen: real tx hash + Etherscan link]
    F -->|"queued (threshold > 1 or WalletConnect Safe)"| H[NestedTxSuccessScreen: deep link to signer Safe's queued tx]
    H -.->|"before fix"| X[Processing screen with safeTxHash rendered as broken Etherscan link]
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (N/A — web-only, no shared package touched)
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics change; existing `OPEN_PARENT_TX` event unchanged)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
