### PR TITLE
chore(deps): bump safe-deployments to 1.37.62 — 1.5.0 addresses on 32 new chains (WA-2936)

### DIFF
--- a/apps/tx-builder/package.json
+++ b/apps/tx-builder/package.json
@@ -25,7 +25,7 @@
     "@safe-global/safe-apps-provider": "^0.18.6",
     "@safe-global/safe-apps-react-sdk": "^4.7.2",
     "@safe-global/safe-apps-sdk": "^9.1.0",
-    "@safe-global/safe-deployments": "^1.37.61",
+    "@safe-global/safe-deployments": "^1.37.62",
     "@safe-global/safe-gateway-typescript-sdk": "^3.22.9",
     "axios": "^1.18.1",
     "ethereum-blockies-base64": "^1.0.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -80,7 +80,7 @@
     "@safe-global/api-kit": "^5.0.2",
     "@safe-global/protocol-kit": "^8.0.5",
     "@safe-global/safe-apps-sdk": "^9.1.0",
-    "@safe-global/safe-deployments": "^1.37.61",
+    "@safe-global/safe-deployments": "^1.37.62",
     "@safe-global/safe-modules-deployments": "^3.0.9",
     "@safe-global/store": "workspace:^",
     "@safe-global/theme": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13626,12 +13626,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@safe-global/safe-deployments@npm:^1.37.61":
-  version: 1.37.61
-  resolution: "@safe-global/safe-deployments@npm:1.37.61"
+"@safe-global/safe-deployments@npm:^1.37.61, @safe-global/safe-deployments@npm:^1.37.62":
+  version: 1.37.62
+  resolution: "@safe-global/safe-deployments@npm:1.37.62"
   dependencies:
     semver: "npm:^7.6.2"
-  checksum: 10/71331c30b2711b34d054d5a977b6a4a78ccde2b3f654d0f2ab79d133a4493e075fe2cb87920f478dfe9a99a51a906ae2b103b5a7753bd5ec2d9deac9f9d9d823
+  checksum: 10/3a3f8128c0fe0e658b40f9462119159d9c335da4449199d622722f219fac0cc82cf50d2c3a399bbbcc04aa9639bc69418ad9bcb3636efb32b28e1e0183bf1a51
   languageName: node
   linkType: hard
 
@@ -13764,7 +13764,7 @@ __metadata:
     "@safe-global/safe-apps-provider": "npm:^0.18.6"
     "@safe-global/safe-apps-react-sdk": "npm:^4.7.2"
     "@safe-global/safe-apps-sdk": "npm:^9.1.0"
-    "@safe-global/safe-deployments": "npm:^1.37.61"
+    "@safe-global/safe-deployments": "npm:^1.37.62"
     "@safe-global/safe-gateway-typescript-sdk": "npm:^3.22.9"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
@@ -13935,7 +13935,7 @@ __metadata:
     "@safe-global/api-kit": "npm:^5.0.2"
     "@safe-global/protocol-kit": "npm:^8.0.5"
     "@safe-global/safe-apps-sdk": "npm:^9.1.0"
-    "@safe-global/safe-deployments": "npm:^1.37.61"
+    "@safe-global/safe-deployments": "npm:^1.37.62"
     "@safe-global/safe-modules-deployments": "npm:^3.0.9"
     "@safe-global/store": "workspace:^"
     "@safe-global/test": "workspace:^"


### PR DESCRIPTION
## What it solves

Resolves: [WA-2936](https://linear.app/safe-global/issue/WA-2936/second-safe-deployments-bump-pick-up-the-newly-registered-chains)

## How this PR fixes it

Address-only dependency bump — no new ABIs, no contract-type regeneration, no protocol-kit change (unlike the first-round bump in WA-2859 / #8395):

- `apps/web` and `apps/tx-builder`: `@safe-global/safe-deployments` `^1.37.61` → `^1.37.62`
- `yarn.lock`: deduped to a **single entry** so that protocol-kit's own `^1.37.61` range also resolves to 1.37.62 — without the dedupe the lockfile splits into two entries and **mobile (which consumes safe-deployments only transitively via `@safe-global/protocol-kit@8.0.5`) would silently stay on 1.37.61**.

All 13 v1.5.0 assets (`safe` … `safe_to_l2_setup`) were verified present for all 32 chains in 1.37.62.

## How to test it

1. `yarn why @safe-global/safe-deployments` — every consumer (web, tx-builder, protocol-kit) resolves to **1.37.62**; the lockfile has exactly one `@safe-global/safe-deployments` entry.
2. Sanity-check an address, e.g.:
   ```js
   require('@safe-global/safe-deployments').getSafeL2SingletonDeployment({ version: '1.5.0', network: '137' })
   ```
   returns the canonical singleton for Polygon (and likewise for the other WA-2918 chains: 10, 56, 100, 42161, …).
3. CI: regular unit/e2e suites — no behaviour change expected on chains whose `recommendedMasterCopyVersion` config has not been flipped.

## Affected flows

- Safe creation and mastercopy-upgrade flows on the 32 newly registered chains — `getLatestSafeVersion` can return 1.5.0 there **once each chain's config is flipped** (separate rollout ticket); until then behaviour is unchanged.
- Contract-address lookups (singleton, proxy factory, fallback handler, MultiSend, SignMessageLib, `safe_migration`, `safe_to_l2_setup`) on those chains.

## Blast radius

- **web** and **tx-builder**: direct dependency bumped.
- **mobile**: transitive via `@safe-global/protocol-kit@8.0.5` — picks up 1.37.62 through the deduped lockfile entry (this is the easy-to-miss part of the change).
- No API contracts, RTK Query endpoints, feature flags, persistence, or routes touched.
- Rollout gating stays in chain config (`recommendedMasterCopyVersion` / config-service), not in this PR.
- Companion bumps in other services: CGW is bumped to 1.37.62 on the WA-2921 branch; tx-service (`safe-eth-py` 7.23.0 + per-env contract setup) is handled separately.

## Risks / not checked

- Lockfile was updated with `--mode=update-lockfile` (no local install/link step) — relying on CI for install + test validation.
- Did not manually exercise creation/upgrade flows on the new chains; on-chain 1.5.0 support there is not yet config-enabled, so no user-visible change was expected or verified in-app.
- Did not test on mobile.
- Did not independently verify the on-chain bytecode of the newly registered addresses (they are canonical deterministic-deployment addresses, verified upstream in the safe-deployments repo).

## Visual summary

```mermaid
graph LR
    subgraph before dedupe
        W1[web ^1.37.62] --> B[1.37.62]
        T1[tx-builder ^1.37.62] --> B
        PK1[protocol-kit ^1.37.61] --> A[1.37.61 ⚠️ mobile left behind]
    end
    subgraph after dedupe
        W2[web ^1.37.62] --> C[single lockfile entry 1.37.62]
        T2[tx-builder ^1.37.62] --> C
        PK2[protocol-kit ^1.37.61<br/>used by mobile] --> C
    end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — not applicable, dependency bump
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).