### PR TITLE
refactor(safenet): trim read-layer comments and remove dead code

### DIFF
--- a/packages/utils/src/features/safenet-checks/abi.ts
+++ b/packages/utils/src/features/safenet-checks/abi.ts
@@ -2,17 +2,12 @@ import { Interface } from 'ethers'
 import { CheckEventType, OracleGeneration } from './types'
 
 /**
- * Event fragments copied verbatim (field names + types) from the protocol repo:
- *   - Consensus: `explorer/src/lib/consensus/abi.ts` + `validator/src/types/abis.ts`
- *   - V1 sentinel: `contracts/src/libraries/{SentinelOracleRequests,SentinelOracleCommitments}.sol`
- *   - V2 sentinel: `contracts/src/libraries/{SentinelOracleRequestsV2,SentinelOracleCommitmentsV2}.sol`
- *   - Shared: `contracts/src/interfaces/IOracle.sol` + `SentinelOracle(V2).sol`
- *
- * The two generations' `NewRequest`/`Committed` have genuinely different
- * signatures (and therefore different topic0s), which is what lets a single
- * topic0→generation map disambiguate them. `DisputeResolved` and `OracleResult`
- * are identical across generations, so they live in one shared bucket (defining
- * them per-generation would collide on topic0).
+ * Event fragments copied verbatim from the protocol repo (Consensus:
+ * `explorer/src/lib/consensus/abi.ts`; sentinel V1/V2: the
+ * `SentinelOracle{Requests,Commitments}(V2)` libraries; shared: `IOracle.sol`).
+ * The V1/V2 `NewRequest`/`Committed` signatures differ, so their topic0s
+ * disambiguate the generation; `OracleResult`/`DisputeResolved` are identical
+ * across generations and live in one shared bucket.
  */
 
 const TX_TUPLE =
@@ -25,13 +20,9 @@ export const CONSENSUS_EVENT_FRAGMENTS = [
 ] as const
 
 /**
- * The **non-oracle** Consensus events: same shape as the oracle pair minus the
- * `oracle` field, so they hash to different topic0s. Confirmed 2026-07-28 as
- * what the live Gnosis beta actually emits — in a 10k-block sample the deployed
- * Consensus emitted ~3k `TransactionProposed` / ~2.9k `TransactionAttested` and
- * zero `OracleTransaction*`. The validator set runs its own deterministic checks
- * on this path and attests the result; the sentinel oracle adds richer checks
- * later. Both resolve to `BENIGN` once the FROST signature verifies.
+ * The non-oracle Consensus events — what live beta traffic emits: the validator
+ * set runs its own deterministic checks and attests, no sentinel oracle in the
+ * loop. Same shape as the oracle pair minus `oracle`, hence distinct topic0s.
  */
 export const CONSENSUS_PLAIN_EVENT_FRAGMENTS = [
   `event TransactionProposed(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, ${TX_TUPLE} transaction)`,
@@ -54,11 +45,7 @@ export const SHARED_ORACLE_EVENT_FRAGMENTS = [
   'event DisputeResolved(bytes32 indexed requestId, uint8 outcome, uint256 slashed)',
 ] as const
 
-/**
- * Read (view) functions the reader calls with `ethers.Contract`. Copied from the
- * protocol explorer's `consensus`/`coordinator` ABIs. `getEpochGroupId` maps an
- * epoch to its FROST group id; `groupKey` returns that group's public key.
- */
+/** Read (view) functions the reader calls, from the protocol explorer's ABIs. */
 export const CONSENSUS_READ_ABI = ['function getEpochGroupId(uint64 epoch) view returns (bytes32 groupId)'] as const
 
 export const COORDINATOR_READ_ABI = [
@@ -160,20 +147,12 @@ export const TOPICS: Readonly<Record<string, TopicDispatch>> = Object.freeze(
   Object.fromEntries(EVENT_DISPATCH.map((dispatch) => [topicHashOf(dispatch), dispatch])),
 )
 
-/**
- * The two Consensus event topic0s (`OracleTransactionProposed` /
- * `OracleTransactionAttested`) — indexed by `safeTxHash` (topic1). Used as the
- * topic0 filter for the first `getLogs`.
- */
+/** Consensus event topic0s — indexed by `safeTxHash` (topic1). */
 export const CONSENSUS_TOPIC0S: readonly string[] = EVENT_DISPATCH.filter(
   (dispatch) => dispatch.iface === consensusInterface || dispatch.iface === consensusPlainInterface,
 ).map(topicHashOf)
 
-/**
- * Every sentinel/oracle event topic0 (V1 + V2 `NewRequest`/`Committed`/
- * `Revealed`, plus the shared `OracleResult`/`DisputeResolved`) — all indexed by
- * `requestId` (topic1). Used as the topic0 filter for the second `getLogs`.
- */
+/** Sentinel/oracle event topic0s — indexed by `requestId` (topic1). */
 export const SENTINEL_TOPIC0S: readonly string[] = EVENT_DISPATCH.filter(
   (dispatch) => dispatch.iface !== consensusInterface && dispatch.iface !== consensusPlainInterface,
 ).map(topicHashOf)

--- a/packages/utils/src/features/safenet-checks/builders/rawLogs.ts
+++ b/packages/utils/src/features/safenet-checks/builders/rawLogs.ts
@@ -24,7 +24,7 @@ export const resetLogCounter = (): void => {
   logCounter = 0
 }
 
-export type LogMeta = { blockNumber?: number; logIndex?: number; transactionHash?: string }
+type LogMeta = { blockNumber?: number; logIndex?: number; transactionHash?: string }
 
 const hash = (): string => faker.string.hexadecimal({ length: 64, prefix: '0x', casing: 'lower' })
 const addr = (): string => faker.finance.ethereumAddress()

--- a/packages/utils/src/features/safenet-checks/constants.ts
+++ b/packages/utils/src/features/safenet-checks/constants.ts
@@ -1,12 +1,8 @@
 /**
  * Configuration for the Safenet read layer. Shared web+mobile, so every value
- * reads the `NEXT_PUBLIC_*` variable first and falls back to `EXPO_PUBLIC_*`.
- *
- * These MUST be referenced statically (`process.env.NEXT_PUBLIC_…`). The web
- * (webpack/Next) and mobile (Expo/Babel) bundlers only inline literal
- * `process.env.<PREFIX>_*` reads — a dynamic `process.env[…]` lookup is left
- * untouched and resolves to `undefined` in the browser, silently leaving the
- * reader with no RPC URLs.
+ * reads `NEXT_PUBLIC_*` first and falls back to `EXPO_PUBLIC_*`. All reads MUST
+ * be static (`process.env.NEXT_PUBLIC_…`): the bundlers only inline literal
+ * lookups, so a dynamic one resolves to `undefined` in the browser.
  */
 
 const parseCsv = (value: string | undefined): string[] =>
@@ -18,15 +14,14 @@ const parseCsv = (value: string | undefined): string[] =>
     : []
 
 /**
- * The Safenet chain id — feeds BOTH the reader's provider network AND the
- * EIP-712 domain used to derive request ids. A wrong value silently derives
- * wrong request ids (checks stuck at SUBMITTED), so the reader asserts it
- * against `eth_chainId` in development.
+ * The Safenet chain id — feeds both the provider network and the EIP-712 domain
+ * request ids derive from. A wrong value leaves every check stuck at SUBMITTED,
+ * so the reader asserts it against `eth_chainId` in development.
  */
 export const SAFENET_CHAIN_ID =
   process.env.NEXT_PUBLIC_SAFENET_CHAIN_ID || process.env.EXPO_PUBLIC_SAFENET_CHAIN_ID || '100'
 
-/** Pinned Gnosis RPC endpoints for the read layer (csv). Rotated on failure. */
+/** Pinned RPC endpoints for the read layer (csv). Rotated on failure. */
 export const SAFENET_RPC_URLS = parseCsv(
   process.env.NEXT_PUBLIC_SAFENET_RPC_URLS || process.env.EXPO_PUBLIC_SAFENET_RPC_URLS || 'https://rpc.gnosischain.com',
 )
@@ -37,36 +32,18 @@ export const SAFENET_CONSENSUS_ADDRESS =
   process.env.EXPO_PUBLIC_SAFENET_CONSENSUS_ADDRESS ||
   '0x223624cBF099e5a8f8cD5aF22aFa424a1d1acEE9'
 
-/**
- * FROSTCoordinator the epoch group keys are read from. Default: Gnosis beta
- * deployment (the coordinator the beta Consensus was deployed against).
- */
+/** FROSTCoordinator the epoch group keys are read from. Default: Gnosis beta. */
 export const SAFENET_COORDINATOR_ADDRESS =
   process.env.NEXT_PUBLIC_SAFENET_COORDINATOR_ADDRESS ||
   process.env.EXPO_PUBLIC_SAFENET_COORDINATOR_ADDRESS ||
   '0xaE27021CEB45316f1efe69D8E362aC07ED3Bd7E4'
 
 /**
- * Sentinel-oracle allowlist (csv). Security-critical, and empty by default.
- *
- * `Consensus.proposeOracleTransaction` is permissionless and takes the oracle
- * address as a caller argument, so the `oracle` field on a proposal event is
- * chosen by whoever called it. Sourcing oracle logs from that field would let
- * anyone emit a fabricated `OracleResult(approved=false)` from their own
- * contract and mark any Safe transaction `MALICIOUS`. The reader only reads
- * oracle events from an address on this list, normalized in the constructor.
- *
- * The allowlist limits which address a verdict can come from. It does not limit
- * who can ask for one. `proposeOracleTransaction` forwards the caller's
- * transaction tuple to the named oracle through `postRequest`, so anyone who
- * pays the request fee can have the sentinels evaluate another user's Safe
- * transaction, including one whose owner only ever used the plain path. That
- * verdict is real and the reader cannot filter it out. This is the tradeoff
- * that comes with populating the list.
- *
- * The default empty list trusts no sentinel oracle, so the oracle path is
- * skipped. That matches live beta, where only the validator attesters run and
- * no sentinel oracle is deployed. Populate this once one is.
+ * Sentinel-oracle allowlist (csv). `proposeOracleTransaction` is permissionless
+ * with a caller-chosen oracle address, so reading verdicts from an unlisted
+ * address would let anyone mark any Safe transaction MALICIOUS with a fabricated
+ * `OracleResult`. Empty (the default) skips the oracle path entirely, matching
+ * live beta where no sentinel oracle is deployed.
  */
 export const SAFENET_ORACLE_ADDRESSES = parseCsv(
   process.env.NEXT_PUBLIC_SAFENET_ORACLE_ADDRESSES || process.env.EXPO_PUBLIC_SAFENET_ORACLE_ADDRESSES,
@@ -85,14 +62,9 @@ export const BLOCK_TIME_SECONDS = 5
 
 /**
  * How far behind the estimated transaction block the targeted window starts.
- *
- * The window is weighted forward on purpose. Every event the read looks for
- * (`Proposed`, `Attested`, `NewRequest`, `Committed`, `OracleResult`) is emitted
- * at or after the Safe transaction, so the backward reach only has to cover
- * estimate error and skew between the caller's submission timestamp and chain
- * time. A converged estimate is within {@link BLOCK_ESTIMATE_TOLERANCE_SECONDS},
- * about 120 blocks at nominal cadence. 1,000 blocks gives roughly 1.4h of slack,
- * leaving about 9,000 blocks (12.5h) ahead, where a late settlement lands.
+ * Weighted forward: every event the read looks for is emitted at or after the
+ * Safe transaction, so the backward reach only covers estimate error (~1.4h),
+ * leaving ~12.5h ahead for a late settlement.
  */
 export const TARGETED_WINDOW_BACK_BLOCKS = 1_000
 
@@ -103,10 +75,9 @@ export const BLOCK_ESTIMATE_TOLERANCE_SECONDS = 600
 export const BLOCK_ESTIMATE_MAX_REFINEMENTS = 2
 
 /**
- * Max JSON-RPC calls batched into a single HTTP request by the provider.
- * Equals `MAX_LOOKBACK_BLOCKS / GETLOGS_CHUNK_BLOCKS`, so a head-relative read
- * is one HTTP round-trip. Changing either of those without changing this splits
- * every head-relative read into two.
+ * Max JSON-RPC calls batched into one HTTP request. Equals
+ * `MAX_LOOKBACK_BLOCKS / GETLOGS_CHUNK_BLOCKS`, so a head-relative read is a
+ * single round-trip.
  */
 export const PROVIDER_BATCH_MAX_COUNT = 3
 
@@ -118,21 +89,13 @@ export const POLL_INTERVAL_FAST_MS = 6_000
 /** Poll interval in the post-deadline late window (a late BENIGN can still land). */
 export const POLL_INTERVAL_LATE_MS = 30_000
 
-/**
- * How many blocks past the deadline the reader keeps polling before giving up.
- * ~1h at Gnosis' ~5s block time, so a late attestation replacing a TIMED_OUT
- * verdict has time to materialize.
- */
+/** How many blocks past the deadline polling continues (~1h at Gnosis cadence). */
 export const LATE_WINDOW_BLOCKS = 720
 
 /**
- * Deadline substitute for checks that never get an on-chain deadline — the
- * plain (non-oracle) path emits no `NewRequest`, so `deadlineBlock` is null
- * for everything live beta produces. An attestation is expected within this
- * many blocks of the check's first observed event (~20 min at Gnosis cadence;
- * beta attests within ~5 blocks). Past it the late window applies, then
- * polling stops — without this, a proposed-but-never-attested check (a
- * rejected transaction, on the plain path) would poll a public RPC at the
- * fast interval forever, once per rendered row.
+ * Deadline substitute for the plain path, which emits none: an attestation is
+ * expected within this many blocks of the first observed event (~20 min; beta
+ * attests within ~5 blocks). Without it, a proposed-but-never-attested check
+ * would poll a public RPC at the fast interval forever.
  */
 export const PLAIN_DEADLINE_BLOCKS = 240

--- a/packages/utils/src/features/safenet-checks/services/__tests__/verifyAttestation.test.ts
+++ b/packages/utils/src/features/safenet-checks/services/__tests__/verifyAttestation.test.ts
@@ -191,32 +191,3 @@ describe('SafenetReader.verifyAttestation — non-oracle path (live Gnosis beta 
     })
   })
 })
