### PR TITLE
feat(safenet): aim the read window and gate sentinel-oracle reads

### DIFF
--- a/packages/utils/src/features/safenet-checks/constants.ts
+++ b/packages/utils/src/features/safenet-checks/constants.ts
@@ -37,6 +37,32 @@ export const SAFENET_CONSENSUS_ADDRESS =
   process.env.EXPO_PUBLIC_SAFENET_CONSENSUS_ADDRESS ||
   '0x223624cBF099e5a8f8cD5aF22aFa424a1d1acEE9'
 
+/**
+ * Sentinel-oracle allowlist (csv). Security-critical, and empty by default.
+ *
+ * `Consensus.proposeOracleTransaction` is permissionless and takes the oracle
+ * address as a caller argument, so the `oracle` field on a proposal event is
+ * chosen by whoever called it. Sourcing oracle logs from that field would let
+ * anyone emit a fabricated `OracleResult(approved=false)` from their own
+ * contract and mark any Safe transaction `MALICIOUS`. The reader only reads
+ * oracle events from an address on this list, normalized in the constructor.
+ *
+ * The allowlist limits which address a verdict can come from. It does not limit
+ * who can ask for one. `proposeOracleTransaction` forwards the caller's
+ * transaction tuple to the named oracle through `postRequest`, so anyone who
+ * pays the request fee can have the sentinels evaluate another user's Safe
+ * transaction, including one whose owner only ever used the plain path. That
+ * verdict is real and the reader cannot filter it out. This is the tradeoff
+ * that comes with populating the list.
+ *
+ * The default empty list trusts no sentinel oracle, so the oracle path is
+ * skipped. That matches live beta, where only the validator attesters run and
+ * no sentinel oracle is deployed. Populate this once one is.
+ */
+export const SAFENET_ORACLE_ADDRESSES = parseCsv(
+  process.env.NEXT_PUBLIC_SAFENET_ORACLE_ADDRESSES || process.env.EXPO_PUBLIC_SAFENET_ORACLE_ADDRESSES,
+)
+
 // --- Lookback tuning ------------------------------------------------------
 
 /** Hard cap on how far back the reader scans for a check's first event. */
@@ -45,5 +71,32 @@ export const MAX_LOOKBACK_BLOCKS = 30_000
 /** Max block span per `getLogs` call (Gnosis public RPC ceiling). */
 export const GETLOGS_CHUNK_BLOCKS = 10_000
 
-/** Max JSON-RPC calls batched into a single HTTP request by the provider. */
+/** Nominal Gnosis block time, used to seed the block-at-timestamp estimate. */
+export const BLOCK_TIME_SECONDS = 5
+
+/**
+ * How far behind the estimated transaction block the targeted window starts.
+ *
+ * The window is weighted forward on purpose. Every event the read looks for
+ * (`Proposed`, `Attested`, `NewRequest`, `Committed`, `OracleResult`) is emitted
+ * at or after the Safe transaction, so the backward reach only has to cover
+ * estimate error and skew between the caller's submission timestamp and chain
+ * time. A converged estimate is within {@link BLOCK_ESTIMATE_TOLERANCE_SECONDS},
+ * about 120 blocks at nominal cadence. 1,000 blocks gives roughly 1.4h of slack,
+ * leaving about 9,000 blocks (12.5h) ahead, where a late settlement lands.
+ */
+export const TARGETED_WINDOW_BACK_BLOCKS = 1_000
+
+/** Stop refining the block estimate once it lands within this many seconds. */
+export const BLOCK_ESTIMATE_TOLERANCE_SECONDS = 600
+
+/** Max refinement round-trips after the first probe (each costs one RPC call). */
+export const BLOCK_ESTIMATE_MAX_REFINEMENTS = 2
+
+/**
+ * Max JSON-RPC calls batched into a single HTTP request by the provider.
+ * Equals `MAX_LOOKBACK_BLOCKS / GETLOGS_CHUNK_BLOCKS`, so a head-relative read
+ * is one HTTP round-trip. Changing either of those without changing this splits
+ * every head-relative read into two.
+ */
 export const PROVIDER_BATCH_MAX_COUNT = 3

--- a/packages/utils/src/features/safenet-checks/services/__tests__/rpcEndpoint.ts
+++ b/packages/utils/src/features/safenet-checks/services/__tests__/rpcEndpoint.ts
@@ -16,7 +16,18 @@ export type RpcConfig = {
   chainId?: string
   head?: number
   headTimestamp?: number
+  /** Seconds between consecutive blocks (default 5, the nominal Gnosis cadence). */
+  blockTimeSeconds?: number
+  /** Nonlinear cadence: unix timestamp for block `n`. Wins over `blockTimeSeconds`. */
+  timestampAt?: (blockNumber: number) => number
   logs?: RawLog[]
+  /**
+   * How numeric `eth_getBlockByNumber` probes fail. `'null'` answers "block not
+   * found". `'error'` answers a JSON-RPC error, which is what a load-balanced
+   * node returns for an old header it cannot serve, and which rejects in ethers
+   * rather than resolving to null.
+   */
+  failBlockProbes?: 'null' | 'error'
   failEverything?: boolean
 }
 
