### PR TITLE
Test pipeline experiment: jest environment resolves a real chain

### DIFF
--- a/apps/web/jest.config.cjs
+++ b/apps/web/jest.config.cjs
@@ -35,7 +35,7 @@ const customJestConfig = {
   testEnvironment: 'jest-fixed-jsdom',
 
   testEnvironmentOptions: {
-    url: 'http://localhost/balances?safe=rin:0xb3b83bf204C458B461de9B0CD2739DB152b4fa5A',
+    url: 'http://localhost/balances?safe=eth:0xb3b83bf204C458B461de9B0CD2739DB152b4fa5A',
     // https://github.com/mswjs/msw/issues/1786#issuecomment-2426900455
     // without this line 4 tests related to firefox fail
     customExportConditions: ['node'],

--- a/apps/web/src/components/common/AddressBookInput/index.test.tsx
+++ b/apps/web/src/components/common/AddressBookInput/index.test.tsx
@@ -23,7 +23,7 @@ const mockUseGetSpaceAddressBook = useGetSpaceAddressBook as jest.MockedFunction
 const spaceContactBuilder = (overrides: Partial<SpaceAddressBookItemDto> = {}): SpaceAddressBookItemDto => ({
   name: 'Server Contact',
   address: checksumAddress(faker.finance.ethereumAddress()),
-  chainIds: ['4'],
+  chainIds: ['1'],
   createdBy: '',
   createdByUserId: 0,
   lastUpdatedBy: '',
@@ -36,8 +36,8 @@ const spaceContactBuilder = (overrides: Partial<SpaceAddressBookItemDto> = {}): 
 // We use Rinkeby and chainId 4 here as this is our default url chain (see jest.setup.js)
 const mockChain = chainBuilder()
   .with({ features: [FEATURES.DOMAIN_LOOKUP] })
-  .with({ chainId: '4' })
-  .with({ shortName: 'rin' })
+  .with({ chainId: '1' })
+  .with({ shortName: 'eth' })
   .build()
 
 // mock useNameResolver

--- a/apps/web/src/components/common/EthHashInfo/__snapshots__/index.stories.test.tsx.snap
+++ b/apps/web/src/components/common/EthHashInfo/__snapshots__/index.stories.test.tsx.snap
@@ -35,6 +35,10 @@ exports[`./index.stories Default 1`] = `
               data-mui-internal-clone-element="true"
               style="cursor: pointer;"
             >
+              <b>
+                eth
+                :
+              </b>
               <span>
                 0xd9Db...9552
               </span>

--- a/apps/web/src/components/common/NamedAddressInfo/index.test.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.test.tsx
@@ -67,7 +67,7 @@ describe('NamedAddressInfo', () => {
       expect(result.getByText('Resolved Test Name')).toBeVisible()
     })
 
-    expect(useGetContractQueryMock).toHaveBeenCalledWith({ chainId: '4', contractAddress: address }, { skip: false })
+    expect(useGetContractQueryMock).toHaveBeenCalledWith({ chainId: '1', contractAddress: address }, { skip: false })
   })
 
   it('should show "This Safe account" when address matches Safe address', async () => {
@@ -140,7 +140,7 @@ describe('useAddressName', () => {
       })
     })
 
-    expect(useGetContractQueryMock).toHaveBeenCalledWith({ chainId: '4', contractAddress: address }, { skip: false })
+    expect(useGetContractQueryMock).toHaveBeenCalledWith({ chainId: '1', contractAddress: address }, { skip: false })
   })
 
   it('should mark contract without ABI as unverified', async () => {

--- a/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -64,6 +64,10 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                           data-mui-internal-clone-element="true"
                           style="cursor: pointer;"
                         >
+                          <b>
+                            eth
+                            :
+                          </b>
                           <span>
                             0xE20CcFf2c38Ef3b64109361D7b7691ff2c7D5f67
                           </span>
@@ -91,7 +95,24 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                       </span>
                       <div
                         class="MuiBox-root css-yjghm1"
-                      />
+                      >
+                        <a
+                          aria-label="View on etherscan.io"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ay7xk8-MuiButtonBase-root-MuiIconButton-root"
+                          data-mui-internal-clone-element="true"
+                          data-testid="explorer-btn"
+                          href="https://etherscan.io/address/0xE20CcFf2c38Ef3b64109361D7b7691ff2c7D5f67"
+                          rel="noreferrer"
+                          tabindex="0"
+                          target="_blank"
+                        >
+                          <mock-icon
+                            aria-hidden=""
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
+                            focusable="false"
+                          />
+                        </a>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -355,7 +376,24 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                             </div>
                                             <div
                                               class="MuiBox-root css-yjghm1"
-                                            />
+                                            >
+                                              <a
+                                                aria-label="View on etherscan.io"
+                                                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ay7xk8-MuiButtonBase-root-MuiIconButton-root"
+                                                data-mui-internal-clone-element="true"
+                                                data-testid="explorer-btn"
+                                                href="https://etherscan.io/address/0x0000000000000000000000000000000000000000"
+                                                rel="noreferrer"
+                                                tabindex="0"
+                                                target="_blank"
+                                              >
+                                                <mock-icon
+                                                  aria-hidden=""
+                                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
+                                                  focusable="false"
+                                                />
+                                              </a>
+                                            </div>
                                           </div>
                                         </div>
                                       </div>
@@ -461,6 +499,11 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                   >
                                     SafeTxGas
                                   </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                                  >
+                                    0
+                                  </p>
                                 </div>
                                 <hr
                                   class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
@@ -473,6 +516,11 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                   >
                                     BaseGas
                                   </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                                  >
+                                    0
+                                  </p>
                                 </div>
                                 <hr
                                   class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
@@ -484,6 +532,11 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                     class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
                                   >
                                     GasPrice
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                                  >
+                                    0
                                   </p>
                                 </div>
                                 <hr
@@ -518,12 +571,31 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                               data-mui-internal-clone-element="true"
                                               style="cursor: pointer;"
                                             >
-                                              <span />
+                                              <span>
+                                                0x0000...0000
+                                              </span>
                                             </span>
                                           </div>
                                           <div
                                             class="MuiBox-root css-yjghm1"
-                                          />
+                                          >
+                                            <a
+                                              aria-label="View on etherscan.io"
+                                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ay7xk8-MuiButtonBase-root-MuiIconButton-root"
+                                              data-mui-internal-clone-element="true"
+                                              data-testid="explorer-btn"
+                                              href="https://etherscan.io/address/0x0000000000000000000000000000000000000000"
+                                              rel="noreferrer"
+                                              tabindex="0"
+                                              target="_blank"
+                                            >
+                                              <mock-icon
+                                                aria-hidden=""
+                                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
+                                                focusable="false"
+                                              />
+                                            </a>
+                                          </div>
                                         </div>
                                       </div>
                                     </div>
@@ -561,12 +633,31 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                               data-mui-internal-clone-element="true"
                                               style="cursor: pointer;"
                                             >
-                                              <span />
+                                              <span>
+                                                0x0000...0000
+                                              </span>
                                             </span>
                                           </div>
                                           <div
                                             class="MuiBox-root css-yjghm1"
-                                          />
+                                          >
+                                            <a
+                                              aria-label="View on etherscan.io"
+                                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ay7xk8-MuiButtonBase-root-MuiIconButton-root"
+                                              data-mui-internal-clone-element="true"
+                                              data-testid="explorer-btn"
+                                              href="https://etherscan.io/address/0x0000000000000000000000000000000000000000"
+                                              rel="noreferrer"
+                                              tabindex="0"
+                                              target="_blank"
+                                            >
+                                              <mock-icon
+                                                aria-hidden=""
+                                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
+                                                focusable="false"
+                                              />
+                                            </a>
+                                          </div>
                                           <svg
                                             aria-hidden="true"
                                             aria-label="The RefundReceiver address is the one that will be reimbursed for the gas costs of executing this transaction."

--- a/apps/web/src/components/tx/confirmation-views/SettingsChange/__snapshots__/SettingsChange.stories.test.tsx.snap
+++ b/apps/web/src/components/tx/confirmation-views/SettingsChange/__snapshots__/SettingsChange.stories.test.tsx.snap
@@ -59,6 +59,10 @@ exports[`./SettingsChange.stories AddOwner 1`] = `
                 data-mui-internal-clone-element="true"
                 style="cursor: pointer;"
               >
+                <b>
+                  eth
+                  :
+                </b>
                 <span>
                   0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
                 </span>
@@ -86,7 +90,24 @@ exports[`./SettingsChange.stories AddOwner 1`] = `
             </span>
             <div
               class="MuiBox-root mui-style-yjghm1"
-            />
+            >
+              <a
+                aria-label="View on etherscan.io"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-ay7xk8-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                data-testid="explorer-btn"
+                href="https://etherscan.io/address/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                rel="noreferrer"
+                tabindex="0"
+                target="_blank"
+              >
+                <mock-icon
+                  aria-hidden=""
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                  focusable="false"
+                />
+              </a>
+            </div>
           </div>
         </div>
       </div>
@@ -209,7 +230,24 @@ exports[`./SettingsChange.stories SwapOwner 1`] = `
             </span>
             <div
               class="MuiBox-root mui-style-yjghm1"
-            />
+            >
+              <a
+                aria-label="View on etherscan.io"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-ay7xk8-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                data-testid="explorer-btn"
+                href="https://etherscan.io/address/0x00000000"
+                rel="noreferrer"
+                tabindex="0"
+                target="_blank"
+              >
+                <mock-icon
+                  aria-hidden=""
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                  focusable="false"
+                />
+              </a>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/web/src/features/swap/components/SwapOrderConfirmationView/__snapshots__/index.stories.test.tsx.snap
+++ b/apps/web/src/features/swap/components/SwapOrderConfirmationView/__snapshots__/index.stories.test.tsx.snap
@@ -377,6 +377,10 @@ exports[`./index.stories CustomRecipient 1`] = `
                       data-mui-internal-clone-element="true"
                       style="cursor: pointer;"
                     >
+                      <b>
+                        eth
+                        :
+                      </b>
                       <span>
                         0x9008D19f58AAbD9eD0D60971565AA8510560ab41
                       </span>
@@ -384,7 +388,24 @@ exports[`./index.stories CustomRecipient 1`] = `
                   </div>
                   <div
                     class="MuiBox-root mui-style-yjghm1"
-                  />
+                  >
+                    <a
+                      aria-label="View on etherscan.io"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-ay7xk8-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      data-testid="explorer-btn"
+                      href="https://etherscan.io/address/0x9008D19f58AAbD9eD0D60971565AA8510560ab41"
+                      rel="noreferrer"
+                      tabindex="0"
+                      target="_blank"
+                    >
+                      <mock-icon
+                        aria-hidden=""
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                        focusable="false"
+                      />
+                    </a>
+                  </div>
                 </div>
               </div>
             </div>
@@ -440,6 +461,10 @@ exports[`./index.stories CustomRecipient 1`] = `
                       data-mui-internal-clone-element="true"
                       style="cursor: pointer;"
                     >
+                      <b>
+                        eth
+                        :
+                      </b>
                       <span>
                         0x1234...7890
                       </span>
@@ -447,7 +472,24 @@ exports[`./index.stories CustomRecipient 1`] = `
                   </div>
                   <div
                     class="MuiBox-root mui-style-yjghm1"
-                  />
+                  >
+                    <a
+                      aria-label="View on etherscan.io"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-ay7xk8-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      data-testid="explorer-btn"
+                      href="https://etherscan.io/address/0x1234567890123456789012345678901234567890"
+                      rel="noreferrer"
+                      tabindex="0"
+                      target="_blank"
+                    >
+                      <mock-icon
+                        aria-hidden=""
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                        focusable="false"
+                      />
+                    </a>
+                  </div>
                 </div>
               </div>
             </div>
@@ -865,6 +907,10 @@ exports[`./index.stories Default 1`] = `
                       data-mui-internal-clone-element="true"
                       style="cursor: pointer;"
                     >
+                      <b>
+                        eth
+                        :
+                      </b>
                       <span>
                         0x9008D19f58AAbD9eD0D60971565AA8510560ab41
                       </span>
@@ -872,7 +918,24 @@ exports[`./index.stories Default 1`] = `
                   </div>
                   <div
                     class="MuiBox-root mui-style-yjghm1"
-                  />
+                  >
+                    <a
+                      aria-label="View on etherscan.io"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-ay7xk8-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      data-testid="explorer-btn"
+                      href="https://etherscan.io/address/0x9008D19f58AAbD9eD0D60971565AA8510560ab41"
+                      rel="noreferrer"
+                      tabindex="0"
+                      target="_blank"
+                    >
+                      <mock-icon
+                        aria-hidden=""
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                        focusable="false"
+                      />
+                    </a>
+                  </div>
                 </div>
               </div>
             </div>

--- a/apps/web/src/hooks/__tests__/useVisibleBalances.test.ts
+++ b/apps/web/src/hooks/__tests__/useVisibleBalances.test.ts
@@ -46,7 +46,7 @@ describe('useVisibleBalances', () => {
           theme: {
             darkMode: false,
           },
-          hiddenTokens: { ['4']: [hiddenTokenAddress] },
+          hiddenTokens: { ['1']: [hiddenTokenAddress] },
         },
         chains: { data: [], error: undefined, loading: false, loaded: true },
       } as unknown as store.RootState),
@@ -109,7 +109,7 @@ describe('useVisibleBalances', () => {
           theme: {
             darkMode: false,
           },
-          hiddenTokens: { ['4']: [hiddenTokenAddress] },
+          hiddenTokens: { ['1']: [hiddenTokenAddress] },
         },
         chains: { data: [], error: undefined, loading: false, loaded: true },
       } as unknown as store.RootState),
@@ -186,7 +186,7 @@ describe('useVisibleBalances', () => {
           theme: {
             darkMode: false,
           },
-          hiddenTokens: { ['4']: [hiddenTokenAddress] },
+          hiddenTokens: { ['1']: [hiddenTokenAddress] },
         },
         chains: { data: [], error: undefined, loading: false, loaded: true },
       } as unknown as store.RootState),
@@ -250,7 +250,7 @@ describe('useVisibleBalances', () => {
           theme: {
             darkMode: false,
           },
-          hiddenTokens: { ['4']: [hiddenTokenAddress] },
+          hiddenTokens: { ['1']: [hiddenTokenAddress] },
         },
         chains: { data: [], error: undefined, loading: false, loaded: true },
       } as unknown as store.RootState),
