### PR TITLE
feat(safenet): verify attestations against the coordinator group key

### DIFF
--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -5,4 +5,7 @@ module.exports = {
   collectCoverage: true,
   collectCoverageFrom: ['<rootDir>/src/**/*.ts'],
   testEnvironment: 'jest-fixed-jsdom',
+  // Opt-in integration specs (`*.integration.test.ts`) hit a live devnet and are
+  // run separately via `yarn test:integration` — never in the default/turbo run.
+  testPathIgnorePatterns: [...(preset.testPathIgnorePatterns ?? []), '\\.integration\\.test\\.ts$'],
 }

--- a/packages/utils/jest.integration.config.js
+++ b/packages/utils/jest.integration.config.js
@@ -1,0 +1,15 @@
+const preset = require('../../config/test/presets/jest-preset')
+
+/**
+ * Opt-in integration config: runs only `*.integration.test.ts` in a node
+ * environment against a live Safenet network (sim :8546 / devnet :8547) selected
+ * by `SAFENET_IT_RPC`. Excluded from the default config and from turbo — invoke
+ * explicitly with `yarn test:integration`. Specs self-skip (with a clear message)
+ * when `SAFENET_IT_RPC` is unset.
+ */
+module.exports = {
+  ...preset,
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/**/*.integration.test.ts'],
+  collectCoverage: false,
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,6 +5,7 @@
   "version": "1.0.0",
   "scripts": {
     "test": "jest",
+    "test:integration": "jest --config jest.integration.config.js",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "type-check": "tsc --noEmit",

--- a/packages/utils/src/features/safenet-checks/abi.ts
+++ b/packages/utils/src/features/safenet-checks/abi.ts
@@ -57,13 +57,9 @@ export const SHARED_ORACLE_EVENT_FRAGMENTS = [
 /**
  * Read (view) functions the reader calls with `ethers.Contract`. Copied from the
  * protocol explorer's `consensus`/`coordinator` ABIs. `getEpochGroupId` maps an
- * epoch to its FROST group id; `groupKey` returns that group's public key;
- * `getCoordinator` discovers the FROSTCoordinator when no override is configured.
+ * epoch to its FROST group id; `groupKey` returns that group's public key.
  */
-export const CONSENSUS_READ_ABI = [
-  'function getCoordinator() view returns (address)',
-  'function getEpochGroupId(uint64 epoch) view returns (bytes32 groupId)',
-] as const
+export const CONSENSUS_READ_ABI = ['function getEpochGroupId(uint64 epoch) view returns (bytes32 groupId)'] as const
 
 export const COORDINATOR_READ_ABI = [
   'function groupKey(bytes32 gid) view returns ((uint256 x, uint256 y) key)',

--- a/packages/utils/src/features/safenet-checks/constants.ts
+++ b/packages/utils/src/features/safenet-checks/constants.ts
@@ -38,6 +38,15 @@ export const SAFENET_CONSENSUS_ADDRESS =
   '0x223624cBF099e5a8f8cD5aF22aFa424a1d1acEE9'
 
 /**
+ * FROSTCoordinator the epoch group keys are read from. Default: Gnosis beta
+ * deployment (the coordinator the beta Consensus was deployed against).
+ */
+export const SAFENET_COORDINATOR_ADDRESS =
+  process.env.NEXT_PUBLIC_SAFENET_COORDINATOR_ADDRESS ||
+  process.env.EXPO_PUBLIC_SAFENET_COORDINATOR_ADDRESS ||
+  '0xaE27021CEB45316f1efe69D8E362aC07ED3Bd7E4'
+
+/**
  * Sentinel-oracle allowlist (csv). Security-critical, and empty by default.
  *
  * `Consensus.proposeOracleTransaction` is permissionless and takes the oracle
@@ -100,3 +109,30 @@ export const BLOCK_ESTIMATE_MAX_REFINEMENTS = 2
  * every head-relative read into two.
  */
 export const PROVIDER_BATCH_MAX_COUNT = 3
+
+// --- Polling tuning -------------------------------------------------------
+
+/** Poll interval before the deadline block. */
+export const POLL_INTERVAL_FAST_MS = 6_000
+
+/** Poll interval in the post-deadline late window (a late BENIGN can still land). */
+export const POLL_INTERVAL_LATE_MS = 30_000
+
+/**
+ * How many blocks past the deadline the reader keeps polling before giving up.
+ * ~1h at Gnosis' ~5s block time, so a late attestation replacing a TIMED_OUT
+ * verdict has time to materialize.
+ */
+export const LATE_WINDOW_BLOCKS = 720
+
+/**
+ * Deadline substitute for checks that never get an on-chain deadline — the
+ * plain (non-oracle) path emits no `NewRequest`, so `deadlineBlock` is null
+ * for everything live beta produces. An attestation is expected within this
+ * many blocks of the check's first observed event (~20 min at Gnosis cadence;
+ * beta attests within ~5 blocks). Past it the late window applies, then
+ * polling stops — without this, a proposed-but-never-attested check (a
+ * rejected transaction, on the plain path) would poll a public RPC at the
+ * fast interval forever, once per rendered row.
+ */
+export const PLAIN_DEADLINE_BLOCKS = 240

--- a/packages/utils/src/features/safenet-checks/services/__tests__/rpcEndpoint.ts
+++ b/packages/utils/src/features/safenet-checks/services/__tests__/rpcEndpoint.ts
@@ -1,4 +1,6 @@
 import { http, HttpResponse } from 'msw'
+import { Interface } from 'ethers'
+import { CONSENSUS_READ_ABI, COORDINATOR_READ_ABI } from '../../abi'
 import type { RawLog } from '../../utils/decodeLogs'
 
 /**
@@ -29,9 +31,18 @@ export type RpcConfig = {
    */
   failBlockProbes?: 'null' | 'error'
   failEverything?: boolean
+  /** `getEpochGroupId(epoch)` result. */
+  epochGroupId?: string
+  /** `coordinator.groupKey(gid)` result. */
+  groupKey?: { x: string; y: string }
+  /** `groupKey` calls revert (an epoch the coordinator has not seen). */
+  failGroupKey?: boolean
 }
 
 const hexToNum = (value: string): number => Number(BigInt(value))
+
+const consensusRead = new Interface([...CONSENSUS_READ_ABI])
+const coordinatorRead = new Interface([...COORDINATOR_READ_ABI])
 
 const filterLogs = (logs: RawLog[], filter: GetLogsFilter): RawLog[] => {
   const topic0s = (Array.isArray(filter.topics[0]) ? filter.topics[0] : [filter.topics[0]]) as string[]
@@ -114,6 +125,21 @@ export const makeEndpoint = (config: RpcConfig) => {
             removed: false,
           })),
         )
+      }
+      case 'eth_call': {
+        const call = req.params[0] as { to: string; data: string }
+        const selector = call.data.slice(0, 10)
+        if (selector === consensusRead.getFunction('getEpochGroupId')!.selector) {
+          return ok(
+            consensusRead.encodeFunctionResult('getEpochGroupId', [config.epochGroupId ?? '0x' + '00'.repeat(32)]),
+          )
+        }
+        if (selector === coordinatorRead.getFunction('groupKey')!.selector) {
+          if (config.failGroupKey) return err('group key not ready')
+          const gk = config.groupKey ?? { x: '1', y: '2' }
+          return ok(coordinatorRead.encodeFunctionResult('groupKey', [[BigInt(gk.x), BigInt(gk.y)]]))
+        }
+        return err('unexpected eth_call')
       }
       default:
         return err(`unhandled ${req.method}`)