@@ -41,6 +52,12 @@ export const makeEndpoint = (config: RpcConfig) => {
   const getLogsCalls: GetLogsFilter[] = []
   const methods: string[] = []
 
+  const blockTimestamp = (number: number): number => {
+    if (config.timestampAt) return config.timestampAt(number)
+    const head = config.head ?? 0
+    return Math.max(0, (config.headTimestamp ?? 1_000_000) - (head - number) * (config.blockTimeSeconds ?? 5))
+  }
+
   const respondOne = (req: { id: number; method: string; params: unknown[] }) => {
     methods.push(req.method)
     if (config.failEverything) {
@@ -52,12 +69,16 @@ export const makeEndpoint = (config: RpcConfig) => {
     switch (req.method) {
       case 'eth_chainId':
         return ok('0x' + Number(config.chainId ?? '100').toString(16))
-      // The reader only ever asks for 'latest' in this slice.
       case 'eth_getBlockByNumber': {
-        const number = config.head ?? 0
+        const head = config.head ?? 0
+        const tag = req.params[0] as string
+        if (tag !== 'latest' && config.failBlockProbes) {
+          return config.failBlockProbes === 'error' ? err('missing trie node') : ok(null)
+        }
+        const number = tag === 'latest' ? head : hexToNum(tag)
         return ok({
           number: '0x' + number.toString(16),
-          timestamp: '0x' + (config.headTimestamp ?? 1_000_000).toString(16),
+          timestamp: '0x' + blockTimestamp(number).toString(16),
           hash: '0x' + '22'.repeat(32),
           parentHash: '0x' + '33'.repeat(32),
           nonce: '0x0000000000000000',

--- a/packages/utils/src/features/safenet-checks/services/__tests__/safenetReader.test.ts
+++ b/packages/utils/src/features/safenet-checks/services/__tests__/safenetReader.test.ts
@@ -1,16 +1,26 @@
 import { setupServer, type SetupServerApi } from 'msw/node'
 import { SafenetReader, type SafenetReaderConfig } from '../safenetReader'
+import { CONSENSUS_TOPIC0S } from '../../abi'
+import { oracleProposalHash } from '../../utils/oracleProposalHash'
 import {
   resetLogCounter,
   buildOracleProposedLog,
   buildOracleAttestedLog,
   buildPlainProposedLog,
   buildPlainAttestedLog,
+  buildOracleResultLog,
+  buildV1Lifecycle,
+  buildV2Lifecycle,
 } from '../../builders/rawLogs'
 import type { RawLog } from '../../utils/decodeLogs'
-import { CheckEventType, type Hex } from '../../types'
-import { makeEndpoint } from './rpcEndpoint'
+import { CheckEventType, OracleGeneration, type Hex } from '../../types'
+import { makeEndpoint, type GetLogsFilter } from './rpcEndpoint'
 
+const consensusCalls = (calls: GetLogsFilter[]): GetLogsFilter[] =>
+  calls.filter((c) => (Array.isArray(c.topics[0]) ? (c.topics[0] as string[]) : []).includes(CONSENSUS_TOPIC0S[0]))
+
+const oracleCalls = (calls: GetLogsFilter[]): GetLogsFilter[] =>
+  calls.filter((c) => !(Array.isArray(c.topics[0]) ? (c.topics[0] as string[]) : []).includes(CONSENSUS_TOPIC0S[0]))
 // Mirrors the fixed addresses the raw-log builders encode (see builders/rawLogs.ts).
 const CONSENSUS = '0x223624cBF099e5a8f8cD5aF22aFa424a1d1acEE9'
 const ORACLE = '0x00000000000000000000000000000000000000AA'
@@ -21,6 +31,7 @@ const makeReader = (over: Partial<SafenetReaderConfig> = {}, url = 'http://rpc.t
     rpcUrls: [url],
     chainId: CHAIN_ID,
     consensus: CONSENSUS,
+    oracles: [],
     ...over,
   })
 
@@ -133,6 +144,7 @@ describe('SafenetReader.fetchCheckState', () => {
       rpcUrls: ['http://rpc.test/1', 'http://rpc.test/2'],
       chainId: CHAIN_ID,
       consensus: CONSENSUS,
+      oracles: [],
     })
     const result = await reader.fetchCheckState(SAFE_TX_HASH)
     expect(result.headBlock).toBe('25000')
@@ -152,6 +164,7 @@ describe('SafenetReader.fetchCheckState', () => {
       rpcUrls: ['http://rpc.test/1', 'http://rpc.test/2', 'http://rpc.test/3'],
       chainId: CHAIN_ID,
       consensus: CONSENSUS,
+      oracles: [],
     })
     const results = await Promise.all([
       reader.fetchCheckState(SAFE_TX_HASH),
@@ -159,6 +172,448 @@ describe('SafenetReader.fetchCheckState', () => {
       reader.fetchCheckState(SAFE_TX_HASH),
     ])
     for (const result of results) expect(result.headBlock).toBe('25000')
+  })
+
+  it('reads a V1 oracle lifecycle: sentinel logs, generation, and the request deadline', async () => {
+    resetLogCounter()
+    const requestId = oracleProposalHash({
+      chainId: CHAIN_ID,
+      consensus: CONSENSUS,
+      epoch: '1',
+      oracle: ORACLE,
+      safeTxHash: SAFE_TX_HASH,
+    })
+    const logs = buildV1Lifecycle({ safeTxHash: SAFE_TX_HASH, requestId, oracle: ORACLE, epoch: 1n })
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader({ oracles: [ORACLE] }).fetchCheckState(SAFE_TX_HASH)
+
+    // Proposed + NewRequest + Committed + OracleResult + Attested.
+    expect(result.events.map((e) => e.type)).toEqual([
+      CheckEventType.ORACLE_PROPOSED,
+      CheckEventType.REQUEST_CREATED,
+      CheckEventType.SENTINEL_COMMITTED,
+      CheckEventType.ORACLE_RESULT,
+      CheckEventType.ORACLE_ATTESTED,
+    ])
+    expect(result.requestId).toBe(requestId)
+    expect(result.epoch).toBe('1')
+    expect(result.deadlineBlock).toBe('150')
+    // V1 sentinel events carry the V1 generation marker.
+    expect(result.generation).toBe(OracleGeneration.V1)
+  })
+
+  it('returns null correlation fields for the plain pair — the beta path has no oracle', async () => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs: plainPairFor(SAFE_TX_HASH) })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader({ oracles: [ORACLE] }).fetchCheckState(SAFE_TX_HASH)
+
+    expect(oracleCalls(endpoint.getLogsCalls)).toHaveLength(0)
+    expect(result.requestId).toBeNull()
+    expect(result.epoch).toBeNull()
+    expect(result.oracle).toBeNull()
+    expect(result.deadlineBlock).toBeNull()
+    expect(result.generation).toBeNull()
+  })
+
+  it('targets Proposed.oracle for the sentinel getLogs when the proposal names an allowlisted oracle', async () => {
+    resetLogCounter()
+    const logs = [buildOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: ORACLE })]
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader({ oracles: [ORACLE] }).fetchCheckState(SAFE_TX_HASH)
+
+    const orac = oracleCalls(endpoint.getLogsCalls)
+    // Guard against a vacuous pass: the sentinel read must actually happen.
+    expect(orac.length).toBeGreaterThan(0)
+    for (const call of orac) {
+      expect(call.address?.toLowerCase()).toBe(ORACLE.toLowerCase())
+    }
+  })
+
+  it('ignores a proposal naming an oracle that is not on the allowlist', async () => {
+    // proposeOracleTransaction is permissionless, so the oracle address in the
+    // event is attacker-chosen. An unlisted one must not be read from at all.
+    resetLogCounter()
+    const logs = buildV1Lifecycle({ safeTxHash: SAFE_TX_HASH, oracle: ORACLE, epoch: 1n })
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader({ oracles: ['0x000000000000000000000000000000000000dEaD'] }).fetchCheckState(
+      SAFE_TX_HASH,
+    )
+
+    expect(oracleCalls(endpoint.getLogsCalls)).toHaveLength(0)
+    expect(result.requestId).toBeNull()
+    expect(result.events.every((event) => event.type !== CheckEventType.ORACLE_RESULT)).toBe(true)
+  })
+
+  it("skips the oracle path entirely when the allowlist is empty (today's default)", async () => {
+    resetLogCounter()
+    const logs = buildV1Lifecycle({ safeTxHash: SAFE_TX_HASH, oracle: ORACLE, epoch: 1n })
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader().fetchCheckState(SAFE_TX_HASH)
+
+    expect(oracleCalls(endpoint.getLogsCalls)).toHaveLength(0)
+    expect(result.requestId).toBeNull()
+  })
+
+  it('reads sentinel logs for EVERY allowlisted proposal, deduplicated, keyed to the latest', async () => {
+    resetLogCounter()
+    const logs = [
+      buildOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: ORACLE }),
+      // Same (epoch, oracle) again — must NOT produce a second identical requestId.
+      buildOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: ORACLE }),
+      buildOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 2n, oracle: ORACLE }),
+    ]
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader({ oracles: [ORACLE] }).fetchCheckState(SAFE_TX_HASH)
+
+    const ids = ['1', '2'].map((epoch) =>
+      oracleProposalHash({ chainId: CHAIN_ID, consensus: CONSENSUS, epoch, oracle: ORACLE, safeTxHash: SAFE_TX_HASH }),
+    )
+    const orac = oracleCalls(endpoint.getLogsCalls)
+    // One getLogs per oracle per chunk, carrying both requestIds (deduped) as a
+    // topic1 OR-array. Compared as a set: ethers sorts topic arrays on the way
+    // out, so proposal order does not reach the wire.
+    expect(orac.length).toBeGreaterThan(0)
+    for (const call of orac) expect([...(call.topics[1] as string[])].sort()).toEqual([...ids].sort())
+    // The correlation fields follow the latest allowlisted proposal.
+    expect(result.epoch).toBe('2')
+    expect(result.requestId).toBe(ids[1])
+  })
+
+  it('reads only the allowlisted oracle when one proposal names it and another names an attacker', async () => {
+    resetLogCounter()
+    const ATTACKER = '0x000000000000000000000000000000000000BEEF'
+    const logs = [
+      buildOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: ORACLE }),
+      buildOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: ATTACKER }),
+    ]
+    // One chunk's worth of head, so the oracle read is exactly one getLogs.
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 5_000, logs })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader({ oracles: [ORACLE] }).fetchCheckState(SAFE_TX_HASH)
+
+    const orac = oracleCalls(endpoint.getLogsCalls)
+    expect(orac).toHaveLength(1)
+    expect(orac[0].address?.toLowerCase()).toBe(ORACLE.toLowerCase())
+    expect(endpoint.getLogsCalls.some((c) => c.address?.toLowerCase() === ATTACKER.toLowerCase())).toBe(false)
+    // The attacker's proposal is the LATEST, but it must not become the active one.
+    expect(result.oracle?.toLowerCase()).toBe(ORACLE.toLowerCase())
+  })
+
+  it('drops an attacker-emitted OracleResult even when it carries the correct requestId', async () => {
+    // The requestId is derivable by anyone, so on its own it proves nothing.
+    // The emitting address is what the reader gates on, not the topic filter.
+    resetLogCounter()
+    const ATTACKER = '0x000000000000000000000000000000000000BEEF'
+    const requestId = oracleProposalHash({
+      chainId: CHAIN_ID,
+      consensus: CONSENSUS,
+      epoch: '1',
+      oracle: ORACLE,
+      safeTxHash: SAFE_TX_HASH,
+    })
+    const logs = [
+      buildOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: ORACLE }),
+      { ...buildOracleResultLog({ requestId, approved: false }), address: ATTACKER },
+    ]
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader({ oracles: [ORACLE] }).fetchCheckState(SAFE_TX_HASH)
+
+    expect(result.requestId).toBe(requestId)
+    expect(result.events.some((event) => event.type === CheckEventType.ORACLE_RESULT)).toBe(false)
+  })
+
+  it('buckets requestIds per oracle — two allowlisted oracles get one getLogs each', async () => {
+    resetLogCounter()
+    const OTHER = '0x00000000000000000000000000000000000000bb'
+    const logs = [
+      buildOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: ORACLE }),
+      buildOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: OTHER }),
+    ]
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader({ oracles: [ORACLE, OTHER] }).fetchCheckState(SAFE_TX_HASH)
+
+    const byAddress = new Map(oracleCalls(endpoint.getLogsCalls).map((c) => [c.address?.toLowerCase(), c]))
+    expect([...byAddress.keys()].sort()).toEqual([ORACLE.toLowerCase(), OTHER.toLowerCase()].sort())
+    for (const [address, call] of byAddress) {
+      const expected = oracleProposalHash({
+        chainId: CHAIN_ID,
+        consensus: CONSENSUS,
+        epoch: '1',
+        oracle: address === ORACLE.toLowerCase() ? ORACLE : OTHER,
+        safeTxHash: SAFE_TX_HASH,
+      })
+      // Each filter carries only its own oracle's id, not a pooled set.
+      expect(call.topics[1]).toEqual([expected])
+    }
+  })
+
+  it('caps the requestId OR-filter at 16, keeping the newest (active) id', async () => {
+    resetLogCounter()
+    const epochs = Array.from({ length: 20 }, (_, index) => BigInt(index + 1))
+    const logs = epochs.map((epoch) => buildOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch, oracle: ORACLE }))
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 5_000, logs })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader({ oracles: [ORACLE] }).fetchCheckState(SAFE_TX_HASH)
+
+    const orac = oracleCalls(endpoint.getLogsCalls)
+    expect(orac).toHaveLength(1)
+    expect(orac[0].topics[1]).toHaveLength(16)
+    // The live re-proposal is the newest one, so its id must survive the cap.
+    expect(result.epoch).toBe('20')
+    expect(orac[0].topics[1]).toContain(result.requestId)
+  })
+
+  it('reads a V2 lifecycle: the reveal deadline and the V2 generation marker', async () => {
+    resetLogCounter()
+    const requestId = oracleProposalHash({
+      chainId: CHAIN_ID,
+      consensus: CONSENSUS,
+      epoch: '1',
+      oracle: ORACLE,
+      safeTxHash: SAFE_TX_HASH,
+    })
+    const logs = buildV2Lifecycle({ safeTxHash: SAFE_TX_HASH, requestId, oracle: ORACLE, epoch: 1n })
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader({ oracles: [ORACLE] }).fetchCheckState(SAFE_TX_HASH)
+
+    expect(result.generation).toBe(OracleGeneration.V2)
+    // V2's revealDeadline is normalized onto the same deadlineBlock as V1's.
+    expect(result.deadlineBlock).toBe('160')
+  })
+
+  it('returns a Redux-serializable result — no bigints survive the read', async () => {
+    resetLogCounter()
+    const requestId = oracleProposalHash({
+      chainId: CHAIN_ID,
+      consensus: CONSENSUS,
+      epoch: '1',
+      oracle: ORACLE,
+      safeTxHash: SAFE_TX_HASH,
+    })
+    const logs = buildV1Lifecycle({ safeTxHash: SAFE_TX_HASH, requestId, oracle: ORACLE, epoch: 1n })
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 25_000, logs })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader({ oracles: [ORACLE] }).fetchCheckState(SAFE_TX_HASH)
+
+    expect(JSON.parse(JSON.stringify(result))).toEqual(result)
+  })
+
+  it('targets a narrow window around the transaction timestamp instead of scanning back from the head', async () => {
+    // Head is block 1,000,000 at t=1,000,000s, blocks every 5s (see the mock).
+    // A transaction 100,000s earlier sits at block 1,000,000 − 20,000 = 980,000.
+    // The window is biased forward: 1,000 blocks back, the rest of the chunk on.
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 1_000_000, headTimestamp: 1_000_000, logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader().fetchCheckState(SAFE_TX_HASH, { timestampMs: 900_000 * 1000 })
+
+    const call = consensusCalls(endpoint.getLogsCalls)[0]
+    expect(call.fromBlock).toBe(979_000)
+    expect(call.toBlock).toBe(988_999)
+  })
+
+  it('reads an old check in a single getLogs — cost does not grow with age', async () => {
+    const HEAD_TS = 1_800_000_000
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 9_000_000, headTimestamp: HEAD_TS, logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    // A year-old transaction: the head-relative scan could never have reached it.
+    await makeReader().fetchCheckState(SAFE_TX_HASH, { timestampMs: (HEAD_TS - 31_536_000) * 1000 })
+
+    expect(consensusCalls(endpoint.getLogsCalls)).toHaveLength(1)
+  })
+})
+
+describe('SafenetReader block targeting — estimate convergence', () => {
+  it('converges on a chain whose real block time drifted from the nominal 5s', async () => {
+    // 10s blocks: the nominal-seeded first guess lands 10,000 blocks off — far
+    // enough that a nominal-only estimator misses the window entirely. One probe
+    // measures the real cadence and the second guess is exact: target t=900,000
+    // → block 990,000, window [989,000, 998,999].
+    const endpoint = makeEndpoint({
+      url: 'http://rpc.test/1',
+      head: 1_000_000,
+      headTimestamp: 1_000_000,
+      blockTimeSeconds: 10,
+      logs: [],
+    })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader().fetchCheckState(SAFE_TX_HASH, { timestampMs: 900_000 * 1000 })
+
+    const calls = consensusCalls(endpoint.getLogsCalls)
+    expect(calls).toHaveLength(1)
+    expect([calls[0].fromBlock, calls[0].toBlock]).toEqual([989_000, 998_999])
+  })
+
+  it('falls back to the head-relative scan when the estimate cannot converge', async () => {
+    // A chain that "paused": no block's timestamp is anywhere near the target,
+    // so every refinement still leaves a huge residual drift. The reader must
+    // not aim a window it knows is off — it scans back from the head instead.
+    const endpoint = makeEndpoint({
+      url: 'http://rpc.test/1',
+      head: 600_000,
+      timestampAt: (n) => (n <= 500_000 ? n : 10_000_000 + (n - 500_000) * 5),
+      logs: [],
+    })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader().fetchCheckState(SAFE_TX_HASH, { timestampMs: 5_000_000 * 1000 })
+
+    const calls = consensusCalls(endpoint.getLogsCalls)
+    expect(calls.map((c) => [c.fromBlock, c.toBlock])).toEqual([
+      [570_001, 580_000],
+      [580_001, 590_000],
+      [590_001, 600_000],
+    ])
+  })
+
+  it('falls back to the head-relative scan when block probes return no block', async () => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 45_000, failBlockProbes: 'null', logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader().fetchCheckState(SAFE_TX_HASH, { timestampMs: 1_000 * 1000 })
+
+    const calls = consensusCalls(endpoint.getLogsCalls)
+    expect(calls[0].fromBlock).toBe(15_001)
+    expect(calls).toHaveLength(3)
+  })
+
+  it('falls back to the head-relative scan when a block probe errors on the only endpoint', async () => {
+    // `missing trie node` for an old header is routine on load-balanced public
+    // RPC, and unlike a null result it rejects in ethers. A probe is an
+    // optimisation, so it must not take the whole read or a rotation with it.
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 45_000, failBlockProbes: 'error', logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader().fetchCheckState(SAFE_TX_HASH, { timestampMs: 1_000 * 1000 })
+
+    expect(result.headBlock).toBe('45000')
+    expect(consensusCalls(endpoint.getLogsCalls)).toHaveLength(3)
+  })
+
+  it('falls back when the cadence local to the target is far faster than the secant to the head', async () => {
+    // A 1s stretch inside an otherwise 5.5s chain. The probes converge on the
+    // secant cadence and stall ~12,850s short; converting that residual with any
+    // head-derived cadence would under-count it by 5x and aim a window ~7,850
+    // blocks past the true block (350,000). Only convergence may aim.
+    const endpoint = makeEndpoint({
+      url: 'http://rpc.test/1',
+      head: 1_000_000,
+      timestampAt: (n) =>
+        n >= 400_000
+          ? 3_100_000 + 5.5 * (n - 400_000)
+          : n >= 300_000
+            ? 3_000_000 + (n - 300_000)
+            : 3_000_000 - 5.5 * (300_000 - n),
+      logs: [],
+    })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader().fetchCheckState(SAFE_TX_HASH, { timestampMs: 3_050_000 * 1000 })
+
+    const calls = consensusCalls(endpoint.getLogsCalls)
+    expect(calls.map((c) => c.fromBlock)).toEqual([970_001, 980_001, 990_001])
+  })
+
+  it('pins the window to the head for a timestamp at or beyond it', async () => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 1_000_000, headTimestamp: 1_000_000, logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    // 30,000s in the future — caller clock skew, or a check read before its
+    // block lands. The head IS the right aim, so this stays a single window.
+    await makeReader().fetchCheckState(SAFE_TX_HASH, { timestampMs: 1_030_000 * 1000 })
+
+    const calls = consensusCalls(endpoint.getLogsCalls)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].toBlock).toBe(1_000_000)
+  })
+
+  it.each([
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+  ])('ignores a %s timestamp and scans head-relative', async (_label, timestampMs) => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 45_000, logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    await makeReader().fetchCheckState(SAFE_TX_HASH, { timestampMs })
+
+    // No probe was issued at all — the guard runs before any estimate.
+    expect(endpoint.methods.filter((method) => method === 'eth_getBlockByNumber')).toHaveLength(1)
+    expect(consensusCalls(endpoint.getLogsCalls)).toHaveLength(3)
+  })
+
+  it('clamps the window at block 0 for a check near genesis', async () => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 8_000, headTimestamp: 40_000, logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    // t=10,000s → block 2,000; centre − 1,000 = 1,000, so no clamp is needed at
+    // 1,000 back, but the head clamp caps the forward reach at the chain tip.
+    await makeReader().fetchCheckState(SAFE_TX_HASH, { timestampMs: 10_000 * 1000 })
+
+    const calls = consensusCalls(endpoint.getLogsCalls)
+    expect(calls).toHaveLength(1)
+    expect([calls[0].fromBlock, calls[0].toBlock]).toEqual([1_000, 8_000])
+  })
+
+  it('returns the events inside an aimed window, including the far forward edge', async () => {
+    // Bounds-only assertions would pass a window shifted by one block. Place a
+    // log at the centre and another at the last block the chunk reaches.
+    resetLogCounter()
+    const centre = 980_000
+    const logs = [
+      buildPlainProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 7n }, { blockNumber: centre, logIndex: 0 }),
+      buildPlainAttestedLog({ safeTxHash: SAFE_TX_HASH, epoch: 7n }, { blockNumber: 988_999, logIndex: 0 }),
+    ]
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 1_000_000, headTimestamp: 1_000_000, logs })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader().fetchCheckState(SAFE_TX_HASH, { timestampMs: 900_000 * 1000 })
+
+    expect(result.events.map((event) => event.blockNumber)).toEqual([centre, 988_999])
   })
 })
 