-
-describe('SafenetReader.blockTimeMs', () => {
-  it('returns the block timestamp in milliseconds', async () => {
-    // head 1,000 at t=1,000,000s with 5s blocks → block 900 is 500s earlier.
-    const { reader } = readerForGolden(gnosis, { head: 1_000, headTimestamp: 1_000_000 })
-
-    expect(await reader.blockTimeMs(900)).toBe(999_500_000)
-  })
-
-  it('costs exactly one header read — the audit-log date is not worth a second', async () => {
-    const { reader, endpoint } = readerForGolden(gnosis, { head: 1_000, headTimestamp: 1_000_000 })
-
-    await reader.blockTimeMs(900)
-
-    expect(endpoint.methods.filter((method) => method === 'eth_getBlockByNumber')).toHaveLength(1)
-  })
-
-  it('degrades to null rather than failing a read whose verdict already verified', async () => {
-    const { reader } = readerForGolden(gnosis, { head: 1_000, failBlockProbes: 'error' })
-
-    expect(await reader.blockTimeMs(900)).toBeNull()
-  })
-
-  it('returns null when no endpoint can serve the header', async () => {
-    const { reader } = readerForGolden(gnosis, { head: 1_000, failBlockProbes: 'null' })
-
-    expect(await reader.blockTimeMs(900)).toBeNull()
-  })
-})