--- a/packages/utils/src/features/safenet-checks/services/__tests__/safenetReader.integration.test.ts
+++ b/packages/utils/src/features/safenet-checks/services/__tests__/safenetReader.integration.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { SafenetReader } from '../safenetReader'
+import { AttestationVerificationStatus, CheckEventType, type Hex, type OracleAttestedEvent } from '../../types'
+
+/**
+ * Opt-in integration spec — runs only under `yarn test:integration` against a
+ * live Safenet network. Point it at the devnet (repo-HEAD V2 + real validators +
+ * AlwaysApproveOracle) so the real-FROST green path can be exercised:
+ *
+ *   SAFENET_IT_RPC=http://127.0.0.1:8547 SAFENET_IT_CHAIN_ID=31337 \
+ *     yarn workspace @safe-global/utils test:integration
+ *
+ * Consensus / coordinator addresses and the single-entry oracle allowlist default
+ * to the checked-in devnet golden vector but can be overridden with
+ * SAFENET_CONSENSUS / SAFENET_COORDINATOR / SAFENET_ORACLE (e.g. the
+ * SENTINEL_ORACLE_V2 emitter for log correlation).
+ * Precondition: `make devnet-up`.
+ */
+type Golden = {
+  chainId: string
+  consensus: string
+  coordinator: string
+  oracle: string
+  epoch: string
+  safeTxHash: Hex
+  requestId: Hex
+  signatureId: Hex
+  groupKey: { x: string; y: string }
+  r: { x: string; y: string }
+  z: string
+}
+
+const golden: Golden = JSON.parse(
+  readFileSync(join(__dirname, '../../__fixtures__/devnet-attestation.golden.json'), 'utf8'),
+)
+
+// `|| undefined` so an empty string (a common way to "unset" in CI) still skips.
+const RPC = process.env.SAFENET_IT_RPC || undefined
+
+const goldenAttested = (): OracleAttestedEvent => ({
+  blockNumber: 0,
+  logIndex: 0,
+  transactionHash: '0x' + '00'.repeat(32),
+  generation: 'STABLE' as OracleAttestedEvent['generation'],
+  type: CheckEventType.ORACLE_ATTESTED,
+  safeTxHash: golden.safeTxHash,
+  chainId: golden.chainId,
+  safe: golden.oracle,
+  epoch: golden.epoch,
+  oracle: golden.oracle,
+  signatureId: golden.signatureId,
+  attestation: { r: { x: golden.r.x, y: golden.r.y }, z: golden.z },
+})
+
+const makeReader = () =>
+  new SafenetReader({
+    rpcUrls: [RPC as string],
+    chainId: process.env.SAFENET_IT_CHAIN_ID ?? golden.chainId,
+    consensus: process.env.SAFENET_CONSENSUS ?? golden.consensus,
+    coordinator: process.env.SAFENET_COORDINATOR ?? golden.coordinator,
+    oracles: [process.env.SAFENET_ORACLE ?? golden.oracle],
+  })
+
+if (!RPC) {
+  describe('SafenetReader integration (skipped)', () => {
+    it('requires SAFENET_IT_RPC — set it to run against a live network', () => {
+      console.warn(
+        '[safenet integration] SAFENET_IT_RPC unset — skipping live checks. Run:\n' +
+          '  SAFENET_IT_RPC=http://127.0.0.1:8547 SAFENET_IT_CHAIN_ID=31337 ' +
+          'yarn workspace @safe-global/utils test:integration',
+      )
+      expect(RPC).toBeUndefined()
+    })
+  })
+} else {
+  describe('SafenetReader integration — live devnet', () => {
+    jest.setTimeout(30_000)
+
+    it('loads the epoch group public key live and matches the golden vector', async () => {
+      const key = await makeReader().loadGroupKey(golden.epoch)
+      expect(key).toEqual(golden.groupKey)
+    })
+
+    it('verifies the real FROST attestation against the live group key (VERIFIED)', async () => {
+      const result = await makeReader().verifyAttestation(goldenAttested())
+      expect(result.status).toBe(AttestationVerificationStatus.VERIFIED)
+    })
+
+    it('derives the same requestId from the on-chain Proposed event (when in lookback range)', async () => {
+      const read = await makeReader().fetchCheckState(golden.safeTxHash)
+      const proposed = read.events.find((event) => event.type === CheckEventType.ORACLE_PROPOSED)
+      if (!proposed) {
+        console.warn('[safenet integration] Proposed event outside the lookback window — skipping requestId equality')
+        return
+      }
+      expect(read.requestId).toBe(golden.requestId)
+    })
+  })
+}

--- a/packages/utils/src/features/safenet-checks/services/__tests__/safenetReader.test.ts
+++ b/packages/utils/src/features/safenet-checks/services/__tests__/safenetReader.test.ts
@@ -31,6 +31,7 @@ const makeReader = (over: Partial<SafenetReaderConfig> = {}, url = 'http://rpc.t
     rpcUrls: [url],
     chainId: CHAIN_ID,
     consensus: CONSENSUS,
+    coordinator: ORACLE,
     oracles: [],
     ...over,
   })
