### PR TITLE
fix: broken error copy in web and mobile (quick wins)

### DIFF
--- a/apps/mobile/e2e/tests/onboarding/import-signer-private-key.yml
+++ b/apps/mobile/e2e/tests/onboarding/import-signer-private-key.yml
@@ -89,7 +89,7 @@ tags:
 # Verify error screen appears (PK doesn't belong to any signer of the Safe)
 - assertVisible: "Private key couldn't be imported"
 - assertVisible: 'This private key does not belong to any signer of this Safe account. Double-check the address and try to import again.'
-- assertVisible: Don’t worry, your private key was not stored!
+- assertVisible: Your private key was not stored.
 
 # Tap "Import again" to go back to import screen
 - tapOn: 'Import again'

--- a/apps/mobile/src/features/ConfirmTx/components/CanNotSign/CanNotSign.test.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/CanNotSign/CanNotSign.test.tsx
@@ -9,6 +9,6 @@ describe('CanNotSign', () => {
 
   it('renders the correct message', () => {
     const { getByText } = render(<CanNotSign />)
-    expect(getByText('Only signers of this safe can sign this transaction')).toBeTruthy()
+    expect(getByText('Only signers of this Safe Account can confirm this transaction')).toBeTruthy()
   })
 })

--- a/apps/mobile/src/features/ConfirmTx/components/CanNotSign/CanNotSign.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/CanNotSign/CanNotSign.tsx
@@ -5,7 +5,7 @@ export function CanNotSign() {
   return (
     <YStack gap="$4" padding="$8" alignItems="center" justifyContent="center" testID="can-not-sign-container">
       <Text fontSize="$4" fontWeight={400} width="100%" textAlign="center" color="$textSecondaryLight">
-        Only signers of this safe can sign this transaction
+        Only signers of this Safe Account can confirm this transaction
       </Text>
     </YStack>
   )

--- a/apps/mobile/src/features/ConfirmTx/components/SignTransaction/SignError.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/SignTransaction/SignError.tsx
@@ -39,7 +39,7 @@ export function SignError({ description }: { description?: string }) {
                 </LargeHeaderTitle>
 
                 <Text textAlign="center" fontSize="$4" width="80%">
-                  {description || 'There was an error executing this transaction.'}
+                  {description || 'Could not sign this transaction. Nothing was submitted.'}
                 </Text>
               </View>
             </View>

--- a/apps/mobile/src/features/ExecuteTx/components/CanNotExecute/CanNotExecute.tsx
+++ b/apps/mobile/src/features/ExecuteTx/components/CanNotExecute/CanNotExecute.tsx
@@ -5,7 +5,7 @@ export function CanNotExecute() {
   return (
     <YStack gap="$4" padding="$8" alignItems="center" justifyContent="center" testID="can-not-sign-container">
       <Text fontSize="$4" fontWeight={400} width="100%" textAlign="center" color="$textSecondaryLight">
-        Only signers of this Safe can execute this transaction
+        Only signers of this Safe Account can execute this transaction
       </Text>
     </YStack>
   )

--- a/apps/mobile/src/features/ImportSigner/components/ImportError/ImportError.tsx
+++ b/apps/mobile/src/features/ImportSigner/components/ImportError/ImportError.tsx
@@ -39,7 +39,7 @@ export function ImportError() {
               </Text>
 
               <Text textAlign="center" fontSize="$4">
-                Don’t worry, your private key was not stored!
+                Your private key was not stored.
               </Text>
             </View>
           </View>

--- a/apps/mobile/src/store/middleware/pendingTxs.ts
+++ b/apps/mobile/src/store/middleware/pendingTxs.ts
@@ -68,7 +68,12 @@ const startRelayWatcher = (listenerApi: AppListenerEffectAPI, txId: string, task
   if (!baseUrl) {
     logger.error('CGW base URL not configured for relay watcher', { txId, taskId })
     listenerApi.dispatch(
-      setPendingTxStatus({ txId, chainId, status: PendingStatus.FAILED, error: 'CGW base URL not configured' }),
+      setPendingTxStatus({
+        txId,
+        chainId,
+        status: PendingStatus.FAILED,
+        error: 'Could not track this transaction. Check the network explorer.',
+      }),
     )
     return
   }

--- a/apps/web/src/components/common/CheckWallet/index.test.tsx
+++ b/apps/web/src/components/common/CheckWallet/index.test.tsx
@@ -248,7 +248,7 @@ describe('CheckWallet', () => {
     )
 
     expect(getByText('Continue')).toBeDisabled()
-    expect(getByLabelText('SDK is not initialized yet'))
+    expect(getByLabelText('Still loading. Try again in a moment.'))
   })
 
   it('should not disable the button if SDK is not initialized and safe is not loaded', () => {

--- a/apps/web/src/components/common/CheckWallet/index.tsx
+++ b/apps/web/src/components/common/CheckWallet/index.tsx
@@ -22,7 +22,7 @@ type CheckWalletProps = {
 
 enum Message {
   WalletNotConnected = 'Please connect your wallet',
-  SDKNotInitialized = 'SDK is not initialized yet',
+  SDKNotInitialized = 'Still loading. Try again in a moment.',
   NotSafeOwner = 'Your connected wallet is not a signer of this Safe account',
   SafeNotActivated = 'You need to activate the Safe before transacting',
 }

--- a/apps/web/src/components/common/CheckWalletWithPermission/index.test.tsx
+++ b/apps/web/src/components/common/CheckWalletWithPermission/index.test.tsx
@@ -173,7 +173,7 @@ describe('CheckWalletWithPermission', () => {
     )
 
     expect(getByText('Continue')).toBeDisabled()
-    expect(getByLabelText('SDK is not initialized yet'))
+    expect(getByLabelText('Still loading. Try again in a moment.'))
   })
 
   it('should not disable the button if SDK is not initialized and safe is not loaded', () => {

--- a/apps/web/src/components/common/CheckWalletWithPermission/index.tsx
+++ b/apps/web/src/components/common/CheckWalletWithPermission/index.tsx
@@ -21,7 +21,7 @@ type CheckWalletWithPermissionProps<
 
 enum Message {
   WalletNotConnected = 'Please connect your wallet',
-  SDKNotInitialized = 'SDK is not initialized yet',
+  SDKNotInitialized = 'Still loading. Try again in a moment.',
   NotSafeOwner = 'Your connected wallet is not a signer of this Safe account',
   SafeNotActivated = 'You need to activate the Safe before transacting',
 }

--- a/apps/web/src/pages/403.tsx
+++ b/apps/web/src/pages/403.tsx
@@ -12,14 +12,13 @@ const Custom403: NextPage = () => {
       </div>
       <h1 style={{ fontSize: '2rem', fontWeight: 700, marginBottom: '1rem' }}>403 – Access Restricted</h1>
       <p>
-        We regret to inform you that access to this service is currently unavailable in your region. For further
-        information, you may refer to our{' '}
+        Safe{'{Wallet}'} is not available in your region. See our{' '}
         <Link href={AppRoutes.terms} passHref legacyBehavior>
           <MUILink target="_blank" rel="noreferrer">
             terms
           </MUILink>
-        </Link>
-        . We apologize for any inconvenience this may cause. Thank you for your understanding.
+        </Link>{' '}
+        for details.
       </p>
     </main>
   )


### PR DESCRIPTION
## What it solves

Resolves: [WA-3006](https://linear.app/safe-global/issue/WA-3006/fix-broken-error-copy-in-web-and-mobile-quick-wins)

Rewrites the user-facing error strings flagged in the copy audit: wrong verbs, internal identifiers (`SDK`, `CGW`), reassurance framing, inconsistent "Safe Account" capitalisation, and the 44-word 403 page.

## How this PR fixes it

| Surface | Before | After |
| -- | -- | -- |
| Mobile sign error fallback (`SignError.tsx`) | There was an error executing this transaction. | Could not sign this transaction. Nothing was submitted. |
| Mobile import signer error (`ImportError.tsx`) | Don't worry, your private key was not stored! | Your private key was not stored. |
| Mobile pending relay tx toast (`pendingTxs.ts`) | CGW base URL not configured | Could not track this transaction. Check the network explorer. |
| Mobile cannot-sign notice (`CanNotSign.tsx`) | Only signers of this safe can sign this transaction | Only signers of this Safe Account can confirm this transaction |
| Mobile cannot-execute notice (`CanNotExecute.tsx`) | Only signers of this Safe can execute this transaction | Only signers of this Safe Account can execute this transaction |
| Web action tooltip (`CheckWallet` + `CheckWalletWithPermission`) | SDK is not initialized yet | Still loading. Try again in a moment. |
| Web 403 page (`403.tsx`) | We regret to inform you that access to this service is currently unavailable in your region. […] Thank you for your understanding. | Safe{Wallet} is not available in your region. See our terms for details. |

Beyond the ticket's file list:
- `CheckWalletWithPermission` duplicates the exact `SDKNotInitialized` enum value, so it is updated together with `CheckWallet` — otherwise the old tooltip would remain on permission-gated buttons.
- `CanNotExecute.tsx` is updated to satisfy the acceptance criterion "Safe Account capitalised consistently across the sign and execute screens".
- Ticket item 2 (`useDelegateKey` constant) is intentionally **not** included: tracing showed the string never renders — it only feeds an unrendered state and dev logs.
- The `logger.error` in `pendingTxs.ts` keeps the technical `CGW base URL not configured` message for debugging; only the toast string changed.

## How to test it

- **403 page**: navigate directly to `/403`.
- **Web tooltip**: connect a wallet, open a Safe, block the RPC endpoint in DevTools (Safe info still loads via CGW, the SDK cannot initialize), hover the disabled "New transaction" button.
- **Import error**: add a Safe in observe mode, import a valid private key that is not an owner — covered by the Maestro flow `apps/mobile/e2e/tests/onboarding/import-signer-private-key.yml`.
- **Cannot-execute / cannot-sign**: open a pending transaction in a read-only Safe (no signer imported) → execute notice; with a signer imported that is not an owner of the viewed Safe → sign notice.
- **Sign error fallback / relay toast**: defensive strings; unit-level coverage only (all `/signing-error` callers pass a description; `getBaseUrl()` always resolves in a running app).

## Affected flows

- Mobile: transaction signing failure screen, signer import failure, pending relay transaction failure toast, transaction confirmation screen for non-signers (sign and execute variants)
- Web: every action button gated by `CheckWallet` / `CheckWalletWithPermission` during SDK init (tooltip only), region-blocked 403 page

## Blast radius

- Copy-only changes; no logic, types, or control flow touched.
- `Message` enum values in `CheckWallet` / `CheckWalletWithPermission` are only rendered (tooltip title) and asserted in their colocated tests — verified via grep/LSP that nothing branches on the string values.
- `pendingTx.error` is display-only (`toast.show(pendingTx.error)` in `usePendingTxsMonitor`); nothing compares it.
- `ExecuteError.tsx` shares the old fallback sentence where the verb is correct — intentionally untouched.
- No shared `packages/**` code touched.

## Risks / not checked

- Web `CGW base URL not configured` errors (`safeDeployment.ts:219`, `txMonitor.ts:124`) are out of ticket scope and unchanged.
- Cypress/Playwright web E2E suites not run locally (no old-copy assertions found by search).
- Mobile Maestro E2E flow updated but not executed locally.
- The 403 page is served by geo-blocking infra; only verified by rendering the route directly.

## Visual summary

```mermaid
flowchart TB
  subgraph Mobile
    A[SignError fallback] -->|"executing" → "Could not sign …"| A2[Sign failure screen]
    B[ImportError] -->|drop "Don't worry …!"| B2[Import signer failure]
    C[pendingTxs middleware] -->|"CGW base URL …" → "Could not track …"| C2[8s error toast]
    D[CanNotSign / CanNotExecute] -->|"safe/Safe" → "Safe Account"| D2[Confirm tx screen]
  end
  subgraph Web
    E[CheckWallet + CheckWalletWithPermission] -->|"SDK is not initialized yet" → "Still loading …"| E2[Action button tooltip]
    F[403.tsx] -->|44 words → 1 sentence| F2[Region-blocked page]
  end
```

UI screenshots: copy-only diffs; reproduce per "How to test it" above.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — updated assertions in `CanNotSign.test.tsx`, `CheckWallet/index.test.tsx`, `CheckWalletWithPermission/index.test.tsx`, and the Maestro import flow
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)