### PR TITLE
Test pipeline experiment: build the smoke bundle once

### DIFF
--- a/.github/actions/cache-deps/action.yml
+++ b/.github/actions/cache-deps/action.yml
@@ -65,6 +65,10 @@ runs:
         path: |
           ${{ github.workspace }}/apps/web/.next/cache
         key: ${{ runner.os }}-nextjs-cypress-${{ hashFiles('apps/web/package.json', 'apps/web/yarn.lock') }}-${{ hashFiles('apps/web/src/**/*', 'apps/web/public/**/*', 'apps/web/*.{js,jsx,cjs,ts,mjs,tsx,json}') }}
+        # Exact key misses on any src change; fall back to the latest build
+        # for the same dependency set so Next.js rebuilds incrementally.
+        restore-keys: |
+          ${{ runner.os }}-nextjs-cypress-${{ hashFiles('apps/web/package.json', 'apps/web/yarn.lock') }}-
 
     - name: Set composite outputs nc
       if: ${{ inputs.mode == 'restore-nc' }}

--- a/.github/actions/cypress/action.yml
+++ b/.github/actions/cypress/action.yml
@@ -42,6 +42,11 @@ inputs:
     required: false
     default: '0'
 
+  prebuilt:
+    description: 'Skip the app build; expects apps/web/out to be present already'
+    required: false
+    default: 'false'
+
 runs:
   using: 'composite'
   steps:
@@ -54,6 +59,7 @@ runs:
       id: setup-chrome
 
     - uses: ./.github/actions/build
+      if: inputs.prebuilt != 'true'
       with:
         secrets: ${{ inputs.secrets }}
       env:

--- a/.github/workflows/web-e2e-smoke.yml
+++ b/.github/workflows/web-e2e-smoke.yml
@@ -18,10 +18,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Experiment: build the static export once and hand it to the shards as an
+  # artifact. Previously each of the 5 shards installed and built the whole
+  # app before running 2-4 minutes of specs.
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    name: Build test bundle
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ./.github/actions/yarn
+
+      - uses: ./.github/actions/build
+        with:
+          secrets: ${{ toJSON(secrets) }}
+        env:
+          NODE_ENV: cypress
+          # `next build` overrides NODE_ENV to 'production' in client bundles, so
+          # APP_ENV-based IS_TEST_E2E doesn't survive. Forward an explicit
+          # NEXT_PUBLIC_ flag that does survive the build.
+          NEXT_PUBLIC_IS_TEST_E2E: 'true'
+
+      - name: Upload static export
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: web-e2e-out
+          path: apps/web/out
+          retention-days: 1
+
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: Cypress Smoke tests
+    needs: build
     permissions:
       contents: read
 
@@ -35,12 +67,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Download static export
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: web-e2e-out
+          path: apps/web/out
+
       - uses: ./.github/actions/cypress
         with:
           secrets: ${{ toJSON(secrets) }}
           spec: cypress/e2e/smoke/*.cy.js
           group: 'Smoke tests'
           tag: 'smoke'
+          prebuilt: 'true'
 
   notify:
     if: failure() && github.event_name == 'push'

--- a/.github/workflows/web-e2e-smoke.yml
+++ b/.github/workflows/web-e2e-smoke.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - apps/web/**
       - packages/**
+      - .github/workflows/web-e2e-smoke.yml
+      - .github/actions/**
   push:
     branches:
       - main
@@ -12,6 +14,8 @@ on:
     paths:
       - apps/web/**
       - packages/**
+      - .github/workflows/web-e2e-smoke.yml
+      - .github/actions/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Fifth step of the test-suite experiment, stacked on #8457.

Smoke wall time was dominated by per-shard setup: install plus a full Next static-export build on every one of the 5 shards, 6-11 minutes each before the first spec, while the specs themselves take 2-4 minutes. Measured on #8451/#8452: a shard with warm caches starts specs at minute 6, a cold one at minute 11.

Two changes:
- web-e2e-smoke.yml builds the export once and hands out/ to the shards as an artifact; the cypress composite gains a prebuilt input that skips its build step. Other cypress workflows are unchanged and can adopt later.
- The .next cache restore gains a deps-scoped restore-keys fallback, so src changes rebuild incrementally instead of from scratch.

Expected: ~10-11 min wall regardless of cache luck (was 13-15 cold), roughly half the runner minutes. The smoke run on this PR is the measurement.

Draft to observe the pipeline.