@@ -144,6 +145,7 @@ describe('SafenetReader.fetchCheckState', () => {
       rpcUrls: ['http://rpc.test/1', 'http://rpc.test/2'],
       chainId: CHAIN_ID,
       consensus: CONSENSUS,
+      coordinator: ORACLE,
       oracles: [],
     })
     const result = await reader.fetchCheckState(SAFE_TX_HASH)
@@ -164,6 +166,7 @@ describe('SafenetReader.fetchCheckState', () => {
       rpcUrls: ['http://rpc.test/1', 'http://rpc.test/2', 'http://rpc.test/3'],
       chainId: CHAIN_ID,
       consensus: CONSENSUS,
+      coordinator: ORACLE,
       oracles: [],
     })
     const results = await Promise.all([

--- a/packages/utils/src/features/safenet-checks/services/__tests__/verifyAttestation.test.ts
+++ b/packages/utils/src/features/safenet-checks/services/__tests__/verifyAttestation.test.ts
@@ -1,0 +1,222 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { setupServer, type SetupServerApi } from 'msw/node'
+import { SafenetReader } from '../safenetReader'
+import { attestedEvent, plainAttestedEvent } from '../../builders/checkEvents'
+import { plainProposalHash } from '../../utils/oracleProposalHash'
+import { AttestationVerificationStatus, type Hex } from '../../types'
+import { makeEndpoint, type RpcConfig } from './rpcEndpoint'
+
+type Golden = {
+  chainId: string
+  consensus: string
+  coordinator: string
+  oracle?: string
+  epoch: string
+  safeTxHash: Hex
+  requestId?: Hex
+  signatureId: Hex
+  groupId: Hex
+  groupKey: { x: string; y: string }
+  r: { x: string; y: string }
+  z: string
+}
+
+/** Real oracle-path attestation captured from the devnet (AlwaysApproveOracle). */
+const devnet: Golden = JSON.parse(
+  readFileSync(join(__dirname, '../../__fixtures__/devnet-attestation.golden.json'), 'utf8'),
+)
+
+/** Real non-oracle attestation captured from Gnosis mainnet beta — the only path live beta emits. */
+const gnosis: Golden = JSON.parse(
+  readFileSync(join(__dirname, '../../__fixtures__/gnosis-plain-attestation.golden.json'), 'utf8'),
+)
+
+let server: SetupServerApi
+afterEach(() => server?.close())
+
+const readerForGolden = (golden: Golden, over: Partial<RpcConfig> = {}) => {
+  const endpoint = makeEndpoint({
+    url: 'http://rpc.test/g',
+    chainId: golden.chainId,
+    epochGroupId: golden.groupId,
+    groupKey: golden.groupKey,
+    ...over,
+  })
+  server = setupServer(endpoint.handler)
+  server.listen()
+  const reader = new SafenetReader({
+    rpcUrls: ['http://rpc.test/g'],
+    chainId: golden.chainId,
+    consensus: golden.consensus,
+    coordinator: golden.coordinator,
+    oracles: golden.oracle ? [golden.oracle] : [],
+  })
+  return { reader, endpoint }
+}
+
+const devnetAttested = () =>
+  attestedEvent({
+    safeTxHash: devnet.safeTxHash,
+    epoch: devnet.epoch,
+    oracle: devnet.oracle,
+    signatureId: devnet.signatureId,
+    attestation: { r: { x: devnet.r.x, y: devnet.r.y }, z: devnet.z },
+  })
+
+describe('SafenetReader.verifyAttestation — oracle path (devnet golden)', () => {
+  it('resolves VERIFIED for the real devnet attestation (getEpochGroupId → groupKey → FROST)', async () => {
+    const { reader } = readerForGolden(devnet)
+    const result = await reader.verifyAttestation(devnetAttested())
+    expect(result).toEqual({
+      status: AttestationVerificationStatus.VERIFIED,
+      signatureId: devnet.signatureId,
+      message: devnet.requestId,
+    })
+  })
+
+  it('resolves PENDING (retryable) when the group key cannot be fetched', async () => {
+    const { reader } = readerForGolden(devnet, { failGroupKey: true })
+    const result = await reader.verifyAttestation(devnetAttested())
+    expect(result.status).toBe(AttestationVerificationStatus.PENDING)
+  })
+
+  it('rotates past an endpoint whose eth_call errors without revert data', async () => {
+    // ethers turns every JSON-RPC error on an eth_call into a CALL_EXCEPTION.
+    // Without revert data that may just be a rate limit or pruned state on one
+    // endpoint, so it must rotate to the next URL, and only a revert carrying
+    // data may short-circuit the rotation.
+    const broken = makeEndpoint({
+      url: 'http://rpc.test/broken',
+      chainId: devnet.chainId,
+      epochGroupId: devnet.groupId,
+      failGroupKey: true,
+    })
+    const healthy = makeEndpoint({
+      url: 'http://rpc.test/healthy',
+      chainId: devnet.chainId,
+      epochGroupId: devnet.groupId,
+      groupKey: devnet.groupKey,
+    })
+    server = setupServer(broken.handler, healthy.handler)
+    server.listen()
+    const reader = new SafenetReader({
+      rpcUrls: ['http://rpc.test/broken', 'http://rpc.test/healthy'],
+      chainId: devnet.chainId,
+      consensus: devnet.consensus,
+      coordinator: devnet.coordinator,
+      oracles: devnet.oracle ? [devnet.oracle] : [],
+    })
+
+    const result = await reader.verifyAttestation(devnetAttested())
+
+    expect(result.status).toBe(AttestationVerificationStatus.VERIFIED)
+    expect(healthy.methods.filter((method) => method === 'eth_call').length).toBeGreaterThan(0)
+  })
+
+  it('resolves INVALID (terminal) when the signature does not verify against the group key', async () => {
+    // A wrong-but-VALID curve point (another epoch's real key) — an off-curve
+    // tamper would be rejected as PENDING by the on-curve gate instead.
+    const { reader } = readerForGolden(devnet, { groupKey: gnosis.groupKey })
+    const result = await reader.verifyAttestation(devnetAttested())
+    expect(result.status).toBe(AttestationVerificationStatus.INVALID)
+  })
+
+  it('caches the group key by epoch — a second verify does no further eth_call', async () => {
+    const { reader, endpoint } = readerForGolden(devnet)
+    await reader.verifyAttestation(devnetAttested())
+    const callsAfterFirst = endpoint.methods.filter((m) => m === 'eth_call').length
+    expect(callsAfterFirst).toBeGreaterThan(0)
+    await reader.verifyAttestation(devnetAttested())
+    const callsAfterSecond = endpoint.methods.filter((m) => m === 'eth_call').length
+    expect(callsAfterSecond).toBe(callsAfterFirst)
+  })
+
+  it('keys the cache by EPOCH — a different epoch triggers its own fetch', async () => {
+    // A single-slot cache (ignoring the key) would serve epoch N's key for
+    // epoch N+1 and terminalize valid attestations after a key rotation.
+    const { reader, endpoint } = readerForGolden(devnet)
+    await reader.verifyAttestation(devnetAttested())
+    const callsAfterFirst = endpoint.methods.filter((m) => m === 'eth_call').length
+    await reader.verifyAttestation(attestedEvent({ ...devnetAttested(), epoch: '999' }))
+    const callsAfterOtherEpoch = endpoint.methods.filter((m) => m === 'eth_call').length
+    expect(callsAfterOtherEpoch).toBeGreaterThan(callsAfterFirst)
+  })
+
+  it('does not cache a failed group-key fetch — a later verify retries the chain', async () => {
+    const { reader, endpoint } = readerForGolden(devnet, { failGroupKey: true })
+    await reader.verifyAttestation(devnetAttested())
+    const callsAfterFailure = endpoint.methods.filter((m) => m === 'eth_call').length
+    await reader.verifyAttestation(devnetAttested())
+    const callsAfterRetry = endpoint.methods.filter((m) => m === 'eth_call').length
+    expect(callsAfterRetry).toBeGreaterThan(callsAfterFailure)
+  })
+
+  it('treats an off-curve group key as retryable PENDING — never terminal, never cached', async () => {
+    // A corrupt-but-decodable eth_call response must not become a cached key
+    // that terminalizes every attestation in the epoch as INVALID.
+    const { reader, endpoint } = readerForGolden(devnet, { groupKey: { x: '1', y: '1' } })
+    const first = await reader.verifyAttestation(devnetAttested())
+    expect(first.status).toBe(AttestationVerificationStatus.PENDING)
+    const callsAfterFirst = endpoint.methods.filter((m) => m === 'eth_call').length
+    const second = await reader.verifyAttestation(devnetAttested())
+    expect(second.status).toBe(AttestationVerificationStatus.PENDING)
+    expect(endpoint.methods.filter((m) => m === 'eth_call').length).toBeGreaterThan(callsAfterFirst)
+  })
+})
+
+describe('SafenetReader.verifyAttestation — non-oracle path (live Gnosis beta golden)', () => {
+  it('derives the PLAIN preimage for a TransactionAttested and verifies the live capture', async () => {
+    // The two paths sign different EIP-712 preimages; live beta only emits this
+    // one. The domain chainId is the Safenet chain (100), NOT the event's Safe
+    // chain (42161 here) — crossing them fails verification.
+    const { reader } = readerForGolden(gnosis)
+    const result = await reader.verifyAttestation(
+      plainAttestedEvent({
+        safeTxHash: gnosis.safeTxHash,
+        epoch: gnosis.epoch,
+        signatureId: gnosis.signatureId,
+        attestation: { r: { x: gnosis.r.x, y: gnosis.r.y }, z: gnosis.z },
+      }),
+    )
+    expect(result).toEqual({
+      status: AttestationVerificationStatus.VERIFIED,
+      signatureId: gnosis.signatureId,
+      message: plainProposalHash({
+        chainId: gnosis.chainId,
+        consensus: gnosis.consensus,
+        epoch: gnosis.epoch,
+        safeTxHash: gnosis.safeTxHash,
+      }),
+    })
+  })
+})
+
+describe('SafenetReader.blockTimeMs', () => {
+  it('returns the block timestamp in milliseconds', async () => {
+    // head 1,000 at t=1,000,000s with 5s blocks → block 900 is 500s earlier.
+    const { reader } = readerForGolden(gnosis, { head: 1_000, headTimestamp: 1_000_000 })
+
+    expect(await reader.blockTimeMs(900)).toBe(999_500_000)
+  })
+
+  it('costs exactly one header read — the audit-log date is not worth a second', async () => {
+    const { reader, endpoint } = readerForGolden(gnosis, { head: 1_000, headTimestamp: 1_000_000 })
+
+    await reader.blockTimeMs(900)
+
+    expect(endpoint.methods.filter((method) => method === 'eth_getBlockByNumber')).toHaveLength(1)
+  })
+
+  it('degrades to null rather than failing a read whose verdict already verified', async () => {
+    const { reader } = readerForGolden(gnosis, { head: 1_000, failBlockProbes: 'error' })
+
+    expect(await reader.blockTimeMs(900)).toBeNull()
+  })
+
+  it('returns null when no endpoint can serve the header', async () => {
+    const { reader } = readerForGolden(gnosis, { head: 1_000, failBlockProbes: 'null' })
+
+    expect(await reader.blockTimeMs(900)).toBeNull()
+  })
+})

--- a/packages/utils/src/features/safenet-checks/services/safenetReader.ts
+++ b/packages/utils/src/features/safenet-checks/services/safenetReader.ts
@@ -1,5 +1,5 @@
-import { JsonRpcProvider } from 'ethers'
-import { CONSENSUS_TOPIC0S, SENTINEL_TOPIC0S } from '../abi'
+import { Contract, isCallException, JsonRpcProvider } from 'ethers'
+import { CONSENSUS_READ_ABI, CONSENSUS_TOPIC0S, COORDINATOR_READ_ABI, SENTINEL_TOPIC0S } from '../abi'
 import {
   BLOCK_ESTIMATE_MAX_REFINEMENTS,
   BLOCK_ESTIMATE_TOLERANCE_SECONDS,
@@ -9,20 +9,26 @@ import {
   PROVIDER_BATCH_MAX_COUNT,
   SAFENET_CHAIN_ID,
   SAFENET_CONSENSUS_ADDRESS,
+  SAFENET_COORDINATOR_ADDRESS,
   SAFENET_ORACLE_ADDRESSES,
   SAFENET_RPC_URLS,
   TARGETED_WINDOW_BACK_BLOCKS,
 } from '../constants'
 import {
+  AttestationVerificationStatus,
   CheckEventType,
   OracleGeneration,
+  type AttestationVerification,
   type Hex,
   type NormalizedCheckEvent,
+  type OracleAttestedEvent,
   type OracleProposedEvent,
+  type PlainAttestedEvent,
 } from '../types'
 import { decodeLogs, type RawLog } from '../utils/decodeLogs'
 import { deadlineBlockOf } from '../utils/deriveCheckState'
-import { oracleProposalHash } from '../utils/oracleProposalHash'
+import { isValidPoint, verifyAttestation as verifyFrostAttestation } from '../utils/frost'
+import { oracleProposalHash, plainProposalHash } from '../utils/oracleProposalHash'
 
 /**
  * Everything one poll reads off-chain for a single check, before the query layer
@@ -68,6 +74,8 @@ export type SafenetReaderConfig = {
   /** Feeds BOTH the provider network AND the EIP-712 request-id domain. */
   chainId: string
   consensus: string
+  /** FROSTCoordinator the epoch group keys are read from. */
+  coordinator: string
   /** Allowlisted sentinel-oracle addresses. Empty = the oracle path is skipped. */
   oracles: string[]
 }
@@ -77,6 +85,7 @@ export const readerConfigFromEnv = (): SafenetReaderConfig => ({
   rpcUrls: SAFENET_RPC_URLS,
   chainId: SAFENET_CHAIN_ID,
   consensus: SAFENET_CONSENSUS_ADDRESS,
+  coordinator: SAFENET_COORDINATOR_ADDRESS,
   oracles: SAFENET_ORACLE_ADDRESSES,
 })
 
@@ -107,24 +116,28 @@ const chunkRanges = (from: number, to: number, size: number): Array<[number, num
 }
 
 /**
- * Chain reader for a check's Safenet lifecycle. Owns a pinned-endpoint provider,
- * rotated on failure. Construct with {@link readerConfigFromEnv} in production;
- * pass an explicit config in tests.
+ * Chain reader for a check's Safenet lifecycle. Owns a pinned-endpoint provider
+ * (rotated on failure) and a per-epoch FROST group-key cache. Construct with
+ * {@link readerConfigFromEnv} in production; pass an explicit config in tests.
  */
 export class SafenetReader {
   private readonly rpcUrls: string[]
   private readonly chainId: string
   private readonly consensus: string
+  private readonly coordinator: string
   private readonly oracles: readonly string[]
 
   private urlIndex = 0
   private currentProvider: JsonRpcProvider | null = null
   private chainIdChecked = false
+  /** Epoch → FROST group public key. The binding is immutable once staged. */
+  private readonly groupKeyCache = new Map<string, { x: string; y: string }>()
 
   constructor(config: SafenetReaderConfig) {
     this.rpcUrls = config.rpcUrls
     this.chainId = config.chainId
     this.consensus = config.consensus
+    this.coordinator = config.coordinator
     this.oracles = config.oracles.map((address) => address.toLowerCase())
   }
 
@@ -164,6 +177,14 @@ export class SafenetReader {
         return await op(provider)
       } catch (error) {
         lastError = error
+        // A deterministic contract revert (e.g. `groupKey` for an epoch the
+        // coordinator has not seen) is not an endpoint failure. Rotating and
+        // retrying every URL would repeat it N times and tear down the shared
+        // provider under concurrent reads. Only revert DATA proves a revert,
+        // though: ethers turns every JSON-RPC error on an eth_call into a
+        // CALL_EXCEPTION, so a data-less one may just be a rate limit or pruned
+        // state on this endpoint, and the next endpoint deserves a try.
+        if (isCallException(error) && error.data != null) throw error
         this.rotate(provider)
       }
     }
@@ -428,6 +449,105 @@ export class SafenetReader {
         deadlineBlock: deadline === null ? null : deadline.toString(),
       }
     })
