### PR TITLE
Revert "chore(ci): pass TestRail credentials via env and pin python deps"

### DIFF
--- a/.github/workflows/web-e2e-full-ondemand.yml
+++ b/.github/workflows/web-e2e-full-ondemand.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     name: Cypress Full Regression on demand tests
-    permissions:
-      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -43,7 +41,7 @@ jobs:
       - name: Install junitparser
         if: always()
         run: |
-          pip install 'junitparser==5.0.1'
+          pip install junitparser
 
       - name: Merge JUnit reports for TestRail
         if: always()
@@ -52,20 +50,16 @@ jobs:
 
       - name: TestRail CLI upload results
         if: always()
-        env:
-          TESTRAIL_USERNAME: ${{ secrets.TESTRAIL_USERNAME }}
-          TESTRAIL_PASSWORD: ${{ secrets.TESTRAIL_PASSWORD }}
-          TESTRAIL_RUN_DESCRIPTION: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          pip install 'trcli==1.15.2'
+          pip install trcli
           if ! trcli -y \
           -h https://gno.testrail.io/ \
           --project "Safe- Web App" \
-          --username "$TESTRAIL_USERNAME" \
-          --password "$TESTRAIL_PASSWORD" \
+          --username ${{ secrets.TESTRAIL_USERNAME }} \
+          --password ${{ secrets.TESTRAIL_PASSWORD }} \
           parse_junit \
           --title "Full Regression Automated Tests, branch: ${GITHUB_REF_NAME}" \
-          --run-description "$TESTRAIL_RUN_DESCRIPTION" \
+          --run-description ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \
           -f "apps/web/reports/junit-report.xml"; then
             echo -e "\e[41;32mTestRail upload failed. Pipeline will continue, please check the upload process.\e[0m"
           fi

--- a/.github/workflows/web-e2e-hp-ondemand.yml
+++ b/.github/workflows/web-e2e-hp-ondemand.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     name: Cypress Happy path on demand tests
-    permissions:
-      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -40,7 +38,7 @@ jobs:
       - name: Install junitparser
         if: always()
         run: |
-          pip install 'junitparser==5.0.1'
+          pip install junitparser
 
       - name: Merge JUnit reports for TestRail
         if: always()
@@ -49,18 +47,14 @@ jobs:
 
       - name: TestRail CLI upload results
         if: always()
-        env:
-          TESTRAIL_USERNAME: ${{ secrets.TESTRAIL_USERNAME }}
-          TESTRAIL_PASSWORD: ${{ secrets.TESTRAIL_PASSWORD }}
-          TESTRAIL_RUN_DESCRIPTION: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          pip install 'trcli==1.15.2'
+          pip install trcli
           trcli -y \
           -h https://gno.testrail.io/ \
           --project "Safe- Web App" \
-          --username "$TESTRAIL_USERNAME" \
-          --password "$TESTRAIL_PASSWORD" \
+          --username ${{ secrets.TESTRAIL_USERNAME }} \
+          --password ${{ secrets.TESTRAIL_PASSWORD }} \
           parse_junit \
           --title "Happy Path Automated Tests, branch: ${GITHUB_REF_NAME}" \
-          --run-description "$TESTRAIL_RUN_DESCRIPTION" \
+          --run-description ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \
           -f "apps/web/reports/junit-report.xml"


### PR DESCRIPTION
Reverts 562606e5e, which reached `dev` through a direct push instead of a pull request. This restores `dev` to the exact content of 396394988 for both workflow files.

`dev` has `allow_force_pushes: false`, so rewriting history back is not possible. A revert commit is the only available mechanism.

The change itself was not the problem and is being re-proposed properly in a separate PR. This PR is purely about getting `dev` back to a reviewed state.

## What it solves

An unreviewed commit is currently the tip of `dev`.

## How this PR fixes it

`git revert --no-edit 562606e5e`. Verified with `git diff 396394988 HEAD -- .github/workflows/`, which is empty, so the revert is exact with no drift.

## How to test it

No behavioural change to verify. `.github/workflows/web-e2e-full-ondemand.yml` and `web-e2e-hp-ondemand.yml` return to their previous contents.

## Visual summary

```mermaid
flowchart LR
  A[396394988<br/>dev, reviewed] --> B[562606e5e<br/>direct push, unreviewed]
  B --> C[0acd2af77<br/>revert, this PR]
  C --> D[dev content ==<br/>396394988]
  B -.re-proposed via PR.-> E[chore/testrail-secrets-via-env]
```