### PR TITLE
ci: bind composite action inputs via env before shell

### DIFF
--- a/.github/actions/branch-slug/action.yml
+++ b/.github/actions/branch-slug/action.yml
@@ -19,7 +19,9 @@ runs:
     - name: Slugify branch name
       id: slugify
       shell: bash
+      env:
+        MAX_LENGTH: ${{ inputs.max-length }}
       run: |
         raw="$(echo "$GITHUB_HEAD_REF" | sed 's|refs/heads/||')"
-        safe="$(echo "$raw" | sed 's/[^a-zA-Z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | sed 's/[A-Z]/\L&/g' | cut -c1-${{ inputs.max-length }} | sed 's/-$//')"
-        echo "slug=$safe" >> $GITHUB_OUTPUT
+        safe="$(echo "$raw" | sed 's/[^a-zA-Z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | sed 's/[A-Z]/\L&/g' | cut -c1-"${MAX_LENGTH}" | sed 's/-$//')"
+        echo "slug=$safe" >> "$GITHUB_OUTPUT"

--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -25,11 +25,14 @@ runs:
     - name: Upload coverage to Datadog
       shell: bash
       continue-on-error: true
-      run: |
-        npx @datadog/datadog-ci coverage upload \
-          --flags "${{ inputs.flag }}" \
-          --base-path "${{ inputs.base-path }}" \
-          "${{ inputs.coverage-path }}"
       env:
         DD_API_KEY: ${{ inputs.api-key }}
         DD_SITE: ${{ inputs.site }}
+        COVERAGE_FLAG: ${{ inputs.flag }}
+        COVERAGE_BASE_PATH: ${{ inputs.base-path }}
+        COVERAGE_PATH: ${{ inputs.coverage-path }}
+      run: |
+        npx @datadog/datadog-ci coverage upload \
+          --flags "${COVERAGE_FLAG}" \
+          --base-path "${COVERAGE_BASE_PATH}" \
+          "${COVERAGE_PATH}"

--- a/.github/actions/yarn/action.yml
+++ b/.github/actions/yarn/action.yml
@@ -29,9 +29,12 @@ runs:
     - name: Export Turbo remote cache env
       if: inputs.turbo-token != ''
       shell: bash
+      env:
+        INPUT_TURBO_TOKEN: ${{ inputs.turbo-token }}
+        INPUT_TURBO_TEAM: ${{ inputs.turbo-team }}
       run: |
-        echo "TURBO_TOKEN=${{ inputs.turbo-token }}" >> "$GITHUB_ENV"
-        echo "TURBO_TEAM=${{ inputs.turbo-team }}" >> "$GITHUB_ENV"
+        echo "TURBO_TOKEN=${INPUT_TURBO_TOKEN}" >> "$GITHUB_ENV"
+        echo "TURBO_TEAM=${INPUT_TURBO_TEAM}" >> "$GITHUB_ENV"
         echo "TURBO_REMOTE_ONLY=false" >> "$GITHUB_ENV"
 
     - name: Restore Yarn Cache & Types


### PR DESCRIPTION
## Summary
Several composite actions interpolated `inputs.*` directly into `run:` scripts:

- `branch-slug` — `cut -c1-${{ inputs.max-length }}`
- `upload-coverage` — Datadog `--flags` / `--base-path` / path
- `yarn` — `TURBO_TOKEN` / `TURBO_TEAM` export

Move those values into `env:` and expand shell variables instead. Behavior unchanged.

## Test plan
- [ ] Preview branch-slug still produces a DNS-safe slug
- [ ] Coverage upload step still runs (continue-on-error unchanged)
- [ ] Yarn setup still exports Turbo remote cache env when token present


Made with [Cursor](https://cursor.com)