+  }
+
+  /**
+   * Resolve an epoch's FROST group public key: `getEpochGroupId(epoch)` →
+   * `coordinator.groupKey(groupId)`. Cached by epoch — the epoch→group binding
+   * is immutable once staged. Throws on RPC failure (including an epoch the
+   * coordinator has not seen yet: `groupKey` reverts rather than returning
+   * zeros) AND on an off-curve response, so {@link verifyAttestation} can treat
+   * both as retryable (`PENDING`) — a corrupt response from a flaky endpoint
+   * must never be cached, where it would terminalize every attestation in the
+   * epoch as INVALID.
+   */
+  async loadGroupKey(epoch: string): Promise<{ x: string; y: string }> {
+    const cached = this.groupKeyCache.get(epoch)
+    if (cached) return cached
+    // Derived OUTSIDE the provider op: a malformed epoch is not an endpoint
+    // failure and must not burn a rotation through the URL list.
+    const epochValue = BigInt(epoch)
+
+    return this.withProvider(async (provider) => {
+      const consensus = new Contract(this.consensus, [...CONSENSUS_READ_ABI], provider)
+      const groupId: string = await consensus.getEpochGroupId(epochValue)
+      const coordinator = new Contract(this.coordinator, [...COORDINATOR_READ_ABI], provider)
+      const key = await coordinator.groupKey(groupId)
+      const point = { x: key.x.toString(), y: key.y.toString() }
+      if (!isValidPoint(point)) {
+        throw new Error(`Safenet reader: coordinator returned an off-curve group key for epoch ${epoch}`)
+      }
+      this.groupKeyCache.set(epoch, point)
+      return point
+    })
+  }
+
+  /**
+   * Verify an attested event's FROST signature against its epoch group key.
+   * A group-key fetch failure is retryable (`PENDING`); a signature that does
+   * not verify is terminal (`INVALID`) and must never render as BENIGN.
+   * Deliberately uncached: once the epoch's group key is cached, a re-verify
+   * is a pure local computation.
+   */
+  async verifyAttestation(attested: OracleAttestedEvent | PlainAttestedEvent): Promise<AttestationVerification> {
+    // The two paths sign different EIP-712 preimages. Deriving it here, from the
+    // event we actually decoded, is the only place that knows which is which —
+    // callers cannot pair the wrong hash with the wrong attestation.
+    const message =
+      attested.type === CheckEventType.ORACLE_ATTESTED
+        ? oracleProposalHash({
+            chainId: this.chainId,
+            consensus: this.consensus,
+            epoch: attested.epoch,
+            oracle: attested.oracle,
+            safeTxHash: attested.safeTxHash,
+          })
+        : plainProposalHash({
+            chainId: this.chainId,
+            consensus: this.consensus,
+            epoch: attested.epoch,
+            safeTxHash: attested.safeTxHash,
+          })
+
+    let groupKey: { x: string; y: string }
+    try {
+      groupKey = await this.loadGroupKey(attested.epoch)
+    } catch {
+      return { status: AttestationVerificationStatus.PENDING, signatureId: attested.signatureId, message }
+    }
+
+    const verified = verifyFrostAttestation({ groupKey, attestation: attested.attestation, message })
+    return {
+      status: verified ? AttestationVerificationStatus.VERIFIED : AttestationVerificationStatus.INVALID,
+      signatureId: attested.signatureId,
+      message,
+    }
+  }
+
+  /**
+   * Wall-clock time of a block in milliseconds. Used to date the attestation in
+   * the audit log.
+   *
+   * `eth_getLogs` responses carry no timestamps, so this is a separate header
+   * read. Call it only once a check has an attestation. The value cannot change
+   * afterwards and polling stops at that point, so it costs one extra RPC per
+   * settled check rather than one per poll.
+   *
+   * Returns `null` on failure. A missing date leaves one column of the audit log
+   * empty, which is a smaller cost than failing a read whose verdict verified.
+   */
+  async blockTimeMs(blockNumber: number): Promise<number | null> {
+    try {
+      return await this.withProvider(async (provider) => {
+        const block = await provider.getBlock(blockNumber)
+        // Thrown so the failure reaches withProvider: a header this endpoint
+        // cannot serve may still be served by the next one.
+        if (!block) throw new Error(`Safenet reader: no header for block ${blockNumber}`)
+        return block.timestamp * 1000
+      })
+    } catch {
+      return null
+    }
   }
 }
 

