### PR TITLE
chore: correct actions/checkout version comment to v7.0.1

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/mobile-checks.yml
+++ b/.github/workflows/mobile-checks.yml
@@ -26,7 +26,7 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/yarn
         with:
           after-install: 'false'
@@ -41,7 +41,7 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/yarn
         with:
           after-install: 'false'
@@ -56,7 +56,7 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/yarn
         with:
           after-install: 'false'

--- a/.github/workflows/mobile-dev-release.yml
+++ b/.github/workflows/mobile-dev-release.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/yarn
         with:

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/yarn
         with:

--- a/.github/workflows/mobile-linear-release.yml
+++ b/.github/workflows/mobile-linear-release.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # Full history required to scan commits for Linear issue IDs
 

--- a/.github/workflows/mobile-storybook-screenshots.yml
+++ b/.github/workflows/mobile-storybook-screenshots.yml
@@ -16,7 +16,7 @@ jobs:
   screenshot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/mobile-unit-tests.yml
+++ b/.github/workflows/mobile-unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/yarn
         with:

--- a/.github/workflows/package-utils-unit-tests.yml
+++ b/.github/workflows/package-utils-unit-tests.yml
@@ -22,7 +22,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/yarn
 

--- a/.github/workflows/page-screenshots-build.yml
+++ b/.github/workflows/page-screenshots-build.yml
@@ -28,7 +28,7 @@ jobs:
       # Pin to the commit SHA the deploy ran against. If the PR head moves
       # between the deploy finishing and this workflow starting, head_branch
       # would resolve to the new tip, mismatching the deployed preview.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0

--- a/.github/workflows/page-screenshots-publish.yml
+++ b/.github/workflows/page-screenshots-publish.yml
@@ -35,7 +35,7 @@ jobs:
       # Check out the default branch only. The workspace must not contain
       # head-branch contents — the validated artifact is the only thing
       # this workflow consumes from the build half.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: dev
           fetch-depth: 1

--- a/.github/workflows/store-codegen-check.yml
+++ b/.github/workflows/store-codegen-check.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/store-codegen-drift.yml
+++ b/.github/workflows/store-codegen-drift.yml
@@ -16,7 +16,7 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/yarn
         with:
           after-install: 'false'

--- a/.github/workflows/tx-builder-checks.yml
+++ b/.github/workflows/tx-builder-checks.yml
@@ -28,7 +28,7 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/yarn
       - name: Run ESLint
         run: yarn workspace @safe-global/tx-builder lint
@@ -40,7 +40,7 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/yarn
       - name: Run Prettier check
         run: yarn workspace @safe-global/tx-builder prettier
@@ -52,7 +52,7 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/yarn
       - name: Type check
         run: yarn workspace @safe-global/tx-builder type-check
@@ -60,7 +60,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/yarn
       - name: Run unit tests
         run: yarn workspace @safe-global/tx-builder test --ci --coverage
@@ -73,7 +73,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/yarn
       - name: Build
         run: yarn workspace @safe-global/tx-builder build

--- a/.github/workflows/tx-builder-deploy.yml
+++ b/.github/workflows/tx-builder-deploy.yml
@@ -50,7 +50,7 @@ jobs:
             ⏳ Building preview deployment...
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -104,7 +104,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/yarn
 
@@ -138,7 +138,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/web-argos-e2e.yml
+++ b/.github/workflows/web-argos-e2e.yml
@@ -34,7 +34,7 @@ jobs:
         containers: [1, 2, 3, 4, 5]
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -86,7 +86,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/yarn
 

