### PR TITLE
fix(e2e): TWAP tests

### DIFF
--- a/apps/web/cypress/e2e/pages/spaces.page.js
+++ b/apps/web/cypress/e2e/pages/spaces.page.js
@@ -285,6 +285,9 @@ export function openSpaceByName(name) {
   // if a single-space account may have auto-redirected into a dashboard).
   cy.contains(spaceCard, name, { timeout: 30000 }).should('be.visible').click()
   cy.url({ timeout: 30000 }).should('include', constants.spaceDashboardUrl).and('include', 'spaceId=')
+  // The URL flips before the dashboard hydrates; the sidebar keeps re-rendering until it settles.
+  // Wait for dashboard content so later sidebar clicks don't detach mid-click on slower CI.
+  cy.get(spaceDashboardTotalValue, { timeout: 30000 }).should('be.visible')
 }
 
 export function clickOnSpaceSelector(spaceName) {

--- a/apps/web/cypress/e2e/pages/swaps.pages.js
+++ b/apps/web/cypress/e2e/pages/swaps.pages.js
@@ -369,6 +369,25 @@ export function setOutputValue(value) {
   })
 }
 
+export function setNumberOfParts(parts) {
+  cy.get('span')
+    .contains(numberOfPartsStr)
+    .next()
+    .find('input')
+    .should('be.visible')
+    .clear()
+    .invoke('val', '')
+    .trigger('input')
+    .then(($input) => {
+      if ($input.val() !== '') {
+        cy.wrap($input).clear().invoke('val', '').trigger('input')
+      }
+    })
+    .should('have.value', '')
+    .type(parts, { force: true })
+    .should('have.value', String(parts))
+}
+
 export function outputInputIsNotEmpty() {
   cy.get(outputCurrencyInput).find('input').invoke('val').should('not.be.empty')
 }

--- a/apps/web/cypress/e2e/pages/swaps.pages.js
+++ b/apps/web/cypress/e2e/pages/swaps.pages.js
@@ -242,18 +242,34 @@ export function clickOnReviewOrderBtn() {
   cy.get(reviewTwapBtn).should('be.enabled').click()
 }
 
