### PR TITLE
chore(deps): bump transitive immutable 5.x to patched 5.1.9

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -30845,9 +30845,9 @@ __metadata:
   linkType: hard
 
 "immutable@npm:^5.0.2":
-  version: 5.0.3
-  resolution: "immutable@npm:5.0.3"
-  checksum: 10/9aca1c783951bb204d7036fbcefac6dd42e7c8ad77ff54b38c5fc0924e6e16ce2d123c95db47c1170ba63dd3f6fc7aa74a29be7adef984031936c4cd1e9e8554
+  version: 5.1.9
+  resolution: "immutable@npm:5.1.9"
+  checksum: 10/dc61ea6f79897320a048f193dec703dff25ad7bb633c3a0294677d2f258764c88da06e7c2b53d1aa51b6657c98d9f1c7341f49735b9b802fe6e834122cf78dcd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What it solves

Resolves two open Dependabot alerts against `immutable` (GHSA-v56q-mh7h-f735 — `List` 32-bit trie overflow DoS, and GHSA-xvcm-6775-5m9r — hash-collision algorithmic complexity DoS in `Map`/`Set`). Both are patched at 5.1.8 on the 5.x line.

## How this PR fixes it

Lockfile-only refresh via `yarn up -R immutable`: the vulnerable copy is a transitive dev dependency (`typescript-plugin-css-modules` → `sass`), and `sass`'s own `^5.0.2` range already admits the patched release, so no resolution pin or `package.json` change is needed. The other copy in the tree (`immutable@4.3.9` via `redux-devtools-expo-dev-plugin`) is already the patched 4.x release and is untouched. Neither copy ships in production bundles — both consumers are dev tooling.

## How to test it

1. `yarn why immutable` — the `^5.0.2` range should resolve to 5.1.9 (≥ 5.1.8) and `^4.3.7` to 4.3.9.
2. `yarn install --immutable` succeeds.
3. CI passes (no source changes).

## Visual summary

```mermaid
flowchart LR
  A[typescript-plugin-css-modules 4.2.3] --> B[sass 1.83.0]
  B -->|"immutable ^5.0.2"| C["immutable 5.0.3 ❌ vulnerable"]
  B2[sass 1.83.0] -->|"immutable ^5.0.2"| D["immutable 5.1.9 ✅ patched"]
  subgraph Before
    A --> B
  end
  subgraph After
    B2
  end
```

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — lockfile-only change

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).