### PR TITLE
ci: cut per-PR cost from deploy, bundle analysis, and unit tests

### DIFF
--- a/.github/workflows/store-codegen-check.yml
+++ b/.github/workflows/store-codegen-check.yml
@@ -43,8 +43,8 @@ jobs:
           fi
 
           # Get the list of changed files in the PR
-          git fetch origin ${{ github.base_ref }}
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          git fetch origin "$GITHUB_BASE_REF"
+          CHANGED_FILES=$(git diff --name-only "origin/$GITHUB_BASE_REF...HEAD")
 
           # Check if schema.json or AUTO_GENERATED files changed
           if echo "$CHANGED_FILES" | grep -qE "packages/store/(scripts/api-schema/schema\.json|src/gateway/AUTO_GENERATED/)"; then

--- a/.github/workflows/web-deploy-dev.yml
+++ b/.github/workflows/web-deploy-dev.yml
@@ -49,6 +49,21 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: 0
+
+      # Experiment: skip the storybook build on PRs that touch no stories and
+      # no storybook config. The PR deploy then excludes storybook/* from the
+      # S3 sync so --delete keeps the previously deployed storybook.
+      - name: Determine storybook scope
+        if: github.event.number
+        id: storybook-scope
+        run: |
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          if echo "$CHANGED" | grep -qE '\.stories\.|storybook|src/stories/|package\.json|yarn\.lock'; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "build=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: ./.github/actions/yarn
 
@@ -58,6 +73,7 @@ jobs:
           # if: startsWith(github.ref, 'refs/heads/main')
 
       - uses: ./.github/actions/build-storybook
+        if: github.event_name == 'push' || steps.storybook-scope.outputs.build == 'true'
         with:
           secrets: ${{ toJSON(secrets) }}
 
@@ -95,6 +111,7 @@ jobs:
         if: github.event.number
         env:
           BUCKET: s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/walletweb/${{ steps.extract_branch.outputs.slug }}
+          SKIP_STORYBOOK: ${{ steps.storybook-scope.outputs.build == 'false' }}
         working-directory: apps/web
         run: bash  ./scripts/github/s3_upload.sh
 

--- a/.github/workflows/web-deploy-dev.yml
+++ b/.github/workflows/web-deploy-dev.yml
@@ -58,7 +58,7 @@ jobs:
         if: github.event.number
         id: storybook-scope
         run: |
-          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          CHANGED=$(git diff --name-only "origin/$GITHUB_BASE_REF...HEAD")
           if echo "$CHANGED" | grep -qE '\.stories\.|storybook|src/stories/|package\.json|yarn\.lock'; then
             echo "build=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/web-nextjs-bundle-analysis.yml