--- a/packages/utils/src/features/safenet-checks/utils/__tests__/computePollingInterval.test.ts
+++ b/packages/utils/src/features/safenet-checks/utils/__tests__/computePollingInterval.test.ts
@@ -1,0 +1,219 @@
+import { computePollingInterval } from '../computePollingInterval'
+import {
+  LATE_WINDOW_BLOCKS,
+  PLAIN_DEADLINE_BLOCKS,
+  POLL_INTERVAL_FAST_MS,
+  POLL_INTERVAL_LATE_MS,
+} from '../../constants'
+import { CheckStatus } from '../../types'
+
+describe('computePollingInterval', () => {
+  it.each([CheckStatus.BENIGN, CheckStatus.MALICIOUS, CheckStatus.VERIFICATION_FAILED])(
+    'stops polling on the terminal status %s',
+    (status) => {
+      expect(computePollingInterval({ status, headBlock: '10', deadlineBlock: '150', firstEventBlock: '100' })).toBe(0)
+    },
+  )
+
+  it('stops polling on UNAVAILABLE (a row with no check must not poll forever)', () => {
+    expect(
+      computePollingInterval({
+        status: CheckStatus.UNAVAILABLE,
+        headBlock: null,
+        deadlineBlock: null,
+        firstEventBlock: null,
+      }),
+    ).toBe(0)
+  })
+
+  it('polls fast before the deadline', () => {
+    expect(
+      computePollingInterval({
+        status: CheckStatus.IN_PROGRESS,
+        headBlock: '140',
+        deadlineBlock: '150',
+        firstEventBlock: '100',
+      }),
+    ).toBe(POLL_INTERVAL_FAST_MS)
+  })
+
+  it('polls fast at head == deadline (still in-window)', () => {
+    expect(
+      computePollingInterval({
+        status: CheckStatus.IN_PROGRESS,
+        headBlock: '150',
+        deadlineBlock: '150',
+        firstEventBlock: '100',
+      }),
+    ).toBe(POLL_INTERVAL_FAST_MS)
+  })
+
+  it('drops to the late interval at head == deadline + 1 (first out-of-window block)', () => {
+    expect(
+      computePollingInterval({
+        status: CheckStatus.TIMED_OUT,
+        headBlock: '151',
+        deadlineBlock: '150',
+        firstEventBlock: '100',
+      }),
+    ).toBe(POLL_INTERVAL_LATE_MS)
+  })
+
+  it('polls fast when the head is unknown, even with a deadline on record', () => {
+    // The arithmetic needs both sides. A missing head fails open to fast,
+    // and must not be read as "past the deadline".
+    expect(
+      computePollingInterval({
+        status: CheckStatus.IN_PROGRESS,
+        headBlock: null,
+        deadlineBlock: '150',
+        firstEventBlock: '100',
+      }),
+    ).toBe(POLL_INTERVAL_FAST_MS)
+  })
+
+  it('polls fast on a pinned TIMED_OUT whose re-read lost both anchors', () => {
+    // A transient empty read nulls the anchors while the pin keeps the status.
+    // Failing open keeps the late-BENIGN upgrade reachable.
+    expect(
+      computePollingInterval({
+        status: CheckStatus.TIMED_OUT,
+        headBlock: '10000',
+        deadlineBlock: null,
+        firstEventBlock: null,
+      }),
+    ).toBe(POLL_INTERVAL_FAST_MS)
+  })
+
+  it('polls fast when nothing anchors a deadline yet (first read not landed)', () => {
+    expect(
+      computePollingInterval({
+        status: CheckStatus.SUBMITTED,
+        headBlock: '140',
+        deadlineBlock: null,
+        firstEventBlock: null,
+      }),
+    ).toBe(POLL_INTERVAL_FAST_MS)
+  })
+
+  it('polls slowly in the post-deadline late window (a late BENIGN can still land)', () => {
+    expect(
+      computePollingInterval({
+        status: CheckStatus.TIMED_OUT,
+        headBlock: '200',
+        deadlineBlock: '150',
+        firstEventBlock: '100',
+      }),
+    ).toBe(POLL_INTERVAL_LATE_MS)
+  })
+
+  it('polls slowly right up to the end of the late window', () => {
+    const deadline = 150
+    const head = deadline + LATE_WINDOW_BLOCKS
+    expect(
+      computePollingInterval({
+        status: CheckStatus.TIMED_OUT,
+        headBlock: String(head),
+        deadlineBlock: String(deadline),
+        firstEventBlock: '100',
+      }),
+    ).toBe(POLL_INTERVAL_LATE_MS)
+  })
+
+  it('stops once the late window closes', () => {
+    const deadline = 150
+    const head = deadline + LATE_WINDOW_BLOCKS + 1
+    expect(
+      computePollingInterval({
+        status: CheckStatus.TIMED_OUT,
+        headBlock: String(head),
+        deadlineBlock: String(deadline),
+        firstEventBlock: '100',
+      }),
+    ).toBe(0)
+  })
+
+  describe('plain path — no on-chain deadline, first event anchors the window', () => {
+    const first = 1_000
+
+    it('polls fast within PLAIN_DEADLINE_BLOCKS of the first event', () => {
+      expect(
+        computePollingInterval({
+          status: CheckStatus.SUBMITTED,
+          headBlock: String(first + PLAIN_DEADLINE_BLOCKS),
+          deadlineBlock: null,
+          firstEventBlock: String(first),
+        }),
+      ).toBe(POLL_INTERVAL_FAST_MS)
+    })
+
+    it('drops to the late interval past the substitute deadline', () => {
+      expect(
+        computePollingInterval({
+          status: CheckStatus.SUBMITTED,
+          headBlock: String(first + PLAIN_DEADLINE_BLOCKS + 1),
+          deadlineBlock: null,
+          firstEventBlock: String(first),
+        }),
+      ).toBe(POLL_INTERVAL_LATE_MS)
+    })
+
+    it('still polls slowly at the last block of the late window (inclusive close)', () => {
+      expect(
+        computePollingInterval({
+          status: CheckStatus.SUBMITTED,
+          headBlock: String(first + PLAIN_DEADLINE_BLOCKS + LATE_WINDOW_BLOCKS),
+          deadlineBlock: null,
+          firstEventBlock: String(first),
+        }),
+      ).toBe(POLL_INTERVAL_LATE_MS)
+    })
+
+    it('stops once the late window closes — a never-attested check must not poll forever', () => {
+      expect(
+        computePollingInterval({
+          status: CheckStatus.SUBMITTED,
+          headBlock: String(first + PLAIN_DEADLINE_BLOCKS + LATE_WINDOW_BLOCKS + 1),
+          deadlineBlock: null,
+          firstEventBlock: String(first),
+        }),
+      ).toBe(0)
+    })
+
+    it('an on-chain deadline wins over the substitute', () => {
+      // Deadline far beyond the substitute window: still fast.
+      expect(
+        computePollingInterval({
+          status: CheckStatus.IN_PROGRESS,
+          headBlock: String(first + PLAIN_DEADLINE_BLOCKS + LATE_WINDOW_BLOCKS + 100),
+          deadlineBlock: String(first + 10_000),
+          firstEventBlock: String(first),
+        }),
+      ).toBe(POLL_INTERVAL_FAST_MS)
+    })
+  })
+
+  describe('AWAITING_VERIFICATION — the status a PENDING verification produces', () => {
+    it('keeps polling fast before the deadline (the group key can still arrive)', () => {
+      expect(
+        computePollingInterval({
+          status: CheckStatus.AWAITING_VERIFICATION,
+          headBlock: '140',
+          deadlineBlock: '150',
+          firstEventBlock: '100',
+        }),
+      ).toBe(POLL_INTERVAL_FAST_MS)
+    })
+
+    it('keeps polling slowly through the late window', () => {
+      expect(
+        computePollingInterval({
+          status: CheckStatus.AWAITING_VERIFICATION,
+          headBlock: '200',
+          deadlineBlock: '150',
+          firstEventBlock: '100',
+        }),
+      ).toBe(POLL_INTERVAL_LATE_MS)
+    })
+  })
+})

