### PR TITLE
fix: stop counting expired and cancelled approvals as failures (WA-2950)

### DIFF
--- a/apps/web/src/components/tx-flow/actions/Propose/ProposerForm.tsx
+++ b/apps/web/src/components/tx-flow/actions/Propose/ProposerForm.tsx
@@ -10,7 +10,7 @@ import { useTxActions } from '@/components/tx/shared/hooks'
 import type { SignOrExecuteProps } from '@/components/tx/shared/types'
 import useWallet from '@/hooks/wallets/useWallet'
 import { Errors, trackError } from '@/services/exceptions'
-import { asError } from '@safe-global/utils/services/exceptions/utils'
+import { asError, getHttpStatusFromError } from '@safe-global/utils/services/exceptions/utils'
 import madProps from '@/utils/mad-props'
 import { TxCardActions } from '@/components/tx-flow/common/TxCard'
 import { useSafeShield } from '@/features/safe-shield/SafeShieldContext'
@@ -54,7 +54,7 @@ export const ProposerForm = ({
       if (isWalletRejection(err)) {
         setIsRejectedByUser(true)
       } else {
-        trackError(Errors._805, err)
+        trackError(Errors._805, err, { httpStatus: getHttpStatusFromError(err) })
       }
       setIsSubmittable(true)
       return

--- a/apps/web/src/components/tx-flow/actions/Propose/ProposerForm.tsx
+++ b/apps/web/src/components/tx-flow/actions/Propose/ProposerForm.tsx
@@ -10,7 +10,7 @@ import { useTxActions } from '@/components/tx/shared/hooks'
 import type { SignOrExecuteProps } from '@/components/tx/shared/types'
 import useWallet from '@/hooks/wallets/useWallet'
 import { Errors, trackError } from '@/services/exceptions'
-import { asError, getHttpStatusFromError } from '@safe-global/utils/services/exceptions/utils'
+import { asError } from '@safe-global/utils/services/exceptions/utils'
 import madProps from '@/utils/mad-props'
 import { TxCardActions } from '@/components/tx-flow/common/TxCard'
 import { useSafeShield } from '@/features/safe-shield/SafeShieldContext'
@@ -54,7 +54,7 @@ export const ProposerForm = ({
       if (isWalletRejection(err)) {
         setIsRejectedByUser(true)
       } else {
-        trackError(Errors._805, err, { httpStatus: getHttpStatusFromError(err) })
+        trackError(Errors._805, err)
       }
       setIsSubmittable(true)
       return

--- a/apps/web/src/services/analytics/mixpanel-events.ts
+++ b/apps/web/src/services/analytics/mixpanel-events.ts
@@ -129,6 +129,7 @@ export enum MixpanelEventParams {
   TX_HASH = 'Transaction Hash',
   RPC_ENDPOINT_KIND = 'RPC Endpoint Kind',
   RPC_HOST = 'RPC Host',
+  HTTP_STATUS = 'HTTP Status',
 }
 
 export enum AuthLoginMethod {

--- a/apps/web/src/services/exceptions/__tests__/index.test.ts
+++ b/apps/web/src/services/exceptions/__tests__/index.test.ts
@@ -220,6 +220,32 @@ describe('CodedException', () => {
       )
     })
 
+    it('merges the HTTP status from call-site context into the Datadog tags', async () => {
+      process.env.NEXT_PUBLIC_IS_PRODUCTION = 'true'
+      const mockCaptureError = jest.fn()
+      mockObservability(mockCaptureError)
+
+      const { trackError, Errors } = await import('..')
+
+      trackError(Errors._805, 'CGW error - 422: Invalid transaction', { httpStatus: 422 })
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tags: expect.objectContaining({ http_status: 422 }),
+        }),
+      )
+    })
+
+    it('omits the HTTP status tag when not provided', async () => {
+      process.env.NEXT_PUBLIC_IS_PRODUCTION = 'true'
+      const mockCaptureError = jest.fn()
+      mockObservability(mockCaptureError)
+
+      const { trackError, Errors } = await import('..')
+
+      trackError(Errors._805, 'proposal failed')
+      expect(mockCaptureError.mock.calls[0][0].tags).not.toHaveProperty('http_status')
+    })
+
     it('omits RPC tags when no endpoint context is provided', async () => {
       process.env.NEXT_PUBLIC_IS_PRODUCTION = 'true'
       const mockCaptureError = jest.fn()
@@ -242,6 +268,63 @@ describe('CodedException', () => {
       const err = trackError(Errors._100)
       expect(mockCaptureError).not.toHaveBeenCalled()
       expect(console.error).toHaveBeenCalledWith(err)
+    })
+  })
+
+  describe('User-driven outcomes (WA-2950)', () => {
+    it('downgrades a tracked user rejection to an info action (no error, no Error Surfaced)', async () => {
+      process.env.NEXT_PUBLIC_IS_PRODUCTION = 'true'
+      const mockCaptureError = jest.fn()
+      const mockInfo = jest.fn()
+      const mockWarn = jest.fn()
+      const mockError = jest.fn()
+      mockObservability(mockCaptureError, { info: mockInfo, warn: mockWarn, error: mockError, debug: jest.fn() })
+
+      const { trackError, Errors } = await import('..')
+
+      trackError(Errors._804, 'user rejected the request')
+
+      expect(mockInfo).toHaveBeenCalledWith(
+        expect.stringContaining('804'),
+        expect.objectContaining({ error_type: ErrorType.USER_REJECTED }),
+      )
+      expect(mockWarn).not.toHaveBeenCalled()
+      expect(mockError).not.toHaveBeenCalled()
+      expect(mockCaptureError).not.toHaveBeenCalled()
+      expect(console.error).not.toHaveBeenCalled()
+    })
+
+    it('downgrades a tracked WalletConnect expiry to an info action', async () => {
+      process.env.NEXT_PUBLIC_IS_PRODUCTION = 'true'
+      const mockCaptureError = jest.fn()
+      const mockInfo = jest.fn()
+      const mockError = jest.fn()
+      mockObservability(mockCaptureError, { info: mockInfo, warn: jest.fn(), error: mockError, debug: jest.fn() })
+
+      const { trackError, Errors } = await import('..')
+
+      trackError(Errors._804, 'Request expired. Please try again.')
+
+      expect(mockInfo).toHaveBeenCalledWith(
+        expect.stringContaining('804'),
+        expect.objectContaining({ error_type: ErrorType.EXPIRED }),
+      )
+      expect(mockError).not.toHaveBeenCalled()
+      expect(mockCaptureError).not.toHaveBeenCalled()
+    })
+
+    it('keeps a genuine execution failure on the error path', async () => {
+      process.env.NEXT_PUBLIC_IS_PRODUCTION = 'true'
+      const mockCaptureError = jest.fn()
+      const mockError = jest.fn()
+      mockObservability(mockCaptureError, { info: jest.fn(), warn: jest.fn(), error: mockError, debug: jest.fn() })
+
+      const { trackError, Errors } = await import('..')
+
+      trackError(Errors._804, 'execution reverted GS013')
+
+      expect(mockCaptureError).toHaveBeenCalledWith(expect.objectContaining({ isUserFacing: true }))
+      expect(mockError).toHaveBeenCalled()
     })
   })
 

--- a/apps/web/src/services/exceptions/__tests__/index.test.ts
+++ b/apps/web/src/services/exceptions/__tests__/index.test.ts
@@ -220,17 +220,48 @@ describe('CodedException', () => {
       )
     })
 
