### PR TITLE
fix: always render the risk confirmation checkbox when confirmation is required

### DIFF
--- a/apps/web/src/components/tx-flow/features/RiskConfirmation.tsx
+++ b/apps/web/src/components/tx-flow/features/RiskConfirmation.tsx
@@ -1,6 +1,5 @@
 import { useContext } from 'react'
 import { SlotName, withSlot } from '../slots'
-import { FEATURES } from '@/utils/featureToggled'
 import { Card, Checkbox, FormControlLabel, Typography } from '@mui/material'
 import Track from '@/components/common/Track'
 import { MODALS_EVENTS } from '@/services/analytics'
@@ -48,7 +47,6 @@ const RiskConfirmationSlot = withSlot({
   Component: RiskConfirmation,
   slotName: SlotName.Footer,
   id: 'riskConfirmation',
-  feature: FEATURES.RISK_MITIGATION,
   useSlotCondition,
 })
 

--- a/apps/web/src/components/tx-flow/features/__tests__/RiskConfirmation.test.tsx
+++ b/apps/web/src/components/tx-flow/features/__tests__/RiskConfirmation.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook } from '@/tests/test-utils'
+import { type PropsWithChildren } from 'react'
+import { SlotProvider, SlotName } from '@/components/tx-flow/slots'
+import { useSlotIds } from '@/components/tx-flow/slots/hooks'
+import RiskConfirmationSlot from '../RiskConfirmation'
+import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
+import { useSafeShield } from '@/features/safe-shield/SafeShieldContext'
+import { useHasFeature } from '@/hooks/useChains'
+
+jest.mock('@/hooks/useChains', () => ({
+  __esModule: true,
+  useCurrentChain: jest.fn(() => ({ chainId: '1', features: [] })),
+  useHasFeature: jest.fn(() => false),
+}))
+
+jest.mock('@/features/safe-shield/SafeShieldContext', () => ({
+  __esModule: true,
+  useSafeShield: jest.fn(),
+}))
+
+const mockUseSafeShield = useSafeShield as jest.MockedFunction<typeof useSafeShield>
+const mockUseHasFeature = useHasFeature as jest.MockedFunction<typeof useHasFeature>
+
+const createWrapper = () => {
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <SafeTxContext.Provider value={{ safeTx: undefined } as any}>
+      <SlotProvider>
+        <RiskConfirmationSlot />
+        {children}
+      </SlotProvider>
+    </SafeTxContext.Provider>
+  )
+  return Wrapper
+}
+
+describe('RiskConfirmation slot registration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('registers the checkbox when risk confirmation is needed, regardless of chain feature flags', () => {
+    // Submit buttons block on needsRiskConfirmation unconditionally, so the checkbox must not be
+    // gated on a chain flag — otherwise submission can deadlock with no way to confirm.
+    mockUseHasFeature.mockReturnValue(false)
+    mockUseSafeShield.mockReturnValue({
+      needsRiskConfirmation: true,
+      isRiskConfirmed: false,
+      setIsRiskConfirmed: jest.fn(),
+    } as unknown as ReturnType<typeof useSafeShield>)
+
+    const { result } = renderHook(() => useSlotIds(SlotName.Footer), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current).toContain('riskConfirmation')
+  })
+
+  it('does not register the checkbox when no risk confirmation is needed', () => {
+    mockUseSafeShield.mockReturnValue({
+      needsRiskConfirmation: false,
+      isRiskConfirmed: false,
+      setIsRiskConfirmed: jest.fn(),
+    } as unknown as ReturnType<typeof useSafeShield>)
+
+    const { result } = renderHook(() => useSlotIds(SlotName.Footer), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current).not.toContain('riskConfirmation')
+  })
+})


### PR DESCRIPTION
## What it solves

Resolves: [WA-2982](https://linear.app/safe-global/issue/WA-2982/show-risk-acknowledgment-checkbox-for-address-poisoning-warnings)

The transaction flow's submit buttons (Sign / Execute / Propose / Execute-through-role / Counterfactual) are disabled whenever `needsRiskConfirmation` is set, with no feature-flag condition. The "I understand the risks…" checkbox that clears this state was, however, registered with `feature: FEATURES.RISK_MITIGATION`. On chains without that feature the checkbox never rendered, so any transaction that set `needsRiskConfirmation` was blocked with no way to proceed.

## How this PR fixes it

Removes the `RISK_MITIGATION` gate from the `RiskConfirmation` slot registration. The slot's own condition (`needsRiskConfirmation`) remains the sole render condition, matching the already-ungated usage of the same component in the message-signing flow (`SignMessage.tsx`).

Each risk source feeding `needsRiskConfirmation` keeps its own gating upstream (e.g. `ADDRESS_POISONING_PROTECTION`, `HYPERNATIVE`), so the checkbox still only appears when a gated analysis actually produces a result.

## How to test it

- Unit test: `apps/web/src/components/tx-flow/features/__tests__/RiskConfirmation.test.tsx` — asserts the slot registers when `needsRiskConfirmation` is true with all chain feature flags off, and does not register otherwise.
- Manual: on a chain **without** `RISK_MITIGATION`, create a transaction that triggers any Safe Shield critical result (e.g. a recipient flagged by an enabled analysis). On the review step the checkbox now renders below the warning; ticking it enables the submit button. On chains **with** `RISK_MITIGATION`, behavior is unchanged.

## Affected flows

- User submits a transaction on a chain without the `RISK_MITIGATION` feature while Safe Shield requires risk confirmation: previously hard-blocked, now confirmable via the checkbox.
- All other flows unchanged (on chains with `RISK_MITIGATION` the gate was already true; the message-signing flow already used the component ungated).

## Blast radius

- `RiskConfirmation` slot (Footer) — rendered only in `ReviewTransactionContent` (V2 review step); consumed by all TxFlow-based flows.
- No change to `needsRiskConfirmation` computation (`SafeShieldContext`) — no new blocking is introduced anywhere; the change is render-only.
- `FEATURES.RISK_MITIGATION` remains in use by `BalanceChanges` and spaces transaction scanning; those are untouched.
- Analytics: the `MODALS_EVENTS.ACCEPT_RISK` event (wrapped around the checkbox) can now fire on chains without `RISK_MITIGATION`; no schema change.
- No API contract, store, or mobile impact.

## Risks / not checked

- Did not exercise the Hypernative / deadlock confirmation paths manually on a chain without `RISK_MITIGATION`; verified manually via the recipient-analysis and untrusted-Safe paths, plus unit tests.
- The batch-execution flow (`ReviewBatch`) blocks on `needsRiskConfirmation` but renders no checkbox on any chain; pre-existing, out of scope here.
- Not tested on mobile (web-only change).


## Visual summary

Before:
<img width="1106" height="615" alt="Screenshot 2026-08-04 at 16 22 32" src="https://github.com/user-attachments/assets/d423a8da-84fb-4918-990e-e58421fef6f8" />
After:
<img width="1123" height="663" alt="Screenshot 2026-08-04 at 16 23 29" src="https://github.com/user-attachments/assets/9ea14b66-c658-4a41-9111-7bf648db6413" />


```mermaid
flowchart TD
    A[Safe Shield analysis sets needsRiskConfirmation] --> B[Submit buttons disabled - no flag condition]
    A --> C{RiskConfirmation slot}
    C -- before: requires RISK_MITIGATION feature --> D[Chains without the flag: checkbox never renders - submission stuck]
    C -- after: needsRiskConfirmation only --> E[Checkbox renders wherever submission is blocked - user can confirm and proceed]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