--- a/packages/utils/src/features/safenet-checks/utils/computePollingInterval.ts
+++ b/packages/utils/src/features/safenet-checks/utils/computePollingInterval.ts
@@ -1,0 +1,63 @@
+import { LATE_WINDOW_BLOCKS, PLAIN_DEADLINE_BLOCKS, POLL_INTERVAL_FAST_MS, POLL_INTERVAL_LATE_MS } from '../constants'
+import { CheckStatus } from '../types'
+
+export type PollingInput = {
+  /**
+   * The merged status (after the monotonic pin), not the raw derivation of a
+   * single read. A transient empty read derives UNAVAILABLE, and feeding that
+   * here would stop polling permanently on a live check.
+   */
+  status: CheckStatus
+  /** Current chain head as a decimal string, or null if unknown. */
+  headBlock: string | null
+  /** The check's deadline block as a decimal string, or null if unknown. */
+  deadlineBlock: string | null
+  /**
+   * Block of the check's earliest observed event, as a decimal string. It
+   * substitutes for the deadline on the plain path, which does not emit one.
+   * Without it, a check that is never attested would poll forever.
+   *
+   * Callers should pass anchors that persist across reads: a transient empty
+   * read nulls both anchors while a pinned status keeps the check live, and
+   * null anchors fail open to the fast interval.
+   */
+  firstEventBlock: string | null
+}
+
+/**
+ * How often to re-poll a check, in ms; `0` = stop (RTK Query's
+ * `pollingInterval` convention).
+ *
+ * Stops permanently on a settled verdict (`BENIGN`, `MALICIOUS`) or terminal
+ * `VERIFICATION_FAILED`. Otherwise polls fast (6s) up to and including the
+ * effective deadline, which is the on-chain deadline block, or
+ * {@link PLAIN_DEADLINE_BLOCKS} past the first observed event when the path has
+ * none. After that it polls slowly (30s) through a ~1h late window, so a late
+ * `BENIGN`/`MALICIOUS` can still replace a `TIMED_OUT`, and stops once the late
+ * window closes. The stop trusts the caller's single head sample. A remount
+ * refetches, so an inflated head from a broken endpoint costs one mount's
+ * late window and cannot change the verdict.
+ */
+export const computePollingInterval = ({ status, headBlock, deadlineBlock, firstEventBlock }: PollingInput): number => {
+  if (status === CheckStatus.BENIGN || status === CheckStatus.MALICIOUS || status === CheckStatus.VERIFICATION_FAILED) {
+    return 0
+  }
+
+  // ponytail: UNAVAILABLE stops immediately instead of backing off. Ceiling: a
+  // check proposed after this read lands is not picked up until the user hits
+  // re-check. Without this, a transaction that never had a check, which is most
+  // of them, polls a public RPC every 6s forever, once per rendered row.
+  if (status === CheckStatus.UNAVAILABLE) return 0
+
+  const head = headBlock !== null ? BigInt(headBlock) : null
+  const deadline =
+    deadlineBlock !== null
+      ? BigInt(deadlineBlock)
+      : firstEventBlock !== null
+        ? BigInt(firstEventBlock) + BigInt(PLAIN_DEADLINE_BLOCKS)
+        : null
+
+  if (deadline === null || head === null || head <= deadline) return POLL_INTERVAL_FAST_MS
+  if (head <= deadline + BigInt(LATE_WINDOW_BLOCKS)) return POLL_INTERVAL_LATE_MS
+  return 0
+}

