### PR TITLE
feat: extract NetworkLogosPill

### DIFF
--- a/apps/web/src/features/multichain/components/NetworkLogosPill/NetworkLogosPill.stories.test.tsx
+++ b/apps/web/src/features/multichain/components/NetworkLogosPill/NetworkLogosPill.stories.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * Auto-generated snapshot tests for Storybook stories
+ * Run "yarn generate:storybook-tests" to regenerate
+ */
+import '../../../../tests/storybook-setup'
+import { composeStories } from '@storybook/react'
+import { render } from '@testing-library/react'
+import type { ComponentType } from 'react'
+
+import * as stories from './NetworkLogosPill.stories'
+
+const composedStories = composeStories(stories)
+
+describe('./NetworkLogosPill.stories', () => {
+  Object.entries(composedStories).forEach(([storyName, Story]) => {
+    test(storyName, () => {
+      const StoryComponent = Story as ComponentType
+      const { container } = render(<StoryComponent />)
+      expect(container.firstChild).toMatchSnapshot()
+    })
+  })
+})

--- a/apps/web/src/features/multichain/components/NetworkLogosPill/NetworkLogosPill.stories.tsx
+++ b/apps/web/src/features/multichain/components/NetworkLogosPill/NetworkLogosPill.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Paper } from '@mui/material'
+import NetworkLogosPill from './index'
+import { StoreDecorator } from '@/stories/storeDecorator'
+
+const meta = {
+  component: NetworkLogosPill,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <StoreDecorator initialState={{}}>
+        <Paper sx={{ padding: 2 }}>
+          <Story />
+        </Paper>
+      </StoreDecorator>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof NetworkLogosPill>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const FewNetworks: Story = {
+  args: {
+    networks: [{ chainId: '1' }, { chainId: '137' }],
+  },
+}
+
+/** More chains than fit: three logos plus the transparent "+N" indicator. */
+export const WithOverflow: Story = {
+  args: {
+    networks: [
+      { chainId: '1' },
+      { chainId: '137' },
+      { chainId: '10' },
+      { chainId: '42161' },
+      { chainId: '8453' },
+      { chainId: '100' },
+    ],
+  },
+}

--- a/apps/web/src/features/multichain/components/NetworkLogosPill/__snapshots__/NetworkLogosPill.stories.test.tsx.snap
+++ b/apps/web/src/features/multichain/components/NetworkLogosPill/__snapshots__/NetworkLogosPill.stories.test.tsx.snap
@@ -1,0 +1,127 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`./NetworkLogosPill.stories FewNetworks 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+>
+  <div
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-l2lphb-MuiPaper-root"
+    style="--Paper-shadow: none;"
+  >
+    <span
+      class="bg-foreground/5 inline-flex items-center rounded-full p-0.75"
+    >
+      <span
+        class="inline-flex"
+        data-slot="tooltip-trigger"
+        id="base-ui-_r_2_"
+      >
+        <div
+          class="networks MuiBox-root mui-style-0"
+          style="--network-logo-size: 22px;"
+        >
+          <span
+            class="inlineIndicator withLogo onlyLogo"
+            data-testid="chain-logo"
+          >
+            <img
+              alt="Ethereum Logo"
+              data-testid="chain-indicator-network-logo-img"
+              height="22"
+              loading="lazy"
+              src="https://safe-transaction-assets.staging.5afe.dev/chains/1/chain_logo.png"
+              style="min-width: 22px;"
+              width="22"
+            />
+          </span>
+          <span
+            class="inlineIndicator withLogo onlyLogo"
+            data-testid="chain-logo"
+          >
+            <img
+              alt="Polygon Logo"
+              data-testid="chain-indicator-network-logo-img"
+              height="22"
+              loading="lazy"
+              src="https://safe-transaction-assets.staging.5afe.dev/chains/137/chain_logo.png"
+              style="min-width: 22px;"
+              width="22"
+            />
+          </span>
+        </div>
+      </span>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`./NetworkLogosPill.stories WithOverflow 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+>
+  <div
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-l2lphb-MuiPaper-root"
+    style="--Paper-shadow: none;"
+  >
+    <span
+      class="bg-foreground/5 inline-flex items-center rounded-full p-0.75"
+    >
+      <span
+        class="inline-flex"
+        data-slot="tooltip-trigger"
+        id="base-ui-_r_5_"
+      >
+        <div
+          class="networks MuiBox-root mui-style-0"
+          style="--network-logo-size: 22px;"
+        >
+          <span
+            class="inlineIndicator withLogo onlyLogo"
+            data-testid="chain-logo"
+          >
+            <img
+              alt="Ethereum Logo"
+              data-testid="chain-indicator-network-logo-img"
+              height="22"
+              loading="lazy"
+              src="https://safe-transaction-assets.staging.5afe.dev/chains/1/chain_logo.png"
+              style="min-width: 22px;"
+              width="22"
+            />
+          </span>
+          <span
+            class="inlineIndicator withLogo onlyLogo"
+            data-testid="chain-logo"
+          >
+            <img
+              alt="Polygon Logo"
+              data-testid="chain-indicator-network-logo-img"
+              height="22"
+              loading="lazy"
+              src="https://safe-transaction-assets.staging.5afe.dev/chains/137/chain_logo.png"
+              style="min-width: 22px;"
+              width="22"
+            />
+          </span>
+          <span
+            class="inlineIndicator withLogo onlyLogo"
+            data-testid="chain-logo"
+          >
+            <mock-icon
+              aria-hidden=""
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium mui-style-104dftr-MuiSvgIcon-root"
+              focusable="false"
+            />
+          </span>
+          <div
+            class="moreChainsIndicator MuiBox-root mui-style-0"
+          >
+            +
+            3
+          </div>
+        </div>
+      </span>
+    </span>
+  </div>
+</div>
+`;

--- a/apps/web/src/features/multichain/components/NetworkLogosPill/index.tsx
+++ b/apps/web/src/features/multichain/components/NetworkLogosPill/index.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from 'react'
+import { cn } from '@/utils/cn'
+import NetworkLogosTooltip from '../NetworkLogosTooltip'
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+
+/** Logo size inside the pill — matches the safe-selector dropdown's SafeRowStats stack. */
+const PILL_LOGO_SIZE = 22
+
+export type NetworkLogosPillProps = {
+  /** Chains rendered as a stacked-logo tooltip trigger; ignored when `children` is set. */
+  networks?: Pick<Chain, 'chainId'>[]
+  /** Max logos before the "+N" indicator */
+  maxVisible?: number
+  className?: string
+  /** Custom pill content (e.g. AccountItemChainBadge) replacing the default logos tooltip. */
+  children?: ReactNode
+}
+
+/**
+ * The standard grey capsule around stacked network logos (22px logos, mask-cutout gaps,
+ * transparent "+N") — the shared look of the networks cell in the accounts table, the space
+ * address book, and the safe-selector dropdown rows.
+ */
+const NetworkLogosPill = ({ networks, maxVisible = 3, className, children }: NetworkLogosPillProps) => (
+  <span className={cn('bg-foreground/5 inline-flex items-center rounded-full p-0.75', className)}>
+    {children ?? (
+      <NetworkLogosTooltip
+        networks={networks ?? []}
+        maxVisible={maxVisible}
+        imageSize={PILL_LOGO_SIZE}
+        // Overrides the default scale-85 trigger, which would shrink the logos inside the pill.
+        triggerRender={<span className="inline-flex" />}
+      />
+    )}
+  </span>
+)
+
+export default NetworkLogosPill

--- a/apps/web/src/features/multichain/index.ts
+++ b/apps/web/src/features/multichain/index.ts
@@ -30,6 +30,8 @@ const NetworkLogosList = dynamic(() => import('./components/NetworkLogosList'))
 
 const NetworkLogosTooltip = dynamic(() => import('./components/NetworkLogosTooltip'))
 
+const NetworkLogosPill = dynamic(() => import('./components/NetworkLogosPill'))
+
 const SafeCreationNetworkInput = dynamic(() => import('./components/SafeCreationNetworkInput'))
 
 const ChangeSignerSetupWarning = dynamic(() =>
@@ -61,6 +63,7 @@ export {
   CreateSafeOnSpecificChain,
   NetworkLogosList,
   NetworkLogosTooltip,
+  NetworkLogosPill,
   SafeCreationNetworkInput,
   ChangeSignerSetupWarning,
   InconsistentSignerSetupWarning,

--- a/apps/web/src/features/multichain/index.ts
+++ b/apps/web/src/features/multichain/index.ts
@@ -18,6 +18,9 @@ export {
   hasMultiChainAddNetworkFeature,
 } from './utils'
 
+// Static export — the pill is tiny and always visible in its consumers' first paint
+export { default as NetworkLogosPill } from './components/NetworkLogosPill'
+
 const CreateSafeOnNewChain = dynamic(() =>
   import('./components/CreateSafeOnNewChain').then((mod) => ({ default: mod.CreateSafeOnNewChain })),
 )
@@ -29,8 +32,6 @@ const CreateSafeOnSpecificChain = dynamic(() =>
 const NetworkLogosList = dynamic(() => import('./components/NetworkLogosList'))
 
 const NetworkLogosTooltip = dynamic(() => import('./components/NetworkLogosTooltip'))
-
-const NetworkLogosPill = dynamic(() => import('./components/NetworkLogosPill'))
 
 const SafeCreationNetworkInput = dynamic(() => import('./components/SafeCreationNetworkInput'))
 
@@ -63,7 +64,6 @@ export {
   CreateSafeOnSpecificChain,
   NetworkLogosList,
   NetworkLogosTooltip,
-  NetworkLogosPill,
   SafeCreationNetworkInput,
   ChangeSignerSetupWarning,
   InconsistentSignerSetupWarning,

--- a/apps/web/src/features/myAccounts/components/SafeAccountsTable/SafeAccountTableRow.tsx
+++ b/apps/web/src/features/myAccounts/components/SafeAccountsTable/SafeAccountTableRow.tsx
@@ -21,6 +21,7 @@ import { useChain } from '@/hooks/useChains'
 import { getBlockExplorerLink } from '@safe-global/utils/utils/chains'
 import { cn } from '@/utils/cn'
 import { AccountItem as BaseAccountItem } from '../AccountItem'
+import { NetworkLogosPill } from '@/features/multichain'
 import type { AccountLine } from './useSafeAccountRows'
 import type { SafeAccountColumn } from './columns'
 import { PendingBadge, ThresholdBadge, formatPendingLabel } from '@/components/common/AccountBadges'
@@ -224,16 +225,14 @@ const CellContent = ({ column, line }: { column: SafeAccountColumn; line: Accoun
         />
       )
     case 'networks':
-      // The grey pill lives here, not in the shared ChainBadge — other surfaces (sidebar list,
-      // multi-account items) render the bare logos.
       return (
-        <span className="bg-foreground/5 inline-flex items-center rounded-full p-0.75">
+        <NetworkLogosPill>
           {line.networks ? (
             <BaseAccountItem.ChainBadge safes={line.networks} />
           ) : (
             <BaseAccountItem.ChainBadge chainId={line.chainId} />
           )}
-        </span>
+        </NetworkLogosPill>
       )
     case 'workspaces':
       return <WorkspaceAvatars spaces={line.workspaces} />

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
@@ -6,7 +6,7 @@ import { Spinner } from '@/components/ui/spinner'
 import { isAddress } from 'ethers'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import Identicon from '@/components/common/Identicon'
-import { NetworkLogosTooltip } from '@/features/multichain'
+import { NetworkLogosPill, NetworkLogosTooltip } from '@/features/multichain'
 import ChainIndicator from '@/components/common/ChainIndicator'
 import type { AddressBookRequestItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import {
@@ -126,13 +126,17 @@ function PendingRequestsTable({ requests }: PendingRequestsTableProps) {
     }
   }
 
-  const renderChains = (req: AddressBookRequestItemDto) => (
-    <NetworkLogosTooltip
-      networks={req.chainIds.map((chainId) => ({ chainId }))}
-      maxVisible={3}
-      trigger={chains.configs.length === req.chainIds.length ? <Badge variant="secondary">All</Badge> : undefined}
-    />
-  )
+  // The "All" badge stands on its own; logo stacks get the standard grey pill.
+  const renderChains = (req: AddressBookRequestItemDto) =>
+    chains.configs.length === req.chainIds.length ? (
+      <NetworkLogosTooltip
+        networks={req.chainIds.map((chainId) => ({ chainId }))}
+        maxVisible={3}
+        trigger={<Badge variant="secondary">All</Badge>}
+      />
+    ) : (
+      <NetworkLogosPill networks={req.chainIds.map((chainId) => ({ chainId }))} />
+    )
 
   const columns: DataTableColumn<AddressBookRequestItemDto>[] = [
     {

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -2,7 +2,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip
 import { isAddress } from 'ethers'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import EmailInfo from '@/components/common/EmailInfo'
-import { NetworkLogosTooltip } from '@/features/multichain'
+import { NetworkLogosPill } from '@/features/multichain'
 import ChainIndicator from '@/components/common/ChainIndicator'
 import { HardDrive } from 'lucide-react'
 import type { SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
@@ -57,9 +57,9 @@ function SpaceAddressBookTable({
   const resolveMemberName = useMemberNameResolver()
   const hasMiddleColumn = showAddedBy || showLastUpdated
 
-  // Chain logo cluster — used in the desktop "Chains" cell
+  // Chain logo cluster — used in the desktop "Chains" cell.
   const renderChains = (entry: AddressBookEntry) => (
-    <NetworkLogosTooltip networks={entry.chainIds.map((chainId) => ({ chainId }))} maxVisible={3} />
+    <NetworkLogosPill networks={entry.chainIds.map((chainId) => ({ chainId }))} />
   )
 
   // Added-by / Last-updated content — used in the desktop column and the mobile detail row.

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/PendingRequestsTable.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/PendingRequestsTable.test.tsx
@@ -48,6 +48,9 @@ jest.mock('@/features/multichain', () => ({
       {trigger}
     </span>
   ),
+  NetworkLogosPill: ({ networks }: { networks: { chainId: string }[] }) => (
+    <span data-testid="network-logos-pill" data-count={networks.length} />
+  ),
 }))
 jest.mock('@/components/common/ChainIndicator', () => {
   const ChainIndicator = () => <span data-testid="chain-indicator" />

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/SpaceAddressBookTable.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/SpaceAddressBookTable.test.tsx
@@ -28,6 +28,9 @@ jest.mock('@/features/multichain', () => ({
   NetworkLogosTooltip: ({ networks, maxVisible }: { networks: { chainId: string }[]; maxVisible?: number }) => (
     <span data-testid="network-logos" data-max-visible={maxVisible} data-count={networks.length} />
   ),
+  NetworkLogosPill: ({ networks }: { networks: { chainId: string }[] }) => (
+    <span data-testid="network-logos" data-count={networks.length} />
+  ),
 }))
 jest.mock('@/components/common/ChainIndicator', () => {
   const ChainIndicator = () => <span data-testid="chain-indicator" />
@@ -92,12 +95,12 @@ describe('SpaceAddressBookTable', () => {
     expect(screen.getByTestId('local-actions')).toBeInTheDocument()
   })
 
-  it('renders the network logos tooltip with maxVisible=3 for chain logos', () => {
+  it('renders the network logos pill with all chain logos', () => {
     const chainIds = ['1', '137', '10', '42161', '8453']
     render(<SpaceAddressBookTable entries={[entryBuilder().with({ chainIds }).build()]} />)
 
+    // The 3-logo cap and +N indicator live inside NetworkLogosPill (see its own stories/tests).
     const logosList = screen.getByTestId('network-logos')
-    expect(logosList).toHaveAttribute('data-max-visible', '3')
     expect(logosList).toHaveAttribute('data-count', '5')
   })
 


### PR DESCRIPTION
## What it solves

Resolves: part of [WA-2892](https://linear.app/safe-global/issue/WA-2892/fix-design-inconsistencies) (design inconsistencies, part 3)

The grey capsule around stacked network logos was duplicated as inline markup in the accounts table, while other surfaces (space address book, pending requests) rendered bare logo stacks that didn't match the design.

## How this PR fixes it

Extracts a shared `NetworkLogosPill` component in `features/multichain` — the standard grey pill (22px logos, mask-cutout gaps, transparent "+N" overflow) — and adopts it in three places:

- **Accounts table** (`SafeAccountTableRow`): the networks cell's inline pill markup is replaced by `NetworkLogosPill` wrapping the existing `ChainBadge` (via the `children` slot).
- **Space address book** (`SpaceAddressBookTable`): the chains cell now renders the pill instead of a bare `NetworkLogosTooltip` logo stack.
- **Pending requests** (`PendingRequestsTable`): logo stacks get the pill; the "All networks" badge keeps its standalone look.

By default the pill renders `NetworkLogosTooltip` (hover reveals the full chain list); a `children` prop allows custom content like the accounts-table chain badge. Includes Storybook stories (`FewNetworks`, `WithOverflow`) with auto-generated snapshot tests.

## How to test it

1. Open the accounts page — network pills in the table should look unchanged.
2. Open a space's address book — the "Chains" column now shows logos inside a grey pill; hover shows the full network list; entries with >3 chains show "+N".
3. Check the pending address book requests tab — same pill for chain subsets, plain "All" badge when an entry covers every chain.
4. Storybook: `NetworkLogosPill` stories.

## Affected flows

- Viewing the Safe accounts table (networks column)
- Viewing a space address book (chains column, desktop)
- Reviewing pending address book requests in a space

## Blast radius

- New export `NetworkLogosPill` from `@/features/multichain` (dynamic import, consistent with sibling exports) — no existing consumers affected.
- `NetworkLogosTooltip` itself is unchanged; only call sites moved.
- Purely presentational — no hooks, slices, endpoints, or persisted state touched. No mobile impact.

## Risks / not checked

- Did not manually verify the mobile-viewport (card) layout of the space address book — only the desktop chains cell uses the pill.
- Visual parity relies on snapshot tests + Storybook; no pixel-diff against Figma.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1[SafeAccountTableRow] --> P1[inline grey pill markup]
    B1[SpaceAddressBookTable] --> T1[bare NetworkLogosTooltip]
    C1[PendingRequestsTable] --> T2[bare NetworkLogosTooltip]
  end
  subgraph After
    A2[SafeAccountTableRow] -->|children: ChainBadge| P[NetworkLogosPill]
    B2[SpaceAddressBookTable] --> P
    C2[PendingRequestsTable] -->|chain subsets| P
    P --> T[NetworkLogosTooltip]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
