### PR TITLE
feat(safenet): expose check state through the store

### DIFF
--- a/apps/mobile/src/store/index.ts
+++ b/apps/mobile/src/store/index.ts
@@ -35,6 +35,8 @@ import estimatedFee from './estimatedFeeSlice'
 import executionMethod from './executionMethodSlice'
 import { cgwClient, setBaseUrl } from '@safe-global/store/gateway/cgwClient'
 import { hypernativeApi } from '@safe-global/store/hypernative/hypernativeApi'
+import { safenetCheckApi } from '@safe-global/store/safenet/safenetCheckApi'
+import { safenetCheckSlice } from '@safe-global/store/safenet/safenetCheckSlice'
 import devToolsEnhancer from 'redux-devtools-expo-dev-plugin'
 import { GATEWAY_URL, isTestingEnv, CONFIG_SERVICE_KEY } from '../config/constants'
 import { web3API } from './signersBalance'
@@ -122,6 +124,10 @@ export const persistBlacklist = [
   'draftTx',
   'toast',
   walletKitSliceName,
+  // Safenet checks are read live from chain each session — never persist the
+  // RTK Query cache or the pinned verdicts.
+  safenetCheckSlice.name,
+  safenetCheckApi.reducerPath,
 ]
 
 export const persistTransforms = [cgwClientFilter, sanitizePendingQueriesTransform]
@@ -169,9 +175,11 @@ const combinedReducer = combineReducers({
   draftTx,
   toast,
   walletKit: persistedWalletKit,
+  [safenetCheckSlice.name]: safenetCheckSlice.reducer,
   [web3API.reducerPath]: web3API.reducer,
   [cgwClient.reducerPath]: cgwClient.reducer,
   [hypernativeApi.reducerPath]: hypernativeApi.reducer,
+  [safenetCheckApi.reducerPath]: safenetCheckApi.reducer,
 })
 
 export const rootReducer = withE2EReset(combinedReducer)
@@ -213,6 +221,7 @@ export const makeStore = () =>
         cgwClient.middleware,
         web3API.middleware,
         hypernativeApi.middleware,
+        safenetCheckApi.middleware,
         notificationsMiddleware,
         analyticsMiddleware,
         notificationSyncMiddleware,

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -29,6 +29,8 @@ import * as hydrate from './useHydrateStore'
 import { ofacApi } from '@/store/api/ofac'
 import { safePassApi } from './api/safePass'
 import { hypernativeApi } from '@safe-global/store/hypernative/hypernativeApi'
+import { safenetCheckApi } from '@safe-global/store/safenet/safenetCheckApi'
+import { safenetCheckSlice } from '@safe-global/store/safenet/safenetCheckSlice'
 import { version as termsVersion } from '@/markdown/terms/version'
 import { cgwClient, setBaseUrl } from '@safe-global/store/gateway/cgwClient'
 import { GATEWAY_URL } from '@/config/gateway'
