### PR TITLE
feat(safenet): add the useSafenetCheck polling hook

### DIFF
--- a/packages/utils/src/features/safenet-checks/builders/index.ts
+++ b/packages/utils/src/features/safenet-checks/builders/index.ts
@@ -1,2 +1,3 @@
 export * from './rawLogs'
 export * from './checkEvents'
+export * from './snapshot'

--- a/packages/utils/src/features/safenet-checks/builders/snapshot.ts
+++ b/packages/utils/src/features/safenet-checks/builders/snapshot.ts
@@ -1,0 +1,34 @@
+import { faker } from '@faker-js/faker'
+import {
+  AttestationVerificationStatus,
+  CheckStatus,
+  UNVERIFIED_ATTESTATION,
+  type Hex,
+  type SafenetCheckSnapshot,
+} from '../types'
+
+const hexHash = (): Hex => faker.string.hexadecimal({ length: 64, prefix: '0x', casing: 'lower' }) as Hex
+
+/** Faker builder for a {@link SafenetCheckSnapshot} — all bigints as strings. */
+export const buildSnapshot = (over: Partial<SafenetCheckSnapshot> = {}): SafenetCheckSnapshot => ({
+  safeTxHash: hexHash(),
+  chainId: '100',
+  status: CheckStatus.SUBMITTED,
+  generation: null,
+  requestId: null,
+  epoch: null,
+  oracle: null,
+  deadlineBlock: null,
+  headBlock: null,
+  attestation: UNVERIFIED_ATTESTATION,
+  events: [],
+  ...over,
+})
+
+/** A snapshot in the terminal verified-BENIGN state. */
+export const buildBenignSnapshot = (over: Partial<SafenetCheckSnapshot> = {}): SafenetCheckSnapshot =>
+  buildSnapshot({
+    status: CheckStatus.BENIGN,
+    attestation: { status: AttestationVerificationStatus.VERIFIED, signatureId: hexHash(), message: hexHash() },
+    ...over,
+  })