@@ -309,7 +309,7 @@ describe('useVisibleBalances', () => {
           currency: 'USD',
           shortName: { qr: true, show: true },
           theme: { darkMode: false },
-          hiddenTokens: { ['4']: [] },
+          hiddenTokens: { ['1']: [] },
           hideDust: true,
         },
         chains: { data: [], error: undefined, loading: false, loaded: true },
@@ -369,7 +369,7 @@ describe('useVisibleBalances', () => {
           currency: 'USD',
           shortName: { qr: true, show: true },
           theme: { darkMode: false },
-          hiddenTokens: { ['4']: [] },
+          hiddenTokens: { ['1']: [] },
           hideDust: false,
         },
         chains: { data: [], error: undefined, loading: false, loaded: true },

--- a/apps/web/src/tests/builders/safeTx.ts
+++ b/apps/web/src/tests/builders/safeTx.ts
@@ -22,6 +22,11 @@ export const createSafeTx = (data = '0x'): SafeTransaction => {
       data,
       operation: 0,
       nonce: 100,
+      safeTxGas: '0',
+      baseGas: '0',
+      gasPrice: '0',
+      gasToken: ZERO_ADDRESS,
+      refundReceiver: ZERO_ADDRESS,
     },
     signatures: new Map([]),
     addSignature: function (sig: SafeSignature): void {


### PR DESCRIPTION
Fourth step of the test-suite experiment, stacked on #8456.

The global jest URL said safe=rin:... while all mock data serves mainnet, so useChain returned undefined in any test that did not mock it and chain-gated rendering silently skipped. This swaps the URL to eth:, repairs 12 tests that encoded chain 4, and completes the createSafeTx fixture whose as-cast hid five missing required fields.

Recovered coverage is the point: one snapshot gained 97 lines of UI (address prefixes, etherscan links) that no jsdom test had ever rendered; the Receipt gas-token path executed in a test for the first time. Also a precondition for reducing the 88-file useChains mock preamble later: the real hooks now work against the ambient environment.

Known flake carried, not chased here: EnvHintButton.test.tsx failed once in one full-suite run, passes alone and in repeat runs; order-dependent, pre-existing suspect.

Draft to observe the pipeline.