--- a/packages/utils/src/features/safenet-checks/services/safenetReader.ts
+++ b/packages/utils/src/features/safenet-checks/services/safenetReader.ts
@@ -31,35 +31,21 @@ import { isValidPoint, verifyAttestation as verifyFrostAttestation } from '../ut
 import { oracleProposalHash, plainProposalHash } from '../utils/oracleProposalHash'
 
 /**
- * Everything one poll reads off-chain for a single check, before the query layer
- * folds in FROST verification and the monotonic merge. Numeric values are decimal
- * strings so the result is Redux-serializable end-to-end.
+ * Everything one poll reads off-chain for a single check. Numeric values are
+ * decimal strings so the result is Redux-serializable.
  */
 export type CheckReadResult = {
   safeTxHash: Hex
-  /** The Safenet chain the Consensus contract lives on — the config chain id. */
+  /** The Safenet chain the Consensus contract lives on (the config chain id). */
   chainId: string
-  /** All decoded lifecycle events, sorted ascending by (blockNumber, logIndex). */
+  /** Decoded lifecycle events, sorted ascending by (blockNumber, logIndex). */
   events: NormalizedCheckEvent[]
-  /** Chain head observed at read time (a decimal string). */
   headBlock: string
-  /**
-   * The oracle generation that drove the active request, once a sentinel event
-   * for it is seen. `null` means no sentinel event has landed yet. It does not
-   * mean the check is generation-agnostic; a Consensus-only lifecycle never
-   * populates this field.
-   */
+  /** Generation of the active request, once a sentinel event is seen. */
   generation: OracleGeneration | null
   /**
-   * Correlation metadata from the latest allowlisted proposal.
-   *
-   * Proposals are permissionless, so an attacker can propose the victim's
-   * transaction to an allowlisted oracle and become the proposal these fields
-   * describe. Do not render them as provenance.
-   *
-   * They still affect the read. `requestId` selects which sentinel logs are
-   * fetched, and those feed the verdict. `deadlineBlock` is the maximum across
-   * requests, so a third-party request can push it out and suppress TIMED_OUT.
+   * Correlation metadata from the latest allowlisted proposal. Proposals are
+   * permissionless, so do not render these as provenance.
    */
   requestId: Hex | null
   epoch: string | null
@@ -69,25 +55,15 @@ export type CheckReadResult = {
 }
 
 export type SafenetReaderConfig = {
-  /** Pinned Gnosis endpoints, rotated on failure. */
+  /** Pinned endpoints, rotated on failure. */
   rpcUrls: string[]
-  /** Feeds BOTH the provider network AND the EIP-712 request-id domain. */
+  /** Feeds both the provider network and the EIP-712 request-id domain. */
   chainId: string
   consensus: string
-  /** FROSTCoordinator the epoch group keys are read from. */
   coordinator: string
   /** Allowlisted sentinel-oracle addresses. Empty = the oracle path is skipped. */
   oracles: string[]
 }
-
-/** Build a reader config from the dual-env constants (the production default). */
-export const readerConfigFromEnv = (): SafenetReaderConfig => ({
-  rpcUrls: SAFENET_RPC_URLS,
-  chainId: SAFENET_CHAIN_ID,
-  consensus: SAFENET_CONSENSUS_ADDRESS,
-  coordinator: SAFENET_COORDINATOR_ADDRESS,
-  oracles: SAFENET_ORACLE_ADDRESSES,
-})
 
 const IS_DEV = process.env.NODE_ENV !== 'production'
 
@@ -95,14 +71,8 @@ const isProposed = (event: NormalizedCheckEvent): event is OracleProposedEvent =
   event.type === CheckEventType.ORACLE_PROPOSED
 
 /**
- * Cap on distinct requestIds per oracle in one sentinel getLogs topic filter.
- *
- * `epoch` comes from `epochs.active` inside the contract, not from the caller,
- * so every proposal of the same check to the same oracle within one epoch
- * derives the same id and collapses at the dedupe below. The number of distinct
- * ids is bounded by epoch rollovers inside the read window, normally one or two.
- * This cap is a backstop against the OR-filter growing past RPC limits. The
- * newest ids are the ones kept.
+ * Cap on distinct requestIds per oracle in one sentinel getLogs filter — a
+ * backstop against the OR-filter growing past RPC limits. Newest ids win.
  */
 const MAX_REQUEST_IDS_PER_ORACLE = 16
 
@@ -117,8 +87,7 @@ const chunkRanges = (from: number, to: number, size: number): Array<[number, num
 
 /**
  * Chain reader for a check's Safenet lifecycle. Owns a pinned-endpoint provider
- * (rotated on failure) and a per-epoch FROST group-key cache. Construct with
- * {@link readerConfigFromEnv} in production; pass an explicit config in tests.
+ * (rotated on failure) and a per-epoch FROST group-key cache.
  */
 export class SafenetReader {
   private readonly rpcUrls: string[]
@@ -130,7 +99,6 @@ export class SafenetReader {
   private urlIndex = 0
   private currentProvider: JsonRpcProvider | null = null
   private chainIdChecked = false
-  /** Epoch → FROST group public key. The binding is immutable once staged. */
   private readonly groupKeyCache = new Map<string, { x: string; y: string }>()
 
   constructor(config: SafenetReaderConfig) {
@@ -154,11 +122,8 @@ export class SafenetReader {
   }
 
   /**
-   * Advance to the next endpoint — but only if `failed` is still the current
-   * provider. Concurrent reads share the pinned provider; without this guard a
-   * read cancelled by a sibling's rotation would rotate AGAIN, skipping over
-   * (or cycling back to) endpoints and burning its retry budget on the same
-   * dead URL.
+   * Advance to the next endpoint, unless a concurrent read already rotated
+   * (rotating again would skip over healthy endpoints).
    */
   private rotate(failed: JsonRpcProvider): void {
     if (this.currentProvider !== failed) return
@@ -177,13 +142,10 @@ export class SafenetReader {
         return await op(provider)
       } catch (error) {
         lastError = error
-        // A deterministic contract revert (e.g. `groupKey` for an epoch the
-        // coordinator has not seen) is not an endpoint failure. Rotating and
-        // retrying every URL would repeat it N times and tear down the shared
-        // provider under concurrent reads. Only revert DATA proves a revert,
-        // though: ethers turns every JSON-RPC error on an eth_call into a
-        // CALL_EXCEPTION, so a data-less one may just be a rate limit or pruned
-        // state on this endpoint, and the next endpoint deserves a try.
+        // A deterministic revert is not an endpoint failure — rethrow instead of
+        // rotating. Only revert data proves a revert: ethers classifies every
+        // JSON-RPC error on an eth_call as CALL_EXCEPTION, and a data-less one
+        // (rate limit, pruned state) deserves the next endpoint.
         if (isCallException(error) && error.data != null) throw error
         this.rotate(provider)
       }
@@ -191,13 +153,12 @@ export class SafenetReader {
     throw lastError
   }
 
-  /** Dev-only, one-shot: warn loudly if the RPC's chain id disagrees with config. */
+  /** Dev-only, one-shot: warn if the RPC's chain id disagrees with config. */
   private async assertChainId(provider: JsonRpcProvider): Promise<void> {
     if (this.chainIdChecked || !IS_DEV) return
     try {
       const actual = Number(await provider.send('eth_chainId', []))
-      // One-shot only after a SUCCESSFUL probe — a dead first endpoint must not
-      // consume the check before rotation reaches the endpoint actually used.
+      // Consume the one shot only after a successful probe.
       this.chainIdChecked = true
       if (actual !== Number(this.chainId)) {
         console.error(
@@ -207,7 +168,7 @@ export class SafenetReader {
         )
       }
     } catch {
-      // The assertion is a development aid, never a hard gate on the read path.
+      // A development aid, never a hard gate on the read path.
     }
   }
 
@@ -216,14 +177,12 @@ export class SafenetReader {
     filter: { address?: string; topics: Array<string | string[]>; fromBlock: number; toBlock: number },
   ): Promise<RawLog[]> {
     const ranges = chunkRanges(filter.fromBlock, filter.toBlock, GETLOGS_CHUNK_BLOCKS)
-    // Issued concurrently so the pinned provider coalesces them into one batched
-    // HTTP request (bounded by PROVIDER_BATCH_MAX_COUNT).
+    // Issued concurrently so the provider coalesces them into one batched request.
     const chunks = await Promise.all(
       ranges.map(([fromBlock, toBlock]) =>
         provider.getLogs({ address: filter.address, topics: filter.topics, fromBlock, toBlock }),
       ),
     )
-    // Onto the decoder's `RawLog` shape — ethers names the log index `.index`.
     return chunks.flat().map((log) => ({
       address: log.address,
       topics: [...log.topics],
@@ -235,17 +194,12 @@ export class SafenetReader {
   }
 
   /**
-   * Choose the block range to read.
+   * Choose the block range to read: a narrow window around the block matching
+   * the transaction timestamp (constant cost at any age), or the head-relative
+   * scan when no timestamp is given or the estimate did not converge.
    *
-   * Given a transaction timestamp, this is a narrow window around the matching
-   * block, so a two-year-old check costs the same as a two-minute-old one.
-   * Without a timestamp, or when the block estimate did not converge, it is the
-   * head-relative scan, which only sees the last {@link MAX_LOOKBACK_BLOCKS}.
-   *
-   * Known limit: the targeted window ends about 12.5h after the transaction. A
-   * settlement that lands later, such as a long arbitration, falls outside every
-   * aimed re-read of an old check. The check then reads TIMED_OUT rather than
-   * reporting a BENIGN it cannot support.
+   * Known limit: the targeted window ends ~12.5h after the transaction, so a
+   * later settlement reads TIMED_OUT rather than a BENIGN it cannot support.
    */
   private async readRange(
     provider: JsonRpcProvider,
@@ -257,36 +211,23 @@ export class SafenetReader {
 
     const targetSeconds = Math.floor(timestampMs / 1000)
     const { block: centre, driftSeconds } = await this.estimateBlockAt(provider, targetSeconds, head)
-    // Aim the window only when the estimate converged. Turning a leftover drift
-    // into a block budget needs the cadence near the target, which nothing here
-    // measures. Over a stretch faster than nominal, a cadence-derived budget
-    // under-counts the error and the window misses the events with no error
-    // raised. A target at or past the head is the exception: the estimate is
-    // pinned to the head, which is the correct aim however stale the clock is.
+    // Aim only when the estimate converged — converting leftover drift into a
+    // block budget needs a local cadence nothing here measures. A target at or
+    // past the head is the exception: the estimate is pinned to the head.
     if (targetSeconds < head.timestamp && Math.abs(driftSeconds) > BLOCK_ESTIMATE_TOLERANCE_SECONDS) {
       return headRelative
     }
 
-    // One chunk wide, so a targeted read is always a single getLogs. Weighted
-    // forward: see TARGETED_WINDOW_BACK_BLOCKS.
+    // One chunk wide, so a targeted read is always a single getLogs.
     const fromBlock = Math.max(0, centre - TARGETED_WINDOW_BACK_BLOCKS)
     return { fromBlock, toBlock: Math.min(head.number, fromBlock + GETLOGS_CHUNK_BLOCKS - 1) }
   }
 
   /**
-   * Estimate the block nearest a unix timestamp, and report how far off the
-   * estimate still is.
-   *
-   * The nominal {@link BLOCK_TIME_SECONDS} only seeds the first guess. Each
-   * refinement uses the block time observed between the probe and the head, so
-   * the estimate converges even when the chain's real cadence drifts from the
-   * nominal value. Costs one RPC call per probe (at most
-   * {@link BLOCK_ESTIMATE_MAX_REFINEMENTS} + 1), and stops early once within
-   * {@link BLOCK_ESTIMATE_TOLERANCE_SECONDS}.
-   *
-   * `driftSeconds` is measured at the returned (probed) block, and is `Infinity`
-   * when no probe succeeded, so callers can tell a converged estimate from a
-   * guess.
+   * Estimate the block nearest a unix timestamp. Each refinement uses the block
+   * time observed between the probe and the head, so the estimate converges even
+   * when the real cadence drifts from nominal. `driftSeconds` is measured at the
+   * returned block and is `Infinity` when no probe succeeded.
    */
   private async estimateBlockAt(
     provider: JsonRpcProvider,
@@ -298,15 +239,13 @@ export class SafenetReader {
     let best = { block: guess, driftSeconds: Number.POSITIVE_INFINITY }
 
     for (let probe = 0; probe <= BLOCK_ESTIMATE_MAX_REFINEMENTS; probe++) {
-      // A failed probe degrades the read, it does not fail it. An endpoint that
-      // cannot serve an old header (`missing trie node` is common on
-      // load-balanced public RPC) falls back to the head-relative scan, and does
-      // not consume a rotation on an otherwise healthy endpoint.
+      // A failed probe (e.g. `missing trie node` on public RPC) degrades to the
+      // head-relative scan rather than failing the read or burning a rotation.
       const block = await provider.getBlock(guess).catch(() => null)
       if (!block) break
       const driftSeconds = block.timestamp - targetSeconds
       const span = head.number - guess
-      // Floored: a run of equal timestamps must not divide by zero below.
+      // Floored so a run of equal timestamps cannot divide by zero below.
       const observedBlockTime = span > 0 ? Math.max((head.timestamp - block.timestamp) / span, 0.1) : BLOCK_TIME_SECONDS
       if (Math.abs(driftSeconds) < Math.abs(best.driftSeconds)) best = { block: guess, driftSeconds }
       if (Math.abs(driftSeconds) <= BLOCK_ESTIMATE_TOLERANCE_SECONDS) break
@@ -319,21 +258,12 @@ export class SafenetReader {
 
   /**
    * Read a check's full lifecycle: Consensus logs keyed by `safeTxHash`, then —
-   * for every proposal naming an allowlisted oracle — the sentinel/oracle logs
-   * keyed by the derived `requestId`s. Returns the sorted event set plus the
-   * derived correlation fields; FROST verification and the status machine live
-   * above this.
-   *
-   * @param safeTxHash - the Safe transaction hash to read.
-   * @param options.timestampMs - when the Safe transaction happened. Given this,
-   *   the read targets a narrow window around the matching block instead of
-   *   walking back {@link MAX_LOOKBACK_BLOCKS} from the head, so cost stays
-   *   constant however old the check is. Falls back to the head-relative scan
-   *   when omitted.
+   * for every proposal naming an allowlisted oracle — the sentinel logs keyed by
+   * the derived `requestId`s. FROST verification and the status machine live
+   * above this. `options.timestampMs` aims the read window (see readRange).
    */
   async fetchCheckState(safeTxHash: string, options: { timestampMs?: number | null } = {}): Promise<CheckReadResult> {
-    // Validated up front: a malformed hash is a caller bug, not an endpoint
-    // failure — it must not burn a rotation through the URL list.
+    // A malformed hash is a caller bug, not an endpoint failure.
     if (!/^0x[0-9a-f]{64}$/i.test(safeTxHash)) {
       throw new Error(`Safenet reader: invalid safeTxHash '${safeTxHash}'`)
     }
@@ -355,19 +285,16 @@ export class SafenetReader {
         fromBlock: range.fromBlock,
         toBlock: range.toBlock,
       })
-      // Sorted here as well as on the combined set below. The requestId cap
-      // relies on chain order, and `eth_getLogs` ordering is a node convention
-      // with no guarantee behind it.
+      // Sorted before the requestId cap below — eth_getLogs ordering is a node
+      // convention with no guarantee behind it.
       const consensusEvents = decodeLogs(consensusLogs).sort(
         (a, b) => a.blockNumber - b.blockNumber || a.logIndex - b.logIndex,
       )
 
-      // Only proposals naming an allowlisted oracle may drive the oracle read.
-      // `proposeOracleTransaction` is permissionless and the oracle address is a
-      // caller argument, so an unfiltered read would let anyone point us at
-      // their own contract and feed us a fabricated `OracleResult`. Every such
-      // proposal is read, including later ones: a check can be re-proposed in a
-      // later epoch, and each epoch derives a distinct requestId.
+      // Only proposals naming an allowlisted oracle may drive the oracle read:
+      // `proposeOracleTransaction` is permissionless with a caller-chosen oracle
+      // address, so an unfiltered read would accept a fabricated `OracleResult`
+      // from anyone's contract.
       const proposals = consensusEvents.filter(
         (event): event is OracleProposedEvent => isProposed(event) && this.oracles.includes(event.oracle.toLowerCase()),
       )
@@ -381,8 +308,7 @@ export class SafenetReader {
           oracle: proposal.oracle,
           safeTxHash: safeTxHash as Hex,
         })
-        // Keyed by the normalized address so one oracle cannot occupy two
-        // buckets, and issue two getLogs, if a decoder changes its casing.
+        // Keyed by the normalized address so one oracle cannot occupy two buckets.
         const key = proposal.oracle.toLowerCase()
         const ids = requestIdsByOracle.get(key) ?? []
         if (!ids.includes(id)) requestIdsByOracle.set(key, [...ids, id].slice(-MAX_REQUEST_IDS_PER_ORACLE))
@@ -399,8 +325,7 @@ export class SafenetReader {
         oracleEvents.push(...decodeLogs(oracleLogs))
       }
 
-      // The latest allowlisted proposal is the live one. Its requestId is the
-      // correlation the sentinel is answering, or will answer.
+      // The latest allowlisted proposal is the live one.
       const active = proposals.reduce<OracleProposedEvent | null>(
         (latest, event) =>
           latest === null ||
@@ -420,21 +345,18 @@ export class SafenetReader {
           })
         : null
 
-      // Ascending by (blockNumber, logIndex), so downstream folds see chain order.
       const events = [...consensusEvents, ...oracleEvents].sort(
         (a, b) => a.blockNumber - b.blockNumber || a.logIndex - b.logIndex,
       )
-      // Scoped to the active request. A check re-proposed across generations
-      // would otherwise report the first generation seen alongside the latest
-      // request's id, describing two different requests at once.
+      // Scoped to the active request so a cross-generation re-proposal cannot
+      // pair the first generation seen with the latest request's id.
       const generation =
         events.find(
           (event) =>
             event.generation !== OracleGeneration.STABLE && 'requestId' in event && event.requestId === requestId,
         )?.generation ?? null
-      // The maximum across all requests, not the active request's. After a
-      // cross-epoch re-proposal the latest deadline belongs to the request that
-      // can still resolve, while `requestId` names the latest proposal.
+      // The maximum across all requests: after a cross-epoch re-proposal the
+      // latest deadline belongs to the request that can still resolve.
       const deadline = deadlineBlockOf(events)
 
       return {
@@ -453,19 +375,15 @@ export class SafenetReader {
 
   /**
    * Resolve an epoch's FROST group public key: `getEpochGroupId(epoch)` →
-   * `coordinator.groupKey(groupId)`. Cached by epoch — the epoch→group binding
-   * is immutable once staged. Throws on RPC failure (including an epoch the
-   * coordinator has not seen yet: `groupKey` reverts rather than returning
-   * zeros) AND on an off-curve response, so {@link verifyAttestation} can treat
-   * both as retryable (`PENDING`) — a corrupt response from a flaky endpoint
-   * must never be cached, where it would terminalize every attestation in the
-   * epoch as INVALID.
+   * `coordinator.groupKey(groupId)`. Cached by epoch (the binding is immutable
+   * once staged). Throws on RPC failure and on an off-curve response so both
+   * stay retryable — a corrupt response must never be cached, where it would
+   * terminalize every attestation in the epoch as INVALID.
    */
   async loadGroupKey(epoch: string): Promise<{ x: string; y: string }> {
     const cached = this.groupKeyCache.get(epoch)
     if (cached) return cached
-    // Derived OUTSIDE the provider op: a malformed epoch is not an endpoint
-    // failure and must not burn a rotation through the URL list.
+    // Derived outside the provider op: a malformed epoch is a caller bug.
     const epochValue = BigInt(epoch)
 
     return this.withProvider(async (provider) => {
@@ -485,14 +403,10 @@ export class SafenetReader {
   /**
    * Verify an attested event's FROST signature against its epoch group key.
    * A group-key fetch failure is retryable (`PENDING`); a signature that does
-   * not verify is terminal (`INVALID`) and must never render as BENIGN.
-   * Deliberately uncached: once the epoch's group key is cached, a re-verify
-   * is a pure local computation.
+   * not verify is terminal (`INVALID`).
    */
   async verifyAttestation(attested: OracleAttestedEvent | PlainAttestedEvent): Promise<AttestationVerification> {
-    // The two paths sign different EIP-712 preimages. Deriving it here, from the
-    // event we actually decoded, is the only place that knows which is which —
-    // callers cannot pair the wrong hash with the wrong attestation.
+    // The two paths sign different EIP-712 preimages; the event type decides.
     const message =
       attested.type === CheckEventType.ORACLE_ATTESTED
         ? oracleProposalHash({
@@ -523,35 +437,16 @@ export class SafenetReader {
       message,
     }
   }
-
-  /**
-   * Wall-clock time of a block in milliseconds. Used to date the attestation in
-   * the audit log.
-   *
-   * `eth_getLogs` responses carry no timestamps, so this is a separate header
-   * read. Call it only once a check has an attestation. The value cannot change
-   * afterwards and polling stops at that point, so it costs one extra RPC per
-   * settled check rather than one per poll.
-   *
-   * Returns `null` on failure. A missing date leaves one column of the audit log
-   * empty, which is a smaller cost than failing a read whose verdict verified.
-   */
-  async blockTimeMs(blockNumber: number): Promise<number | null> {
-    try {
-      return await this.withProvider(async (provider) => {
-        const block = await provider.getBlock(blockNumber)
-        // Thrown so the failure reaches withProvider: a header this endpoint
-        // cannot serve may still be served by the next one.
-        if (!block) throw new Error(`Safenet reader: no header for block ${blockNumber}`)
-        return block.timestamp * 1000
-      })
-    } catch {
-      return null
-    }
-  }
 }
 
 let defaultReader: SafenetReader | null = null
 
-/** The process-wide pinned-provider reader singleton (built from env constants). */
-export const getSafenetReader = (): SafenetReader => (defaultReader ??= new SafenetReader(readerConfigFromEnv()))
+/** The process-wide reader singleton, built from the env constants. */
+export const getSafenetReader = (): SafenetReader =>
+  (defaultReader ??= new SafenetReader({
+    rpcUrls: SAFENET_RPC_URLS,
+    chainId: SAFENET_CHAIN_ID,
+    consensus: SAFENET_CONSENSUS_ADDRESS,
+    coordinator: SAFENET_COORDINATOR_ADDRESS,
+    oracles: SAFENET_ORACLE_ADDRESSES,
+  }))

--- a/packages/utils/src/features/safenet-checks/types/events.ts
+++ b/packages/utils/src/features/safenet-checks/types/events.ts
@@ -1,24 +1,14 @@
 /**
- * Normalized Safenet lifecycle events.
- *
- * Every onchain value that is a `uint256`/`uint64`/`uint` is carried as a
- * decimal `string` so the whole tree is Redux-serializable (no bigints ever
- * cross the decode boundary). Point coordinates and scalars (FROST `r`/`z`) are
- * likewise strings.
- *
- * `Hex` is the Safe SDK's own (`@safe-global/types-kit`, already a dependency
- * of this package) — re-exported so feature code keeps importing from
- * `../types`.
+ * Normalized Safenet lifecycle events. Every onchain uint is carried as a
+ * decimal string so the whole tree is Redux-serializable. `Hex` is re-exported
+ * from `@safe-global/types-kit` so feature code keeps importing from `../types`.
  */
 
 import type { Hex } from '@safe-global/types-kit'
 
 export type { Hex }
 
-/**
- * Which sentinel-oracle generation produced an event. Consensus events and the
- * shared `OracleResult`/`DisputeResolved` are generation-agnostic (`STABLE`).
- */
+/** Which sentinel-oracle generation produced an event (`STABLE` = agnostic). */
 export enum OracleGeneration {
   V1 = 'V1',
   V2 = 'V2',
@@ -26,22 +16,13 @@ export enum OracleGeneration {
 }
 
 export enum CheckEventType {
-  /** Consensus `OracleTransactionProposed` — the check enters existence. */
+  /** Consensus `OracleTransactionProposed`. */
   ORACLE_PROPOSED = 'ORACLE_PROPOSED',
   /** Consensus `OracleTransactionAttested` — carries the FROST signature. */
   ORACLE_ATTESTED = 'ORACLE_ATTESTED',
-  /**
-   * Consensus `TransactionProposed` — the **non-oracle** path: the validator set
-   * is asked to attest a Safe transaction with no sentinel oracle in the loop.
-   * No fee, no bond, no verdict. This is what live beta traffic overwhelmingly
-   * uses today.
-   */
+  /** Consensus `TransactionProposed` — the non-oracle path live beta uses. */
   PLAIN_PROPOSED = 'PLAIN_PROPOSED',
-  /**
-   * Consensus `TransactionAttested` — the non-oracle attestation. Proves the
-   * validator set signed the transaction; proves **nothing** about whether it is
-   * safe, because no security check ran.
-   */
+  /** Consensus `TransactionAttested` — the non-oracle attestation. */
   PLAIN_ATTESTED = 'PLAIN_ATTESTED',
   /** Sentinel `NewRequest` — carries the per-check deadline block. */
   REQUEST_CREATED = 'REQUEST_CREATED',
@@ -72,7 +53,7 @@ export type OracleProposedEvent = CheckEventBase & {
   oracle: string
 }
 
-export type FrostSignature = {
+type FrostSignature = {
   r: { x: string; y: string }
   z: string
 }
@@ -112,11 +93,7 @@ export type RequestCreatedEvent = CheckEventBase & {
   proposer: string
   fee: string
   bondTarget: string
-  /**
-   * The block the check times out at. Normalized across generations: V1's
-   * single `deadline`, or V2's `revealDeadline` (the last block a verdict can
-   * still land). V2's earlier `commitDeadline` is kept separately.
-   */
+  /** Normalized across generations: V1 `deadline`, V2 `revealDeadline`. */
   deadlineBlock: string
   commitDeadlineBlock: string | null
 }
@@ -126,9 +103,9 @@ export type SentinelCommittedEvent = CheckEventBase & {
   requestId: Hex
   sentinel: string
   bondAmount: string
-  /** Present in V1 only — V1 commits carry the verdict directly. */
+  /** V1 only — V1 commits carry the verdict directly. */
   approved: boolean | null
-  /** Present in V1 only. */
+  /** V1 only. */
   position: string | null
 }
 

--- a/packages/utils/src/features/safenet-checks/types/snapshot.ts
+++ b/packages/utils/src/features/safenet-checks/types/snapshot.ts
@@ -3,9 +3,8 @@ import type { Hex, NormalizedCheckEvent, OracleGeneration } from './events'
 
 /**
  * The full read-layer view of one check at one poll. Everything numeric is a
- * decimal `string` so the snapshot is safe to hold in Redux. Recomputed from
- * scratch each poll from the sorted event set (idempotent, reorg-self-healing);
- * the monotonic merge is applied on top separately.
+ * decimal string so the snapshot is safe to hold in Redux. Recomputed from
+ * scratch each poll; the monotonic merge is applied on top separately.
  */
 export type SafenetCheckSnapshot = {
   safeTxHash: Hex
@@ -15,11 +14,9 @@ export type SafenetCheckSnapshot = {
   /** Which oracle generation drove the active request, once a sentinel event lands. */
   generation: OracleGeneration | null
   /**
-   * Correlation for the latest allowlisted proposal, once known.
-   *
-   * Proposals are permissionless, so an attacker can become the proposal these
-   * describe. Do not render them as provenance ("proposed by …") and do not
-   * branch a verdict on them. Use `status` for that.
+   * Correlation for the latest allowlisted proposal, once known. Proposals are
+   * permissionless — do not render these as provenance or branch a verdict on
+   * them; use `status` for that.
    */
   requestId: Hex | null
   epoch: string | null

--- a/packages/utils/src/features/safenet-checks/types/status.ts
+++ b/packages/utils/src/features/safenet-checks/types/status.ts
@@ -1,9 +1,8 @@
 import type { Hex } from './events'
 
 /**
- * Full lifecycle status. The last two (`AWAITING_VERIFICATION`,
- * `VERIFICATION_FAILED`) are internal-only: they never reach the UI directly —
- * {@link toPublicStatus} folds them into the public set. Crucially,
+ * Full lifecycle status. `AWAITING_VERIFICATION` and `VERIFICATION_FAILED` are
+ * internal-only — {@link toPublicStatus} folds them into the public set, and
  * `VERIFICATION_FAILED` never becomes `BENIGN`.
  */
 export enum CheckStatus {
@@ -15,14 +14,7 @@ export enum CheckStatus {
   AWAITING_VERIFICATION = 'AWAITING_VERIFICATION',
   /** Attested, but the FROST signature failed verification (terminal). */
   VERIFICATION_FAILED = 'VERIFICATION_FAILED',
-  /**
-   * Attested AND cryptographically verified. The only green state.
-   *
-   * Reached from either path: the validator set's own deterministic checks
-   * (`TransactionAttested`, what beta runs today) or the sentinel-oracle checks
-   * (`OracleTransactionAttested`, richer checks, not yet live). Both require a
-   * verified FROST signature first.
-   */
+  /** Attested AND cryptographically verified. The only green state. */
   BENIGN = 'BENIGN',
   /** A negative verdict was observed (rejected / disapproved). */
   MALICIOUS = 'MALICIOUS',
@@ -42,12 +34,9 @@ export type PublicCheckStatus =
   | CheckStatus.UNAVAILABLE
 
 /**
- * Map an internal status to its public projection.
- *
- * `AWAITING_VERIFICATION` reads as still-working (`IN_PROGRESS`);
- * `VERIFICATION_FAILED` reads as `TIMED_OUT` (the copy is timeout-style — a
- * check whose attestation cannot be trusted is treated as not-completed, never
- * as safe).
+ * Map an internal status to its public projection: `AWAITING_VERIFICATION`
+ * reads as still-working, `VERIFICATION_FAILED` as `TIMED_OUT` — an attestation
+ * that cannot be trusted is not-completed, never safe.
  */
 export const toPublicStatus = (status: CheckStatus): PublicCheckStatus => {
   switch (status) {

--- a/packages/utils/src/features/safenet-checks/utils/computePollingInterval.ts
+++ b/packages/utils/src/features/safenet-checks/utils/computePollingInterval.ts
@@ -1,42 +1,27 @@
 import { LATE_WINDOW_BLOCKS, PLAIN_DEADLINE_BLOCKS, POLL_INTERVAL_FAST_MS, POLL_INTERVAL_LATE_MS } from '../constants'
 import { CheckStatus } from '../types'
 
-export type PollingInput = {
+type PollingInput = {
   /**
-   * The merged status (after the monotonic pin), not the raw derivation of a
-   * single read. A transient empty read derives UNAVAILABLE, and feeding that
-   * here would stop polling permanently on a live check.
+   * The merged status (after the monotonic pin), not a single read's raw
+   * derivation — a transient UNAVAILABLE would stop polling a live check.
    */
   status: CheckStatus
-  /** Current chain head as a decimal string, or null if unknown. */
   headBlock: string | null
-  /** The check's deadline block as a decimal string, or null if unknown. */
   deadlineBlock: string | null
   /**
-   * Block of the check's earliest observed event, as a decimal string. It
-   * substitutes for the deadline on the plain path, which does not emit one.
-   * Without it, a check that is never attested would poll forever.
-   *
-   * Callers should pass anchors that persist across reads: a transient empty
-   * read nulls both anchors while a pinned status keeps the check live, and
+   * Block of the check's earliest observed event; substitutes for the deadline
+   * on the plain path. Callers should pass anchors that persist across reads —
    * null anchors fail open to the fast interval.
    */
   firstEventBlock: string | null
 }
 
 /**
- * How often to re-poll a check, in ms; `0` = stop (RTK Query's
- * `pollingInterval` convention).
- *
- * Stops permanently on a settled verdict (`BENIGN`, `MALICIOUS`) or terminal
- * `VERIFICATION_FAILED`. Otherwise polls fast (6s) up to and including the
- * effective deadline, which is the on-chain deadline block, or
- * {@link PLAIN_DEADLINE_BLOCKS} past the first observed event when the path has
- * none. After that it polls slowly (30s) through a ~1h late window, so a late
- * `BENIGN`/`MALICIOUS` can still replace a `TIMED_OUT`, and stops once the late
- * window closes. The stop trusts the caller's single head sample. A remount
- * refetches, so an inflated head from a broken endpoint costs one mount's
- * late window and cannot change the verdict.
+ * How often to re-poll a check, in ms; `0` = stop (RTK Query's convention).
+ * Stops on a settled verdict; otherwise fast (6s) up to the effective deadline
+ * (on-chain, or {@link PLAIN_DEADLINE_BLOCKS} past the first event), slow (30s)
+ * through the ~1h late window, then stops.
  */
 export const computePollingInterval = ({ status, headBlock, deadlineBlock, firstEventBlock }: PollingInput): number => {
   if (status === CheckStatus.BENIGN || status === CheckStatus.MALICIOUS || status === CheckStatus.VERIFICATION_FAILED) {
@@ -44,9 +29,8 @@ export const computePollingInterval = ({ status, headBlock, deadlineBlock, first
   }
 
   // ponytail: UNAVAILABLE stops immediately instead of backing off. Ceiling: a
-  // check proposed after this read lands is not picked up until the user hits
-  // re-check. Without this, a transaction that never had a check, which is most
-  // of them, polls a public RPC every 6s forever, once per rendered row.
+  // check proposed after this read is not picked up until a manual re-check.
+  // Without this, every transaction that never had a check polls forever.
   if (status === CheckStatus.UNAVAILABLE) return 0
 
   const head = headBlock !== null ? BigInt(headBlock) : null

--- a/packages/utils/src/features/safenet-checks/utils/deriveCheckState.ts
+++ b/packages/utils/src/features/safenet-checks/utils/deriveCheckState.ts
@@ -6,7 +6,7 @@ import {
   type NormalizedCheckEvent,
 } from '../types'
 
-export type DeriveCheckStateInput = {
+type DeriveCheckStateInput = {
   /** All decoded events for one check (order-independent; derive is a fold). */
   events: ReadonlyArray<NormalizedCheckEvent>
   /** FROST verification result for the attestation, if any. */
@@ -28,24 +28,14 @@ export const deadlineBlockOf = (events: ReadonlyArray<NormalizedCheckEvent>): bi
 }
 
 /**
- * True if the oracle has SETTLED on a rejection.
- *
- * Only `OracleResult` counts. A single sentinel's `Committed`/`Revealed` is one
- * bonded vote, not a verdict: the oracle resolves by unanimity, and a split goes
- * to arbitration which can still approve. Treating one dissent as final would
- * let any single sentinel permanently red-flag a transaction, and `MALICIOUS` is
- * terminal.
- *
- * Invariant (contract coupling): arbitrated rejections still reach this —
- * `SentinelOracle.resolveDispute` emits an `OracleResult` alongside
- * `DisputeResolved`. A hypothetical path emitting `DisputeResolved` WITHOUT its
- * paired `OracleResult` would read as `IN_PROGRESS`/`TIMED_OUT` here, never
- * `MALICIOUS`.
+ * True if the oracle has SETTLED on a rejection. Only `OracleResult` counts: a
+ * single sentinel's `Committed`/`Revealed` is one bonded vote, not a verdict —
+ * a split goes to arbitration, which can still approve, and arbitrated
+ * rejections re-emit `OracleResult` alongside `DisputeResolved`.
  */
 const hasNegativeVerdict = (events: ReadonlyArray<NormalizedCheckEvent>): boolean =>
   events.some((event) => event.type === CheckEventType.ORACLE_RESULT && event.approved === false)
 
-/** True once anything at all has been observed for this hash. */
 const hasAnyProposal = (events: ReadonlyArray<NormalizedCheckEvent>): boolean =>
   events.some((event) => event.type === CheckEventType.ORACLE_PROPOSED || event.type === CheckEventType.PLAIN_PROPOSED)
 
@@ -60,30 +50,23 @@ const hasOracleActivity = (events: ReadonlyArray<NormalizedCheckEvent>): boolean
   )
 
 /**
- * Derive the internal check status from a check's full event set.
+ * Derive the check status from its full event set. Recomputed from scratch each
+ * poll (idempotent, reorg-self-healing). Precedence, highest first:
  *
- * Recompute-from-scratch each poll (idempotent, reorg-self-healing). Precedence,
- * highest first:
- *
- *  1. A negative verdict → `MALICIOUS` (even late, even past deadline).
- *  2. Attested → `BENIGN` if the FROST signature verified, `VERIFICATION_FAILED`
- *     if it did not (never `BENIGN`), else `AWAITING_VERIFICATION`. This sits
- *     above the deadline check so a late-but-verified attestation replaces a
- *     would-be `TIMED_OUT`.
- *  3. Past the deadline block (`head > deadline`) → `TIMED_OUT` (incl. frozen
- *     disputes, which never emit a resolving `OracleResult`).
- *  4. Any oracle lifecycle activity → `IN_PROGRESS` (a positive `OracleResult`
- *     alone lands here — it is NOT `BENIGN` without a verified attestation).
- *  5. Otherwise → `SUBMITTED`.
+ *  1. Negative verdict → `MALICIOUS` (even late, even past deadline).
+ *  2. Attested → `BENIGN` only if the FROST signature verified,
+ *     `VERIFICATION_FAILED` if it did not, else `AWAITING_VERIFICATION`.
+ *     Above the deadline check so a late attestation beats `TIMED_OUT`.
+ *  3. Past the deadline block → `TIMED_OUT` (incl. frozen disputes).
+ *  4. Any oracle activity → `IN_PROGRESS` (a positive `OracleResult` alone is
+ *     NOT `BENIGN` without a verified attestation).
+ *  5. Otherwise → `SUBMITTED`, requiring an actual proposal event.
  */
 export const deriveCheckState = ({ events, attestation, headBlock }: DeriveCheckStateInput): CheckStatus => {
   if (hasNegativeVerdict(events)) return CheckStatus.MALICIOUS
 
-  // The attested branches deliberately do NOT require the matching proposal
-  // event: an attestation is self-authenticating (its FROST signature commits
-  // to safeTxHash/epoch/consensus/chainId), and a targeted read window can
-  // catch the attestation while clipping the proposal. Gating on the proposal
-  // would degrade a VERIFIED check to UNAVAILABLE on such a partial fetch.
+  // No proposal-event gate on the attested branches: an attestation is
+  // self-authenticating, and a targeted window can clip the proposal.
   const attested = events.some((event) => event.type === CheckEventType.ORACLE_ATTESTED)
   if (attested) {
     if (attestation.status === AttestationVerificationStatus.VERIFIED) return CheckStatus.BENIGN
@@ -91,11 +74,8 @@ export const deriveCheckState = ({ events, attestation, headBlock }: DeriveCheck
     return CheckStatus.AWAITING_VERIFICATION
   }
 
-  // Non-oracle path: the validator set ran its own deterministic checks and
-  // attested the result. That is a real passed check, so it resolves to BENIGN —
-  // but only on a verified signature, exactly like the oracle path. Sits below
-  // the oracle branch (richer checks win) and above the deadline check (it is a
-  // settled outcome, not a pending one).
+  // Non-oracle path: the validator set's own checks passed — BENIGN, but only
+  // on a verified signature, exactly like the oracle path.
   const plainAttested = events.some((event) => event.type === CheckEventType.PLAIN_ATTESTED)
   if (plainAttested) {
     if (attestation.status === AttestationVerificationStatus.VERIFIED) return CheckStatus.BENIGN
@@ -110,9 +90,6 @@ export const deriveCheckState = ({ events, attestation, headBlock }: DeriveCheck
 
   if (hasOracleActivity(events)) return CheckStatus.IN_PROGRESS
 
-  // `SUBMITTED` means "we saw the proposal, nothing has happened yet" — it must
-  // require an actual proposal event. Falling through to it on an empty event
-  // set claimed a check was in flight for every transaction that never had one.
   if (hasAnyProposal(events)) return CheckStatus.SUBMITTED
 
   return CheckStatus.UNAVAILABLE

--- a/packages/utils/src/features/safenet-checks/utils/frost.ts
+++ b/packages/utils/src/features/safenet-checks/utils/frost.ts
@@ -6,21 +6,14 @@ import { getBytes } from 'ethers'
 import type { Hex } from '../types'
 
 /**
- * FROST(secp256k1, SHA-256) signature verification — RFC-9591, ported from
- * `repos/safenet/explorer/src/lib/frost/` onto the pinned `@noble/curves` 1.9.7,
- * with the `z < N` scalar-range check the Solidity verifier enforces
- * (`contracts/src/libraries/FROST.sol:157-161`).
- *
- * `@noble/curves` ships a `schnorr` module, but it is BIP-340: x-only public
- * keys and a `BIP0340/challenge` tagged hash. FROST derives its challenge by
- * hash-to-field under its own domain separator and signs over full compressed
- * points, so `schnorr.verify` rejects every valid Safenet attestation. Hence
- * this file.
+ * FROST(secp256k1, SHA-256) signature verification per RFC-9591. Hand-rolled
+ * because `@noble/curves`' `schnorr` is BIP-340 (x-only keys, different
+ * challenge hash) and rejects every valid Safenet attestation.
  */
 
 const N = secp256k1.Point.Fn.ORDER
 
-/** RFC-9591 `H2` — the challenge hash. DST is the FROST context string + "chal". */
+/** RFC-9591 `H2` — the challenge hash. */
 export const h2 = (input: Uint8Array): bigint =>
   hash_to_field(input, 1, {
     m: 1,
@@ -51,7 +44,6 @@ export const isValidPoint = (point: { x: string; y: string }): boolean => {
 export type AttestationInput = {
   /** Epoch group public key, affine coordinates as decimal strings. */
   groupKey: { x: string; y: string }
-  /** The FROST signature carried by the attestation. */
   attestation: { r: { x: string; y: string }; z: string }
   /** The signed message — the EIP-712 proposal hash for the path that emitted it. */
   message: Hex
@@ -59,22 +51,16 @@ export type AttestationInput = {
 
 /**
  * Verify an attestation against the epoch group key: recompute `R = z·G - c·Y`
- * and check it equals the group commitment.
- *
- * Total (never throws): any invalid input — an out-of-range scalar, an off-curve
- * point — resolves to `false` rather than an exception, so a bad attestation can
- * never break a poll.
+ * and check it equals the group commitment. Total — any invalid input resolves
+ * to `false` rather than an exception.
  */
 export const verifyAttestation = (input: AttestationInput): boolean => {
   try {
-    // Destructured inside the try: at parameter position it would throw on a
-    // null/undefined argument, which the read layer polls in a loop.
+    // Destructured inside the try so a null argument returns false, not throws.
     const { groupKey, attestation, message } = input
     const z = BigInt(attestation.z)
-    // FROST.sol enforces `z < N`, so state it here rather than inherit it.
-    // `@noble/curves` also rejects out-of-range scalars today, which makes this
-    // line currently unobservable — keep it anyway: if noble ever reduced mod N
-    // instead of throwing, dropping it would silently accept malleable `z`.
+    // FROST.sol enforces `z < N`; noble currently rejects out-of-range scalars
+    // too, but that must not be inherited silently — it guards malleable `z`.
     if (z < 0n || z >= N) return false
 
     const groupPublicKey = toPoint(BigInt(groupKey.x), BigInt(groupKey.y))

--- a/packages/utils/src/features/safenet-checks/utils/mergeMonotonic.ts
+++ b/packages/utils/src/features/safenet-checks/utils/mergeMonotonic.ts
@@ -1,19 +1,11 @@
 import { CheckStatus } from '../types'
 
 /**
- * Monotonic merge — the "never take back a verdict" layer, applied on top of the
- * recompute-from-scratch status so a poll (or a reorg) can't visibly walk a
- * verdict backwards.
- *
- * For each already-pinned status, the table lists which incoming statuses are
- * allowed to replace it; anything else keeps the pinned status. Highlights:
- *  - `MALICIOUS` is terminal. `BENIGN` is terminal except for `MALICIOUS`: a
- *    late arbitration result is the one correction that increases safety, so it
- *    is the only transition allowed to override a shown verdict.
- *  - A late `BENIGN` or `MALICIOUS` may replace `TIMED_OUT` (the two allowed
- *    late upgrades).
- *  - `VERIFICATION_FAILED` may become `MALICIOUS` but never `BENIGN`.
- *  - A transient `UNAVAILABLE` never overwrites a known status.
+ * Allowed replacements per pinned status — the "never take back a verdict"
+ * layer on top of the recompute-from-scratch derivation. `MALICIOUS` is
+ * terminal; `BENIGN` yields only to `MALICIOUS` (a late arbitration result is
+ * the one correction that increases safety); `BENIGN`/`MALICIOUS` may replace
+ * `TIMED_OUT`; `VERIFICATION_FAILED` may become `MALICIOUS` but never `BENIGN`.
  */
 const ALLOWED_TRANSITIONS: Record<CheckStatus, ReadonlyArray<CheckStatus>> = {
   [CheckStatus.UNAVAILABLE]: [
@@ -52,13 +44,7 @@ const ALLOWED_TRANSITIONS: Record<CheckStatus, ReadonlyArray<CheckStatus>> = {
   [CheckStatus.MALICIOUS]: [],
 }
 
-/**
- * Merge a freshly-derived status onto the pinned one.
- *
- * @param pinned - the previously-committed status, or null on first observation
- * @param next - the status just derived from the current event set
- * @returns the status to show/persist
- */
+/** Merge a freshly-derived status onto the pinned one (null = first observation). */
 export const mergeMonotonic = (pinned: CheckStatus | null | undefined, next: CheckStatus): CheckStatus => {
   if (pinned == null) return next
   if (pinned === next) return pinned

--- a/packages/utils/src/features/safenet-checks/utils/oracleProposalHash.ts
+++ b/packages/utils/src/features/safenet-checks/utils/oracleProposalHash.ts
@@ -2,18 +2,13 @@ import { TypedDataEncoder } from 'ethers'
 import type { Hex } from '../types'
 
 /**
- * The EIP-712 oracle-transaction proposal hash — ported from
- * `repos/safenet/validator/src/consensus/verify/oracleTx/hashing.ts` (viem
- * `hashTypedData`) onto ethers' `TypedDataEncoder`.
- *
- * The domain is ONLY `{ chainId, verifyingContract }` (no name/version/salt).
- * This hash is both the message the FROST attestation signs AND the oracle
- * `requestId` — so deriving it gives the read layer request-id correlation for
- * free (verified live: it equals the onchain `requestId`).
+ * The EIP-712 oracle-transaction proposal hash. The domain is ONLY
+ * `{ chainId, verifyingContract }` — no name/version/salt — and `chainId` is
+ * the Safenet chain Consensus is deployed to, NOT the Safe's home chain carried
+ * in the event. This hash is both the message the FROST attestation signs and
+ * the oracle `requestId`.
  */
 export type OracleProposal = {
-  /** The chain Consensus is deployed to, which is what the domain uses — NOT the
-   * `chainId` carried in the event, which is the chain the Safe lives on. */
   chainId: string
   /** The Consensus contract address — the EIP-712 `verifyingContract`. */
   consensus: string
@@ -38,16 +33,10 @@ export const oracleProposalHash = ({ chainId, consensus, epoch, oracle, safeTxHa
   }) as Hex
 
 /**
- * The EIP-712 message a **non-oracle** `TransactionAttested` signs — the
- * attestation produced when the validator set runs its own deterministic checks
- * with no sentinel oracle involved. Same domain as
+ * The EIP-712 message a non-oracle `TransactionAttested` signs. Same domain as
  * {@link oracleProposalHash}, one fewer field (no `oracle`).
- *
- * Source: `contracts/src/libraries/ConsensusMessages.sol`
- * (`TRANSACTION_PROPOSAL_TYPEHASH` = `keccak256("TransactionProposal(uint64
- * epoch,bytes32 safeTxHash)")`).
  */
-export type PlainProposal = Omit<OracleProposal, 'oracle'> & { oracle?: never }
+type PlainProposal = Omit<OracleProposal, 'oracle'> & { oracle?: never }
 
 export const PLAIN_PROPOSAL_TYPES = {
   TransactionProposal: [


### PR DESCRIPTION
Housekeeping pass over the merged Safenet read layer (#8424, #8448, #8469)
before the store slice lands on top. No behavior change: the diff is comments,
dead exports, and one method that lost its consumer.

## Comment reduction

The read layer carried long narrative comments — review-round justifications,
dated evidence, restated code. They are cut to short statements of the
non-obvious invariants (allowlist rationale, the data-gated call-exception
guard, the EIP-712 domain chain id, the FROST-vs-BIP-340 distinction, derive
precedence, monotonic transitions). Net −307 lines across 13 files, all in
`packages/utils/src/features/safenet-checks/`.

## Dead code

- `SafenetReader.blockTimeMs` and its four tests are removed. It existed to
  date the audit-log step, and that design changed: the attestation lands on
  the Safenet chain and can postdate home-chain execution, so the row will
  render without a date and nothing consumes the header read.
- `readerConfigFromEnv` had one caller in its own file; inlined into
  `getSafenetReader`.
- Dead `export` keywords dropped from types used only in their defining files:
  `FrostSignature`, `DeriveCheckStateInput`, `PollingInput`, `PlainProposal`,
  and the builders' `LogMeta`. The functions and fields they describe are
  unchanged.

Exports that only tests consume were checked and deliberately kept: the ABI
fragment arrays and `Interface` instances (the log builders encode through
them), `h2` (RFC-9591 known-answer pinning), and the per-event union member
types (builder signatures).

## Testing

`yarn workspace @safe-global/utils {test,type-check,lint}` and prettier pass;
1244 tests (1248 minus the four `blockTimeMs` cases).