--- a/packages/utils/src/features/safenet-checks/hooks/__tests__/useSafenetCheck.test.ts
+++ b/packages/utils/src/features/safenet-checks/hooks/__tests__/useSafenetCheck.test.ts
@@ -1,0 +1,203 @@
+import { renderHook } from '@testing-library/react'
+import { useSelector } from 'react-redux'
+import { useGetSafenetCheckQuery } from '@safe-global/store/safenet/safenetCheckApi'
+import type { PinnedVerdict } from '@safe-global/store/safenet/safenetCheckSlice'
+import { useSafenetCheck } from '../useSafenetCheck'
+import { POLL_INTERVAL_FAST_MS, POLL_INTERVAL_LATE_MS } from '../../constants'
+import { CheckStatus, UNVERIFIED_ATTESTATION, type SafenetCheckSnapshot } from '../../types'
+import { buildBenignSnapshot, buildSnapshot, plainProposedEvent } from '../../builders'
+
+jest.mock('@safe-global/store/safenet/safenetCheckApi', () => ({
+  useGetSafenetCheckQuery: jest.fn(),
+}))
+jest.mock('react-redux', () => ({ useSelector: jest.fn() }))
+
+const mockQuery = useGetSafenetCheckQuery as unknown as jest.Mock
+const mockSelector = useSelector as unknown as jest.Mock
+
+const HASH = ('0x' + 'ab'.repeat(32)) as `0x${string}`
+
+/** The slice of the RTK query result the hook consumes, as the mock returns it. */
+type QueryResult = {
+  data?: SafenetCheckSnapshot
+  error?: { message: string }
+  isError?: boolean
+  isLoading?: boolean
+  isFetching?: boolean
+  refetch?: jest.Mock
+}
+
+const refetchFn = jest.fn()
+
+const queryResult = (over: QueryResult = {}): QueryResult => ({
+  data: undefined,
+  error: undefined,
+  isLoading: false,
+  isFetching: false,
+  refetch: refetchFn,
+  ...over,
+})
+
+const FETCH_ERROR = { message: 'rpc down' }
+
+/** Last options object the query hook was invoked with. */
+const lastOptions = () => mockQuery.mock.calls[mockQuery.mock.calls.length - 1][1]
+
+beforeEach(() => {
+  mockQuery.mockReset()
+  mockSelector.mockReset()
+  refetchFn.mockReset()
+  mockSelector.mockReturnValue(undefined)
+})
+
+describe('useSafenetCheck', () => {
+  it('skips the query when no safeTxHash is given', () => {
+    mockQuery.mockReturnValue(queryResult())
+
+    renderHook(() => useSafenetCheck(undefined))
+
+    expect(mockQuery.mock.calls[0][0]).toEqual({ safeTxHash: '', timestampMs: null })
+    expect(mockQuery.mock.calls[0][1]).toMatchObject({ skip: true })
+  })
+
+  it('passes the transaction timestamp through so the reader can target its block window', () => {
+    mockQuery.mockReturnValue(queryResult())
+
+    renderHook(() => useSafenetCheck('0xabc', 1_700_000_000_000))
+
+    expect(mockQuery.mock.calls[0][0]).toEqual({ safeTxHash: '0xabc', timestampMs: 1_700_000_000_000 })
+  })
+
+  describe('polling interval selection', () => {
+    it('stops polling once a verdict is verified BENIGN, and skips polling while unfocused', () => {
+      mockQuery.mockReturnValue(queryResult({ data: buildBenignSnapshot({ safeTxHash: HASH }) }))
+
+      renderHook(() => useSafenetCheck(HASH))
+
+      expect(lastOptions().pollingInterval).toBe(0)
+      // The one deliberate option keeping background tabs off the chain.
+      expect(lastOptions().skipPollingIfUnfocused).toBe(true)
+    })
+
+    // The plain (non-oracle) path never emits a deadline — the hook substitutes
+    // the first observed event's block, so a never-attested check still stops.
+    it('polls fast on the plain path while inside the substitute deadline', () => {
+      mockQuery.mockReturnValue(
+        queryResult({
+          data: buildSnapshot({
+            status: CheckStatus.SUBMITTED,
+            headBlock: '150',
+            deadlineBlock: null,
+            events: [plainProposedEvent({ blockNumber: 100 })],
+          }),
+        }),
+      )
+
+      renderHook(() => useSafenetCheck(HASH))
+
+      expect(lastOptions().pollingInterval).toBe(POLL_INTERVAL_FAST_MS)
+    })
+  })
+
+  describe('error mapping', () => {
+    it('maps an error with no data to UNAVAILABLE', () => {
+      mockQuery.mockReturnValue(queryResult({ error: FETCH_ERROR }))
+
+      const { result } = renderHook(() => useSafenetCheck(HASH))
+
+      expect(result.current.status).toBe(CheckStatus.UNAVAILABLE)
+      expect(result.current.publicStatus).toBe(CheckStatus.UNAVAILABLE)
+      expect(result.current.isStale).toBe(false)
+    })
+
+    it('keeps retrying at the slow cadence when the first fetch failed (nothing to show)', () => {
+      mockQuery.mockReturnValue(queryResult({ error: FETCH_ERROR }))
+
+      renderHook(() => useSafenetCheck(HASH))
+
+      // A transient endpoint failure must not read as "no check exists" and
+      // stop polling — on mobile this retry is the only recovery path.
+      expect(lastOptions().pollingInterval).toBe(POLL_INTERVAL_LATE_MS)
+    })
+
+    it('holds the slow cadence while a retry is in flight (error retained, request pending)', () => {
+      // RTK Query flips isError off during a retry's pending phase but retains
+      // `error`; keying on isError here advertised interval 0 mid-retry.
+      mockQuery.mockReturnValue(queryResult({ error: FETCH_ERROR, isError: false, isFetching: true }))
+
+      renderHook(() => useSafenetCheck(HASH))
+
+      expect(lastOptions().pollingInterval).toBe(POLL_INTERVAL_LATE_MS)
+    })
+
+    it('restores the computed interval once a retry succeeds', () => {
+      mockQuery.mockReturnValue(queryResult({ error: FETCH_ERROR }))
+      const { rerender } = renderHook(() => useSafenetCheck(HASH))
+      expect(lastOptions().pollingInterval).toBe(POLL_INTERVAL_LATE_MS)
+
+      mockQuery.mockReturnValue(queryResult({ data: buildBenignSnapshot({ safeTxHash: HASH }) }))
+      rerender()
+
+      expect(lastOptions().pollingInterval).toBe(0)
+    })
+
+    it('keeps the last snapshot and flags isStale on an error with retained data', () => {
+      const snapshot = buildBenignSnapshot({ safeTxHash: HASH })
+      mockQuery.mockReturnValue(queryResult({ error: FETCH_ERROR, data: snapshot }))
+
+      const { result } = renderHook(() => useSafenetCheck(HASH))
+
+      expect(result.current.status).toBe(CheckStatus.BENIGN)
+      expect(result.current.isStale).toBe(true)
+      expect(result.current.snapshot).toBe(snapshot)
+    })
+  })
+
+  describe('read-path pin merge', () => {
+    it('never downgrades below the pinned verdict', () => {
+      const pinned: PinnedVerdict = { status: CheckStatus.BENIGN, atBlock: '10', verification: UNVERIFIED_ATTESTATION }
+      mockSelector.mockReturnValue(pinned)
+      // A reorg drops the attestation and the fresh read derives IN_PROGRESS.
+      mockQuery.mockReturnValue(
+        queryResult({ data: buildSnapshot({ status: CheckStatus.IN_PROGRESS, safeTxHash: HASH }) }),
+      )
+
+      const { result } = renderHook(() => useSafenetCheck(HASH))
+
+      expect(result.current.status).toBe(CheckStatus.BENIGN)
+      expect(result.current.publicStatus).toBe(CheckStatus.BENIGN)
+    })
+
+    it('keeps the pinned verdict through a transient UNAVAILABLE', () => {
+      const pinned: PinnedVerdict = {
+        status: CheckStatus.MALICIOUS,
+        atBlock: '10',
+        verification: UNVERIFIED_ATTESTATION,
+      }
+      mockSelector.mockReturnValue(pinned)
+      mockQuery.mockReturnValue(queryResult({ error: FETCH_ERROR }))
+
+      const { result } = renderHook(() => useSafenetCheck(HASH))
+
+      expect(result.current.status).toBe(CheckStatus.MALICIOUS)
+    })
+  })
+
+  it('exposes refetch that re-runs the query', () => {
+    mockQuery.mockReturnValue(queryResult({ data: buildSnapshot({ safeTxHash: HASH }) }))
+
+    const { result } = renderHook(() => useSafenetCheck(HASH))
+    result.current.refetch()
+
+    expect(refetchFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call refetch on a skipped query', () => {
+    mockQuery.mockReturnValue(queryResult())
+
+    const { result } = renderHook(() => useSafenetCheck(undefined))
+    result.current.refetch()
+
+    expect(refetchFn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/utils/src/features/safenet-checks/hooks/index.ts
+++ b/packages/utils/src/features/safenet-checks/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useSafenetCheck'

--- a/packages/utils/src/features/safenet-checks/hooks/useSafenetCheck.ts
+++ b/packages/utils/src/features/safenet-checks/hooks/useSafenetCheck.ts
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useSelector } from 'react-redux'
+import { useGetSafenetCheckQuery } from '@safe-global/store/safenet/safenetCheckApi'
+import { selectPinnedVerdict, type SafenetCheckPartialState } from '@safe-global/store/safenet/safenetCheckSlice'
+import { POLL_INTERVAL_FAST_MS, POLL_INTERVAL_LATE_MS } from '../constants'
+import { CheckStatus, toPublicStatus, type PublicCheckStatus } from '../types/status'
+import type { SafenetCheckSnapshot } from '../types/snapshot'
+import { computePollingInterval } from '../utils/computePollingInterval'
+import { mergeMonotonic } from '../utils/mergeMonotonic'
+
+export type SafenetCheckView = {
+  /** The last good snapshot; retained across a failed refetch (see `isStale`). */
+  snapshot: SafenetCheckSnapshot | undefined
+  /** Internal merged status. Can be `AWAITING_VERIFICATION` or `VERIFICATION_FAILED`. */
+  status: CheckStatus
+  publicStatus: PublicCheckStatus
+  isLoading: boolean
+  isFetching: boolean
+  /** Showing a retained snapshot because the latest fetch failed. */
+  isStale: boolean
+  refetch: () => void
+}
+
+/**
+ * Subscribe to a check's chain-read lifecycle for a `safeTxHash`. Wraps the
+ * store's `getSafenetCheck` query with the dynamic poll interval, the merge
+ * against the session-pinned verdict, and the stale/UNAVAILABLE error mapping.
+ * Platform-neutral (no DOM access). `timestampMs` aims the reader's block
+ * window; pass the submission time when known. Callers sharing one hash must
+ * agree on supplying it — the cache keys by hash, and the last fetch's args
+ * aim every later poll.
+ */
+export const useSafenetCheck = (safeTxHash: string | undefined, timestampMs?: number | null): SafenetCheckView => {
+  const skip = !safeTxHash
+
+  // The interval feeds back into the query below, so the (status → interval →
+  // next poll) loop is reconfigured from the query's own output via an effect.
+  const [pollingInterval, setPollingInterval] = useState(POLL_INTERVAL_FAST_MS)
+
+  const query = useGetSafenetCheckQuery(
+    { safeTxHash: safeTxHash ?? '', timestampMs: timestampMs ?? null },
+    {
+      skip,
+      pollingInterval,
+      // No refetchOnFocus: a settled check does not change, and a history page
+      // would cost ~3 chain reads per row on every tab switch back.
+      skipPollingIfUnfocused: true,
+    },
+  )
+
+  const pinned = useSelector((state: SafenetCheckPartialState) =>
+    safeTxHash ? selectPinnedVerdict(state, safeTxHash) : undefined,
+  )
+
+  const snapshot = query.data
+  const hasData = snapshot !== undefined
+  // Keyed on the retained error, not `isError`: RTK Query flips `isError` off
+  // during each retry's pending phase while `error` and `data` persist.
+  const hasError = query.error !== undefined
+  const isStale = hasError && hasData
+
+  // With no snapshot to show the base is UNAVAILABLE; the monotonic merge
+  // still keeps any pinned floor from an earlier success.
+  const base = snapshot?.status ?? CheckStatus.UNAVAILABLE
+  const status = mergeMonotonic(pinned?.status, base)
+  const publicStatus = toPublicStatus(status)
+
+  // Events are sorted ascending, so [0] substitutes for the deadline on the
+  // plain path, which does not emit one.
+  const firstEventBlock = snapshot?.events[0] !== undefined ? String(snapshot.events[0].blockNumber) : null
+
+  useEffect(() => {
+    // A failed fetch with nothing to show is a transient endpoint problem, not
+    // "no check exists" — keep retrying at the slow cadence. This is the only
+    // recovery path on mobile, which has no focus-refetch listeners.
+    if (hasError && !hasData) {
+      setPollingInterval(POLL_INTERVAL_LATE_MS)
+      return
+    }
+    setPollingInterval(
+      computePollingInterval({
+        status,
+        headBlock: snapshot?.headBlock ?? null,
+        deadlineBlock: snapshot?.deadlineBlock ?? null,
+        firstEventBlock,
+      }),
+    )
+  }, [hasError, hasData, status, snapshot?.headBlock, snapshot?.deadlineBlock, firstEventBlock])
+
+  const { refetch: queryRefetch } = query
+  const refetch = useCallback(() => {
+    if (!skip) queryRefetch()
+  }, [skip, queryRefetch])
+
+  return {
+    snapshot,
+    status,
+    publicStatus,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    isStale,
+    refetch,
+  }
+}


### PR DESCRIPTION
Fifth slice of the Safenet read layer, on top of the store slice. One
question: how does a component subscribe to a check? `useSafenetCheck` wraps
the store's `getSafenetCheck` query and owns the polling loop. No UI yet; the
history surface is the next slice.

## The hook

`useSafenetCheck(safeTxHash, timestampMs)` returns the snapshot, the merged
internal status, its public projection, and loading/stale flags.

- The poll interval is a function of the query's own output
  (`computePollingInterval`), so it is reconfigured through an effect: fast
  before the effective deadline, slow through the late window, stopped on a
  settled verdict.
- Error handling keys on the retained `query.error`, not `isError`: RTK Query
  flips `isError` off during each retry's pending phase while `error` and
  `data` persist. Keying on `isError` made `isStale` blink off during every
  in-flight retry and flapped the advertised interval 30s→0→30s per cycle.
- A failed fetch with a retained snapshot shows that snapshot as `isStale`. A
  failed fetch with nothing to show maps to `UNAVAILABLE` and retries at the
  slow cadence — the only recovery path on mobile, which has no focus-refetch
  listeners.
- The read-path merge against the session pin runs here too, so a component
  render between polls can never show a status the store would take back.
- `refetchOnFocus` stays off: a settled check does not change, and a history
  page of N rows would cost ~3N chain reads per tab switch back.
  `skipPollingIfUnfocused` covers the background-tab case.

Platform-neutral: react + react-redux only, no DOM access. Neither is
declared in the utils manifest — the package already ships react hooks with
react resolved from the host apps, and react-redux resolves the same way.

## Test builders

`buildSnapshot` / `buildBenignSnapshot` join the existing builders so store
and web suites can construct snapshots without hand-rolled literals.

## Testing

The suite covers what the hook adds over the layers below (interval window
arithmetic already has its own 21-case suite): interval delivery into the
query options, the plain-path first-event substitution, stop on a settled
verdict, `skipPollingIfUnfocused`, the slow-retry branch, cadence held while a
retry is in flight (error retained, request pending — fails if keyed on
`isError`), interval restoration after recovery, stale mapping, pinned-floor
merge on a backward re-derivation, skip behavior for an undefined hash, and
the refetch skip-guard.

`yarn workspace @safe-global/utils {test,type-check,lint}` passes.