--- a/packages/utils/src/features/safenet-checks/services/safenetReader.ts
+++ b/packages/utils/src/features/safenet-checks/services/safenetReader.ts
@@ -1,15 +1,28 @@
 import { JsonRpcProvider } from 'ethers'
-import { CONSENSUS_TOPIC0S } from '../abi'
+import { CONSENSUS_TOPIC0S, SENTINEL_TOPIC0S } from '../abi'
 import {
+  BLOCK_ESTIMATE_MAX_REFINEMENTS,
+  BLOCK_ESTIMATE_TOLERANCE_SECONDS,
+  BLOCK_TIME_SECONDS,
   GETLOGS_CHUNK_BLOCKS,
   MAX_LOOKBACK_BLOCKS,
   PROVIDER_BATCH_MAX_COUNT,
   SAFENET_CHAIN_ID,
   SAFENET_CONSENSUS_ADDRESS,
+  SAFENET_ORACLE_ADDRESSES,
   SAFENET_RPC_URLS,
+  TARGETED_WINDOW_BACK_BLOCKS,
 } from '../constants'
-import type { Hex, NormalizedCheckEvent } from '../types'
+import {
+  CheckEventType,
+  OracleGeneration,
+  type Hex,
+  type NormalizedCheckEvent,
+  type OracleProposedEvent,
+} from '../types'
 import { decodeLogs, type RawLog } from '../utils/decodeLogs'
