### PR TITLE
[POC] feat(Policies): set spending limits for multiple tokens at once

### DIFF
--- a/apps/web/src/components/tx-flow/flows/NewSpendingLimit/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/NewSpendingLimit/index.tsx
@@ -8,9 +8,7 @@ import { SpendingLimitsFeature, type NewSpendingLimitFlowProps } from '@/feature
 
 const defaultValues: NewSpendingLimitFlowProps = {
   beneficiary: '',
-  tokenAddress: ZERO_ADDRESS,
-  amount: '',
-  resetTime: '0',
+  limits: [{ tokenAddress: ZERO_ADDRESS, amount: '', resetTime: '0' }],
 }
 
 const NewSpendingLimitFlow = () => {

--- a/apps/web/src/features/spending-limits/components/CreateSpendingLimit/LimitRow.tsx
+++ b/apps/web/src/features/spending-limits/components/CreateSpendingLimit/LimitRow.tsx
@@ -1,0 +1,116 @@
+import { useCallback, useMemo } from 'react'
+import { Controller, useFormContext } from 'react-hook-form'
+import { FormControl, IconButton, InputLabel, MenuItem, Select, Stack, SvgIcon } from '@mui/material'
+import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded'
+
+import DeleteIcon from '@/public/images/common/delete.svg'
+import TokenAmountInput from '@/components/common/TokenAmountInput'
+import { type Balances } from '@safe-global/store/gateway/AUTO_GENERATED/balances'
+import { validateAmount, validateDecimalLength } from '@safe-global/utils/utils/validation'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
+import useChainId from '@/hooks/useChainId'
+import css from '@/components/tx/ExecuteCheckbox/styles.module.css'
+
+import { getResetTimeOptions } from '../../constants'
+import { SpendingLimitFields, type NewSpendingLimitFlowProps } from '../../types'
+import { _validateSpendingLimit } from './validation'
+
+const LimitRow = ({
+  index,
+  balances,
+  removable,
+  onRemove,
+  amountFieldNames,
+}: {
+  index: number
+  balances: Balances['items']
+  removable: boolean
+  onRemove: (index: number) => void
+  amountFieldNames: string[]
+}) => {
+  const chainId = useChainId()
+  const { control, getValues, watch } = useFormContext<NewSpendingLimitFlowProps>()
+
+  const resetTimeOptions = useMemo(() => getResetTimeOptions(chainId), [chainId])
+
+  const tokenAddress = watch(`${SpendingLimitFields.limits}.${index}.${SpendingLimitFields.tokenAddress}`)
+  const selectedToken = tokenAddress
+    ? balances.find((item) => sameAddress(item.tokenInfo.address, tokenAddress))
+    : undefined
+  const decimals = selectedToken?.tokenInfo.decimals
+
+  const validateLimit = useCallback(
+    (value: string) => {
+      const amountError =
+        validateAmount(value) || validateDecimalLength(value, decimals) || _validateSpendingLimit(value, decimals)
+
+      if (amountError) return amountError
+
+      // Two setAllowance calls for the same token in one MultiSend would silently overwrite each other
+      const rows = getValues(SpendingLimitFields.limits) ?? []
+      const isDuplicate = rows.some(
+        (row, rowIndex) => rowIndex !== index && sameAddress(row.tokenAddress, rows[index]?.tokenAddress),
+      )
+
+      return isDuplicate ? 'This token already has a limit in this transaction' : undefined
+    },
+    [decimals, getValues, index],
+  )
+
+  return (
+    <Stack spacing={2}>
+      <Stack direction="row" alignItems="flex-start" spacing={1}>
+        <Stack flex={1}>
+          <TokenAmountInput
+            balances={balances}
+            selectedToken={selectedToken}
+            validate={validateLimit}
+            fieldArray={{ name: SpendingLimitFields.limits, index }}
+            deps={amountFieldNames}
+          />
+        </Stack>
+
+        {removable && (
+          <IconButton
+            data-testid="remove-limit-btn"
+            onClick={() => onRemove(index)}
+            aria-label="Remove limit"
+            size="small"
+          >
+            <SvgIcon component={DeleteIcon} inheritViewBox fontSize="small" />
+          </IconButton>
+        )}
+      </Stack>
+
+      <FormControl fullWidth className={css.select}>
+        <InputLabel shrink={false}>Time Period</InputLabel>
+        <Controller
+          rules={{ required: true }}
+          control={control}
+          name={`${SpendingLimitFields.limits}.${index}.${SpendingLimitFields.resetTime}`}
+          render={({ field }) => (
+            <Select
+              data-testid="time-period-section"
+              {...field}
+              sx={{ textAlign: 'right', fontWeight: 700 }}
+              IconComponent={ExpandMoreRoundedIcon}
+            >
+              {resetTimeOptions.map((resetTime) => (
+                <MenuItem
+                  data-testid="time-period-item"
+                  key={resetTime.value}
+                  value={resetTime.value}
+                  sx={{ overflow: 'hidden' }}
+                >
+                  {resetTime.label}
+                </MenuItem>
+              ))}
+            </Select>
+          )}
+        />
+      </FormControl>
+    </Stack>
+  )
+}
+
+export default LimitRow

--- a/apps/web/src/features/spending-limits/components/CreateSpendingLimit/index.tsx
+++ b/apps/web/src/features/spending-limits/components/CreateSpendingLimit/index.tsx
@@ -1,66 +1,48 @@
-import { useCallback, useContext, useMemo } from 'react'
-import { Controller, FormProvider, useForm } from 'react-hook-form'
-import { Button, CardActions, FormControl, InputLabel, MenuItem, Select, Typography } from '@mui/material'
-import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded'
-import { parseUnits, AbiCoder } from 'ethers'
+import { useContext, useMemo } from 'react'
+import { FormProvider, useFieldArray, useForm } from 'react-hook-form'
+import { Button, CardActions, Divider, FormControl, Stack, SvgIcon, Typography } from '@mui/material'
 
+import AddIcon from '@/public/images/common/add.svg'
 import AddressBookInput from '@/components/common/AddressBookInput'
 import { useSafeShieldForAddressPoisoning } from '@/features/safe-shield/SafeShieldContext'
-import useChainId from '@/hooks/useChainId'
-import { getResetTimeOptions } from '../../constants'
-import { useVisibleBalances } from '@/hooks/useVisibleBalances'
+import { ZERO_ADDRESS } from '@safe-global/utils/utils/constants'
 import TxCard from '@/components/tx-flow/common/TxCard'
-import css from '@/components/tx/ExecuteCheckbox/styles.module.css'
-import TokenAmountInput from '@/components/common/TokenAmountInput'
-import { validateAmount, validateDecimalLength } from '@safe-global/utils/utils/validation'
+import { useVisibleBalances } from '@/hooks/useVisibleBalances'
 import { TxFlowContext, type TxFlowContextType } from '@/components/tx-flow/TxFlowProvider'
 import { SpendingLimitFields, type NewSpendingLimitFlowProps } from '../../types'
 import useIsSpendingLimitSupported from '../../hooks/useIsSpendingLimitSupported'
 import SpendingLimitNotSupported from './SpendingLimitNotSupported'
+import LimitRow from './LimitRow'
 
-export const _validateSpendingLimit = (val: string, decimals?: number | null) => {
-  // Allowance amount is uint96 https://github.com/safe-global/safe-modules/blob/main/modules/allowances/contracts/AllowanceModule.sol#L52
-  try {
-    const amount = parseUnits(val, decimals ?? 'Gwei')
-    AbiCoder.defaultAbiCoder().encode(['int96'], [amount])
-  } catch (e) {
-    return Number(val) > 1 ? 'Amount is too big' : 'Amount is too small'
-  }
-}
+export { _validateSpendingLimit } from './validation'
+
+const MAX_LIMITS = 5
 
 const CreateSpendingLimit = () => {
-  const chainId = useChainId()
   const isSupported = useIsSpendingLimitSupported()
   const { balances } = useVisibleBalances()
   const { onNext, data } = useContext<TxFlowContextType<NewSpendingLimitFlowProps>>(TxFlowContext)
-
-  const resetTimeOptions = useMemo(() => getResetTimeOptions(chainId), [chainId])
 
   const formMethods = useForm<NewSpendingLimitFlowProps>({
     defaultValues: data,
     mode: 'onChange',
   })
 
-  const { handleSubmit, watch, control } = formMethods
+  const { handleSubmit, watch, control, formState } = formMethods
 
-  const tokenAddress = watch(SpendingLimitFields.tokenAddress)
   const beneficiary = watch(SpendingLimitFields.beneficiary)
 
   // Copilot address-poisoning check for the beneficiary
   useSafeShieldForAddressPoisoning([beneficiary])
-  const selectedToken = tokenAddress
-    ? balances.items.find((item) => item.tokenInfo.address === tokenAddress)
-    : undefined
 
-  const validateSpendingLimit = useCallback(
-    (value: string) => {
-      return (
-        validateAmount(value) ||
-        validateDecimalLength(value, selectedToken?.tokenInfo.decimals) ||
-        _validateSpendingLimit(value, selectedToken?.tokenInfo.decimals)
-      )
-    },
-    [selectedToken?.tokenInfo.decimals],
+  const { fields: limitFields, append, remove } = useFieldArray({ control, name: SpendingLimitFields.limits })
+
+  const canAddMoreLimits = limitFields.length < MAX_LIMITS
+
+  // Changing one row's token can make another row a duplicate, so all rows re-validate together
+  const amountFieldNames = useMemo(
+    () => limitFields.map((_, index) => `${SpendingLimitFields.limits}.${index}.${SpendingLimitFields.amount}`),
+    [limitFields],
   )
 
   if (!isSupported) {
@@ -79,44 +61,48 @@ const CreateSpendingLimit = () => {
             />
           </FormControl>
 
-          <TokenAmountInput balances={balances.items} selectedToken={selectedToken} validate={validateSpendingLimit} />
+          <Typography variant="h4" fontWeight={700}>
+            Limits
+          </Typography>
+          <Typography mb={2}>
+            Set an allowance per token. Each token refills automatically after its own reset time period.
+          </Typography>
 
-          <Typography variant="h4" fontWeight={700} mt={3}>
-            Reset Timer
-          </Typography>
-          <Typography>
-            Set a reset time so the allowance automatically refills after the defined time period.
-          </Typography>
-          <FormControl fullWidth className={css.select}>
-            <InputLabel shrink={false}>Time Period</InputLabel>
-            <Controller
-              rules={{ required: true }}
-              control={control}
-              name={SpendingLimitFields.resetTime}
-              render={({ field }) => (
-                <Select
-                  data-testid="time-period-section"
-                  {...field}
-                  sx={{ textAlign: 'right', fontWeight: 700 }}
-                  IconComponent={ExpandMoreRoundedIcon}
-                >
-                  {resetTimeOptions.map((resetTime) => (
-                    <MenuItem
-                      data-testid="time-period-item"
-                      key={resetTime.value}
-                      value={resetTime.value}
-                      sx={{ overflow: 'hidden' }}
-                    >
-                      {resetTime.label}
-                    </MenuItem>
-                  ))}
-                </Select>
-              )}
-            />
-          </FormControl>
+          <Stack spacing={4}>
+            {limitFields.map((field, index) => (
+              <LimitRow
+                key={field.id}
+                index={index}
+                balances={balances.items}
+                removable={limitFields.length > 1}
+                onRemove={remove}
+                amountFieldNames={amountFieldNames}
+              />
+            ))}
+          </Stack>
+
+          <Stack direction="row" alignItems="center" justifyContent="space-between" mt={3}>
+            <Button
+              data-testid="add-limit-btn"
+              variant="text"
+              onClick={() => append({ tokenAddress: ZERO_ADDRESS, amount: '', resetTime: '0' })}
+              disabled={!canAddMoreLimits}
+              startIcon={<SvgIcon component={AddIcon} inheritViewBox fontSize="small" />}
+              size="large"
+            >
+              Add token
+            </Button>
+            <Typography
+              data-testid="limits-count"
+              variant="body2"
+              color={canAddMoreLimits ? 'primary' : 'error.main'}
+            >{`${limitFields.length}/${MAX_LIMITS}`}</Typography>
+          </Stack>
+
+          <Divider sx={{ mt: 2 }} />
 
           <CardActions>
-            <Button data-testid="next-btn" variant="contained" type="submit">
+            <Button data-testid="next-btn" variant="contained" type="submit" disabled={!formState.isValid}>
               Next
             </Button>
           </CardActions>

--- a/apps/web/src/features/spending-limits/components/CreateSpendingLimit/validation.ts
+++ b/apps/web/src/features/spending-limits/components/CreateSpendingLimit/validation.ts
@@ -1,0 +1,11 @@
+import { parseUnits, AbiCoder } from 'ethers'
+
+export const _validateSpendingLimit = (val: string, decimals?: number | null) => {
+  // Allowance amount is uint96 https://github.com/safe-global/safe-modules/blob/main/modules/allowances/contracts/AllowanceModule.sol#L52
+  try {
+    const amount = parseUnits(val, decimals ?? 'Gwei')
+    AbiCoder.defaultAbiCoder().encode(['int96'], [amount])
+  } catch (e) {
+    return Number(val) > 1 ? 'Amount is too big' : 'Amount is too small'
+  }
+}

--- a/apps/web/src/features/spending-limits/components/ReviewSpendingLimit/index.tsx
+++ b/apps/web/src/features/spending-limits/components/ReviewSpendingLimit/index.tsx
@@ -1,7 +1,7 @@
 import { useCurrentChain } from '@/hooks/useChains'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { useEffect, useMemo, useContext } from 'react'
-import { Typography, Alert, Box } from '@mui/material'
+import { Typography, Alert, Box, Stack } from '@mui/material'
 
 import SpendingLimitLabel from '@/components/common/SpendingLimitLabel'
 import { getResetTimeOptions } from '../../constants'
@@ -11,13 +11,14 @@ import useChainId from '@/hooks/useChainId'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 import { selectSpendingLimits } from '../../store/spendingLimitsSlice'
 import { formatVisualAmount, safeParseUnits } from '@safe-global/utils/utils/formatters'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
 import type { NewSpendingLimitFlowProps } from '../../types'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import ReviewTransaction, { type ReviewTransactionProps } from '@/components/tx/ReviewTransactionV2'
 import { TxFlowContext, type TxFlowContextType } from '@/components/tx-flow/TxFlowProvider'
 import TxDetailsRow from '@/components/tx/ConfirmTxDetails/TxDetailsRow'
-import { createNewSpendingLimitTx } from '../../services/spendingLimitExecution'
+import { createNewSpendingLimitTx, findExistingSpendingLimit } from '../../services/spendingLimitExecution'
 import { useAppSelector } from '@/store'
 
 const ReviewSpendingLimit = ({ onSubmit, children }: ReviewTransactionProps) => {
@@ -28,93 +29,70 @@ const ReviewSpendingLimit = ({ onSubmit, children }: ReviewTransactionProps) => 
   const chain = useCurrentChain()
   const { balances } = useBalances()
   const { setSafeTx, setSafeTxError } = useContext(SafeTxContext)
-  const token = balances.items.find((item) => item.tokenInfo.address === data?.tokenAddress)
-  const { decimals } = token?.tokenInfo || {}
 
-  const amountInWei = useMemo(
-    () => safeParseUnits(data?.amount || '0', token?.tokenInfo.decimals)?.toString() || '0',
-    [data?.amount, token?.tokenInfo.decimals],
-  )
+  const resetTimeOptions = useMemo(() => getResetTimeOptions(chainId), [chainId])
 
-  const existingSpendingLimit = useMemo(() => {
-    return spendingLimits.find(
-      (spendingLimit) =>
-        spendingLimit.beneficiary === data?.beneficiary && spendingLimit.token.address === data?.tokenAddress,
-    )
-  }, [spendingLimits, data])
+  // Each row is resolved against the balances list for its token info and decimals
+  const rows = useMemo(() => {
+    if (!data) return []
+
+    return data.limits.map((limit) => {
+      const token = balances.items.find((item) => sameAddress(item.tokenInfo.address, limit.tokenAddress))
+      const decimals = token?.tokenInfo.decimals
+      const existing = findExistingSpendingLimit(spendingLimits, data.beneficiary, limit.tokenAddress)
+
+      return {
+        ...limit,
+        token,
+        decimals,
+        existing,
+        amountInWei: safeParseUnits(limit.amount || '0', decimals)?.toString() || '0',
+        resetTimeLabel:
+          limit.resetTime === '0'
+            ? 'One-time spending limit'
+            : resetTimeOptions.find((time) => time.value === limit.resetTime)?.label,
+      }
+    })
+  }, [data, balances.items, spendingLimits, resetTimeOptions])
 
   useEffect(() => {
     if (!chain || !data) return
 
     createNewSpendingLimitTx(
-      data,
+      {
+        beneficiary: data.beneficiary,
+        limits: rows.map(({ tokenAddress, amount, resetTime, decimals }) => ({
+          tokenAddress,
+          amount,
+          resetTime,
+          decimals,
+        })),
+      },
       spendingLimits,
       chainId,
       chain,
       safe.modules,
       safe.deployed,
-      decimals,
-      existingSpendingLimit,
     )
       .then(setSafeTx)
       .catch(setSafeTxError)
-  }, [
-    chain,
-    chainId,
-    decimals,
-    existingSpendingLimit,
-    data,
-    safe.modules,
-    safe.deployed,
-    setSafeTx,
-    setSafeTxError,
-    spendingLimits,
-  ])
+  }, [chain, chainId, data, rows, safe.modules, safe.deployed, setSafeTx, setSafeTxError, spendingLimits])
 
-  const isOneTime = data?.resetTime === '0'
-  const resetTime = useMemo(() => {
-    return isOneTime
-      ? 'One-time spending limit'
-      : getResetTimeOptions(chainId).find((time) => time.value === data?.resetTime)?.label
-  }, [isOneTime, data?.resetTime, chainId])
+  const replacedTokens = rows.filter((row) => row.existing).map((row) => row.token?.tokenInfo.symbol || 'token')
 
   const onFormSubmit = () => {
-    trackEvent({
-      ...SETTINGS_EVENTS.SPENDING_LIMIT.RESET_PERIOD,
-      label: resetTime,
+    rows.forEach((row) => {
+      trackEvent({
+        ...SETTINGS_EVENTS.SPENDING_LIMIT.RESET_PERIOD,
+        label: row.resetTimeLabel,
+      })
     })
 
     onSubmit()
   }
 
-  const existingAmount = existingSpendingLimit
-    ? formatVisualAmount(BigInt(existingSpendingLimit?.amount), decimals)
-    : undefined
-
-  const oldResetTime = existingSpendingLimit
-    ? getResetTimeOptions(chainId).find((time) => time.value === existingSpendingLimit?.resetTimeMin)?.label
-    : undefined
-
   return (
     <ReviewTransaction onSubmit={onFormSubmit} withDecodedData={false}>
-      {token && (
-        <SendAmountBlock amountInWei={amountInWei} tokenInfo={token.tokenInfo} title="Amount">
-          {existingAmount && existingAmount !== data?.amount && (
-            <>
-              <Typography
-                data-testid="old-token-amount"
-                color="error"
-                sx={{ textDecoration: 'line-through' }}
-                component="span"
-              >
-                {existingAmount}
-              </Typography>
-              →
-            </>
-          )}
-        </SendAmountBlock>
-      )}
-
       <TxDetailsRow label="Beneficiary" grid>
         <Box data-testid="beneficiary-address">
           <EthHashInfo
@@ -127,46 +105,73 @@ const ReviewSpendingLimit = ({ onSubmit, children }: ReviewTransactionProps) => 
         </Box>
       </TxDetailsRow>
 
-      <TxDetailsRow label="Reset time" grid>
-        {existingSpendingLimit ? (
-          <>
-            <SpendingLimitLabel
-              label={
-                <>
-                  {existingSpendingLimit.resetTimeMin !== data?.resetTime && (
-                    <>
-                      <Typography
-                        data-testid="old-reset-time"
-                        color="error"
-                        component="span"
-                        sx={{
-                          textDecoration: 'line-through',
-                        }}
-                      >
-                        {oldResetTime}
-                      </Typography>
-                      {' → '}
-                    </>
-                  )}
-                  <Typography component="span">{resetTime}</Typography>
-                </>
-              }
-              isOneTime={existingSpendingLimit.resetTimeMin === '0'}
-            />
-          </>
-        ) : (
-          <SpendingLimitLabel
-            data-testid="spending-limit-label"
-            label={resetTime || 'One-time spending limit'}
-            isOneTime={!!resetTime && isOneTime}
-          />
-        )}
-      </TxDetailsRow>
+      {rows.map((row, index) => {
+        const existingAmount = row.existing ? formatVisualAmount(BigInt(row.existing.amount), row.decimals) : undefined
+        const oldResetTime = row.existing
+          ? resetTimeOptions.find((time) => time.value === row.existing?.resetTimeMin)?.label
+          : undefined
 
-      {existingSpendingLimit && (
+        return (
+          <Stack key={`${row.tokenAddress}-${index}`} spacing={1}>
+            {row.token && (
+              <SendAmountBlock amountInWei={row.amountInWei} tokenInfo={row.token.tokenInfo} title="Amount">
+                {existingAmount && existingAmount !== row.amount && (
+                  <>
+                    <Typography
+                      data-testid="old-token-amount"
+                      color="error"
+                      sx={{ textDecoration: 'line-through' }}
+                      component="span"
+                    >
+                      {existingAmount}
+                    </Typography>
+                    →
+                  </>
+                )}
+              </SendAmountBlock>
+            )}
+
+            <TxDetailsRow label="Reset time" grid>
+              {row.existing ? (
+                <SpendingLimitLabel
+                  label={
+                    <>
+                      {row.existing.resetTimeMin !== row.resetTime && (
+                        <>
+                          <Typography
+                            data-testid="old-reset-time"
+                            color="error"
+                            component="span"
+                            sx={{ textDecoration: 'line-through' }}
+                          >
+                            {oldResetTime}
+                          </Typography>
+                          {' → '}
+                        </>
+                      )}
+                      <Typography component="span">{row.resetTimeLabel}</Typography>
+                    </>
+                  }
+                  isOneTime={row.existing.resetTimeMin === '0'}
+                />
+              ) : (
+                <SpendingLimitLabel
+                  data-testid="spending-limit-label"
+                  label={row.resetTimeLabel || 'One-time spending limit'}
+                  isOneTime={row.resetTime === '0'}
+                />
+              )}
+            </TxDetailsRow>
+          </Stack>
+        )
+      })}
+
+      {replacedTokens.length > 0 && (
         <Alert severity="warning" sx={{ border: 'unset' }}>
           <Typography data-testid="limit-replacement-warning" fontWeight={700}>
-            You are about to replace an existing spending limit
+            {replacedTokens.length === 1
+              ? 'You are about to replace an existing spending limit'
+              : `You are about to replace existing spending limits for ${replacedTokens.join(', ')}`}
           </Typography>
         </Alert>
       )}

--- a/apps/web/src/features/spending-limits/services/spendingLimitExecution.ts
+++ b/apps/web/src/features/spending-limits/services/spendingLimitExecution.ts
@@ -22,6 +22,17 @@ import { txDispatch, TxEvent } from '@/services/tx/txEvents'
 import { didRevert } from '@/utils/ethers-utils'
 import { getUncheckedSigner } from '@/services/tx/tx-sender/sdk'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
+
+export const findExistingSpendingLimit = (
+  spendingLimits: SpendingLimitState[],
+  beneficiary: string,
+  tokenAddress: string,
+): SpendingLimitState | undefined =>
+  spendingLimits.find(
+    (spendingLimit) =>
+      sameAddress(spendingLimit.beneficiary, beneficiary) && sameAddress(spendingLimit.token.address, tokenAddress),
+  )
 
 export const createNewSpendingLimitTx = async (
   data: NewSpendingLimitData,
@@ -30,8 +41,6 @@ export const createNewSpendingLimitTx = async (
   chain: Chain,
   safeModules: SafeState['modules'],
   deployed: boolean,
-  tokenDecimals?: number | null,
-  existingSpendingLimit?: SpendingLimitState,
 ) => {
   const sdk = getSafeSDK()
   if (!sdk) return
@@ -73,25 +82,32 @@ export const createNewSpendingLimitTx = async (
     }
   }
 
-  const existingDelegate = spendingLimits.find((spendingLimit) => spendingLimit.beneficiary === data.beneficiary)
+  // addDelegate is per beneficiary, not per token, so it is only ever needed once
+  const existingDelegate = spendingLimits.find((spendingLimit) =>
+    sameAddress(spendingLimit.beneficiary, data.beneficiary),
+  )
   if (!existingDelegate) {
     txs.push(createAddDelegateTx(data.beneficiary, spendingLimitAddress))
   }
 
-  if (existingSpendingLimit && existingSpendingLimit.spent !== '0') {
-    txs.push(createResetAllowanceTx(data.beneficiary, data.tokenAddress, spendingLimitAddress))
-  }
+  data.limits.forEach(({ tokenAddress, amount, resetTime, decimals }) => {
+    // setAllowance does not clear the spent amount, so an already-spent allowance has to be reset first
+    const existingSpendingLimit = findExistingSpendingLimit(spendingLimits, data.beneficiary, tokenAddress)
+    if (existingSpendingLimit && existingSpendingLimit.spent !== '0') {
+      txs.push(createResetAllowanceTx(data.beneficiary, tokenAddress, spendingLimitAddress))
+    }
 
-  const tx = createSetAllowanceTx(
-    data.beneficiary,
-    data.tokenAddress,
-    parseUnits(data.amount, tokenDecimals ?? undefined).toString(),
-    parseInt(data.resetTime),
-    data.resetTime !== '0' ? currentMinutes() - 30 : 0,
-    spendingLimitAddress,
-  )
-
-  txs.push(tx)
+    txs.push(
+      createSetAllowanceTx(
+        data.beneficiary,
+        tokenAddress,
+        parseUnits(amount, decimals ?? undefined).toString(),
+        parseInt(resetTime),
+        resetTime !== '0' ? currentMinutes() - 30 : 0,
+        spendingLimitAddress,
+      ),
+    )
+  })
 
   return createMultiSendCallOnlyTx(txs)
 }

--- a/apps/web/src/features/spending-limits/types.ts
+++ b/apps/web/src/features/spending-limits/types.ts
@@ -7,23 +7,32 @@ export type { SpendingLimitState } from './store/spendingLimitsSlice'
 // Form fields for creating spending limits
 enum SpendingLimitFormFields {
   beneficiary = 'beneficiary',
+  limits = 'limits',
   resetTime = 'resetTime',
 }
 
 export const SpendingLimitFields = { ...SpendingLimitFormFields, ...TokenAmountFields }
 
-export type NewSpendingLimitFlowProps = {
-  [SpendingLimitFields.beneficiary]: string
+export type SpendingLimitRowValues = {
   [SpendingLimitFields.tokenAddress]: string
   [SpendingLimitFields.amount]: string
   [SpendingLimitFields.resetTime]: string
 }
 
+export type NewSpendingLimitFlowProps = {
+  [SpendingLimitFields.beneficiary]: string
+  [SpendingLimitFields.limits]: SpendingLimitRowValues[]
+}
+
 export type NewSpendingLimitData = {
   beneficiary: string
-  tokenAddress: string
-  amount: string
-  resetTime: string
+  limits: {
+    tokenAddress: string
+    amount: string
+    resetTime: string
+    // Resolved by the review screen from the balances list
+    decimals?: number | null
+  }[]
 }
 
 export type SpendingLimitTxParams = {

--- a/apps/web/src/services/tx/__tests__/spendingLimitParams.test.ts
+++ b/apps/web/src/services/tx/__tests__/spendingLimitParams.test.ts
@@ -12,9 +12,7 @@ import { createNewSpendingLimitTx } from '@/features/spending-limits/services/sp
 
 const mockData: NewSpendingLimitFlowProps = {
   beneficiary: ZERO_ADDRESS,
-  tokenAddress: ZERO_ADDRESS,
-  amount: '1',
-  resetTime: '0',
+  limits: [{ tokenAddress: ZERO_ADDRESS, amount: '1', resetTime: '0' }],
 }
 
 const mockChain = chainBuilder().build()
@@ -47,27 +45,27 @@ describe('createNewSpendingLimitTx', () => {
 
   it('returns undefined if there is no sdk instance', async () => {
     jest.spyOn(safeCoreSDK, 'getSafeSDK').mockReturnValue(undefined)
-    const result = await createNewSpendingLimitTx(mockData, [], '4', mockChain, mockModules, true, 18)
+    const result = await createNewSpendingLimitTx(mockData, [], '4', mockChain, mockModules, true)
 
     expect(result).toBeUndefined()
   })
 
   it('returns undefined if there is no contract address', async () => {
     jest.spyOn(safeCoreSDK, 'getSafeSDK').mockReturnValue(mockSDK)
-    const result = await createNewSpendingLimitTx(mockData, [], '4', mockChain, mockModules, true, 18)
+    const result = await createNewSpendingLimitTx(mockData, [], '4', mockChain, mockModules, true)
 
     expect(result).toBeUndefined()
   })
 
   it('creates a tx to enable the spending limit module if its not registered yet', async () => {
-    await createNewSpendingLimitTx(mockData, [], '4', mockChain, [], true, 18)
+    await createNewSpendingLimitTx(mockData, [], '4', mockChain, [], true)
 
     expect(mockCreateEnableModuleTx).toHaveBeenCalledTimes(1)
   })
 
   it('creates a tx to add a delegate if beneficiary is not a delegate yet', async () => {
     const spy = jest.spyOn(spendingLimitParams, 'createAddDelegateTx')
-    await createNewSpendingLimitTx(mockData, [], '4', mockChain, mockModules, true, 18)
+    await createNewSpendingLimitTx(mockData, [], '4', mockChain, mockModules, true)
 
     expect(spy).toHaveBeenCalledTimes(1)
   })
@@ -86,15 +84,15 @@ describe('createNewSpendingLimitTx', () => {
     ]
 
     const spy = jest.spyOn(spendingLimitParams, 'createAddDelegateTx')
-    await createNewSpendingLimitTx(mockData, mockSpendingLimits, '4', mockChain, mockModules, true, 18)
+    await createNewSpendingLimitTx(mockData, mockSpendingLimits, '4', mockChain, mockModules, true)
 
     expect(spy).not.toHaveBeenCalled()
   })
 
   it('creates a tx to reset an existing allowance if some of the allowance was already spent', async () => {
-    const existingSpendingLimitMock = {
+    const existingSpendingLimitMock: SpendingLimitState = {
       beneficiary: ZERO_ADDRESS,
-      token: { address: '0x10', decimals: 18, symbol: 'TST' },
+      token: { address: ZERO_ADDRESS, decimals: 18, symbol: 'TST' },
       amount: '1',
       resetTimeMin: '0',
       lastResetMin: '0',
@@ -103,15 +101,15 @@ describe('createNewSpendingLimitTx', () => {
     }
 
     const spy = jest.spyOn(spendingLimitParams, 'createResetAllowanceTx')
-    await createNewSpendingLimitTx(mockData, [], '4', mockChain, mockModules, true, 18, existingSpendingLimitMock)
+    await createNewSpendingLimitTx(mockData, [existingSpendingLimitMock], '4', mockChain, mockModules, true)
 
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
   it('does not create a tx to reset an existing allowance if none was spent', async () => {
-    const existingSpendingLimitMock = {
+    const existingSpendingLimitMock: SpendingLimitState = {
       beneficiary: ZERO_ADDRESS,
-      token: { address: '0x10', decimals: 18, symbol: 'TST' },
+      token: { address: ZERO_ADDRESS, decimals: 18, symbol: 'TST' },
       amount: '1',
       resetTimeMin: '0',
       lastResetMin: '0',
@@ -120,20 +118,20 @@ describe('createNewSpendingLimitTx', () => {
     }
 
     const spy = jest.spyOn(spendingLimitParams, 'createResetAllowanceTx')
-    await createNewSpendingLimitTx(mockData, [], '4', mockChain, mockModules, true, 18, existingSpendingLimitMock)
+    await createNewSpendingLimitTx(mockData, [existingSpendingLimitMock], '4', mockChain, mockModules, true)
 
     expect(spy).not.toHaveBeenCalled()
   })
 
   it('creates a tx to set the allowance', async () => {
     const spy = jest.spyOn(spendingLimitParams, 'createSetAllowanceTx')
-    await createNewSpendingLimitTx(mockData, [], '4', mockChain, mockModules, true, 18)
+    await createNewSpendingLimitTx(mockData, [], '4', mockChain, mockModules, true)
 
     expect(spy).toHaveBeenCalled()
   })
   it('encodes all txs as a single multiSend tx', async () => {
     const spy = jest.spyOn(txSender, 'createMultiSendCallOnlyTx')
-    await createNewSpendingLimitTx(mockData, [], '4', mockChain, mockModules, true, 18)
+    await createNewSpendingLimitTx(mockData, [], '4', mockChain, mockModules, true)
 
     expect(spy).toHaveBeenCalled()
   })


### PR DESCRIPTION
Allowances in the AllowanceModule are keyed by (safe, delegate, token), so a beneficiary could always hold several token allowances — but the UI only ever built one setAllowance call per transaction.

The new spending limit form now takes a beneficiary plus a repeatable list of token / amount / reset time rows (capped at 5), and emits them as a single MultiSend. enableModule and addDelegate stay outside the loop since both are per beneficiary rather than per token; the conditional resetAllowance is emitted per row, immediately before that token's setAllowance, preserving the existing semantics.

Duplicate tokens are rejected in the form because two setAllowance calls for the same token in one MultiSend would silently overwrite each other.

The store, loader, settings table and the spend-side execution path are unchanged — they already key on (beneficiary, token).

POC: no new tests or Storybook story. Existing test mocks updated for the new signature.