-export function placeTwapOrder() {
+export function placeTwapOrder(attempt = 0) {
+  const maxAttempts = 5
   cy.wait(3000)
+
+  // The quote auto-refreshes (~every 30s) and re-disables "Place TWAP order" behind a
+  // "Price Updated" -> "Accept" prompt. Accept the refreshed quote, then place the order;
+  // if the quote refreshes again before we click, retry.
   cy.get('button')
     .contains(acceptStrBtn)
     .should(() => {})
-    .then(($button) => {
-      if (!$button.length) {
-        return
+    .then(($accept) => {
+      if ($accept.length) {
+        cy.wrap($accept).click()
       }
-      cy.wrap($button).click()
     })
-  cy.get('button').contains(placeTwapOrderStrBtn).should('be.enabled').click()
+
+  cy.get('button')
+    .contains(placeTwapOrderStrBtn)
+    .then(($button) => {
+      if ($button.is(':disabled')) {
+        if (attempt >= maxAttempts) {
+          throw new Error('"Place TWAP order" stayed disabled after accepting refreshed quotes')
+        }
+        placeTwapOrder(attempt + 1)
+      } else {
+        cy.wrap($button).click()
+      }
+    })
 }
 
 export function confirmPriceImpact() {
@@ -264,6 +280,16 @@ export function confirmPriceImpact() {
     .then(($checkbox) => {
       if ($checkbox.length) {
         cy.wrap($checkbox).click()
+      }
+    })
+
+  // High price-impact orders now require typing "confirm" before the order can proceed.
+  cy.get(confirmPriceImpactInput)
+    .should(() => {})
+    .then(($input) => {
+      if ($input.length) {
+        cy.wrap($input).clear().type('confirm')
+        cy.get(confirmPriceImpactBtn).should('be.enabled').click()
       }
     })
 }

--- a/apps/web/cypress/e2e/pages/swaps.pages.js
+++ b/apps/web/cypress/e2e/pages/swaps.pages.js
@@ -19,7 +19,7 @@ export const assetsSwapBtn = '[data-testid="swap-btn"]'
 export const dashboardSwapBtn = '[data-testid="overview-swap-btn"]'
 export const customRecipient = 'div[id="recipient"]'
 const recipientToggle = 'span[id="toggle-recipient-mode-button"]'
-const twapsAddressToggle = 'button[class*="Toggle__Wrapper"]'
+const twapsCustomRecipientStr = 'Custom Recipient'
 const explorerBtn = '[data-testid="explorer-btn"]'
 const limitPriceFld = '[data-testid="limit-price"]'
 const expiryFld = '[data-testid="expiry"]'
@@ -419,8 +419,8 @@ export function outputInputIsNotEmpty() {
 }
 
 export function enableTwapCustomRecipient(option) {
-  main.verifyMinimumElementsCount(twapsAddressToggle, 1)
-  if (!option) cy.get(twapsAddressToggle).eq(0).click()
+  cy.contains(twapsCustomRecipientStr).should('be.visible')
+  if (!option) cy.contains(twapsCustomRecipientStr).click()
 }
 
 export function enableCustomRecipient(option) {

--- a/apps/web/cypress/e2e/regression/twaps_integration.cy.js
+++ b/apps/web/cypress/e2e/regression/twaps_integration.cy.js
@@ -121,7 +121,7 @@ describe('TWAP tests', { defaultCommandTimeout: 30000 }, () => {
     })
   })
 
-  it(
+  it.only(
     'Verify entering a blocked address in the custom recipient input blocks the form',
     { defaultCommandTimeout: 60000 },
     () => {

--- a/apps/web/cypress/e2e/regression/twaps_integration.cy.js
+++ b/apps/web/cypress/e2e/regression/twaps_integration.cy.js
@@ -103,7 +103,9 @@ describe('TWAP tests', { defaultCommandTimeout: 30000 }, () => {
     })
   })
 
-  it('Verify "Sell amount too low" if the amount of tokens is worth less than 200 USD', () => {
+  // CoW enforces a live per-part minimum ($10); the title's "200 USD" is a stale 2024 assumption.
+  // 4 parts keeps 1 COW under the floor regardless of price; 2 parts flaked in CI.
+  it.only('Verify "Sell amount too small" is shown when the per-part sell amount is below CoW\'s minimum', () => {
     swaps.acceptLegalDisclaimer()
     cy.wait(4000)
     main.getIframeBody(iframeSelector).within(() => {
@@ -114,6 +116,7 @@ describe('TWAP tests', { defaultCommandTimeout: 30000 }, () => {
       swaps.selectInputCurrency(swaps.swapTokens.cow)
       swaps.setInputValue(1)
       swaps.selectOutputCurrency(swaps.swapTokens.dai)
+      swaps.setNumberOfParts(4)
       swaps.checkSmallSellAmountMessageDisplayed()
     })
   })

--- a/apps/web/cypress/e2e/regression/twaps_integration.cy.js
+++ b/apps/web/cypress/e2e/regression/twaps_integration.cy.js
@@ -121,7 +121,7 @@ describe('TWAP tests', { defaultCommandTimeout: 30000 }, () => {
     })
   })
 
-  it.only(
+  it(
     'Verify entering a blocked address in the custom recipient input blocks the form',
     { defaultCommandTimeout: 60000 },
     () => {

--- a/apps/web/cypress/e2e/regression/twaps_integration.cy.js
+++ b/apps/web/cypress/e2e/regression/twaps_integration.cy.js
@@ -105,7 +105,7 @@ describe('TWAP tests', { defaultCommandTimeout: 30000 }, () => {
 
   // CoW enforces a live per-part minimum ($10); the title's "200 USD" is a stale 2024 assumption.
   // 4 parts keeps 1 COW under the floor regardless of price; 2 parts flaked in CI.
-  it.only('Verify "Sell amount too small" is shown when the per-part sell amount is below CoW\'s minimum', () => {
+  it('Verify "Sell amount too small" is shown when the per-part sell amount is below CoW\'s minimum', () => {
     swaps.acceptLegalDisclaimer()
     cy.wait(4000)
     main.getIframeBody(iframeSelector).within(() => {


### PR DESCRIPTION
## What it solves

Resolves: [WA-2806](https://linear.app/safe-global/issue/WA-2806/fix-twap-e2e-test-flows)
Fixes three flaky/broken TWAP & Spaces Cypress regression tests that pass locally but fail in CI, caused by upstream CoW widget changes and a Safe dashboard hydration race.

## How this PR fixes it

- **TWAP "Sell amount too small"** — CoW now enforces a live **$10-per-part** minimum, not a fixed total. With 1 COW / 2 parts the per-part value straddled the threshold and flipped pass/fail with the COW price. Now sets **4 parts** (`setNumberOfParts` helper) so the per-part value stays well under the floor regardless of price. Renamed the test (old title said "200 USD", a stale 2024 assumption).
- **TWAP "Verify order details"** — CoW added a "type confirm" high-price-impact modal and a "Price Updated → Accept" quote-refresh that re-disables "Place TWAP order". `confirmPriceImpact` now handles the confirm modal; `placeTwapOrder` retries through the Accept refresh so the place click doesn't land on a disabled button.
- **Spaces "invite & accept"** — the sidebar settings button detached mid-`click()` during dashboard hydration ("page updated while this command was executing"). `openSpaceByName` now waits for dashboard content (`space-dashboard-total-value`) so hydration completes before the subsequent sidebar navigation.

## How to test it

`yarn workspace @safe-global/web cypress:open` --> run `twaps_integration.cy.js` (order-details + sell-amount tests) and `spaces_basicflow.cy.js` (invite & accept).

## Affected flows

- TWAP order: create → review → place order (price-impact + quote-refresh gates)
- TWAP validation: per-part minimum "Sell amount too small"
- Spaces: open space → settings → delete (post-invite cleanup)

## Blast radius

- `swaps.pages.js`: `confirmPriceImpact`, `placeTwapOrder`, `enableTwapCustomRecipient` (checkbox-by-label), new `setNumberOfParts` — used only by TWAP specs.
- `spaces.page.js`: `openSpaceByName` — single caller (`spaces_basicflow.cy.js`).
- Test-only changes; no app/runtime code touched.

## Risks / not checked

- Not fully re-verified end-to-end in CI (the flakes only reproduce under CI timing); CoW widget interactions were validated manually via browser MCP but blocked intermittently by CoW's Cloudflare challenge.
- `staking_history.cy.js` left unchanged — its CI failure is a CGW staking-enrichment/data issue (generic decode returned instead of "Withdraw request"), not a test-code problem.
- Did not test on mobile (N/A — Cypress web E2E only).

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