+import { deadlineBlockOf } from '../utils/deriveCheckState'
+import { oracleProposalHash } from '../utils/oracleProposalHash'
 
 /**
  * Everything one poll reads off-chain for a single check, before the query layer
@@ -24,14 +37,39 @@ export type CheckReadResult = {
   events: NormalizedCheckEvent[]
   /** Chain head observed at read time (a decimal string). */
   headBlock: string
+  /**
+   * The oracle generation that drove the active request, once a sentinel event
+   * for it is seen. `null` means no sentinel event has landed yet. It does not
+   * mean the check is generation-agnostic; a Consensus-only lifecycle never
+   * populates this field.
+   */
+  generation: OracleGeneration | null
+  /**
+   * Correlation metadata from the latest allowlisted proposal.
+   *
+   * Proposals are permissionless, so an attacker can propose the victim's
+   * transaction to an allowlisted oracle and become the proposal these fields
+   * describe. Do not render them as provenance.
+   *
+   * They still affect the read. `requestId` selects which sentinel logs are
+   * fetched, and those feed the verdict. `deadlineBlock` is the maximum across
+   * requests, so a third-party request can push it out and suppress TIMED_OUT.
+   */
+  requestId: Hex | null
+  epoch: string | null
+  oracle: string | null
+  /** Block the check times out at (V1 `deadline` / V2 `revealDeadline`). */
+  deadlineBlock: string | null
 }
 
 export type SafenetReaderConfig = {
   /** Pinned Gnosis endpoints, rotated on failure. */
   rpcUrls: string[]
-  /** Feeds the provider network; the EIP-712 request-id domain in later slices. */
+  /** Feeds BOTH the provider network AND the EIP-712 request-id domain. */
   chainId: string
   consensus: string
+  /** Allowlisted sentinel-oracle addresses. Empty = the oracle path is skipped. */
+  oracles: string[]
 }
 
 /** Build a reader config from the dual-env constants (the production default). */