--- a/.github/workflows/web-checks.yml
+++ b/.github/workflows/web-checks.yml
@@ -30,7 +30,7 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/yarn
         with:
           turbo-token: ${{ secrets.TURBO_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/yarn
         with:
           turbo-token: ${{ secrets.TURBO_TOKEN }}
@@ -73,7 +73,7 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/yarn
         with:
           turbo-token: ${{ secrets.TURBO_TOKEN }}
@@ -89,7 +89,7 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/yarn
         with:
           turbo-token: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/web-chromatic.yml
+++ b/.github/workflows/web-chromatic.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write # Comment on PRs
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # Required for TurboSnap git history analysis
 

--- a/.github/workflows/web-deploy-dev.yml
+++ b/.github/workflows/web-deploy-dev.yml
@@ -40,7 +40,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]'
 
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 

--- a/.github/workflows/web-deploy-dockerhub.yml
+++ b/.github/workflows/web-deploy-dockerhub.yml
@@ -39,7 +39,7 @@ jobs:
       (github.event_name == 'release' && github.event.action == 'released') ||
       github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           platforms: arm64

--- a/.github/workflows/web-e2e-full-ondemand.yml
+++ b/.github/workflows/web-e2e-full-ondemand.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         containers: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/cypress
         with:

--- a/.github/workflows/web-e2e-hp-ondemand.yml
+++ b/.github/workflows/web-e2e-hp-ondemand.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         containers: [1, 2, 3]
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/cypress
         with:

--- a/.github/workflows/web-e2e-smoke.yml
+++ b/.github/workflows/web-e2e-smoke.yml
@@ -31,7 +31,7 @@ jobs:
         containers: [1, 2, 3, 4, 5]
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/web-linear-release.yml
+++ b/.github/workflows/web-linear-release.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # Full history required to scan commits for Linear issue IDs
 

--- a/.github/workflows/web-nextjs-bundle-analysis.yml
+++ b/.github/workflows/web-nextjs-bundle-analysis.yml
@@ -22,7 +22,7 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install dependencies
         uses: ./.github/actions/yarn

--- a/.github/workflows/web-release-start.yml
+++ b/.github/workflows/web-release-start.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_BOT_TOKEN }}

--- a/.github/workflows/web-storybook-screenshots-build.yml
+++ b/.github/workflows/web-storybook-screenshots-build.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       # Pin to the commit SHA the deploy ran against so the checked-out tree
       # matches the deployed preview even if the PR head has moved since.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0

--- a/.github/workflows/web-storybook-screenshots-publish.yml
+++ b/.github/workflows/web-storybook-screenshots-publish.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       # Check out the default branch. The validated artifact is the only
       # thing this workflow consumes from the build half.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: dev
           fetch-depth: 1

--- a/.github/workflows/web-storybook-tests.yml
+++ b/.github/workflows/web-storybook-tests.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/yarn
 

--- a/.github/workflows/web-tag-release.yml
+++ b/.github/workflows/web-tag-release.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           fetch-depth: 0
@@ -106,7 +106,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/web-tanstack-checks.yml
+++ b/.github/workflows/web-tanstack-checks.yml
@@ -26,7 +26,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/yarn
         with:
           turbo-token: ${{ secrets.TURBO_TOKEN }}
@@ -48,7 +48,7 @@ jobs:
   verify-changed:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - uses: ./.github/actions/yarn

--- a/.github/workflows/web-unit-tests.yml
+++ b/.github/workflows/web-unit-tests.yml
@@ -27,7 +27,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/yarn
 


### PR DESCRIPTION
## What it solves

Resolves: [WA-2983](https://linear.app/safe-global/issue/WA-2983/fix-comments-in-web-workflows-to-avoid-false-security-warnings)

Mitigates false-positive security alerts on CI. Every `actions/checkout` step is pinned to commit `3d3c42e5aac5ba805825da76410c181273ba90b1` but the trailing version comment read `# v6.0.0`, which does not match the tag that SHA actually resolves to (`v7.0.1`). The mismatch triggers spurious security warnings and prevents Dependabot from recognizing the current version.

## How this PR fixes it

Updates the version comment from `# v6.0.0` to `# v7.0.1` on all 45 `actions/checkout@3d3c42e5…` references across 39 workflow files. The pinned SHA is unchanged — this is a comment-only edit. With the comment now matching the SHA, Dependabot can correctly detect the current version and auto-update both SHA and comment on future bumps.

## How to test it

```bash
git diff --stat
grep -rn "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" .github/  # all show # v7.0.1
grep -rn "# v6.0.0" .github/                                                    # no results
```

## Affected flows

- CI workflows only (checkout step). No application or user-facing behavior changes.

## Blast radius

- 39 GitHub Actions workflow files under `.github/workflows/`.
- Comment-only change; the pinned commit SHA is identical, so runtime action behavior is unchanged.
- No app code, shared packages, hooks, selectors, endpoints, or feature flags touched.

## Risks / not checked

- No CI behavior change expected since the SHA is unchanged.

## Visual summary

```mermaid
flowchart LR
  A["checkout@3d3c42e5 # v6.0.0"] -->|comment ≠ SHA tag| B[False security alert]
  A -->|Dependabot misreads version| C[No auto-update]
  D["checkout@3d3c42e5 # v7.0.1"] -->|comment = SHA tag| E[No alert]
  D -->|Dependabot reads correctly| F[Auto-updates SHA + comment]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
