### PR TITLE
fix: resolve React console warnings across app

### DIFF
--- a/apps/web/src/components/balances/AssetsTable/AssetRowContent.tsx
+++ b/apps/web/src/components/balances/AssetsTable/AssetRowContent.tsx
@@ -98,11 +98,11 @@ export const AssetRowContent = ({
       </div>
       {showMobileValue && (
         <Box className={css.mobileValue}>
-          <Typography>
+          <Typography component="div">
             <FiatBalance balanceItem={item} />
           </Typography>
           {item.fiatBalance24hChange && (
-            <Typography variant="caption">
+            <Typography variant="caption" component="div">
               <FiatChange balanceItem={item} inline />
             </Typography>
           )}

--- a/apps/web/src/components/balances/AssetsTable/index.tsx
+++ b/apps/web/src/components/balances/AssetsTable/index.tsx
@@ -197,11 +197,11 @@ const AssetsTable = ({
               rawValue: rawFiatValue,
               content: (
                 <Box textAlign="right">
-                  <Typography>
+                  <Typography component="div">
                     <FiatBalance balanceItem={item} />
                   </Typography>
                   {item.fiatBalance24hChange && (
-                    <Typography variant="body2">
+                    <Typography variant="body2" component="div">
                       <FiatChange balanceItem={item} inline />
                     </Typography>
                   )}

--- a/apps/web/src/components/common/Disclaimer/__snapshots__/index.stories.test.tsx.snap
+++ b/apps/web/src/components/common/Disclaimer/__snapshots__/index.stories.test.tsx.snap
@@ -33,11 +33,11 @@ exports[`./index.stories BlockedAddress 1`] = `
         >
           Blocked Address
         </h3>
-        <p
+        <div
           class="MuiTypography-root MuiTypography-body2 mui-style-17vdyq3-MuiTypography-root"
         >
           This signer address is blocked by the Safe interface, due to being associated with the blocked activities by the U.S. Department of Treasury in the Specially Designated Nationals (SDN) list.
-        </p>
+        </div>
         <hr
           class="MuiDivider-root MuiDivider-fullWidth mui-style-1facvfi-MuiDivider-root"
         />
@@ -86,7 +86,7 @@ exports[`./index.stories LegalDisclaimer 1`] = `
         >
           Legal Disclaimer
         </h3>
-        <p
+        <div
           class="MuiTypography-root MuiTypography-body2 mui-style-17vdyq3-MuiTypography-root"
         >
           <div
@@ -146,7 +146,7 @@ exports[`./index.stories LegalDisclaimer 1`] = `
               </p>
             </div>
           </div>
-        </p>
+        </div>
         <hr
           class="MuiDivider-root MuiDivider-fullWidth mui-style-1facvfi-MuiDivider-root"
         />

--- a/apps/web/src/components/common/Disclaimer/index.tsx
+++ b/apps/web/src/components/common/Disclaimer/index.tsx
@@ -51,7 +51,9 @@ const Disclaimer = ({
           >
             {title}
           </Typography>
-          <Typography variant="body2">{content}</Typography>
+          <Typography variant="body2" component="div">
+            {content}
+          </Typography>
           <Divider />
         </Stack>
         <Box

--- a/apps/web/src/components/dashboard/PendingTxs/PendingTxListItem.tsx
+++ b/apps/web/src/components/dashboard/PendingTxs/PendingTxListItem.tsx
@@ -39,7 +39,7 @@ const PendingTx = ({ transaction }: PendingTxType): ReactElement => {
             <TxTypeIcon tx={transaction} />
           </Box>
           <Box sx={{ minWidth: 0 }}>
-            <Typography className={css.txDescription}>
+            <Typography component="div" className={css.txDescription}>
               <TxTypeText tx={transaction} />
               <TxInfo info={transaction.txInfo} />
             </Typography>

--- a/apps/web/src/components/safe-messages/MsgListItem/ExpandableMsgItem.tsx
+++ b/apps/web/src/components/safe-messages/MsgListItem/ExpandableMsgItem.tsx
@@ -16,6 +16,7 @@ const ExpandableMsgItem = ({ msg, expanded = false }: { msg: MessageItem; expand
         data-testid="message-item"
         expandIcon={<ExpandMoreIcon />}
         sx={{ justifyContent: 'flex-start', overflowX: 'auto' }}
+        component="div"
       >
         <MsgSummary msg={msg} />
       </AccordionSummary>

--- a/apps/web/src/features/actions-tray/components/ActionsTray/ActionsTray.tsx
+++ b/apps/web/src/features/actions-tray/components/ActionsTray/ActionsTray.tsx
@@ -172,6 +172,7 @@ const ActionsTray = ({ noAssets, variant = 'safe' }: ActionsTrayProps): ReactEle
                           className={cn('px-6 hover:bg-secondary-hover dark:border-border')}
                           data-testid="overview-swap-btn"
                           disabled={swapDisabled}
+                          nativeButton={swapDisabled}
                           render={
                             !swapDisabled ? (
                               <Link href={{ pathname: AppRoutes.swap, query: router.query }} />
@@ -209,6 +210,7 @@ const ActionsTray = ({ noAssets, variant = 'safe' }: ActionsTrayProps): ReactEle
                 size="icon"
                 className="rounded-lg hover:bg-secondary-hover dark:border-border"
                 disabled={!isOk}
+                nativeButton={!isOk}
                 render={isOk ? <Link href={txBuilderLink} /> : undefined}
                 aria-label="Transaction builder"
               >

--- a/apps/web/src/features/actions-tray/components/ActionsTray/ActionsTray.tsx
+++ b/apps/web/src/features/actions-tray/components/ActionsTray/ActionsTray.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router'
 import Link from 'next/link'
 import { ArrowUpRight, QrCode, Repeat, SquareDashedBottomCode } from 'lucide-react'
 import { Tooltip } from '@mui/material'
-import { Button } from '@/components/ui/button'
+import { Button, buttonVariants } from '@/components/ui/button'
 import Track from '@/components/common/Track'
 import QrCodeButton from '@/components/common/QrCodeButton'
 import CheckWallet from '@/components/common/CheckWallet'
@@ -166,22 +166,28 @@ const ActionsTray = ({ noAssets, variant = 'safe' }: ActionsTrayProps): ReactEle
                           <Repeat className="size-5" strokeWidth={1.5} />
                           Swap
                         </Button>
-                      ) : (
+                      ) : swapDisabled ? (
                         <Button
                           variant={secondaryVariant}
                           className={cn('px-6 hover:bg-secondary-hover dark:border-border')}
                           data-testid="overview-swap-btn"
-                          disabled={swapDisabled}
-                          nativeButton={swapDisabled}
-                          render={
-                            !swapDisabled ? (
-                              <Link href={{ pathname: AppRoutes.swap, query: router.query }} />
-                            ) : undefined
-                          }
+                          disabled
                         >
                           <Repeat className="size-5" strokeWidth={1.5} />
                           Swap
                         </Button>
+                      ) : (
+                        <Link
+                          href={{ pathname: AppRoutes.swap, query: router.query }}
+                          data-testid="overview-swap-btn"
+                          className={cn(
+                            buttonVariants({ variant: secondaryVariant }),
+                            'px-6 hover:bg-secondary-hover dark:border-border',
+                          )}
+                        >
+                          <Repeat className="size-5" strokeWidth={1.5} />
+                          Swap
+                        </Link>
                       )}
                     </span>
                   </Tooltip>
@@ -204,14 +210,23 @@ const ActionsTray = ({ noAssets, variant = 'safe' }: ActionsTrayProps): ReactEle
                 <SquareDashedBottomCode className="size-5" strokeWidth={1.5} />
                 Build transaction
               </Button>
+            ) : isOk ? (
+              <Link
+                href={txBuilderLink}
+                aria-label="Transaction builder"
+                className={cn(
+                  buttonVariants({ variant: secondaryVariant, size: 'icon' }),
+                  'rounded-lg hover:bg-secondary-hover dark:border-border',
+                )}
+              >
+                <SquareDashedBottomCode className="size-5 text-muted-foreground" strokeWidth={1.5} />
+              </Link>
             ) : (
               <Button
                 variant={secondaryVariant}
                 size="icon"
                 className="rounded-lg hover:bg-secondary-hover dark:border-border"
-                disabled={!isOk}
-                nativeButton={!isOk}
-                render={isOk ? <Link href={txBuilderLink} /> : undefined}
+                disabled
                 aria-label="Transaction builder"
               >
                 <SquareDashedBottomCode className="size-5 text-muted-foreground" strokeWidth={1.5} />

--- a/apps/web/src/features/actions-tray/components/ActionsTray/__tests__/ActionsTray.test.tsx
+++ b/apps/web/src/features/actions-tray/components/ActionsTray/__tests__/ActionsTray.test.tsx
@@ -225,8 +225,10 @@ describe('ActionsTray geoblocking', () => {
       const user = userEvent.setup()
       renderTray({ isBlockedCountry: false, variant: 'safe' })
 
-      const buildTxControl = screen.getByRole('link', { name: /transaction builder/i })
+      // Base UI applies role="button" to the rendered link when nativeButton is false
+      const buildTxControl = screen.getByRole('button', { name: /transaction builder/i })
       expect(buildTxControl).toBeEnabled()
+      expect(buildTxControl).toHaveAttribute('href')
 
       const tooltipTrigger = buildTxControl.parentElement
       expect(tooltipTrigger).toBeTruthy()

--- a/apps/web/src/features/actions-tray/components/ActionsTray/__tests__/ActionsTray.test.tsx
+++ b/apps/web/src/features/actions-tray/components/ActionsTray/__tests__/ActionsTray.test.tsx
@@ -225,9 +225,7 @@ describe('ActionsTray geoblocking', () => {
       const user = userEvent.setup()
       renderTray({ isBlockedCountry: false, variant: 'safe' })
 
-      // Base UI applies role="button" to the rendered link when nativeButton is false
-      const buildTxControl = screen.getByRole('button', { name: /transaction builder/i })
-      expect(buildTxControl).toBeEnabled()
+      const buildTxControl = screen.getByRole('link', { name: /transaction builder/i })
       expect(buildTxControl).toHaveAttribute('href')
 
       const tooltipTrigger = buildTxControl.parentElement

--- a/apps/web/src/features/myAccounts/components/AccountsHeader/index.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsHeader/index.tsx
@@ -26,6 +26,7 @@ const AddSafeButton = ({ trackingLabel, onLinkClick }: { trackingLabel: string; 
         size="lg"
         onClick={onLinkClick}
         className="w-full rounded-lg h-full px-5 text-base "
+        nativeButton={false}
         render={<NextLink href={{ pathname: AppRoutes.newSafe.load, query: { next } }} />}
       >
         <AddIcon color="currentColor" className="size-5 fill-primary" />

--- a/apps/web/src/features/myAccounts/components/AccountsHeader/index.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsHeader/index.tsx
@@ -9,7 +9,7 @@ import useWallet from '@/hooks/wallets/useWallet'
 import AddIcon from '@/public/images/common/add.svg'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
 import { FEATURES } from '@safe-global/utils/utils/chains'
-import { Button } from '@/components/ui/button'
+import { buttonVariants } from '@/components/ui/button'
 import { Typography } from '@/components/ui/typography'
 import { cn } from '@/utils/cn'
 import NextLink from 'next/link'
@@ -20,18 +20,15 @@ const AddSafeButton = ({ trackingLabel, onLinkClick }: { trackingLabel: string; 
   const next = useNewSafeNextParam()
   return (
     <Track {...OVERVIEW_EVENTS.ADD_TO_WATCHLIST} label={trackingLabel}>
-      <Button
+      <NextLink
         data-testid="add-safe-button"
-        variant="outline"
-        size="lg"
+        href={{ pathname: AppRoutes.newSafe.load, query: { next } }}
         onClick={onLinkClick}
-        className="w-full rounded-lg h-full px-5 text-base "
-        nativeButton={false}
-        render={<NextLink href={{ pathname: AppRoutes.newSafe.load, query: { next } }} />}
+        className={cn(buttonVariants({ variant: 'outline', size: 'lg' }), 'h-full w-full rounded-lg px-5 text-base')}
       >
         <AddIcon color="currentColor" className="size-5 fill-primary" />
         Add
-      </Button>
+      </NextLink>
     </Track>
   )
 }

--- a/apps/web/src/features/myAccounts/components/MyAccountsV2/components/GetStartedCard/index.tsx
+++ b/apps/web/src/features/myAccounts/components/MyAccountsV2/components/GetStartedCard/index.tsx
@@ -61,6 +61,7 @@ const GetStartedCard = () => {
               size="lg"
               className="h-12 w-full text-[15px]"
               data-testid="watch-account-button"
+              nativeButton={false}
               render={<NextLink href={{ pathname: AppRoutes.newSafe.load, query: { next } }} />}
             >
               Watch any account

--- a/apps/web/src/features/myAccounts/components/MyAccountsV2/components/GetStartedCard/index.tsx
+++ b/apps/web/src/features/myAccounts/components/MyAccountsV2/components/GetStartedCard/index.tsx
@@ -6,7 +6,7 @@ import Track from '@/components/common/Track'
 import { AppRoutes } from '@/config/routes'
 import { useNewSafeNextParam } from '@/components/new-safe/getReturnUrl'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
-import { Button } from '@/components/ui/button'
+import { Button, buttonVariants } from '@/components/ui/button'
 import { Typography } from '@/components/ui/typography'
 import { useDarkMode } from '@/hooks/useDarkMode'
 import { cn } from '@/utils/cn'
@@ -56,16 +56,13 @@ const GetStartedCard = () => {
           </div>
 
           <Track {...OVERVIEW_EVENTS.ADD_TO_WATCHLIST} label={OVERVIEW_LABELS.login_page}>
-            <Button
-              variant="ghost"
-              size="lg"
-              className="h-12 w-full text-[15px]"
+            <NextLink
+              href={{ pathname: AppRoutes.newSafe.load, query: { next } }}
               data-testid="watch-account-button"
-              nativeButton={false}
-              render={<NextLink href={{ pathname: AppRoutes.newSafe.load, query: { next } }} />}
+              className={cn(buttonVariants({ variant: 'ghost', size: 'lg' }), 'h-12 w-full text-[15px]')}
             >
               Watch any account
-            </Button>
+            </NextLink>
           </Track>
         </div>
       </div>

--- a/apps/web/src/features/nfts/components/NftGrid/index.tsx
+++ b/apps/web/src/features/nfts/components/NftGrid/index.tsx
@@ -13,6 +13,7 @@ import {
   Table,
   TableBody,
   TableCell,
+  type TableCellProps,
   TableContainer,
   TableHead,
   TableRow,
@@ -40,7 +41,15 @@ interface NftsTableProps {
 const PAGE_SIZE = 10
 const INITIAL_SKELETON_SIZE = 3
 
-const headCells = [
+interface HeadCell {
+  id: string
+  label: string
+  width: string
+  xsHidden?: boolean
+  align?: TableCellProps['align']
+}
+
+const headCells: HeadCell[] = [
   {
     id: 'collection',
     label: 'Collection',
@@ -61,7 +70,7 @@ const headCells = [
     id: 'checkbox',
     label: '',
     width: '7%',
-    textAlign: 'right',
+    align: 'right',
   },
 ]
 
@@ -172,12 +181,11 @@ const NftGrid = ({
               {headCells.map((headCell) => (
                 <TableCell
                   key={headCell.id}
-                  align="left"
+                  align={headCell.align ?? 'left'}
                   padding="normal"
                   sx={{
                     display: headCell.xsHidden ? { xs: 'none', sm: 'table-cell' } : undefined,
                     width: headCell.width,
-                    'text-align': headCell.textAlign,
                   }}
                 >
                   {headCell.id === 'collection' ? (

--- a/apps/web/src/features/spaces/components/Sidebar/ApiCtaSidebar/ApiCtaSidebar.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/ApiCtaSidebar/ApiCtaSidebar.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react'
 import Image from 'next/image'
 import { X } from 'lucide-react'
-import { Button } from '@/components/ui/button'
+import { buttonVariants } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Typography } from '@/components/ui/typography'
 import { SidebarMenuItem, SidebarMenuButton, useSidebar } from '@/components/ui/sidebar'
@@ -83,15 +83,17 @@ export const ApiCtaSidebar = (): ReactElement => {
           Authenticated access, predictable quotas, and webhooks for teams that rely on Safe as critical infrastructure.
         </Typography>
 
-        <Button
-          variant="outline"
-          size="sm"
-          className="w-auto self-start !bg-background hover:!bg-muted"
-          nativeButton={false}
-          render={<a href={API_DOCS_URL} target="_blank" rel="noopener noreferrer" />}
+        <a
+          href={API_DOCS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(
+            buttonVariants({ variant: 'outline', size: 'sm' }),
+            'w-auto self-start !bg-background hover:!bg-muted',
+          )}
         >
           Get API key
-        </Button>
+        </a>
       </div>
     </SidebarMenuItem>
   )

--- a/apps/web/src/features/spaces/components/Sidebar/ApiCtaSidebar/ApiCtaSidebar.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/ApiCtaSidebar/ApiCtaSidebar.tsx
@@ -87,6 +87,7 @@ export const ApiCtaSidebar = (): ReactElement => {
           variant="outline"
           size="sm"
           className="w-auto self-start !bg-background hover:!bg-muted"
+          nativeButton={false}
           render={<a href={API_DOCS_URL} target="_blank" rel="noopener noreferrer" />}
         >
           Get API key

--- a/apps/web/src/features/spaces/components/Sidebar/ApiCtaSidebar/__tests__/ApiCtaSidebar.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/ApiCtaSidebar/__tests__/ApiCtaSidebar.test.tsx
@@ -48,23 +48,6 @@ jest.mock('@/components/ui/sidebar', () => ({
   useSidebar: () => ({ state: mockSidebarState, isMobile: false }),
 }))
 
-jest.mock('@/components/ui/button', () => ({
-  Button: ({
-    children,
-    render: renderProp,
-  }: {
-    children: ReactNode
-    render?: React.ReactElement<{ href: string; target?: string; rel?: string }>
-  }) =>
-    renderProp ? (
-      <a href={renderProp.props.href} target={renderProp.props.target} rel={renderProp.props.rel}>
-        {children}
-      </a>
-    ) : (
-      <button>{children}</button>
-    ),
-}))
-
 jest.mock('../../styles.module.css', () => ({}))
 
 describe('ApiCtaSidebar', () => {

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/AboutPage.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/AboutPage.test.tsx
@@ -161,7 +161,7 @@ describe('AboutPage', () => {
 
     it('GitHub button links to APP_HOMEPAGE', () => {
       renderWithStore()
-      const link = screen.getByRole('link', { name: /GitHub/i })
+      const link = screen.getByRole('button', { name: /GitHub/i })
       expect(link).toHaveAttribute('href', APP_HOMEPAGE)
     })
   })

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/AboutPage.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/AboutPage.test.tsx
@@ -161,7 +161,7 @@ describe('AboutPage', () => {
 
     it('GitHub button links to APP_HOMEPAGE', () => {
       renderWithStore()
-      const link = screen.getByRole('button', { name: /GitHub/i })
+      const link = screen.getByRole('link', { name: /GitHub/i })
       expect(link).toHaveAttribute('href', APP_HOMEPAGE)
     })
   })

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/AboutPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/AboutPage.tsx
@@ -247,6 +247,7 @@ const AboutPage = () => {
           <Button
             variant="outline"
             size="sm"
+            nativeButton={false}
             render={<a href={APP_HOMEPAGE} target="_blank" rel="noreferrer noopener" />}
           >
             <ArrowUpRight className="h-3.5 w-3.5" />

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/AboutPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/AboutPage.tsx
@@ -19,7 +19,7 @@ import { APP_HOMEPAGE, APP_VERSION } from '@/config/version'
 import { BRAND_NAME } from '@/config/constants'
 import { AppRoutes } from '@/config/routes'
 import { HELP_CENTER_URL } from '@safe-global/utils/config/constants'
-import { Button } from '@/components/ui/button'
+import { buttonVariants } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Typography } from '@/components/ui/typography'
 import { useLoadFeature } from '@/features/__core__'
@@ -244,15 +244,15 @@ const AboutPage = () => {
               </Typography>
             </span>
           </span>
-          <Button
-            variant="outline"
-            size="sm"
-            nativeButton={false}
-            render={<a href={APP_HOMEPAGE} target="_blank" rel="noreferrer noopener" />}
+          <a
+            href={APP_HOMEPAGE}
+            target="_blank"
+            rel="noreferrer noopener"
+            className={buttonVariants({ variant: 'outline', size: 'sm' })}
           >
             <ArrowUpRight className="h-3.5 w-3.5" />
             GitHub
-          </Button>
+          </a>
         </div>
       </section>
 

--- a/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
@@ -144,9 +144,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
     render(<SpacesList />)
 
     expect(screen.getByText(/create your first workspace/i)).toBeInTheDocument()
-    // The "Create workspace" CTA is an anchor exposed with role="button" (Base UI
-    // Button + NextLink composition with nativeButton={false}).
-    const cta = screen.getByRole('button', { name: /create workspace/i })
+    const cta = screen.getByRole('link', { name: /create workspace/i })
     expect(cta).toHaveAttribute('href')
 
     // Sign in card must NOT render in this branch.

--- a/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
@@ -144,8 +144,10 @@ describe('SpacesList — auth/expiry state rendering', () => {
     render(<SpacesList />)
 
     expect(screen.getByText(/create your first workspace/i)).toBeInTheDocument()
-    // The "Create workspace" CTA link is rendered (Button + NextLink composition).
-    expect(screen.getByRole('link', { name: /create workspace/i })).toBeInTheDocument()
+    // The "Create workspace" CTA is an anchor exposed with role="button" (Base UI
+    // Button + NextLink composition with nativeButton={false}).
+    const cta = screen.getByRole('button', { name: /create workspace/i })
+    expect(cta).toHaveAttribute('href')
 
     // Sign in card must NOT render in this branch.
     expect(screen.queryByTestId('sign-in-options')).not.toBeInTheDocument()
@@ -316,7 +318,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
     render(<SpacesList />)
 
     const button = screen.getByTestId('create-space-button')
-    expect(button).toHaveAttribute('disabled')
+    expect(button).toHaveAttribute('aria-disabled', 'true')
 
     await userEvent.hover(button)
     expect(await screen.findByText(/limit of 10 workspaces reached/i)).toBeInTheDocument()

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -54,6 +54,7 @@ const AddSpaceButton = ({
         size === 'lg' && 'h-full rounded-lg px-6 py-3 text-base',
         disabled && 'cursor-not-allowed opacity-50 grayscale',
       )}
+      nativeButton={false}
       render={disabled ? <span /> : <NextLink href={AppRoutes.welcome.createSpace} />}
       disabled={disabled}
       onClick={disabled ? undefined : onClick}

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -9,7 +9,7 @@ import { useAppSelector } from '@/store'
 import { isAuthenticated } from '@/store/authSlice'
 import { Box, Card, Link, Stack, Typography } from '@mui/material'
 import { Check } from 'lucide-react'
-import { Button } from '@/components/ui/button'
+import { buttonVariants } from '@/components/ui/button'
 import { Typography as ShadcnTypography } from '@/components/ui/typography'
 import { type GetSpaceResponse, useSpacesGetV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
@@ -45,20 +45,14 @@ const AddSpaceButton = ({
   variant?: 'default' | 'outline'
   label?: string
 }) => {
-  const button = (
-    <Button
-      data-testid="create-space-button"
-      variant={variant}
-      size={size}
-      className={cn(
-        size === 'lg' && 'h-full rounded-lg px-6 py-3 text-base',
-        disabled && 'cursor-not-allowed opacity-50 grayscale',
-      )}
-      nativeButton={false}
-      render={disabled ? <span /> : <NextLink href={AppRoutes.welcome.createSpace} />}
-      disabled={disabled}
-      onClick={disabled ? undefined : onClick}
-    >
+  const className = cn(
+    buttonVariants({ variant, size }),
+    size === 'lg' && 'h-full rounded-lg px-6 py-3 text-base',
+    disabled && 'cursor-not-allowed opacity-50 grayscale',
+  )
+
+  const content = (
+    <>
       <AddIcon
         className={cn(
           variant === 'default' ? 'fill-primary-foreground' : 'fill-foreground',
@@ -66,14 +60,29 @@ const AddSpaceButton = ({
         )}
       />
       {label}
-    </Button>
+    </>
   )
 
-  if (!disabled) return button
+  if (!disabled) {
+    return (
+      <NextLink
+        data-testid="create-space-button"
+        href={AppRoutes.welcome.createSpace}
+        className={className}
+        onClick={onClick}
+      >
+        {content}
+      </NextLink>
+    )
+  }
 
   return (
     <Tooltip>
-      <TooltipTrigger render={<div className="inline-flex" />}>{button}</TooltipTrigger>
+      <TooltipTrigger render={<div className="inline-flex" />}>
+        <span data-testid="create-space-button" aria-disabled="true" className={className}>
+          {content}
+        </span>
+      </TooltipTrigger>
       <TooltipContent>Limit of {SPACES_LIMIT} workspaces reached</TooltipContent>
     </Tooltip>
   )


### PR DESCRIPTION
## What it solves

Resolves a batch of React console warnings that appear across the app in development, and — following review feedback — restores proper link semantics on navigational CTAs:

- **Hydration errors from invalid DOM nesting** — `In HTML, <div> cannot be a descendant of <p>` (and `<p>` inside `<p>`), caused by MUI `Typography`/`AccordionSummary` rendering as `<p>` while wrapping block-level children (`Stack`, `Grid`, `Chip`, nested `Typography`).
- **Base UI button semantics warnings** — `A component that acts as a button expected a native <button>` for every `Button` that renders an `<a>`/`<span>` through the `render` prop. Silencing this with `nativeButton={false}` would expose navigation links as `role="button"`, hiding them from screen-reader link navigation with mismatched key behavior (Space would not activate them) — so navigational CTAs are recomposed as real links instead.
- **Emotion warning** — `Using kebab-case for css properties in objects is not supported` from a `'text-align'` key in the NFT table's `sx` object.

## How this PR fixes it

- Adds `component="div"` to `Typography` (and one `AccordionSummary`) wrappers whose children render block elements: pending-transactions dashboard item, assets table fiat value/change cells (desktop + mobile), shared `Disclaimer` content wrapper, expandable message list item. Disclaimer story snapshots updated (pure `<p>` → `<div>` diff).
- Recomposes navigational CTAs from `Button render={<a|Link>}` to real anchors styled with `buttonVariants(...)`, preserving `role="link"`, Enter activation, and screen-reader link lists:
  - ActionsTray: Swap and Transaction-builder (safe variant) render a styled `Link` when enabled and fall back to a genuine disabled `<button>` when disabled
  - SpacesList: "Create workspace" CTA is a styled `NextLink`; the limit-reached state is a `<span aria-disabled="true">` with the existing tooltip
  - ApiCtaSidebar "Get API key", AccountsHeader "Add", GetStartedCard "Watch any account", space settings AboutPage "GitHub" — all plain styled anchors now
- Replaces the kebab-case `'text-align'` sx key in `NftGrid` with the native `TableCell` `align` prop, backed by a typed `HeadCell` interface.

## How to test it

1. Run the app in dev mode with the browser console open.
2. Visit the dashboard (pending transactions, actions tray), Assets (tokens + NFTs), messages list, Spaces list/sidebar/settings About page, and any widget disclaimer (Swap/Stake/Earn) — verify none of the warnings above are logged and the UI is visually unchanged.
3. Keyboard-navigate to the Swap, Create workspace, Add safe, Watch any account, Get API key, and GitHub CTAs: each announces as a link, activates with Enter, and appears in screen-reader link navigation.

## Affected flows

- Dashboard: pending transaction list items; Send/Swap/Receive/Transaction-builder actions tray
- Assets: token table fiat values, NFT table header alignment
- Messages: expandable message list items
- Spaces: create-workspace CTA, sidebar API CTA, settings About page
- My accounts: add-safe and watch-account CTAs
- Widget disclaimers (Swap/Stake/Earn) and blocked-address disclaimer

## Blast radius

- `components/common/Disclaimer` is shared by 5 consumers (Swap, Stake, Earn, `DisclaimerWrapper`, `BlockedAddress`) — its content wrapper now renders `<div>` instead of `<p>`; `body2` styling is variant-driven so visuals are unchanged.
- `buttonVariants` from `components/ui/button` gains 6 new read-only consumers; the cva itself is untouched, so all existing `Button` usages are unaffected.
- Recomposed CTAs keep their `data-testid`s, tooltips, `Track` wrappers, and click handlers; DOM element changes from `<button role>`-composed markup to plain anchors could affect styling that targeted `button` element selectors (none found) or E2E selectors relying on roles.
- No shared hooks, selectors, slices, endpoints, or mobile packages touched.

## Risks / not checked

- No manual screen-reader (VoiceOver/NVDA) pass over the recomposed CTAs; link semantics verified via testing-library role queries only.
- No visual screenshot diff of the disclaimers or recomposed CTAs (risk low — `buttonVariants` emits the identical class set the `Button` primitive applied).
- Right-alignment of the NFT table checkbox header now actually applies (the kebab-case key was silently ignored before) — minor intentional visual correction.
- Cypress E2E suites not run locally; any test targeting these CTAs by `button` role/element would need the link role instead.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    P1["Typography renders p"] --> D1["child renders div (Stack/Grid/Chip)"] --> W1["hydration error"]
    B1["Base UI Button render={a / Link}"] --> A1["anchor forced into button semantics"] --> W2["warning + a11y mismatch"]
  end
  subgraph After
    P2["Typography component='div'"] --> D2["child renders div"] --> OK1["valid nesting"]
    B2["NextLink / a styled with buttonVariants"] --> A2["real link: role='link', Enter activates"] --> OK2["no warning, correct semantics"]
    B3["disabled state"] --> A3["native disabled button or aria-disabled span"] --> OK2
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics changes; `Track` wrappers and click tracking preserved
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — tests updated to assert link roles, `aria-disabled`, and `href`s
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