-    it('merges the HTTP status from call-site context into the Datadog tags', async () => {
+    it('extracts the HTTP status from the thrown error into the Datadog tags', async () => {
       process.env.NEXT_PUBLIC_IS_PRODUCTION = 'true'
       const mockCaptureError = jest.fn()
       mockObservability(mockCaptureError)
 
       const { trackError, Errors } = await import('..')
 
-      trackError(Errors._805, 'CGW error - 422: Invalid transaction', { httpStatus: 422 })
+      trackError(Errors._805, new Error('CGW error - 422: Invalid transaction'))
       expect(mockCaptureError).toHaveBeenCalledWith(
         expect.objectContaining({
           tags: expect.objectContaining({ http_status: 422 }),
+          context: expect.objectContaining({ httpStatus: 422 }),
+        }),
+      )
+    })
+
+    it('extracts a structural status property from the thrown error', async () => {
+      process.env.NEXT_PUBLIC_IS_PRODUCTION = 'true'
+      const mockCaptureError = jest.fn()
+      mockObservability(mockCaptureError)
+
+      const { trackError, Errors } = await import('..')
+
+      trackError(Errors._805, Object.assign(new Error('proposal failed'), { status: 404 }))
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tags: expect.objectContaining({ http_status: 404 }),
+        }),
+      )
+    })
+
+    it('lets an explicit call-site httpStatus override the extracted one', async () => {
+      process.env.NEXT_PUBLIC_IS_PRODUCTION = 'true'
+      const mockCaptureError = jest.fn()
+      mockObservability(mockCaptureError)
+
+      const { trackError, Errors } = await import('..')
+
+      trackError(Errors._805, new Error('CGW error - 422: Invalid transaction'), { httpStatus: 400 })
+      expect(mockCaptureError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tags: expect.objectContaining({ http_status: 400 }),
         }),
       )
     })

--- a/apps/web/src/services/exceptions/index.ts
+++ b/apps/web/src/services/exceptions/index.ts
@@ -52,6 +52,7 @@ export class CodedException extends Error {
       error_layer: layer,
       ...(context?.rpcEndpointKind && { rpc_endpoint_kind: context.rpcEndpointKind }),
       ...(context?.rpcHost && { rpc_host: context.rpcHost }),
+      ...(context?.httpStatus && { http_status: context.httpStatus }),
     }
   }
 