@@ -39,9 +77,25 @@ export const readerConfigFromEnv = (): SafenetReaderConfig => ({
   rpcUrls: SAFENET_RPC_URLS,
   chainId: SAFENET_CHAIN_ID,
   consensus: SAFENET_CONSENSUS_ADDRESS,
+  oracles: SAFENET_ORACLE_ADDRESSES,
 })
 
 const IS_DEV = process.env.NODE_ENV !== 'production'
+
+const isProposed = (event: NormalizedCheckEvent): event is OracleProposedEvent =>
+  event.type === CheckEventType.ORACLE_PROPOSED
+
+/**
+ * Cap on distinct requestIds per oracle in one sentinel getLogs topic filter.
+ *
+ * `epoch` comes from `epochs.active` inside the contract, not from the caller,
+ * so every proposal of the same check to the same oracle within one epoch
+ * derives the same id and collapses at the dedupe below. The number of distinct
+ * ids is bounded by epoch rollovers inside the read window, normally one or two.
+ * This cap is a backstop against the OR-filter growing past RPC limits. The
+ * newest ids are the ones kept.
+ */
+const MAX_REQUEST_IDS_PER_ORACLE = 16
 
 /** Inclusive [from, to] block ranges of at most `size` blocks each. */
 const chunkRanges = (from: number, to: number, size: number): Array<[number, number]> => {
@@ -54,13 +108,14 @@ const chunkRanges = (from: number, to: number, size: number): Array<[number, num
 
 /**
  * Chain reader for a check's Safenet lifecycle. Owns a pinned-endpoint provider,
- * rotated on failure. Construct with
- * {@link readerConfigFromEnv} in production; pass an explicit config in tests.
+ * rotated on failure. Construct with {@link readerConfigFromEnv} in production;
+ * pass an explicit config in tests.
  */
 export class SafenetReader {
   private readonly rpcUrls: string[]
   private readonly chainId: string
   private readonly consensus: string
+  private readonly oracles: readonly string[]
 
   private urlIndex = 0
   private currentProvider: JsonRpcProvider | null = null
@@ -70,6 +125,7 @@ export class SafenetReader {
     this.rpcUrls = config.rpcUrls
     this.chainId = config.chainId
     this.consensus = config.consensus
+    this.oracles = config.oracles.map((address) => address.toLowerCase())
   }
 
   private provider(): JsonRpcProvider {
@@ -158,12 +214,103 @@ export class SafenetReader {
   }
 
   /**
-   * Read a check's lifecycle: Consensus logs keyed by `safeTxHash` — both the
-   * plain pair (all live beta emits) and the oracle-path Consensus events.
-   * Returns the sorted event set; sentinel-oracle log correlation, FROST
-   * verification, and the status machine live above this.
+   * Choose the block range to read.
+   *
+   * Given a transaction timestamp, this is a narrow window around the matching
+   * block, so a two-year-old check costs the same as a two-minute-old one.
+   * Without a timestamp, or when the block estimate did not converge, it is the
+   * head-relative scan, which only sees the last {@link MAX_LOOKBACK_BLOCKS}.
+   *
+   * Known limit: the targeted window ends about 12.5h after the transaction. A
+   * settlement that lands later, such as a long arbitration, falls outside every
+   * aimed re-read of an old check. The check then reads TIMED_OUT rather than
+   * reporting a BENIGN it cannot support.
    */
-  async fetchCheckState(safeTxHash: string): Promise<CheckReadResult> {
+  private async readRange(
+    provider: JsonRpcProvider,
+    timestampMs: number | null | undefined,
+    head: { number: number; timestamp: number },
+  ): Promise<{ fromBlock: number; toBlock: number }> {
+    const headRelative = { fromBlock: Math.max(0, head.number - MAX_LOOKBACK_BLOCKS + 1), toBlock: head.number }
+    if (timestampMs == null || !Number.isFinite(timestampMs)) return headRelative
+
+    const targetSeconds = Math.floor(timestampMs / 1000)
+    const { block: centre, driftSeconds } = await this.estimateBlockAt(provider, targetSeconds, head)
+    // Aim the window only when the estimate converged. Turning a leftover drift
+    // into a block budget needs the cadence near the target, which nothing here
+    // measures. Over a stretch faster than nominal, a cadence-derived budget
+    // under-counts the error and the window misses the events with no error
+    // raised. A target at or past the head is the exception: the estimate is
+    // pinned to the head, which is the correct aim however stale the clock is.
+    if (targetSeconds < head.timestamp && Math.abs(driftSeconds) > BLOCK_ESTIMATE_TOLERANCE_SECONDS) {
+      return headRelative
+    }
+
+    // One chunk wide, so a targeted read is always a single getLogs. Weighted
+    // forward: see TARGETED_WINDOW_BACK_BLOCKS.
+    const fromBlock = Math.max(0, centre - TARGETED_WINDOW_BACK_BLOCKS)
+    return { fromBlock, toBlock: Math.min(head.number, fromBlock + GETLOGS_CHUNK_BLOCKS - 1) }
+  }
+
+  /**
+   * Estimate the block nearest a unix timestamp, and report how far off the
+   * estimate still is.
+   *
+   * The nominal {@link BLOCK_TIME_SECONDS} only seeds the first guess. Each
+   * refinement uses the block time observed between the probe and the head, so
+   * the estimate converges even when the chain's real cadence drifts from the
+   * nominal value. Costs one RPC call per probe (at most
+   * {@link BLOCK_ESTIMATE_MAX_REFINEMENTS} + 1), and stops early once within
+   * {@link BLOCK_ESTIMATE_TOLERANCE_SECONDS}.
+   *
+   * `driftSeconds` is measured at the returned (probed) block, and is `Infinity`
+   * when no probe succeeded, so callers can tell a converged estimate from a
+   * guess.
+   */
+  private async estimateBlockAt(
+    provider: JsonRpcProvider,
+    targetSeconds: number,
+    head: { number: number; timestamp: number },
+  ): Promise<{ block: number; driftSeconds: number }> {
+    const clamp = (block: number) => Math.min(head.number, Math.max(0, block))
+    let guess = clamp(head.number - Math.floor((head.timestamp - targetSeconds) / BLOCK_TIME_SECONDS))
+    let best = { block: guess, driftSeconds: Number.POSITIVE_INFINITY }
+
+    for (let probe = 0; probe <= BLOCK_ESTIMATE_MAX_REFINEMENTS; probe++) {
+      // A failed probe degrades the read, it does not fail it. An endpoint that
+      // cannot serve an old header (`missing trie node` is common on
+      // load-balanced public RPC) falls back to the head-relative scan, and does
+      // not consume a rotation on an otherwise healthy endpoint.
+      const block = await provider.getBlock(guess).catch(() => null)
+      if (!block) break
+      const driftSeconds = block.timestamp - targetSeconds
+      const span = head.number - guess
+      // Floored: a run of equal timestamps must not divide by zero below.
+      const observedBlockTime = span > 0 ? Math.max((head.timestamp - block.timestamp) / span, 0.1) : BLOCK_TIME_SECONDS
+      if (Math.abs(driftSeconds) < Math.abs(best.driftSeconds)) best = { block: guess, driftSeconds }
+      if (Math.abs(driftSeconds) <= BLOCK_ESTIMATE_TOLERANCE_SECONDS) break
+      const next = clamp(guess - Math.round(driftSeconds / observedBlockTime))
+      if (next === guess) break
+      guess = next
+    }
+    return best
+  }
+
+  /**
+   * Read a check's full lifecycle: Consensus logs keyed by `safeTxHash`, then —
+   * for every proposal naming an allowlisted oracle — the sentinel/oracle logs
+   * keyed by the derived `requestId`s. Returns the sorted event set plus the
+   * derived correlation fields; FROST verification and the status machine live
+   * above this.
+   *
+   * @param safeTxHash - the Safe transaction hash to read.
+   * @param options.timestampMs - when the Safe transaction happened. Given this,
+   *   the read targets a narrow window around the matching block instead of
+   *   walking back {@link MAX_LOOKBACK_BLOCKS} from the head, so cost stays
+   *   constant however old the check is. Falls back to the head-relative scan
+   *   when omitted.
+   */
+  async fetchCheckState(safeTxHash: string, options: { timestampMs?: number | null } = {}): Promise<CheckReadResult> {
     // Validated up front: a malformed hash is a caller bug, not an endpoint
     // failure — it must not burn a rotation through the URL list.
     if (!/^0x[0-9a-f]{64}$/i.test(safeTxHash)) {
@@ -176,9 +323,10 @@ export class SafenetReader {
       if (!latest) throw new Error('Safenet reader: could not read the chain head')
       const head = latest.number
 
-      // Head-relative scan — sees the last MAX_LOOKBACK_BLOCKS (~42h on Gnosis).
-      // Timestamp-aimed windows (constant cost at any age) arrive in the next slice.
-      const range = { fromBlock: Math.max(0, head - MAX_LOOKBACK_BLOCKS + 1), toBlock: head }
+      const range = await this.readRange(provider, options.timestampMs, {
+        number: head,
+        timestamp: latest.timestamp,
+      })
 
       const consensusLogs = await this.getLogsChunked(provider, {
         address: this.consensus,
@@ -186,16 +334,98 @@ export class SafenetReader {
         fromBlock: range.fromBlock,
         toBlock: range.toBlock,
       })
-      const consensusEvents = decodeLogs(consensusLogs)
+      // Sorted here as well as on the combined set below. The requestId cap
+      // relies on chain order, and `eth_getLogs` ordering is a node convention
+      // with no guarantee behind it.
+      const consensusEvents = decodeLogs(consensusLogs).sort(
+        (a, b) => a.blockNumber - b.blockNumber || a.logIndex - b.logIndex,
+      )
+
+      // Only proposals naming an allowlisted oracle may drive the oracle read.
+      // `proposeOracleTransaction` is permissionless and the oracle address is a
+      // caller argument, so an unfiltered read would let anyone point us at
+      // their own contract and feed us a fabricated `OracleResult`. Every such
+      // proposal is read, including later ones: a check can be re-proposed in a
+      // later epoch, and each epoch derives a distinct requestId.
+      const proposals = consensusEvents.filter(
+        (event): event is OracleProposedEvent => isProposed(event) && this.oracles.includes(event.oracle.toLowerCase()),
+      )
+
+      const requestIdsByOracle = new Map<string, Hex[]>()
+      for (const proposal of proposals) {
+        const id = oracleProposalHash({
+          chainId: this.chainId,
+          consensus: this.consensus,
+          epoch: proposal.epoch,
+          oracle: proposal.oracle,
+          safeTxHash: safeTxHash as Hex,
+        })
+        // Keyed by the normalized address so one oracle cannot occupy two
+        // buckets, and issue two getLogs, if a decoder changes its casing.
+        const key = proposal.oracle.toLowerCase()
+        const ids = requestIdsByOracle.get(key) ?? []
+        if (!ids.includes(id)) requestIdsByOracle.set(key, [...ids, id].slice(-MAX_REQUEST_IDS_PER_ORACLE))
+      }
+
+      const oracleEvents: NormalizedCheckEvent[] = []
+      for (const [oracle, requestIds] of requestIdsByOracle) {
+        const oracleLogs = await this.getLogsChunked(provider, {
+          address: oracle,
+          topics: [[...SENTINEL_TOPIC0S], requestIds],
+          fromBlock: range.fromBlock,
+          toBlock: range.toBlock,
+        })
+        oracleEvents.push(...decodeLogs(oracleLogs))
+      }
+
+      // The latest allowlisted proposal is the live one. Its requestId is the
+      // correlation the sentinel is answering, or will answer.
+      const active = proposals.reduce<OracleProposedEvent | null>(
+        (latest, event) =>
+          latest === null ||
+          event.blockNumber > latest.blockNumber ||
+          (event.blockNumber === latest.blockNumber && event.logIndex > latest.logIndex)
+            ? event
+            : latest,
+        null,
+      )
+      const requestId: Hex | null = active
+        ? oracleProposalHash({
+            chainId: this.chainId,
+            consensus: this.consensus,
+            epoch: active.epoch,
+            oracle: active.oracle,
+            safeTxHash: safeTxHash as Hex,
+          })
+        : null
 
       // Ascending by (blockNumber, logIndex), so downstream folds see chain order.
-      const events = [...consensusEvents].sort((a, b) => a.blockNumber - b.blockNumber || a.logIndex - b.logIndex)
+      const events = [...consensusEvents, ...oracleEvents].sort(
+        (a, b) => a.blockNumber - b.blockNumber || a.logIndex - b.logIndex,
+      )
+      // Scoped to the active request. A check re-proposed across generations
+      // would otherwise report the first generation seen alongside the latest
+      // request's id, describing two different requests at once.
+      const generation =
+        events.find(
+          (event) =>
+            event.generation !== OracleGeneration.STABLE && 'requestId' in event && event.requestId === requestId,
+        )?.generation ?? null
+      // The maximum across all requests, not the active request's. After a
+      // cross-epoch re-proposal the latest deadline belongs to the request that
+      // can still resolve, while `requestId` names the latest proposal.
+      const deadline = deadlineBlockOf(events)
 
       return {
         safeTxHash: safeTxHash as Hex,
         chainId: this.chainId,
         events,
         headBlock: head.toString(),
+        generation,
+        requestId,
+        epoch: active?.epoch ?? null,
+        oracle: active?.oracle ?? null,
+        deadlineBlock: deadline === null ? null : deadline.toString(),
       }
     })
   }

--- a/packages/utils/src/features/safenet-checks/types/snapshot.ts
+++ b/packages/utils/src/features/safenet-checks/types/snapshot.ts
@@ -12,9 +12,15 @@ export type SafenetCheckSnapshot = {
   /** The Safenet chain the Consensus contract lives on (e.g. Gnosis '100'). */
   chainId: string
   status: CheckStatus
-  /** Which oracle generation drove this check, once known. */
+  /** Which oracle generation drove the active request, once a sentinel event lands. */
   generation: OracleGeneration | null
-  /** The oracle request id (equals the oracle-proposal hash), once known. */
+  /**
+   * Correlation for the latest allowlisted proposal, once known.
+   *
+   * Proposals are permissionless, so an attacker can become the proposal these
+   * describe. Do not render them as provenance ("proposed by …") and do not
+   * branch a verdict on them. Use `status` for that.
+   */
   requestId: Hex | null
   epoch: string | null
   oracle: string | null

--- a/packages/utils/src/features/safenet-checks/utils/deriveCheckState.ts
+++ b/packages/utils/src/features/safenet-checks/utils/deriveCheckState.ts
@@ -15,8 +15,8 @@ export type DeriveCheckStateInput = {
   headBlock: string | null
 }
 
-/** Highest deadline block across the check's request events, or null. */
-const deadlineBlockOf = (events: ReadonlyArray<NormalizedCheckEvent>): bigint | null => {
+/** Highest deadline block across the check's request events, or null. Shared with the reader. */
+export const deadlineBlockOf = (events: ReadonlyArray<NormalizedCheckEvent>): bigint | null => {
   let deadline: bigint | null = null
   for (const event of events) {
     if (event.type === CheckEventType.REQUEST_CREATED) {


### PR DESCRIPTION
Second slice of the Safenet read layer, on top of #8424. No UI and no status
changes. It adds two things to the reader: timestamp-aimed block windows, and
sentinel-oracle reads behind an allowlist.

## Timestamp-aimed read windows

#8424 scanned the last 30k blocks back from the chain head, about 42h on Gnosis.
A check older than that was invisible.

`fetchCheckState` now takes the Safe transaction's timestamp, estimates the block
at that time, and reads one 10k-block window around it. The read costs the same
for a check of any age.

The estimate starts from the nominal 5s block time and refines using the cadence
measured between the probe and the head. It costs at most 2 extra
`eth_getBlockByNumber` calls and stops early once within 10 minutes of the target.

Two constraints on that:

The window is only aimed when the estimate converged. Turning a leftover drift
into a block count needs the cadence near the target, which nothing measures. If
the chain ran faster than nominal over that stretch, the block count comes out
too low and the window misses the events with no error. When the estimate does
not converge, the reader uses the head-relative scan instead.

A block probe that fails also falls back. `missing trie node` is common on public
RPC for old headers, and it rejects instead of returning null. Unhandled, one
such response fails the entire read: the production default has a single RPC URL,
so there is no rotation to absorb it.

The window is 1,000 blocks back and about 9,000 forward. Every event the read
looks for is emitted at or after the Safe transaction, so the backward part only
has to cover estimate error and caller clock skew.

Known limit: the window ends about 12.5h after the transaction. A settlement
later than that falls outside an aimed re-read of an old check, and the check
reads TIMED_OUT instead of BENIGN.

## Allowlist-gated sentinel-oracle reads

`Consensus.proposeOracleTransaction` is permissionless and takes the oracle
address as an argument, so the `oracle` field on a proposal event is chosen by
whoever called it. Reading oracle logs from that address would let anyone emit
`OracleResult(approved=false)` from a contract they control and mark any Safe
transaction MALICIOUS.

The reader only reads oracle events from addresses in
`SAFENET_ORACLE_ADDRESSES`. That list is empty by default, which matches live
beta: validator attesters only, no sentinel oracle deployed. With an empty list
the oracle path is skipped entirely.

Every allowlisted proposal is read, not only the first. A check can be re-proposed
in a later epoch, and each epoch derives a different `requestId` (EIP-712 over
chainId, consensus, epoch, oracle, safeTxHash). They go out as one topic1
OR-array per oracle.

The allowlist limits which address a verdict can come from. It does not limit who
can ask for one. `proposeOracleTransaction` forwards the caller's transaction
tuple to the named oracle through `postRequest`, so anyone who pays the request
fee can have the sentinels evaluate another user's transaction. That verdict is
real and the reader cannot filter it out. This is documented next to the constant
so the tradeoff is visible when someone populates the list.

The correlation fields (`requestId`, `epoch`, `oracle`, `generation`,
`deadlineBlock`) can be influenced the same way. Both `CheckReadResult` and
`SafenetCheckSnapshot` say so in their doc comments. They should not be rendered
as provenance. `generation` is scoped to the active request so it cannot describe
one request while `requestId` names another.

## Details for review

`deadlineBlock` is the maximum across all requests rather than the active one's.
After a cross-epoch re-proposal, the latest deadline belongs to the request that
can still resolve. Commented at the callsite.

`MAX_REQUEST_IDS_PER_ORACLE = 16` is a backstop rather than the main control.
`epoch` comes from `epochs.active` inside the contract, not from the caller, so
repeated proposals within one epoch derive the same id and collapse at the
dedupe. The number of distinct ids is bounded by epoch rollovers inside the
window.

Consensus events are sorted at decode, not only on the combined set. The id cap
depends on chain order, and `eth_getLogs` ordering is a node convention with no
guarantee behind it.

`PROVIDER_BATCH_MAX_COUNT` equals `MAX_LOOKBACK_BLOCKS / GETLOGS_CHUNK_BLOCKS`,
so a head-relative read is one HTTP request. Changing either of the other two
without changing this one splits it into two. Noted on the constant.

## Testing

34 tests in the reader suite, up from 22. They run through a real ethers
`JsonRpcProvider` against an msw JSON-RPC endpoint that answers single and
batched bodies, with configurable block cadence including a nonlinear
`timestampAt`, and both probe failure modes.

Cases added: a proposal naming an attacker alongside an allowlisted one; an
attacker contract emitting `OracleResult` carrying the correct requestId;
per-oracle id bucketing; the 16-id cap keeping the newest; a chain whose local
cadence is much faster than the secant to the head; a rejecting block probe on a
single-URL config; NaN and Infinity timestamps; the genesis clamp; and a JSON
round-trip for Redux serializability.

Checked against `rpc.gnosischain.com`: a real check 49,225 blocks behind the head
is found by the aimed window, and returns nothing without a timestamp.

`yarn workspace @safe-global/utils {test,type-check,lint}` and
`@safe-global/store type-check` pass.