+++ b/.github/workflows/web-nextjs-bundle-analysis.yml
@@ -5,6 +5,7 @@ name: 'Web Next.js Bundle Analysis'
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - apps/web/**
   push:
@@ -13,6 +14,7 @@ on:
     paths:
       - apps/web/**
       - packages/**
+  workflow_dispatch:
 permissions:
   contents: read # for checkout repository
   actions: read # for fetching base branch bundle stats
@@ -20,7 +22,12 @@ permissions:
 
 jobs:
   analyze:
+    # Experiment: on PRs, run only when the bundle-analysis label is set.
+    # The push run on dev stays; it produces the base artifact PRs compare
+    # against.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'bundle-analysis')
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/web-unit-tests.yml
+++ b/.github/workflows/web-unit-tests.yml
@@ -29,12 +29,20 @@ jobs:
 
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Experiment: shard PR runs 4 ways. Jest applies --shard after
+    # --changedSince selection, so each shard runs a quarter of the selected
+    # set. Push runs stay single (shard 1); shards 2-4 skip install and exit.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - uses: ./.github/actions/yarn
+        if: github.event_name == 'pull_request' || matrix.shard == 1
 
       # Experiment: replace the coverage-report action, which ran the full
       # suite twice per PR (head + base). Jest's --changedSince only maps
@@ -55,27 +63,27 @@ jobs:
 
       - name: Run affected tests
         if: github.event_name == 'pull_request' && steps.scope.outputs.full == 'false'
-        run: yarn test --ci --silent --watchAll=false --changedSince=origin/${{ github.base_ref }} --passWithNoTests
+        run: yarn test --ci --silent --watchAll=false --changedSince=origin/${{ github.base_ref }} --passWithNoTests --shard=${{ matrix.shard }}/4
         working-directory: apps/web
         env:
           NEXT_PUBLIC_IS_OFFICIAL_HOST: true
 
       - name: Run full suite (out-of-root changes)
         if: github.event_name == 'pull_request' && steps.scope.outputs.full == 'true'
-        run: yarn test --ci --silent --watchAll=false
+        run: yarn test --ci --silent --watchAll=false --shard=${{ matrix.shard }}/4
         working-directory: apps/web
         env:
           NEXT_PUBLIC_IS_OFFICIAL_HOST: true
 
       - name: Run tests (push only)
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && matrix.shard == 1
         run: yarn test:ci
         working-directory: apps/web
         env:
           NEXT_PUBLIC_IS_OFFICIAL_HOST: true
 
       - name: Upload coverage to Datadog
-        if: success() && github.event_name == 'push'
+        if: success() && github.event_name == 'push' && matrix.shard == 1
         uses: ./.github/actions/upload-coverage
         with:
           api-key: ${{ secrets.DATADOG_API_KEY }}
@@ -85,7 +93,7 @@ jobs:
           flag: workspace:web
 
       - name: Notify Slack on failure
-        if: failure() && github.event_name == 'push'
+        if: failure() && github.event_name == 'push' && matrix.shard == 1
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_DEV_ALERT }}

--- a/.github/workflows/web-unit-tests.yml
+++ b/.github/workflows/web-unit-tests.yml
@@ -54,7 +54,7 @@ jobs:
         if: github.event_name == 'pull_request'
         id: scope
         run: |
-          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          CHANGED=$(git diff --name-only "origin/$GITHUB_BASE_REF...HEAD")
           if echo "$CHANGED" | grep -qE '^(packages/|config/|yarn\.lock$|package\.json$)|^apps/web/(jest\.config\.cjs|jest\.setup\.js|package\.json|next\.config\.mjs|tsconfig\.json|mocks/|src/tests/)'; then
             echo "full=true" >> "$GITHUB_OUTPUT"
           else
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run affected tests
         if: github.event_name == 'pull_request' && steps.scope.outputs.full == 'false'
-        run: yarn test --ci --silent --watchAll=false --changedSince=origin/${{ github.base_ref }} --passWithNoTests --shard=${{ matrix.shard }}/4
+        run: yarn test --ci --silent --watchAll=false --changedSince="origin/$GITHUB_BASE_REF" --passWithNoTests --shard=${{ matrix.shard }}/4
         working-directory: apps/web
         env:
           NEXT_PUBLIC_IS_OFFICIAL_HOST: true

--- a/apps/web/scripts/github/s3_upload.sh
+++ b/apps/web/scripts/github/s3_upload.sh
@@ -8,8 +8,14 @@ fi
 
 cd out
 
-# Upload the build to S3
-aws s3 sync . $BUCKET --delete
+# Upload the build to S3. When the storybook build was skipped
+# (SKIP_STORYBOOK=true, PR deploys only), exclude storybook/* so
+# --delete does not remove the previously deployed storybook.
+if [[ "$SKIP_STORYBOOK" == "true" ]]; then
+  aws s3 sync . $BUCKET --delete --exclude 'storybook/*'
+else
+  aws s3 sync . $BUCKET --delete
+fi
 
 function parallel_limit {
     local max="$1"


### PR DESCRIPTION
Part of the test suite experiment stack. Base is test-msw-handlers (#8463).

Three changes, one commit each.

**1. Conditional storybook build on PR deploys.** deploy-dev built storybook on every PR. A scope step diffs the PR against its base for `.stories.`, storybook config, `src/stories/`, `package.json`, or `yarn.lock`. No match skips the build. The S3 sync then excludes `storybook/*` so `--delete` keeps the previously deployed storybook. Push deploys to dev and main are unchanged. Known tradeoff: the PR comment's storybook link shows the last deployed storybook when the build is skipped.

**2. Label gate on bundle analysis.** Every apps/web PR paid install plus full build for the bundle comment. The job now runs on PRs only with the `bundle-analysis` label (trigger types include `labeled`, so adding the label starts a run). The push run on dev stays because it produces the base artifact PRs compare against. Added workflow_dispatch and a 20 minute timeout.

**3. Shard unit PR runs 4 ways.** Jest applies `--shard` after `--changedSince` selection, so each shard runs a quarter of the selected set. The scope guard from #8451 is unchanged and runs per shard. Push runs stay single on shard 1 with coverage, Datadog, and Slack untouched; shards 2-4 skip install on push.

A fourth item from the review (dropping the apps/web trigger from web-tanstack checks) was withdrawn: web-tanstack declares `"@safe-global/web": "workspace:*"` in its package.json, so the trigger is correct.

Expected effect: PR deploy drops ~4-5 min when storybook is skipped, bundle analysis (~8 min) disappears from unlabeled PRs, and the unit gate wall time drops roughly in proportion to shard count on full runs. Numbers will be posted from this PR's own runs.

Draft, do not merge. Measurement comment follows.