@@ -77,6 +78,18 @@ export class CodedException extends Error {
   }
 
   public track(context?: ErrorContext): void {
+    // User-driven outcomes (rejection, approval-prompt expiry) are expected
+    // behaviour, not failures: recorded as info-level Datadog actions only —
+    // no RUM error, no Error Surfaced analytics event (WA-2950).
+    const { isUserFacing } = normalizeError({ code: this.code, message: this.message, isUserFacing: true })
+    if (!isUserFacing) {
+      console.info(IS_PRODUCTION ? this.message : this)
+      if (IS_PRODUCTION) {
+        logger.info(this.message, this.getObservabilityContext(context))
+      }
+      return
+    }
+
     console.error(IS_PRODUCTION ? this.message : this)
 
     if (IS_PRODUCTION) {

--- a/apps/web/src/services/exceptions/index.ts
+++ b/apps/web/src/services/exceptions/index.ts
@@ -1,6 +1,6 @@
 import { IS_PRODUCTION } from '@/config/constants'
 import ErrorCodes from '@safe-global/utils/services/exceptions/ErrorCodes'
-import { asError } from '@safe-global/utils/services/exceptions/utils'
+import { asError, getHttpStatusFromError } from '@safe-global/utils/services/exceptions/utils'
 import { normalizeError } from '@safe-global/utils/services/exceptions/normalizeError'
 import { logger, captureError } from '../observability'
 import type { ErrorContext } from '../observability/types'
@@ -12,6 +12,8 @@ export type { ErrorContext }
 export class CodedException extends Error {
   public readonly code: number
   public readonly content: string
+  /** HTTP status of the wrapped request failure, when one is recoverable from `thrown`. */
+  public readonly httpStatus?: number
 
   private getCode(content: ErrorCodes): number {
     const codePrefix = content.split(':')[0]
@@ -29,6 +31,17 @@ export class CodedException extends Error {
     this.message = `Code ${content}${extraInfo}`
     this.code = this.getCode(content)
     this.content = content
+    this.httpStatus = getHttpStatusFromError(thrown)
+  }
+
+  /**
+   * Call-site context enriched with the HTTP status extracted from the thrown
+   * error, so every `trackError`/`logError` site gets the facet for free. An
+   * explicit `context.httpStatus` wins over the extracted one.
+   */
+  private withHttpStatus(context?: ErrorContext): ErrorContext | undefined {
+    if (this.httpStatus === undefined) return context
+    return { httpStatus: this.httpStatus, ...context }
   }
 
   /**
@@ -71,9 +84,10 @@ export class CodedException extends Error {
     console.warn(IS_PRODUCTION ? this.message : this)
 
     if (IS_PRODUCTION) {
-      const tags = this.getObservabilityContext(context)
+      const enrichedContext = this.withHttpStatus(context)
+      const tags = this.getObservabilityContext(enrichedContext)
       logger.warn(this.message, tags)
-      captureError({ error: this, isUserFacing: false, code: this.code, tags, context })
+      captureError({ error: this, isUserFacing: false, code: this.code, tags, context: enrichedContext })
     }
   }
 
@@ -85,7 +99,7 @@ export class CodedException extends Error {
     if (!isUserFacing) {
       console.info(IS_PRODUCTION ? this.message : this)
       if (IS_PRODUCTION) {
-        logger.info(this.message, this.getObservabilityContext(context))
+        logger.info(this.message, this.getObservabilityContext(this.withHttpStatus(context)))
       }
       return
     }
@@ -93,9 +107,10 @@ export class CodedException extends Error {
     console.error(IS_PRODUCTION ? this.message : this)
 
     if (IS_PRODUCTION) {
-      const tags = this.getObservabilityContext(context)
+      const enrichedContext = this.withHttpStatus(context)
+      const tags = this.getObservabilityContext(enrichedContext)
       logger.error(this.message, tags)
-      captureError({ error: this, isUserFacing: true, code: this.code, tags, context })
+      captureError({ error: this, isUserFacing: true, code: this.code, tags, context: enrichedContext })
     }
   }
 }

--- a/apps/web/src/services/observability/providers/__tests__/datadog.test.ts
+++ b/apps/web/src/services/observability/providers/__tests__/datadog.test.ts
@@ -403,5 +403,42 @@ describe('DatadogProvider', () => {
         expect(filterRumEvent(event, {} as any)).toBe(true)
       }
     })
+
+    describe('user-driven outcomes (WA-2950)', () => {
+      it('reclassifies unhandled WalletConnect TTL expiries as warn actions instead of errors', async () => {
+        const { filterRumEvent } = await import('../datadog')
+        for (const message of ['Request expired. Please try again.', 'Proposal expired']) {
+          const event = buildErrorEvent({ source: 'source', message })
+          expect(filterRumEvent(event, {} as any)).toBe(false)
+          expect(mockAddAction).toHaveBeenCalledWith(
+            message,
+            expect.objectContaining({ level: 'info', error_type: 'expired' }),
+          )
+        }
+      })
+
+      it('reclassifies unhandled user rejections as warn actions instead of errors', async () => {
+        const { filterRumEvent } = await import('../datadog')
+        for (const message of ['Rejected', 'Error: Rejected', 'User rejected.']) {
+          const event = buildErrorEvent({ source: 'source', message })
+          expect(filterRumEvent(event, {} as any)).toBe(false)
+          expect(mockAddAction).toHaveBeenCalledWith(
+            message,
+            expect.objectContaining({ level: 'info', error_type: 'user_rejected' }),
+          )
+        }
+      })
+
+      it('keeps errors that merely contain the word rejected', async () => {
+        const { filterRumEvent } = await import('../datadog')
+        const event = buildErrorEvent({
+          source: 'source',
+          message: 'Transaction rejected by guard module',
+          stack: 'at handler (https://app.safe.global/_next/static/chunks/main.js:1:1)',
+        })
+        expect(filterRumEvent(event, {} as any)).toBe(true)
+        expect(mockAddAction).not.toHaveBeenCalled()
+      })
+    })
   })
 })

--- a/apps/web/src/services/observability/providers/datadog.ts
+++ b/apps/web/src/services/observability/providers/datadog.ts
@@ -1,4 +1,5 @@
 import type { ILogger, IObservabilityProvider, ObservedError } from '../types'
+import { matchUserOutcome } from '@safe-global/utils/services/exceptions/normalizeError'
 import {
   datadogRum,
   type RumEvent,
@@ -124,6 +125,17 @@ export const filterRumEvent = (event: RumEvent, context: RumEventDomainContext):
   if (NON_USER_IMPACTING_SOURCES.has(errorEvent.error.source)) return false
   if (isKnownNoise(errorEvent.error.message)) return false
   if (originatesFromExtension(errorEvent.error.stack)) return false
+
+  // User-driven outcomes surfaced as unhandled errors by third-party SDKs
+  // (WalletConnect TTL expiry, a wallet's bare "Rejected" reply) never pass
+  // through trackError/the normalizer. Re-emit them as info-level actions —
+  // kept queryable as an approval-flow drop-off signal — and drop the RUM
+  // error so they stay off the Error-Free Views SLO (WA-2950).
+  const userOutcome = matchUserOutcome(errorEvent.error.message)
+  if (userOutcome) {
+    datadogRum.addAction(errorEvent.error.message, { level: 'info', error_type: userOutcome })
+    return false
+  }
 
   // context.error is the raw value originally passed to addError/captureException
   const { error: rawError } = context as RumErrorEventDomainContext

--- a/apps/web/src/services/observability/providers/mixpanel/__tests__/error-tracking.test.ts
+++ b/apps/web/src/services/observability/providers/mixpanel/__tests__/error-tracking.test.ts
@@ -61,6 +61,19 @@ describe('trackErrorSurfaced', () => {
     })
   })
 
+  it('maps the HTTP status context to a Mixpanel property', () => {
+    trackErrorSurfaced({
+      code: 805,
+      message: 'Code 805: Error proposing (CGW error - 422: Invalid transaction)',
+      isUserFacing: true,
+      context: { httpStatus: 422 },
+    })
+
+    expect(mockedTrack.mock.calls[0][1]).toMatchObject({
+      [MixpanelEventParams.HTTP_STATUS]: 422,
+    })
+  })
+
   it('maps RPC endpoint context (kind + host) to Mixpanel properties', () => {
     trackErrorSurfaced({
       code: 105,
@@ -90,6 +103,25 @@ describe('trackErrorSurfaced', () => {
     expect(mockedTrack.mock.calls[0][1]).toMatchObject({
       [MixpanelEventParams.IS_USER_FACING]: false,
       [MixpanelEventParams.ERROR_DOMAIN]: ErrorDomain.DATA_LOADING,
+    })
+  })
+
+  describe('user-driven outcomes (WA-2950)', () => {
+    it.each([
+      'Code 804: Error executing a transaction (user rejected the request)',
+      'Code 804: Error executing a transaction (Rejected)',
+      'Request expired. Please try again.',
+      'Proposal expired',
+    ])('does not emit Error Surfaced for %p', (message) => {
+      trackErrorSurfaced({ code: 804, message, isUserFacing: true })
+
+      expect(mockedTrack).not.toHaveBeenCalled()
+    })
+
+    it('still emits Error Surfaced for a genuine execution failure', () => {
+      trackErrorSurfaced({ code: 804, message: 'Code 804: execution reverted GS013', isUserFacing: true })
+
+      expect(mockedTrack).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/apps/web/src/services/observability/providers/mixpanel/error-tracking.ts
+++ b/apps/web/src/services/observability/providers/mixpanel/error-tracking.ts
@@ -1,4 +1,4 @@
-import { normalizeError } from '@safe-global/utils/services/exceptions/normalizeError'
+import { matchUserOutcome, normalizeError } from '@safe-global/utils/services/exceptions/normalizeError'
 import type { ErrorContext, SurfacedError } from '../../types'
 import { MixpanelEvent, MixpanelEventParams } from '@/services/analytics/mixpanel-events'
 import { mixpanelTrack } from '@/services/analytics/mixpanel'
@@ -7,7 +7,7 @@ import { mixpanelTrack } from '@/services/analytics/mixpanel'
  * Maps the analytics-agnostic `ErrorContext` to Mixpanel event properties.
  * Only present keys are emitted, so events stay compact and free of `undefined`.
  */
-const mapContext = (context?: ErrorContext): Record<string, string> => {
+const mapContext = (context?: ErrorContext): Record<string, string | number> => {
   if (!context) return {}
   return {
     ...(context.txHash && { [MixpanelEventParams.TX_HASH]: context.txHash }),
@@ -15,6 +15,7 @@ const mapContext = (context?: ErrorContext): Record<string, string> => {
     ...(context.transactionType && { [MixpanelEventParams.TRANSACTION_TYPE]: context.transactionType }),
     ...(context.rpcEndpointKind && { [MixpanelEventParams.RPC_ENDPOINT_KIND]: context.rpcEndpointKind }),
     ...(context.rpcHost && { [MixpanelEventParams.RPC_HOST]: context.rpcHost }),
+    ...(context.httpStatus && { [MixpanelEventParams.HTTP_STATUS]: context.httpStatus }),
   }
 }
 
@@ -27,6 +28,12 @@ const mapContext = (context?: ErrorContext): Record<string, string> => {
  * Wallet Label) are attached automatically as Mixpanel super-properties.
  */
 export const trackErrorSurfaced = ({ code, message, isUserFacing, context }: SurfacedError): void => {
+  // User-driven outcomes (rejection, approval-prompt expiry) are not errors —
+  // they never surface as an Error Surfaced event (WA-2950).
+  if (matchUserOutcome(message)) {
+    return
+  }
+
   const normalized = normalizeError({ code, message, isUserFacing })
 
   mixpanelTrack(MixpanelEvent.ERROR_SURFACED, {

--- a/apps/web/src/services/observability/types.ts
+++ b/apps/web/src/services/observability/types.ts
@@ -31,6 +31,13 @@ export interface ErrorContext {
   rpcEndpointKind?: RpcEndpointKind
   /** Host of the failing RPC endpoint (no token/path), e.g. `mainnet.infura.io`. */
   rpcHost?: string
+  /**
+   * HTTP status of the failed request, when the error wraps one (see
+   * `getHttpStatusFromError`). Recorded as a queryable facet so client-caused
+   * responses (4xx) can be distinguished from server failures (5xx) in
+   * dashboards before any reclassification decision is made.
+   */
+  httpStatus?: number
 }
 
 /**

--- a/apps/web/src/utils/__tests__/wallets.test.ts
+++ b/apps/web/src/utils/__tests__/wallets.test.ts
@@ -8,6 +8,7 @@ import {
   isEIP7702DelegatedAccount,
   EIP_7702_DELEGATED_ACCOUNT_PREFIX,
   isWalletUnlocked,
+  isWalletRejection,
 } from '@/utils/wallets'
 import { PRIVATE_KEY_MODULE_LABEL } from '@/services/private-key-module/constants'
 
@@ -86,6 +87,33 @@ describe('wallets', () => {
 
       expect(await isWalletUnlocked('MetaMask')).toBe(false)
       expect(braveRequest).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('isWalletRejection', () => {
+    it('detects an ethers ACTION_REJECTED error', () => {
+      const err = Object.assign(new Error('user rejected action'), { code: 'ACTION_REJECTED' })
+      expect(isWalletRejection(err)).toBe(true)
+    })
+
+    it('detects a lowercase rejection message', () => {
+      expect(isWalletRejection(new Error('user rejected the request'))).toBe(true)
+    })
+
+    it('does not detect a bare capitalised "Rejected" (handled downstream by the error normalizer, WA-2950)', () => {
+      expect(isWalletRejection(new Error('Rejected'))).toBe(false)
+    })
+
+    it('detects a WalletConnect "User rejected." reply', () => {
+      expect(isWalletRejection(new Error('User rejected.'))).toBe(true)
+    })
+
+    it('does not flag unrelated errors', () => {
+      expect(isWalletRejection(new Error('insufficient funds for gas'))).toBe(false)
+    })
+
+    it('does not flag genuine failures that merely contain a capitalised "Rejected"', () => {
+      expect(isWalletRejection(new Error('Transaction Rejected by guard'))).toBe(false)
     })
   })
 

--- a/packages/utils/src/services/exceptions/__tests__/normalizeError.test.ts
+++ b/packages/utils/src/services/exceptions/__tests__/normalizeError.test.ts
@@ -1,4 +1,4 @@
-import { normalizeError, sanitizeErrorMessage } from '../normalizeError'
+import { matchUserOutcome, normalizeError, sanitizeErrorMessage } from '../normalizeError'
 import { ErrorDomain, ErrorLayer, ErrorType } from '../errorTaxonomy'
 
 describe('sanitizeErrorMessage', () => {
@@ -123,4 +123,112 @@ describe('normalizeError', () => {
 
     expect(result.sanitizedMessage).not.toContain('0x1234567890abcdef1234567890ABCDEF12345678')
   })
+
+  describe('user-driven outcomes (WA-2950)', () => {
+    it('classifies a WalletConnect request TTL expiry as expired and not user-facing', () => {
+      const result = normalizeError({
+        code: 0,
+        message: 'Request expired. Please try again.',
+        isUserFacing: true,
+      })
+
+      expect(result.type).toBe(ErrorType.EXPIRED)
+      expect(result.isUserFacing).toBe(false)
+    })
+
+    it('classifies a WalletConnect proposal TTL expiry as expired and not user-facing', () => {
+      const result = normalizeError({ code: 0, message: 'Proposal expired', isUserFacing: true })
+
+      expect(result.type).toBe(ErrorType.EXPIRED)
+      expect(result.isUserFacing).toBe(false)
+    })
+
+    it('classifies a coded error wrapping an expiry as expired', () => {
+      const result = normalizeError({
+        code: 804,
+        message: 'Code 804: Error executing a transaction (Request expired. Please try again.)',
+        isUserFacing: true,
+      })
+
+      expect(result.type).toBe(ErrorType.EXPIRED)
+      expect(result.isUserFacing).toBe(false)
+    })
+
+    it('forces isUserFacing to false for a user rejection', () => {
+      const result = normalizeError({
+        code: 804,
+        message: 'Code 804: Error executing a transaction (user rejected the request)',
+        isUserFacing: true,
+      })
+
+      expect(result.type).toBe(ErrorType.USER_REJECTED)
+      expect(result.isUserFacing).toBe(false)
+    })
+
+    it('detects a bare "Rejected" wallet reply wrapped by a coded error', () => {
+      const result = normalizeError({
+        code: 804,
+        message: 'Code 804: Error executing a transaction (Rejected)',
+        isUserFacing: true,
+      })
+
+      expect(result.type).toBe(ErrorType.USER_REJECTED)
+      expect(result.isUserFacing).toBe(false)
+    })
+
+    it('detects a bare "Rejected" message', () => {
+      const result = normalizeError({ code: 0, message: 'Rejected', isUserFacing: true })
+
+      expect(result.type).toBe(ErrorType.USER_REJECTED)
+      expect(result.isUserFacing).toBe(false)
+    })
+
+    it('keeps a swap order expiry classified as order_expired and user-facing', () => {
+      const result = normalizeError({ code: 806, message: 'Code 806: Your order expired', isUserFacing: true })
+
+      expect(result.type).toBe(ErrorType.ORDER_EXPIRED)
+      expect(result.isUserFacing).toBe(true)
+    })
+
+    it('does not swallow a revert reason that merely contains "rejected"', () => {
+      const result = normalizeError({
+        code: 804,
+        message: 'Code 804: execution reverted: transfer rejected by token guard',
+        isUserFacing: true,
+      })
+
+      expect(result.type).not.toBe(ErrorType.USER_REJECTED)
+      expect(result.isUserFacing).toBe(true)
+    })
+
+    it('keeps a genuine execution failure user-facing', () => {
+      const result = normalizeError({
+        code: 804,
+        message: 'Code 804: execution reverted GS013',
+        isUserFacing: true,
+      })
+
+      expect(result.type).toBe(ErrorType.ON_CHAIN_REVERT)
+      expect(result.isUserFacing).toBe(true)
+    })
+  })
+})
+
+describe('matchUserOutcome', () => {
+  it.each([
+    ['Request expired. Please try again.', ErrorType.EXPIRED],
+    ['Proposal expired', ErrorType.EXPIRED],
+    ['Rejected', ErrorType.USER_REJECTED],
+    ['Error: Rejected', ErrorType.USER_REJECTED],
+    ['User rejected.', ErrorType.USER_REJECTED],
+  ])('classifies %p as a user outcome', (message, expected) => {
+    expect(matchUserOutcome(message)).toBe(expected)
+  })
+
+  it.each(['Boom', 'Transaction rejected by guard module', 'nonce too low', 'Your order expired', undefined, ''])(
+    'returns undefined for %p',
+    (message) => {
+      expect(matchUserOutcome(message)).toBeUndefined()
+    },
+  )
 })

--- a/packages/utils/src/services/exceptions/__tests__/utils.test.ts
+++ b/packages/utils/src/services/exceptions/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { asError } from '../utils'
+import { asError, getHttpStatusFromError } from '../utils'
 import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 
 describe('utils', () => {
@@ -91,6 +91,37 @@ describe('utils', () => {
       const result = asError(thrown)
       expect(result.message).toBe('HTTP Error 500')
       expect(result.status).toBe(500)
+    })
+  })
+
+  describe('getHttpStatusFromError', () => {
+    it('reads a numeric status property (RTK Query / asError)', () => {
+      expect(getHttpStatusFromError({ status: 422 })).toBe(422)
+      expect(getHttpStatusFromError(Object.assign(new Error('x'), { status: 404 }))).toBe(404)
+    })
+
+    it('reads a numeric statusCode property', () => {
+      expect(getHttpStatusFromError({ statusCode: 429 })).toBe(429)
+    })
+
+    it('parses the status from a CGW SDK error message', () => {
+      expect(getHttpStatusFromError(new Error('CGW error - 422: Invalid transaction'))).toBe(422)
+    })
+
+    it('parses a wrapped CGW SDK error message', () => {
+      expect(getHttpStatusFromError(new Error('Code 805: Error proposing (CGW error - 400: Bad request)'))).toBe(400)
+    })
+
+    it('ignores non-HTTP numbers (CGW internal codes, string statuses)', () => {
+      expect(getHttpStatusFromError(new Error('CGW error - 1337: Some internal code'))).toBeUndefined()
+      expect(getHttpStatusFromError({ status: 'FETCH_ERROR' })).toBeUndefined()
+      expect(getHttpStatusFromError({ status: 42 })).toBeUndefined()
+    })
+
+    it('returns undefined when no status is present', () => {
+      expect(getHttpStatusFromError(new Error('something broke'))).toBeUndefined()
+      expect(getHttpStatusFromError(undefined)).toBeUndefined()
+      expect(getHttpStatusFromError('string error')).toBeUndefined()
     })
   })
 })

--- a/packages/utils/src/services/exceptions/errorTaxonomy.ts
+++ b/packages/utils/src/services/exceptions/errorTaxonomy.ts
@@ -39,6 +39,7 @@ export enum ErrorType {
   NONCE_CONFLICT = 'nonce_conflict',
   SLIPPAGE_EXCEEDED = 'slippage_exceeded',
   ORDER_EXPIRED = 'order_expired',
+  EXPIRED = 'expired',
   INSUFFICIENT_FUNDS = 'insufficient_funds',
   ON_CHAIN_REVERT = 'on_chain_revert',
   // Per-code defaults (from ERROR_CODE_MAP)

--- a/packages/utils/src/services/exceptions/normalizeError.ts
+++ b/packages/utils/src/services/exceptions/normalizeError.ts
@@ -38,18 +38,41 @@ const GS_CODE_RE = /\bGS\d{3}\b/
  */
 const TYPE_MATCHERS: ReadonlyArray<readonly [RegExp, ErrorType]> = [
   [
-    /user rejected|user denied|rejected the request|action_rejected|rejected by user|\b4001\b/i,
+    // The anchored alternatives catch wallets that reply with a bare "Rejected"
+    // (raw, "Error: "-prefixed by RUM auto-capture, or wrapped by CodedException
+    // as "... (Rejected)") without swallowing revert reasons that merely
+    // contain the word.
+    /user rejected|user denied|rejected the request|action_rejected|rejected by user|\b4001\b|^(?:error:\s*)?rejected\.?$|\(rejected\.?\)$/i,
     ErrorType.USER_REJECTED,
   ],
   [/eth_sign/i, ErrorType.ETH_SIGN_DISABLED],
   [/insufficient funds/i, ErrorType.INSUFFICIENT_FUNDS],
   [/slippage/i, ErrorType.SLIPPAGE_EXCEEDED],
   [/order.*expired|expired.*order/i, ErrorType.ORDER_EXPIRED],
+  [/request expired|proposal expired|session request expired|pairing expired/i, ErrorType.EXPIRED],
   [/nonce/i, ErrorType.NONCE_CONFLICT],
   [/timeout|timed out/i, ErrorType.WALLET_TIMEOUT],
   [/chain mismatch|wrong network|network changed/i, ErrorType.CHAIN_MISMATCH],
   [/ledger/i, ErrorType.LEDGER_ERROR],
 ]
+
+/**
+ * User-driven outcomes (declining to sign, letting an approval prompt pass its
+ * TTL) are expected behaviour, not failures — they must never count as
+ * user-facing errors regardless of what the call site claims (WA-2950).
+ */
+const USER_OUTCOME_TYPES: ReadonlySet<ErrorType> = new Set([ErrorType.USER_REJECTED, ErrorType.EXPIRED])
+
+/**
+ * Returns the user-outcome type (`user_rejected` / `expired`) a raw error
+ * message classifies as, or `undefined` for genuine failures. For sinks that
+ * see errors outside the `normalizeError` pipeline (e.g. RUM auto-capture).
+ */
+export const matchUserOutcome = (message: string | undefined): ErrorType | undefined => {
+  if (!message) return undefined
+  const type = refineType(message)
+  return type !== undefined && USER_OUTCOME_TYPES.has(type) ? type : undefined
+}
 
 export const sanitizeErrorMessage = (message: string): string => message.replace(HEX_BLOB_RE, '[redacted]')
 
@@ -96,7 +119,7 @@ export const normalizeError = ({ code, message, isUserFacing }: NormalizeErrorIn
     type,
     layer,
     code: codeStr,
-    isUserFacing,
+    isUserFacing: USER_OUTCOME_TYPES.has(type) ? false : isUserFacing,
     sanitizedMessage: sanitizeErrorMessage(message),
   }
 }

--- a/packages/utils/src/services/exceptions/utils.ts
+++ b/packages/utils/src/services/exceptions/utils.ts
@@ -64,3 +64,30 @@ export const asError = (thrown: unknown): ErrorWithStatus => {
 
   return new Error(message) as ErrorWithStatus
 }
+
+/** CGW SDK errors flatten the HTTP status into the message: "CGW error - 422: ..." */
+const CGW_STATUS_RE = /\bCGW error - ([1-5]\d{2}):/
+
+const isHttpStatus = (value: unknown): value is number => typeof value === 'number' && value >= 100 && value <= 599
+
+/**
+ * Extracts the HTTP status of a failed request from an unknown thrown value,
+ * checking structural fields first (RTK Query / `asError` set `status`, the
+ * CGW SDK's `ErrorResponse` uses `statusCode`) and falling back to the CGW SDK
+ * message format. Returns `undefined` when no plausible HTTP status is found,
+ * so non-HTTP numbers (e.g. CGW internal codes) are never misreported.
+ */
+export const getHttpStatusFromError = (thrown: unknown): number | undefined => {
+  if (typeof thrown === 'object' && thrown !== null) {
+    const { status, statusCode } = thrown as { status?: unknown; statusCode?: unknown }
+    if (isHttpStatus(status)) return status
+    if (isHttpStatus(statusCode)) return statusCode
+  }
+
+  if (thrown instanceof Error) {
+    const match = thrown.message.match(CGW_STATUS_RE)
+    if (match) return Number(match[1])
+  }
+
+  return undefined
+}


### PR DESCRIPTION
## What it solves

Resolves: [WA-2950](https://linear.app/safe-global/issue/WA-2950/stop-counting-expired-and-cancelled-approvals-as-failures)

Our error rate is inflated by users simply changing their minds: WalletConnect throws when an approval prompt passes its TTL (`Request expired. Please try again.`, `Proposal expired`), and wallets reply with `Rejected` / user-rejected variants when the user declines to sign. Nothing is broken in any of these (~1,175 events / 30 days, ~6% of the total error count), but they are reported as user-facing errors, count against the Error-Free Views SLO, and make real regressions harder to see.

This follows standard industry practice: client-caused outcomes are recorded but not counted as failures (the same reasoning behind availability SLOs counting 5xx but not 4xx), and EIP-1193 standardizes user rejection (code 4001) as an expected outcome of the provider API.

## How this PR fixes it

**Reclassification, not suppression** — the events stay queryable everywhere; they just stop counting as failures.

1. **Taxonomy** (`packages/utils`): new `ErrorType.EXPIRED`, plus normalizer matchers for WalletConnect TTL expiries and bare `Rejected` wallet replies (anchored, so revert reasons merely *containing* the word keep reporting as errors — the Code 804 family is split, not blanket-reclassified).
2. **`normalizeError` forces `isUserFacing: false`** when the type resolves to `user_rejected` / `expired`, regardless of what the call site claims. The shared `matchUserOutcome()` helper exposes the same classification to sinks outside the pipeline.
3. **`CodedException.track()`** consults the normalizer first: user outcomes are recorded as info-level Datadog actions (tagged `error_type: user_rejected|expired`) instead of RUM errors, and skip `captureError` entirely.
4. **`filterRumEvent`** catches the unhandled path (WalletConnect SDK errors auto-captured by RUM that never pass through `trackError`): matching error events are re-emitted as info actions and dropped as RUM errors.
5. **Mixpanel**: `Error Surfaced` is no longer emitted for user outcomes.
6. **HTTP status facet** (groundwork, no behaviour change): `CodedException` extracts the HTTP status of the wrapped request failure directly from the thrown error (`getHttpStatusFromError()` — structural `status`/`statusCode` fields or the CGW SDK message format), so **every** `trackError`/`logError` call site emits it automatically as a Datadog `http_status` tag and Mixpanel `HTTP Status` prop. A future 4xx/5xx fault-attribution decision can then be made with production data. An explicit `context.httpStatus` wins as an override.

## How to test it

1. `yarn workspace @safe-global/utils test --testPathPattern exceptions` — normalizer + status-extraction suites (49 tests).
2. `yarn workspace @safe-global/web test --testPathPattern "services/exceptions|providers/__tests__/datadog|mixpanel/__tests__|__tests__/wallets"` — pipeline, RUM filter and analytics suites.
3. Manually (staging + Datadog): open a WalletConnect approval prompt and let it expire, or decline to sign in the wallet → the event appears as an info **action** with `error_type: expired|user_rejected` and no RUM **error** is recorded; no `Error Surfaced` event reaches Mixpanel.
4. Sanity: force a genuine failure (e.g. an on-chain revert with a `GS###` code) → still a RUM error + `Error Surfaced`, unchanged.

## Affected flows

- Any flow where the user declines to sign in their wallet (sign, execute, propose, batch, message signing, recovery, spending limits, Safe creation) — telemetry classification only; UI behaviour unchanged.
- WalletConnect session approval / request flows where a prompt passes its TTL — telemetry classification only.
- Datadog Error-Free Views SLO and Mixpanel `Error Surfaced` event volumes (expect ~6% of error events to move to info actions / disappear from `Error Surfaced`).

## Blast radius

- `normalizeError` / `errorTaxonomy` (`packages/utils`) — consumers: `CodedException` (web) and Mixpanel `trackErrorSurfaced` (web). **No mobile consumers** (verified by search); mobile is unaffected.
- `CodedException.track()` — every `trackError` call site in the web app routes through it; only messages classifying as `user_rejected`/`expired` change path.
- `filterRumEvent` — `beforeSend` for all RUM events; new branch only matches anchored user-outcome messages, existing noise/extension/resource filters untouched.
- `ErrorContext` — additive optional field (`httpStatus`); existing call sites unaffected.
- `MixpanelEventParams` — additive enum member (`HTTP Status`).
- `apps/web/src/utils/wallets.ts` (`isWalletRejection`) — **deliberately left untouched** to avoid widening rejection detection at 16 UI call sites.

## Risks / not checked

- The Datadog-side SLO query/monitor updates and the before/after error-rate documentation are dashboard work, not code — still to be done after this deploys (tracked in the ticket's DoD).
- Message matchers are anchored and fail safe: an unknown wallet's rejection phrasing stays classified as an error (over-reporting, never under-reporting).
- Did not test on mobile (no mobile consumers of the changed modules).
- HTTP status extraction relies on the thrown error carrying a structural `status`/`statusCode` or the CGW SDK message format; errors that stringify their status differently simply omit the facet (additive tag, never wrong data).
- Bare `Rejected` replies still show the generic error banner (not the friendly rejection UI) — `isWalletRejection` was intentionally not broadened; can be a separate, focused PR.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1[User declines to sign /<br>prompt expires] --> B1[trackError]
    B1 --> C1["isUserFacing: true (hardcoded)"]
    C1 --> D1[Datadog RUM addError<br>counts against SLO]
    C1 --> E1[Mixpanel Error Surfaced]
  end
  subgraph After
    A2[User declines to sign /<br>prompt expires] --> B2[trackError]
    B2 --> N2{"normalizeError:<br>user_rejected / expired?"}
    N2 -->|yes| I2["Datadog info action<br>error_type facet — off the SLO,<br>no Error Surfaced"]
    N2 -->|"no (genuine failure)"| D2[Datadog RUM addError + Mixpanel<br>unchanged]
    A3[Unhandled WalletConnect SDK error] --> F2[filterRumEvent beforeSend]
    F2 -->|matchUserOutcome| I2
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (not applicable — no mobile consumers of the changed modules)
- [x] I've documented how it affects the analytics (if at all) 📊 (`Error Surfaced` no longer fires for user outcomes; new `HTTP Status` property)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 (all behaviour TDD'd; 49 utils + 194 web tests in the touched suites)
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