--- a/packages/utils/src/features/safenet-checks/utils/frost.ts
+++ b/packages/utils/src/features/safenet-checks/utils/frost.ts
@@ -38,6 +38,16 @@ const toPoint = (x: bigint, y: bigint) => {
   return point
 }
 
+/** True when (x, y) parses as a valid, non-identity secp256k1 point. */
+export const isValidPoint = (point: { x: string; y: string }): boolean => {
+  try {
+    toPoint(BigInt(point.x), BigInt(point.y))
+    return true
+  } catch {
+    return false
+  }
+}
+
 export type AttestationInput = {
   /** Epoch group public key, affine coordinates as decimal strings. */
   groupKey: { x: string; y: string }


### PR DESCRIPTION
Third slice of the Safenet read layer, on top of #8448. It adds the part that
makes verdicts trustworthy: client-side FROST verification of attestations,
wired to the chain. It also adds the polling policy the store slice will
consume, and the header read that dates the attestation in the audit log.

## Attestation verification

`loadGroupKey(epoch)` resolves an epoch's FROST group public key on chain:
`Consensus.getEpochGroupId(epoch)` then `FROSTCoordinator.groupKey(groupId)`.
Keys are cached per epoch. The epoch-to-group binding is immutable once staged,
so the cache never needs invalidation.

Two failure classes are kept apart on purpose:

- A key fetch failure, including `groupKey` reverting for an epoch the
  coordinator has not seen, is retryable. `verifyAttestation` maps it to
  `PENDING` and a later poll tries again.
- A signature that does not verify against its group key is terminal:
  `INVALID`, which the status machine renders as a failure and never as BENIGN.

The key is validated on-curve before it is cached. A corrupt but decodable
`eth_call` response from a flaky endpoint therefore stays retryable. Caching it
would mark every attestation in that epoch INVALID for the rest of the session.

`verifyAttestation` derives the EIP-712 preimage from the event it received.
The oracle and plain paths sign different preimages (the oracle one binds the
oracle address and is keyed per request; the plain one is not), and the event
type is the only reliable source of which is which. Deriving it anywhere else
would let a caller pair the wrong hash with the wrong attestation.

`withProvider` gained one guard: a contract revert that carries revert data is
rethrown instead of rotating the endpoint. Rotating on a revert would repeat it
against every URL in the list and tear down the shared provider under
concurrent reads. The guard requires revert data because ethers classifies
every JSON-RPC error on an `eth_call` as a call exception: a data-less one may
just be a rate limit or pruned state on that endpoint, and rotating to the next
URL is the correct response. Without that distinction, an endpoint that serves
logs but errors `eth_call` would pin the group-key fetch to itself and leave
the attestation stuck PENDING on multi-URL configs.

## Polling policy

`computePollingInterval` is a pure function of the check snapshot. It returns
milliseconds, with 0 meaning stop:

- Settled verdict (`BENIGN`, `MALICIOUS`) or terminal `VERIFICATION_FAILED`:
  stop.
- `UNAVAILABLE`: stop. Most transactions never had a check, and each rendered
  row would otherwise poll a public RPC every 6s for the whole session.
- Before the effective deadline: fast (6s).
- After it, for `LATE_WINDOW_BLOCKS` (~1h): slow (30s), so a late attestation
  can still replace a TIMED_OUT verdict.
- After the late window: stop.

The plain path never emits a deadline (`NewRequest` is an oracle-path event),
so `deadlineBlock` is null for everything live beta produces. The effective
deadline substitutes `firstEventBlock + PLAIN_DEADLINE_BLOCKS` (~20min; beta
attests within about 5 blocks). Without the substitute, a proposed check whose
transaction was rejected would poll at the fast interval forever.

## Attestation timestamp

`blockTimeMs(blockNumber)` reads one block header and returns its timestamp in
milliseconds. `eth_getLogs` responses carry no timestamps, so dating the
audit-log step costs one extra read. The store slice calls it only once an
attestation exists, and polling stops at that point, so the cost is one RPC per
settled check. It returns null on failure: a missing date leaves one audit-log
column empty, and must not fail a read whose verdict verified.

## Testing

Verification is pinned by two golden fixtures, both captured from real
networks:

- the devnet oracle-path attestation (AlwaysApproveOracle), and
- a live Gnosis beta plain-path attestation. This is the only path beta emits,
  and it pins the domain subtlety: the EIP-712 domain chainId is the Safenet
  chain (100), while the event carries the Safe's home chain (42161 in the
  fixture). Crossing them fails verification.

The suite covers: VERIFIED on both goldens, PENDING on key-fetch failure with
no caching of the failure, INVALID on a wrong-but-on-curve key, PENDING on an
off-curve key (retryable, never cached), per-epoch cache behavior (one eth_call
pair per epoch), rotation past an endpoint whose `eth_call` errors without
revert data, and the four `blockTimeMs` cases (value, single header read, null
on error, null when no endpoint serves the header).

`computePollingInterval` is boundary-tested: each status short-circuit, both
edges of the deadline and the late window on the explicit-deadline and
substitute paths, the null-head and null-anchor fail-open rows, and the
deadline-over-substitute precedence.

An opt-in integration spec (`yarn test:integration`) runs the same reader
against a live sim or devnet, selected by `SAFENET_IT_RPC`. It is excluded from
the default jest config and from turbo, and self-skips with a clear message
when the env var is unset, so CI never touches a live network.

`yarn workspace @safe-global/utils {test,type-check,lint}` and
`@safe-global/store type-check` pass.