@@ -68,6 +70,8 @@ const rootReducer = combineReducers({
   [ofacApi.reducerPath]: ofacApi.reducer,
   [safePassApi.reducerPath]: safePassApi.reducer,
   [hypernativeApi.reducerPath]: hypernativeApi.reducer,
+  [safenetCheckSlice.name]: safenetCheckSlice.reducer,
+  [safenetCheckApi.reducerPath]: safenetCheckApi.reducer,
   [slices.gatewayApi.reducerPath]: slices.gatewayApi.reducer,
   [cgwClient.reducerPath]: cgwClient.reducer,
   [slices.authSlice.reducerPath]: slices.authSlice.reducer,
@@ -107,6 +111,7 @@ const middleware: Middleware<{}, RootState>[] = [
   ofacApi.middleware,
   safePassApi.middleware,
   hypernativeApi.middleware,
+  safenetCheckApi.middleware,
   slices.gatewayApi.middleware,
 ]
 

--- a/packages/store/src/safenet/__tests__/safenetCheckApi.test.ts
+++ b/packages/store/src/safenet/__tests__/safenetCheckApi.test.ts
@@ -1,0 +1,266 @@
+import { configureStore, type UnknownAction } from '@reduxjs/toolkit'
+import {
+  AttestationVerificationStatus,
+  CheckStatus,
+  UNVERIFIED_ATTESTATION,
+  getSafenetReader,
+  type CheckReadResult,
+} from '@safe-global/utils/features/safenet-checks'
+import {
+  attestedEvent,
+  plainAttestedEvent,
+  requestCreatedEvent,
+} from '@safe-global/utils/features/safenet-checks/builders'
+import { safenetCheckApi } from '../safenetCheckApi'
+import {
+  pinVerdict,
+  safenetCheckSlice,
+  selectPinnedVerdict,
+  type SafenetCheckPartialState,
+  type SafenetCheckSliceState,
+} from '../safenetCheckSlice'
+
+jest.mock('@safe-global/utils/features/safenet-checks', () => ({
+  ...jest.requireActual('@safe-global/utils/features/safenet-checks'),
+  getSafenetReader: jest.fn(),
+}))
+
+const mockedGetReader = getSafenetReader as jest.MockedFunction<typeof getSafenetReader>
+
+const HASH = ('0x' + 'cd'.repeat(32)) as `0x${string}`
+const REQUEST_ID = ('0x' + 'ef'.repeat(32)) as `0x${string}`
+
+const fakeReader = { fetchCheckState: jest.fn(), verifyAttestation: jest.fn() }
+
+const baseRead = (over: Partial<CheckReadResult> = {}): CheckReadResult => ({
+  safeTxHash: HASH,
+  chainId: '100',
+  events: [],
+  headBlock: '100',
+  generation: null,
+  requestId: null,
+  epoch: null,
+  oracle: null,
+  deadlineBlock: null,
+  ...over,
+})
+
+const makeTestStore = () =>
+  configureStore({
+    reducer: {
+      [safenetCheckSlice.name]: safenetCheckSlice.reducer,
+      [safenetCheckApi.reducerPath]: safenetCheckApi.reducer,
+    },
+    middleware: (getDefault) => getDefault().concat(safenetCheckApi.middleware),
+  })
+
+const runQuery = (store: ReturnType<typeof makeTestStore>) =>
+  store.dispatch(safenetCheckApi.endpoints.getSafenetCheck.initiate({ safeTxHash: HASH }, { forceRefetch: true }))
+
+beforeEach(() => {
+  fakeReader.fetchCheckState.mockReset()
+  fakeReader.verifyAttestation.mockReset()
+  mockedGetReader.mockReturnValue(fakeReader as unknown as ReturnType<typeof getSafenetReader>)
+})
+
+describe('safenetCheckApi.getSafenetCheck', () => {
+  // The non-oracle path is the only one live beta emits, so it needs its own
+  // case: it reaches the same verify call, with no requestId in the read.
+  it('verifies a non-oracle attestation and derives BENIGN', async () => {
+    const attested = plainAttestedEvent({ safeTxHash: HASH })
+    fakeReader.fetchCheckState.mockResolvedValue(baseRead({ events: [attested], requestId: null }))
+    fakeReader.verifyAttestation.mockResolvedValue({
+      status: AttestationVerificationStatus.VERIFIED,
+      signatureId: attested.signatureId,
+      message: '0xplain',
+    })
+
+    const store = makeTestStore()
+    const result = await runQuery(store)
+
+    expect(fakeReader.verifyAttestation).toHaveBeenCalledWith(attested)
+    expect(result.data?.status).toBe(CheckStatus.BENIGN)
+  })
+
+  it('derives BENIGN when an attestation verifies, and pins it', async () => {
+    fakeReader.fetchCheckState.mockResolvedValue(
+      baseRead({ events: [attestedEvent({ safeTxHash: HASH })], requestId: REQUEST_ID, epoch: '1' }),
+    )
+    fakeReader.verifyAttestation.mockResolvedValue({
+      status: AttestationVerificationStatus.VERIFIED,
+      signatureId: REQUEST_ID,
+      message: REQUEST_ID,
+    })
+    const store = makeTestStore()
+
+    const result = await runQuery(store)
+
+    expect(result.data?.status).toBe(CheckStatus.BENIGN)
+    expect(selectPinnedVerdict(store.getState() as SafenetCheckPartialState, HASH)?.status).toBe(CheckStatus.BENIGN)
+  })
+
+  it('does not verify when there is no attestation, and derives IN_PROGRESS from activity', async () => {
+    fakeReader.fetchCheckState.mockResolvedValue(
+      baseRead({ events: [requestCreatedEvent({ deadlineBlock: '1000' })], deadlineBlock: '1000', headBlock: '100' }),
+    )
+    const store = makeTestStore()
+
+    const result = await runQuery(store)
+
+    expect(fakeReader.verifyAttestation).not.toHaveBeenCalled()
+    expect(result.data?.status).toBe(CheckStatus.IN_PROGRESS)
+    expect(selectPinnedVerdict(store.getState() as SafenetCheckPartialState, HASH)?.status).toBe(
+      CheckStatus.IN_PROGRESS,
+    )
+  })
+
+  it('never walks a pinned verdict backwards — a later transient re-derivation keeps BENIGN', async () => {
+    const store = makeTestStore()
+
+    // Poll 1: attested + verified → BENIGN, pinned.
+    fakeReader.fetchCheckState.mockResolvedValueOnce(
+      baseRead({ events: [attestedEvent({ safeTxHash: HASH })], requestId: REQUEST_ID, epoch: '1' }),
+    )
+    fakeReader.verifyAttestation.mockResolvedValueOnce({
+      status: AttestationVerificationStatus.VERIFIED,
+      signatureId: REQUEST_ID,
+      message: REQUEST_ID,
+    })
+    const first = await runQuery(store)
+    expect(first.data?.status).toBe(CheckStatus.BENIGN)
+
+    // Poll 2: a reorg drops the attestation → would derive IN_PROGRESS, but the
+    // pinned BENIGN is terminal, so the merged status stays BENIGN.
+    fakeReader.fetchCheckState.mockResolvedValueOnce(
+      baseRead({ events: [requestCreatedEvent({ deadlineBlock: '1000' })], deadlineBlock: '1000', headBlock: '100' }),
+    )
+    const second = await runQuery(store)
+
+    expect(second.data?.status).toBe(CheckStatus.BENIGN)
+    expect(selectPinnedVerdict(store.getState() as SafenetCheckPartialState, HASH)?.status).toBe(CheckStatus.BENIGN)
+  })
+
+  it('upgrades the pin forward on a rank increase (IN_PROGRESS → BENIGN)', async () => {
+    const store = makeTestStore()
+
+    fakeReader.fetchCheckState.mockResolvedValueOnce(
+      baseRead({ events: [requestCreatedEvent({ deadlineBlock: '1000' })], deadlineBlock: '1000', headBlock: '100' }),
+    )
+    await runQuery(store)
+    expect(selectPinnedVerdict(store.getState() as SafenetCheckPartialState, HASH)?.status).toBe(
+      CheckStatus.IN_PROGRESS,
+    )
+
+    fakeReader.fetchCheckState.mockResolvedValueOnce(
+      baseRead({ events: [attestedEvent({ safeTxHash: HASH })], requestId: REQUEST_ID, epoch: '1' }),
+    )
+    fakeReader.verifyAttestation.mockResolvedValueOnce({
+      status: AttestationVerificationStatus.VERIFIED,
+      signatureId: REQUEST_ID,
+      message: REQUEST_ID,
+    })
+    const second = await runQuery(store)
+
+    expect(second.data?.status).toBe(CheckStatus.BENIGN)
+    expect(selectPinnedVerdict(store.getState() as SafenetCheckPartialState, HASH)?.status).toBe(CheckStatus.BENIGN)
+  })
+
+  it('returns an error (RTK Query retains the last snapshot) when the read fails', async () => {
+    fakeReader.fetchCheckState.mockRejectedValue(new Error('rpc down'))
+    const store = makeTestStore()
+
+    const result = await runQuery(store)
+
+    expect(result.data).toBeUndefined()
+    expect(result.status).toBe('rejected')
+    expect(selectPinnedVerdict(store.getState() as SafenetCheckPartialState, HASH)).toBeUndefined()
+  })
+
+  it('marks the attestation UNVERIFIED in the snapshot when there is no attestation event', async () => {
+    fakeReader.fetchCheckState.mockResolvedValue(baseRead({ events: [requestCreatedEvent({ deadlineBlock: '1000' })] }))
+    const store = makeTestStore()
+
+    const result = await runQuery(store)
+
+    expect(result.data?.attestation).toEqual(UNVERIFIED_ATTESTATION)
+  })
+
+  it('verifies the ORACLE attestation when both paths attested, regardless of chain order', async () => {
+    // Ascending event order puts the plain attestation FIRST (beta attests in
+    // ~5 blocks; the oracle path needs commit/reveal) — the oracle one must
+    // still be the event that gets verified, since deriveCheckState consumes
+    // the verification result through its oracle branch first.
+    const plain = plainAttestedEvent({ safeTxHash: HASH, blockNumber: 100 })
+    const oracle = attestedEvent({ safeTxHash: HASH, blockNumber: 200 })
+    fakeReader.fetchCheckState.mockResolvedValue(baseRead({ events: [plain, oracle] }))
+    fakeReader.verifyAttestation.mockResolvedValue({
+      status: AttestationVerificationStatus.VERIFIED,
+      signatureId: REQUEST_ID,
+      message: REQUEST_ID,
+    })
+    const store = makeTestStore()
+
+    await runQuery(store)
+
+    expect(fakeReader.verifyAttestation).toHaveBeenCalledTimes(1)
+    expect(fakeReader.verifyAttestation).toHaveBeenCalledWith(oracle)
+  })
+
+  it('never pins UNAVAILABLE — a no-check transaction leaves the slice untouched', async () => {
+    fakeReader.fetchCheckState.mockResolvedValue(baseRead({ events: [] }))
+    const store = makeTestStore()
+
+    const result = await runQuery(store)
+
+    expect(result.data?.status).toBe(CheckStatus.UNAVAILABLE)
+    expect(selectPinnedVerdict(store.getState() as SafenetCheckPartialState, HASH)).toBeUndefined()
+  })
+
+  it('does not re-dispatch the pin when a re-poll derives the same status', async () => {
+    const pins: unknown[] = []
+    const store = configureStore({
+      reducer: {
+        [safenetCheckSlice.name]: (state: SafenetCheckSliceState | undefined, action: UnknownAction) => {
+          if (pinVerdict.match(action)) pins.push(action)
+          return safenetCheckSlice.reducer(state, action)
+        },
+        [safenetCheckApi.reducerPath]: safenetCheckApi.reducer,
+      },
+      middleware: (getDefault) => getDefault().concat(safenetCheckApi.middleware),
+    })
+    fakeReader.fetchCheckState.mockResolvedValue(baseRead({ events: [plainAttestedEvent({ safeTxHash: HASH })] }))
+    fakeReader.verifyAttestation.mockResolvedValue({
+      status: AttestationVerificationStatus.VERIFIED,
+      signatureId: REQUEST_ID,
+      message: REQUEST_ID,
+    })
+
+    await runQuery(store)
+    await runQuery(store)
+
+    expect(pins).toHaveLength(1)
+  })
+
+  it('forwards timestampMs so the reader can aim its block window', async () => {
+    fakeReader.fetchCheckState.mockResolvedValue(baseRead())
+    const store = makeTestStore()
+
+    await store.dispatch(
+      safenetCheckApi.endpoints.getSafenetCheck.initiate({ safeTxHash: HASH, timestampMs: 1_700_000_000_000 }),
+    )
+
+    expect(fakeReader.fetchCheckState).toHaveBeenCalledWith(HASH, { timestampMs: 1_700_000_000_000 })
+  })
+
+  it('keeps ONE cache entry per hash however the timestamp varies (single poll loop)', async () => {
+    fakeReader.fetchCheckState.mockResolvedValue(baseRead())
+    const store = makeTestStore()
+
+    await store.dispatch(safenetCheckApi.endpoints.getSafenetCheck.initiate({ safeTxHash: HASH, timestampMs: 1_000 }))
+    await store.dispatch(safenetCheckApi.endpoints.getSafenetCheck.initiate({ safeTxHash: HASH, timestampMs: 2_000 }))
+
+    const queries = store.getState()[safenetCheckApi.reducerPath].queries
+    expect(Object.keys(queries)).toHaveLength(1)
+    expect(fakeReader.fetchCheckState).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/store/src/safenet/__tests__/safenetCheckSlice.test.ts
+++ b/packages/store/src/safenet/__tests__/safenetCheckSlice.test.ts
@@ -1,0 +1,89 @@
+import {
+  AttestationVerificationStatus,
+  CheckStatus,
+  UNVERIFIED_ATTESTATION,
+} from '@safe-global/utils/features/safenet-checks'
+import {
+  pinVerdict,
+  safenetCheckInitialState,
+  safenetCheckSlice,
+  selectPinnedVerdict,
+  type SafenetCheckSliceState,
+} from '../safenetCheckSlice'
+
+const reduce = (state: SafenetCheckSliceState, action: Parameters<typeof safenetCheckSlice.reducer>[1]) =>
+  safenetCheckSlice.reducer(state, action)
+
+const HASH_A = '0x' + 'aa'.repeat(32)
+const HASH_B = '0x' + 'bb'.repeat(32)
+
+describe('safenetCheckSlice', () => {
+  it('starts empty', () => {
+    expect(safenetCheckInitialState).toEqual({ pinned: {} })
+  })
+
+  it('pins a verdict keyed by safeTxHash', () => {
+    const next = reduce(
+      safenetCheckInitialState,
+      pinVerdict({
+        safeTxHash: HASH_A,
+        status: CheckStatus.IN_PROGRESS,
+        atBlock: '42',
+        verification: UNVERIFIED_ATTESTATION,
+      }),
+    )
+    expect(next.pinned[HASH_A]).toEqual({
+      status: CheckStatus.IN_PROGRESS,
+      atBlock: '42',
+      verification: UNVERIFIED_ATTESTATION,
+    })
+  })
+
+  it('overwrites the pin for the same hash and keeps other hashes untouched', () => {
+    const verified = {
+      status: AttestationVerificationStatus.VERIFIED,
+      signatureId: ('0x' + '11'.repeat(32)) as `0x${string}`,
+      message: ('0x' + '22'.repeat(32)) as `0x${string}`,
+    }
+    let state = reduce(
+      safenetCheckInitialState,
+      pinVerdict({
+        safeTxHash: HASH_A,
+        status: CheckStatus.IN_PROGRESS,
+        atBlock: '42',
+        verification: UNVERIFIED_ATTESTATION,
+      }),
+    )
+    state = reduce(
+      state,
+      pinVerdict({
+        safeTxHash: HASH_B,
+        status: CheckStatus.SUBMITTED,
+        atBlock: '10',
+        verification: UNVERIFIED_ATTESTATION,
+      }),
+    )
+    state = reduce(
+      state,
+      pinVerdict({ safeTxHash: HASH_A, status: CheckStatus.BENIGN, atBlock: '99', verification: verified }),
+    )
+
+    expect(state.pinned[HASH_A]).toEqual({ status: CheckStatus.BENIGN, atBlock: '99', verification: verified })
+    expect(state.pinned[HASH_B].status).toBe(CheckStatus.SUBMITTED)
+  })
+
+  it('selects a pinned verdict, or undefined when none exists', () => {
+    const state = reduce(
+      safenetCheckInitialState,
+      pinVerdict({
+        safeTxHash: HASH_A,
+        status: CheckStatus.BENIGN,
+        atBlock: '99',
+        verification: UNVERIFIED_ATTESTATION,
+      }),
+    )
+    const root = { [safenetCheckSlice.name]: state }
+    expect(selectPinnedVerdict(root, HASH_A)?.status).toBe(CheckStatus.BENIGN)
+    expect(selectPinnedVerdict(root, HASH_B)).toBeUndefined()
+  })
+})

--- a/packages/store/src/safenet/safenetCheckApi.ts
+++ b/packages/store/src/safenet/safenetCheckApi.ts
@@ -1,0 +1,96 @@
+import { createApi } from '@reduxjs/toolkit/query/react'
+import {
+  CheckEventType,
+  CheckStatus,
+  UNVERIFIED_ATTESTATION,
+  deriveCheckState,
+  getSafenetReader,
+  mergeMonotonic,
+  type AttestationVerification,
+  type OracleAttestedEvent,
+  type PlainAttestedEvent,
+  type SafenetCheckSnapshot,
+} from '@safe-global/utils/features/safenet-checks'
+import { pinVerdict, selectPinnedVerdict, type SafenetCheckPartialState } from './safenetCheckSlice'
+
+/**
+ * Standalone chain-reading API for Safenet checks — no HTTP endpoint, the work
+ * happens in a custom `queryFn` (the ofac.ts pattern): read the chain, verify
+ * the attestation, run the status machine, merge against the session-pinned
+ * verdict. A fetch failure returns `{ error }`; RTK Query keeps serving the
+ * last good snapshot.
+ */
+const noopBaseQuery = async () => ({ data: null })
+
+/**
+ * `timestampMs` is when the Safe transaction was submitted (proposal time, not
+ * execution time — checks are proposed around the first signature) and only
+ * aims the reader's block window. All callers of one hash share a cache entry,
+ * so the semantic has to stay canonical. See `serializeQueryArgs` below.
+ */
+export type SafenetCheckArg = {
+  safeTxHash: string
+  timestampMs?: number | null
+}
+
+export const safenetCheckApi = createApi({
+  reducerPath: 'safenetCheckApi',
+  baseQuery: noopBaseQuery,
+  endpoints: (builder) => ({
+    getSafenetCheck: builder.query<SafenetCheckSnapshot, SafenetCheckArg>({
+      async queryFn({ safeTxHash, timestampMs }, { getState, dispatch }) {
+        try {
+          const reader = getSafenetReader()
+          const read = await reader.fetchCheckState(safeTxHash, { timestampMs })
+
+          // Prefer the oracle attestation when both are present: it is the one
+          // backed by sentinel checks, and deriveCheckState consumes the
+          // verification result through its oracle branch first. Plain
+          // events.find would verify whichever attested first on chain.
+          const attestedEvent =
+            read.events.find((event): event is OracleAttestedEvent => event.type === CheckEventType.ORACLE_ATTESTED) ??
+            read.events.find((event): event is PlainAttestedEvent => event.type === CheckEventType.PLAIN_ATTESTED)
+          const attestation: AttestationVerification = attestedEvent
+            ? await reader.verifyAttestation(attestedEvent)
+            : UNVERIFIED_ATTESTATION
+
+          const derived = deriveCheckState({ events: read.events, attestation, headBlock: read.headBlock })
+          const pinned = selectPinnedVerdict(getState() as SafenetCheckPartialState, safeTxHash)
+          const status = mergeMonotonic(pinned?.status, derived)
+
+          // mergeMonotonic only advances, so a changed status is a rank
+          // increase — pin it as the new session floor. UNAVAILABLE is not a
+          // verdict and would grow the slice by one inert entry per rendered row.
+          if (status !== pinned?.status && status !== CheckStatus.UNAVAILABLE) {
+            dispatch(pinVerdict({ safeTxHash, status, atBlock: read.headBlock, verification: attestation }))
+          }
+
+          const snapshot: SafenetCheckSnapshot = {
+            safeTxHash: read.safeTxHash,
+            chainId: read.chainId,
+            status,
+            generation: read.generation,
+            requestId: read.requestId,
+            epoch: read.epoch,
+            oracle: read.oracle,
+            deadlineBlock: read.deadlineBlock,
+            headBlock: read.headBlock,
+            attestation,
+            events: read.events,
+          }
+          return { data: snapshot }
+        } catch (error) {
+          // Kept Redux-serializable; the hook only needs the failure signal.
+          return { error: { message: error instanceof Error ? error.message : String(error) } }
+        }
+      },
+      // `timestampMs` only aims the block window — the check's identity is its
+      // hash. Without this, two renderings of the same check with different
+      // timestamps would open a second cache entry and a second poll loop.
+      serializeQueryArgs: ({ endpointName, queryArgs }) => `${endpointName}(${queryArgs.safeTxHash})`,
+      keepUnusedDataFor: 300,
+    }),
+  }),
+})
+
+export const { useGetSafenetCheckQuery } = safenetCheckApi

--- a/packages/store/src/safenet/safenetCheckSlice.ts
+++ b/packages/store/src/safenet/safenetCheckSlice.ts
@@ -1,0 +1,41 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { AttestationVerification, CheckStatus } from '@safe-global/utils/features/safenet-checks'
+
+/**
+ * A verdict pinned for the current session. The pin is the monotonic floor the
+ * query layer merges against so a poll (or a chain reorg) can never visibly walk
+ * a check's status backwards. Session-only — never persisted (see the mobile
+ * `persistBlacklist` and the web store leaving it out of `persistedSlices`).
+ */
+export type PinnedVerdict = {
+  status: CheckStatus
+  /** Chain head at which this verdict was pinned (decimal string), or null. */
+  atBlock: string | null
+  verification: AttestationVerification
+}
+
+export type SafenetCheckSliceState = {
+  /** Pinned verdicts keyed by `safeTxHash`. */
+  pinned: Record<string, PinnedVerdict>
+}
+
+export const safenetCheckInitialState: SafenetCheckSliceState = { pinned: {} }
+
+export const safenetCheckSlice = createSlice({
+  name: 'safenetChecks',
+  initialState: safenetCheckInitialState,
+  reducers: {
+    pinVerdict: (state, action: PayloadAction<{ safeTxHash: string } & PinnedVerdict>) => {
+      const { safeTxHash, status, atBlock, verification } = action.payload
+      state.pinned[safeTxHash] = { status, atBlock, verification }
+    },
+  },
+})
+
+export const { pinVerdict } = safenetCheckSlice.actions
+
+/** Minimal root-state shape a selector needs — compatible with either app store. */
+export type SafenetCheckPartialState = { [safenetCheckSlice.name]: SafenetCheckSliceState }
+
+export const selectPinnedVerdict = (state: SafenetCheckPartialState, safeTxHash: string): PinnedVerdict | undefined =>
+  state[safenetCheckSlice.name].pinned[safeTxHash]

--- a/packages/utils/src/features/safenet-checks/builders/index.ts
+++ b/packages/utils/src/features/safenet-checks/builders/index.ts
@@ -1,0 +1,2 @@
+export * from './rawLogs'
+export * from './checkEvents'

--- a/packages/utils/src/features/safenet-checks/index.ts
+++ b/packages/utils/src/features/safenet-checks/index.ts
@@ -1,0 +1,6 @@
+export * from './types'
+export * from './constants'
+export * from './services/safenetReader'
+export * from './utils/deriveCheckState'
+export * from './utils/mergeMonotonic'
+export * from './utils/computePollingInterval'


### PR DESCRIPTION
Fourth slice of the Safenet read layer. It answers one question: how does a
check reach application state? An RTK Query api reads the chain through the
reader and a small slice pins verdicts for the session. No UI in this slice;
the polling hook and the history surface follow separately.

## Store api

`safenetCheckApi.getSafenetCheck` has no HTTP endpoint — the work happens in a
custom `queryFn` (the ofac.ts pattern): `fetchCheckState`, verify the
attestation if one is present, `deriveCheckState`, then `mergeMonotonic`
against the session-pinned verdict. A fetch failure returns `{ error }` and RTK
Query keeps serving the last good snapshot.

Two decisions worth review attention:

- When both attestation families are present, the oracle one is verified.
  `deriveCheckState` consumes the verification result through its oracle branch
  first, and a plain `events.find` would verify whichever attested first on
  chain — usually the plain one, since the oracle path needs commit/reveal.
- The cache key is the hash alone (`serializeQueryArgs`). `timestampMs` only
  aims the reader's block window; keying on it would give the same check a
  second cache entry and a second poll loop when rendered with different
  timestamps.

## Pinned verdicts

`safenetCheckSlice` holds one `PinnedVerdict` per hash — the monotonic floor
the api merges against, so a poll or a reorg can never visibly walk a status
backwards. Session-only: the slice and the api cache are excluded from
persistence on both apps (a stale pinned verdict would suppress a later
arbitration result after restart). `UNAVAILABLE` is never pinned — most
transactions never had a check, and each rendered row would otherwise grow the
slice by one inert entry.

## Testing

The api suite drives a mocked reader through the store: BENIGN on both
attestation families, oracle-preferred verification regardless of chain order,
pin forward on rank increase, no backward walk after a reorg re-derivation, no
re-dispatch on an unchanged status, UNAVAILABLE never pinned, error passthrough
with the pin untouched, timestamp forwarding, and one cache entry per hash for
varying timestamps. The slice suite covers the reducer and selector directly.

`yarn workspace @safe-global/store {test,type-check,lint}` and
`@safe-global/{utils,web} type-check` pass.
