### PR TITLE
ci: stop yarn cache churn on PR runs, restore from dev via prefix fallback

### DIFF
--- a/.github/actions/cache-deps/action.yml
+++ b/.github/actions/cache-deps/action.yml
@@ -37,6 +37,12 @@ runs:
           ${{ github.workspace }}/.yarn/install-state.gz
           ${{ github.workspace }}/packages/utils/src/types
         key: ${{ runner.os }}-web-core-modules-${{ hashFiles('**/package.json','**/yarn.lock') }}
+        # Exact key misses whenever any package.json or the lockfile changes;
+        # fall back to the latest cache so yarn install runs incrementally.
+        # A prefix hit does not set cache-hit, so install and after-install
+        # still run and regenerate node_modules and generated types.
+        restore-keys: |
+          ${{ runner.os }}-web-core-modules-
 
     - name: Set composite outputs yarn
       if: ${{ inputs.mode == 'restore-yarn' }}

--- a/.github/actions/yarn/action.yml
+++ b/.github/actions/yarn/action.yml
@@ -55,8 +55,11 @@ runs:
       shell: bash
       run: yarn workspace @safe-global/web after-install
 
+    # Save only outside pull_request runs. Each yarn cache is ~2.2 GB and PR
+    # merge-ref saves were saturating the 10 GB repo quota, evicting the dev
+    # caches every PR restores from. PR runs restore via restore-keys instead.
     - name: Save Yarn Cache & Types
-      if: steps.restore-yarn-types.outputs.cache-hit-yarn != 'true'
+      if: steps.restore-yarn-types.outputs.cache-hit-yarn != 'true' && github.event_name != 'pull_request'
       uses: ./.github/actions/cache-deps
       with:
         mode: save-yarn


### PR DESCRIPTION
Part of the test suite experiment stack. Base is test-ci-costdown (#8464).

**Problem.** The repo Actions cache quota sits at 8.4 of 10 GB. Every entry lives on a PR merge ref or a feature branch; `refs/heads/dev` holds zero caches. Each yarn cache (`node_modules` + berry cache + Cypress) is 2.2 GB, so four PR runs saturate the quota and LRU eviction deletes the dev caches. A PR run can only restore from its own merge ref, its base branch, and dev, so almost every first PR run pays a ~6 minute cold install. Measured in the #8462 smoke run: yarn step 5m46s, log line `Cache not found for input keys: Linux-web-core-modules-...`.

**Change, two lines of behavior.**
1. The yarn restore in `.github/actions/cache-deps` gains a `restore-keys` prefix fallback. A deps change now restores the newest cache for an incremental install instead of a cold one. A prefix hit does not set `cache-hit`, so `yarn install --immutable` and `after-install` still run and correctness is unchanged.
2. The save step in `.github/actions/yarn` is skipped on `pull_request` events. Only push runs (dev, main) populate the cache. Quota churn stops and the dev cache survives.

**Tradeoff.** Re-runs of the same PR no longer warm their own merge ref. They depend on a dev cache existing. Today dev has none (evicted), so the first observation runs here will still be cold; the next push to dev repopulates it and every PR after that gets a warm restore.

**Expected steady state.** One 2.2 GB yarn cache per active deps hash on dev plus the small Next.js caches, total well under quota. First PR runs drop from ~6 min install to ~1 min.

Draft, do not merge. Measurement comment follows after a dev cache exists.