### PR TITLE
fix: shadcn UI fixes

### DIFF
--- a/apps/web/src/components/common/Disclaimer/__snapshots__/index.stories.test.tsx.snap
+++ b/apps/web/src/components/common/Disclaimer/__snapshots__/index.stories.test.tsx.snap
@@ -44,13 +44,6 @@ exports[`./index.stories BlockedAddress 1`] = `
           >
             This signer address is blocked by the Safe interface, due to being associated with the blocked activities by the U.S. Department of Treasury in the Specially Designated Nationals (SDN) list.
           </div>
-          <div
-            aria-orientation="horizontal"
-            class="bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch"
-            data-orientation="horizontal"
-            data-slot="separator"
-            role="separator"
-          />
         </div>
         <div
           class="flex justify-center pt-6 pb-4"
@@ -183,13 +176,6 @@ exports[`./index.stories LegalDisclaimer 1`] = `
               </div>
             </div>
           </div>
-          <div
-            aria-orientation="horizontal"
-            class="bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch"
-            data-orientation="horizontal"
-            data-slot="separator"
-            role="separator"
-          />
         </div>
         <div
           class="flex justify-center pt-6 pb-4"

--- a/apps/web/src/components/common/Disclaimer/index.tsx
+++ b/apps/web/src/components/common/Disclaimer/index.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement, ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
-import { Separator } from '@/components/ui/separator'
 import { Typography } from '@/components/ui/typography'
 import InfoIcon from '@/public/images/notifications/info.svg'
 import css from './styles.module.css'
@@ -35,7 +34,6 @@ const Disclaimer = ({
           <Typography variant="paragraph-small" as="div">
             {content}
           </Typography>
-          <Separator />
         </div>
         <div className="flex justify-center pt-6 pb-4">
           <Button size="sm" onClick={onAccept}>

--- a/apps/web/src/components/common/NetworkSelector/NetworkMultiSelectorInput.test.tsx
+++ b/apps/web/src/components/common/NetworkSelector/NetworkMultiSelectorInput.test.tsx
@@ -28,13 +28,17 @@ describe('NetworkMultiSelectorInput', () => {
       </Form>,
     )
 
-  it('opens the listbox on input click and closes it on an outside pointerdown', () => {
+  it('opens the listbox on input click and closes it on an outside press', () => {
     renderInput()
 
     fireEvent.click(screen.getByRole('combobox'))
     expect(screen.getByRole('listbox')).toBeInTheDocument()
 
+    // base-ui's Popover dismisses on an outside press; fire the full sequence so it triggers
+    // regardless of the resolved `outsidePressEvent` mode.
     fireEvent.pointerDown(document.body)
+    fireEvent.mouseDown(document.body)
+    fireEvent.click(document.body)
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
   })
 

--- a/apps/web/src/components/common/NetworkSelector/NetworkMultiSelectorInput.tsx
+++ b/apps/web/src/components/common/NetworkSelector/NetworkMultiSelectorInput.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react'
+import { useCallback, useRef, useState, type ReactElement } from 'react'
 import { XIcon } from 'lucide-react'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import ChainIndicator from '../ChainIndicator'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Typography } from '@/components/ui/typography'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import css from './styles.module.css'
 import { useFormContext } from 'react-hook-form'
 import useChains from '@/hooks/useChains'
@@ -34,29 +35,6 @@ const NetworkMultiSelectorInput = ({
   const [open, setOpen] = useState(false)
   const [inputValue, setInputValue] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
-  const wrapperRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!open) return
-
-    const onPointerDown = (event: PointerEvent) => {
-      if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
-        setOpen(false)
-      }
-    }
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setOpen(false)
-      }
-    }
-
-    document.addEventListener('pointerdown', onPointerDown)
-    document.addEventListener('keydown', onKeyDown)
-    return () => {
-      document.removeEventListener('pointerdown', onPointerDown)
-      document.removeEventListener('keydown', onKeyDown)
-    }
-  }, [open])
 
   const getOptionDisabled = isOptionDisabled || (() => false)
 
@@ -174,67 +152,78 @@ const NetworkMultiSelectorInput = ({
   }
 
   return (
-    <div ref={wrapperRef} className={css.multiSelectWrapper}>
-      <div
-        className={`${css.multiSelectControl} ${error ? css.multiSelectError : ''}`}
-        onClick={() => inputRef.current?.focus()}
-      >
-        {renderChips()}
+    <div className={css.multiSelectWrapper}>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger
+          render={
+            <div
+              className={`${css.multiSelectControl} ${error ? css.multiSelectError : ''}`}
+              onClick={() => inputRef.current?.focus()}
+            />
+          }
+        >
+          {renderChips()}
 
-        <input
-          ref={inputRef}
-          role="combobox"
-          aria-expanded={open}
-          aria-controls={`${name}-listbox`}
-          aria-invalid={error || undefined}
-          className={css.multiSelectInput}
-          placeholder={value.length === 0 ? 'Select networks' : undefined}
-          value={inputValue}
-          onChange={(e) => {
-            setInputValue(e.target.value)
-            setOpen(true)
-          }}
-          onClick={() => setOpen((prev) => !prev)}
-        />
-
-        {value.length > 0 && (
-          <button
-            type="button"
-            aria-label="Clear all"
-            className={css.clearAll}
-            onClick={(e) => {
-              e.stopPropagation()
-              handleChange([])
+          <input
+            ref={inputRef}
+            role="combobox"
+            aria-expanded={open}
+            aria-controls={`${name}-listbox`}
+            aria-invalid={error || undefined}
+            className={css.multiSelectInput}
+            placeholder={value.length === 0 ? 'Select networks' : undefined}
+            value={inputValue}
+            onChange={(e) => {
+              setInputValue(e.target.value)
+              setOpen(true)
             }}
-          >
-            <XIcon data-testid="CloseIcon" className="size-4" />
-          </button>
-        )}
-      </div>
+          />
 
-      {open && (
-        <ul id={`${name}-listbox`} role="listbox" aria-multiselectable className={css.multiSelectList}>
-          {visibleOptions.map((chain) => {
-            const disabled =
-              showSelectAll && chain.chainId === SELECT_ALL_OPTION.chainId ? false : getOptionDisabled(chain as Chain)
-            const selected =
-              showSelectAll && chain.chainId === SELECT_ALL_OPTION.chainId ? isAllSelected : isSelected(chain.chainId)
+          {value.length > 0 && (
+            <button
+              type="button"
+              aria-label="Clear all"
+              className={css.clearAll}
+              onClick={(e) => {
+                e.stopPropagation()
+                handleChange([])
+              }}
+            >
+              <XIcon data-testid="CloseIcon" className="size-4" />
+            </button>
+          )}
+        </PopoverTrigger>
 
-            return (
-              <li
-                key={chain.chainId}
-                role="option"
-                aria-disabled={Boolean(disabled)}
-                aria-selected={Boolean(selected)}
-                className={css.multiSelectOption}
-                onClick={() => handleOptionClick(chain, disabled)}
-              >
-                {renderOptionContent(chain)}
-              </li>
-            )
-          })}
-        </ul>
-      )}
+        {/* Portaled by PopoverContent so it escapes the dialog's overflow clipping. */}
+        <PopoverContent
+          align="start"
+          sideOffset={4}
+          initialFocus={inputRef}
+          className="max-h-[300px] w-[var(--anchor-width)] overflow-y-auto p-1"
+        >
+          <ul id={`${name}-listbox`} role="listbox" aria-multiselectable className="m-0 list-none p-0">
+            {visibleOptions.map((chain) => {
+              const disabled =
+                showSelectAll && chain.chainId === SELECT_ALL_OPTION.chainId ? false : getOptionDisabled(chain as Chain)
+              const selected =
+                showSelectAll && chain.chainId === SELECT_ALL_OPTION.chainId ? isAllSelected : isSelected(chain.chainId)
+
+              return (
+                <li
+                  key={chain.chainId}
+                  role="option"
+                  aria-disabled={Boolean(disabled)}
+                  aria-selected={Boolean(selected)}
+                  className={css.multiSelectOption}
+                  onClick={() => handleOptionClick(chain, disabled)}
+                >
+                  {renderOptionContent(chain)}
+                </li>
+              )
+            })}
+          </ul>
+        </PopoverContent>
+      </Popover>
 
       {helperText && (
         <Typography variant="paragraph-mini" className={error ? 'text-destructive' : 'text-muted-foreground'}>

--- a/apps/web/src/components/common/Notifications/index.tsx
+++ b/apps/web/src/components/common/Notifications/index.tsx
@@ -7,20 +7,23 @@ import { closeNotification, readNotification, selectNotifications } from '@/stor
 import { Alert, AlertAction } from '@/components/ui/alert'
 import { Link } from '@/components/ui/link'
 import { Button } from '@/components/ui/button'
+import { cn } from '@/utils/cn'
 import css from './styles.module.css'
 import NextLink from 'next/link'
-import { ChevronRight, X } from 'lucide-react'
+import { ChevronRight, X, CircleAlert, CircleCheck, TriangleAlert, Info } from 'lucide-react'
 import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
 import Track from '../Track'
 import { isRelativeUrl } from '@/utils/url'
 
 type NotificationVariant = 'success' | 'info' | 'warning' | 'error'
 
-const variantToAlertVariant: Record<NotificationVariant, 'default' | 'destructive' | 'warning'> = {
-  success: 'default',
-  info: 'default',
-  warning: 'warning',
-  error: 'destructive',
+// Toast styling per severity — a light tinted background with a colored icon and neutral (dark) text,
+// matching how MUI's Alert looked before the shadcn migration (text is never colour-on-colour).
+const variantStyles: Record<NotificationVariant, { background: string; icon: ReactNode }> = {
+  success: { background: 'bg-success-subtle', icon: <CircleCheck style={{ color: 'var(--color-success-main)' }} /> },
+  info: { background: 'bg-info-subtle', icon: <Info style={{ color: 'var(--color-info-dark)' }} /> },
+  warning: { background: 'bg-warning-subtle', icon: <TriangleAlert style={{ color: 'var(--color-warning-main)' }} /> },
+  error: { background: 'bg-error-subtle', icon: <CircleAlert style={{ color: 'var(--color-error-main)' }} /> },
 }
 
 export const NotificationLink = ({
@@ -143,8 +146,12 @@ const Toast = ({
   const autoHideProps = useAutoHide(getAutoHideDuration(variant, autoHideDurationOverride), onClose)
 
   return (
-    <Alert variant={variantToAlertVariant[variant]} className="w-[340px] shadow-lg" {...autoHideProps}>
-      {icon ? (icon as ReactNode) : null}
+    <Alert
+      variant="default"
+      className={cn('w-[340px] border-transparent shadow-lg', variantStyles[variant].background)}
+      {...autoHideProps}
+    >
+      {icon ? (icon as ReactNode) : variantStyles[variant].icon}
       <AlertAction>
         <Button variant="ghost" size="icon-xs" aria-label="Close" onClick={handleManualClose}>
           <X />

--- a/apps/web/src/components/common/PromoBanner/PromoBanner.tsx
+++ b/apps/web/src/components/common/PromoBanner/PromoBanner.tsx
@@ -133,6 +133,7 @@ const PromoBanner = ({
 
           {description ? (
             <Typography
+              as="div"
               variant="paragraph-small"
               className={`${css.bannerText} ${css.bannerDescription}`}
               style={customFontColor ? { color: customFontColor } : undefined}

--- a/apps/web/src/components/common/PromoBanner/__snapshots__/PromoBanner.stories.test.tsx.snap
+++ b/apps/web/src/components/common/PromoBanner/__snapshots__/PromoBanner.stories.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`./PromoBanner.stories Default 1`] = `
 <div
@@ -35,13 +35,13 @@ exports[`./PromoBanner.stories Default 1`] = `
           >
             Discover new features
           </h4>
-          <span
+          <div
             class="m-0 text-sm leading-5 font-normal bannerText bannerDescription"
             data-slot="typography"
             data-variant="paragraph-small"
           >
             Learn about the latest updates and improvements to Safe
-          </span>
+          </div>
           <a
             class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 bannerCtaText"
             data-slot="button"
@@ -180,14 +180,14 @@ exports[`./PromoBanner.stories WithCustomColors 1`] = `
           >
             Special offer
           </h4>
-          <span
+          <div
             class="m-0 text-sm leading-5 font-normal bannerText bannerDescription"
             data-slot="typography"
             data-variant="paragraph-small"
             style="color: rgb(255, 215, 0);"
           >
             Limited time promotion for Safe users
-          </span>
+          </div>
           <a
             class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 bannerCtaText"
             data-slot="button"
@@ -263,13 +263,13 @@ exports[`./PromoBanner.stories WithOnClick 1`] = `
           >
             Take action now
           </h4>
-          <span
+          <div
             class="m-0 text-sm leading-5 font-normal bannerText bannerDescription"
             data-slot="typography"
             data-variant="paragraph-small"
           >
             Click the button to perform a custom action
-          </span>
+          </div>
           <button
             class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-8 gap-1 px-4 in-data-[slot=button-group]:rounded-sm has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 bannerCtaContained"
             data-slot="button"
@@ -346,13 +346,13 @@ exports[`./PromoBanner.stories WithoutDismiss 1`] = `
           >
             Welcome to Safe
           </h4>
-          <span
+          <div
             class="m-0 text-sm leading-5 font-normal bannerText bannerDescription"
             data-slot="typography"
             data-variant="paragraph-small"
           >
             Your gateway to secure digital asset management
-          </span>
+          </div>
           <a
             class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 bannerCtaText"
             data-slot="button"
@@ -390,13 +390,13 @@ exports[`./PromoBanner.stories WithoutImage 1`] = `
           >
             Important announcement
           </h4>
-          <span
+          <div
             class="m-0 text-sm leading-5 font-normal bannerText bannerDescription"
             data-slot="typography"
             data-variant="paragraph-small"
           >
             Check out our latest security features
-          </span>
+          </div>
           <a
             class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 bannerCtaText"
             data-slot="button"

--- a/apps/web/src/components/common/PromoBanner/styles.module.css
+++ b/apps/web/src/components/common/PromoBanner/styles.module.css
@@ -31,6 +31,7 @@
 
 .bannerCtaText {
   color: var(--color-static-main);
+  font-weight: bold !important;
   margin-left: 0 !important;
   padding: var(--space-1) !important;
   margin-left: -8px !important;

--- a/apps/web/src/components/common/TrustedSafesModal/ManageTrustedSafesContent.tsx
+++ b/apps/web/src/components/common/TrustedSafesModal/ManageTrustedSafesContent.tsx
@@ -137,7 +137,7 @@ const ManageTrustedSafesContent = ({ modal, secondaryLabel, onSecondary, onSaved
               onClick={() => (allSelected ? deselectAll() : selectAll())}
               disabled={isLoading || totalSafesCount === 0}
               data-testid="manage-trusted-select-all"
-              className="flex shrink-0 items-center gap-2 rounded-md px-2 py-1 text-sm text-muted-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex shrink-0 items-center gap-2 rounded-md py-1 pl-[21px] pr-2 text-sm text-muted-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
             >
               <Checkbox checked={allSelected} indeterminate={someSelected && !allSelected} tabIndex={-1} aria-hidden />
               Select all · {selectedCount} of {totalSafesCount} selected

--- a/apps/web/src/components/common/TrustedSafesModal/ManageTrustedSafesContent.tsx
+++ b/apps/web/src/components/common/TrustedSafesModal/ManageTrustedSafesContent.tsx
@@ -128,7 +128,7 @@ const ManageTrustedSafesContent = ({ modal, secondaryLabel, onSecondary, onSaved
             </div>
           )}
 
-          <div className="mb-3 mx-1 block items-center gap-3">
+          <div className="mb-3 flex flex-wrap items-center gap-3">
             <button
               type="button"
               role="checkbox"
@@ -137,12 +137,12 @@ const ManageTrustedSafesContent = ({ modal, secondaryLabel, onSecondary, onSaved
               onClick={() => (allSelected ? deselectAll() : selectAll())}
               disabled={isLoading || totalSafesCount === 0}
               data-testid="manage-trusted-select-all"
-              className="flex shrink-0 items-center gap-2 rounded-md py-1 pl-[21px] pr-2 text-sm text-muted-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex shrink-0 items-center gap-2 rounded-md px-2 py-1 text-sm text-muted-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
             >
               <Checkbox checked={allSelected} indeterminate={someSelected && !allSelected} tabIndex={-1} aria-hidden />
               Select all · {selectedCount} of {totalSafesCount} selected
             </button>
-            <div className="flex flex-1 items-center justify-end gap-3">
+            <div className="flex grow basis-72 items-center justify-end gap-3">
               <InputGroup variant="search" className="max-w-sm flex-1">
                 <InputGroupAddon>
                   <Search className="size-4" />

--- a/apps/web/src/components/common/TrustedSafesModal/SecurityBanner.tsx
+++ b/apps/web/src/components/common/TrustedSafesModal/SecurityBanner.tsx
@@ -15,15 +15,12 @@ interface SecurityBannerProps {
  */
 const SecurityBanner = ({ title, className }: SecurityBannerProps) => {
   return (
-    <Alert
-      variant="warning"
-      className={cn('mb-4 dark:bg-[var(--color-warning-background)] dark:text-[var(--color-warning-main)]', className)}
-    >
-      <TriangleAlert className="dark:text-[var(--color-warning-main)]" />
+    <Alert variant="warning" outlined={false} className={cn('mb-4', className)}>
+      <TriangleAlert />
       {title && <AlertTitle className="font-bold">{title}</AlertTitle>}
-      <AlertDescription className="dark:text-current">
+      <AlertDescription>
         Some Safe accounts may be malicious or impersonations. Only trust Safe accounts you can verify.{' '}
-        <ExternalLink href={HelpCenterArticle.ADDRESS_POISONING} noIcon className="underline dark:text-inherit">
+        <ExternalLink href={HelpCenterArticle.ADDRESS_POISONING} noIcon className="underline">
           Learn more
         </ExternalLink>
       </AlertDescription>

--- a/apps/web/src/components/common/TrustedSafesModal/SecurityBanner.tsx
+++ b/apps/web/src/components/common/TrustedSafesModal/SecurityBanner.tsx
@@ -20,7 +20,7 @@ const SecurityBanner = ({ title, className }: SecurityBannerProps) => {
       {title && <AlertTitle className="font-bold">{title}</AlertTitle>}
       <AlertDescription>
         Some Safe accounts may be malicious or impersonations. Only trust Safe accounts you can verify.{' '}
-        <ExternalLink href={HelpCenterArticle.ADDRESS_POISONING} noIcon className="underline">
+        <ExternalLink href={HelpCenterArticle.ADDRESS_POISONING} noIcon className="font-bold [&>span]:underline">
           Learn more
         </ExternalLink>
       </AlertDescription>

--- a/apps/web/src/components/new-safe/create/index.tsx
+++ b/apps/web/src/components/new-safe/create/index.tsx
@@ -182,8 +182,8 @@ const CreateSafe = () => {
   }
 
   return (
-    <div className="mx-auto w-full max-w-[1200px] px-4">
-      <div className="mt-4 grid grid-cols-12 justify-center gap-x-6 md:mt-14">
+    <div className="mx-auto w-full max-w-[1200px] px-4 sm:px-6">
+      <div className="grid grid-cols-12 justify-center gap-x-6">
         <div className="col-span-12">
           <Typography variant="h2" className="pb-4">
             Create new Safe account

--- a/apps/web/src/components/new-safe/create/steps/SetNameStep/index.tsx
+++ b/apps/web/src/components/new-safe/create/steps/SetNameStep/index.tsx
@@ -124,6 +124,7 @@ function SetNameStep({
                 name={SetNameStepFields.name}
                 label={errors?.[SetNameStepFields.name]?.message || 'Name'}
                 placeholder={fallbackName}
+                className="[&_label]:text-base [&_label]:font-semibold"
                 InputLabelProps={{ shrink: true }}
                 InputProps={{
                   endAdornment: (
@@ -145,7 +146,7 @@ function SetNameStep({
             </div>
 
             <div className="col-span-12">
-              <Typography variant="h4" className="mt-4 inline-flex items-center gap-2">
+              <Typography variant="paragraph-bold" className="mt-4 inline-flex items-center gap-2">
                 Select networks
               </Typography>
               <Typography variant="paragraph-small" className="mb-4 block">

--- a/apps/web/src/components/new-safe/load/index.tsx
+++ b/apps/web/src/components/new-safe/load/index.tsx
@@ -52,14 +52,14 @@ const LoadSafe = ({ initialData }: { initialData?: TxStepperProps<LoadSafeFormDa
   const initialSafe = initialData ?? loadSafeDefaultData
 
   return (
-    <div data-testid="load-safe-form" className="mx-auto w-full max-w-[1200px] px-4">
-      <div className="mt-4 grid grid-cols-12 justify-center gap-x-6 md:mt-14">
-        <div className="col-span-12 md:col-span-10 lg:col-span-8">
+    <div data-testid="load-safe-form" className="mx-auto w-full max-w-[1200px] px-4 sm:px-6">
+      <div className="grid grid-cols-12 gap-x-6">
+        <div className="col-span-12 md:col-span-10 md:col-start-2 lg:col-span-8 lg:col-start-3">
           <Typography variant="h2" className="pb-4">
             Add existing Safe account
           </Typography>
         </div>
-        <div className="order-1 col-span-12 md:order-0 md:col-span-10 lg:col-span-8">
+        <div className="order-1 col-span-12 md:order-0 md:col-span-10 md:col-start-2 lg:col-span-8 lg:col-start-3">
           <CardStepper
             // Populate initial data
             key={initialSafe.address}

--- a/apps/web/src/components/settings/owner/OwnerList/index.tsx
+++ b/apps/web/src/components/settings/owner/OwnerList/index.tsx
@@ -117,14 +117,14 @@ export const OwnerList = () => {
           them.
         </Typography>
 
-        <div className="flex justify-between py-4">
+        <div className="flex flex-wrap justify-between gap-3 py-4">
           <CheckWallet>
             {(isOk) => (
               <Track {...SETTINGS_EVENTS.SETUP.MANAGE_SIGNERS}>
                 <Button
                   data-testid="manage-signers-btn"
                   onClick={() => setTxFlow(<ManageSignersFlow />)}
-                  variant="ghost"
+                  variant="outline"
                   disabled={!isOk}
                 >
                   <EditOwnerIcon className="size-4" />

--- a/apps/web/src/features/hypernative/components/HnBanner/__snapshots__/HnBanner.stories.test.tsx.snap
+++ b/apps/web/src/features/hypernative/components/HnBanner/__snapshots__/HnBanner.stories.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`./HnBanner.stories Default 1`] = `
 <div
@@ -36,7 +36,7 @@ exports[`./HnBanner.stories Default 1`] = `
           >
             Enforce enterprise-grade security
           </h4>
-          <span
+          <div
             class="m-0 text-sm leading-5 font-normal bannerText bannerDescription"
             data-slot="typography"
             data-variant="paragraph-small"
@@ -49,7 +49,7 @@ exports[`./HnBanner.stories Default 1`] = `
               Hypernative
             </span>
             .
-          </span>
+          </div>
           <button
             class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground h-8 gap-1 px-4 in-data-[slot=button-group]:rounded-sm has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 bannerCtaText"
             data-slot="button"
@@ -147,7 +147,7 @@ exports[`./HnBanner.stories NonDismissable 1`] = `
           >
             Enforce enterprise-grade security
           </h4>
-          <span
+          <div
             class="m-0 text-sm leading-5 font-normal bannerText bannerDescription"
             data-slot="typography"
             data-variant="paragraph-small"
@@ -160,7 +160,7 @@ exports[`./HnBanner.stories NonDismissable 1`] = `
               Hypernative
             </span>
             .
-          </span>
+          </div>
           <button
             class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground h-8 gap-1 px-4 in-data-[slot=button-group]:rounded-sm has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 bannerCtaText"
             data-slot="button"

--- a/apps/web/src/features/no-fee-campaign/components/NoFeeCampaignBanner/__snapshots__/index.stories.test.tsx.snap
+++ b/apps/web/src/features/no-fee-campaign/components/NoFeeCampaignBanner/__snapshots__/index.stories.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`./NoFeeCampaignBanner.stories Default 1`] = `
 <div
@@ -28,7 +28,7 @@ exports[`./NoFeeCampaignBanner.stories Default 1`] = `
       >
         Enjoy Free January
       </h4>
-      <span
+      <div
         class="m-0 text-sm leading-5 font-normal bannerText bannerDescription"
         data-slot="typography"
         data-variant="paragraph-small"
@@ -45,7 +45,7 @@ exports[`./NoFeeCampaignBanner.stories Default 1`] = `
         >
           Learn more
         </a>
-      </span>
+      </div>
       <button
         class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none bg-primary text-primary-foreground hover:bg-primary/80 disabled:bg-muted disabled:text-muted-foreground aria-disabled:bg-muted aria-disabled:text-muted-foreground disabled:[&_svg]:text-muted-foreground aria-disabled:[&_svg]:text-muted-foreground dark:[&_svg]:text-black dark:disabled:bg-muted dark:disabled:text-muted-foreground dark:aria-disabled:bg-muted dark:aria-disabled:text-muted-foreground dark:disabled:[&_svg]:text-muted-foreground dark:aria-disabled:[&_svg]:text-muted-foreground h-8 gap-1 px-4 in-data-[slot=button-group]:rounded-sm has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 bannerCtaContained"
         data-disabled=""

--- a/apps/web/src/features/spaces/components/AddMemberModal/MemberInfoForm.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/MemberInfoForm.tsx
@@ -19,7 +19,7 @@ const MemberInfoForm = ({
   const { control } = useFormContext()
 
   return (
-    <div className="flex flex-row items-center gap-4">
+    <div className="flex flex-row items-end gap-4">
       <NameInput
         data-testid="member-name-input"
         name="name"
@@ -37,10 +37,10 @@ const MemberInfoForm = ({
         defaultValue={MemberRole.MEMBER}
         render={({ field: { value, onChange } }) => (
           <Select value={value} onValueChange={onChange} required disabled={disableRole}>
-            <SelectTrigger className="min-w-[150px]">
+            <SelectTrigger aria-label="Role" className="min-w-[150px]">
               <SelectValue>{(role) => <RoleMenuItem role={role as MemberRole} />}</SelectValue>
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent align="end" alignItemWithTrigger={false} showBackdrop className="w-[340px]">
               <SelectItem value={MemberRole.ADMIN}>
                 <RoleMenuItem role={MemberRole.ADMIN} hasDescription />
               </SelectItem>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -95,7 +95,7 @@ function SpaceAddressBookTable({
       minWidth: 240,
       sortValue: (e) => e.address,
       cell: (entry, { isCompact }) => (
-        <div className="text-[0.8em] font-mono">
+        <div className="text-[0.8em] font-mono [&_a]:size-4 [&_button]:size-4 [&_svg]:size-4">
           <EthHashInfo
             address={entry.address}
             shortAddress={isCompact}

--- a/apps/web/src/features/stake/components/StakingPromoBanner/index.tsx
+++ b/apps/web/src/features/stake/components/StakingPromoBanner/index.tsx
@@ -36,7 +36,7 @@ const StakingPromoBanner = ({ onDismiss }: { onDismiss: () => void }) => {
               href={LEARN_MORE_LINK}
               noIcon
               onClick={onLearnMore}
-              className="font-bold text-inherit underline"
+              className="font-bold text-inherit [&>span]:underline"
             >
               Learn more
             </ExternalLink>

--- a/apps/web/src/features/stake/components/StakingPromoBanner/styles.module.css
+++ b/apps/web/src/features/stake/components/StakingPromoBanner/styles.module.css
@@ -4,14 +4,9 @@
   --promo-banner-radius: 12px;
 }
 
-/* 24px padding */
-.stakingPromoBanner :global(.MuiPaper-root) {
+/* 24px padding (targets PromoBanner's root div) */
+.stakingPromoBanner > div {
   padding: 24px;
-}
-
-/* 16px gap between the illustration and the content column */
-.stakingPromoBanner :global(.MuiStack-root) > :global(* + *) {
-  margin-left: 16px;
 }
 
 /* Coin illustration: 55px wide, aligned to the top */

--- a/apps/web/src/pages/swap.tsx
+++ b/apps/web/src/pages/swap.tsx
@@ -40,7 +40,7 @@ const SwapPage: NextPage = () => {
         <title>{`${BRAND_NAME} – Swap`}</title>
       </Head>
 
-      <main style={{ height: 'calc(100vh - 52px)' }}>
+      <main style={{ height: 'calc(100vh - var(--topbar-height))' }}>
         {isFeatureEnabled === true && isCowEnabled === true ? (
           <SwapWidget sell={sell} />
         ) : isFeatureEnabled === true && isCowEnabled === false ? (


### PR DESCRIPTION
## What it solves

Resolves: [WA-3011](https://linear.app/safe-global/issue/WA-3011/shadcn-post-migration-findings)

Post-shadcn-migration UI regressions across several flows: lost backgrounds/paddings, broken layouts, clipped dropdowns, and mis-styled links/icons.

## How this PR fixes it

- **Trusted Safes modal** — `SecurityBanner`: restored warning tint (`outlined={false}`), bold + underlined "Learn more". `ManageTrustedSafesContent`: fixed the Select-all / search / sort row (flex + wrap, left-aligned checkbox).
- **Toasts** (`Notifications`) — restored per-severity tinted background, colored icon and neutral text; info is blue again.
- **PromoBanner / StakingPromoBanner** — CTA drops to its own line and is bold, "Learn more" bold+underlined, restored 24px padding (dead `.Mui*` selectors → real DOM).
- **Disclaimer** — removed the duplicate separator above the button (shared by swap/earn/stake/bridge). `/swap` disclaimer re-centered via `--topbar-height`.
- **Settings › Signers** — "Manage signers" matches "Export as CSV" (`variant="outline"`); button row wraps on small screens.
- **Spaces Address Book** — smaller copy/explorer icons; `NetworkMultiSelectorInput` dropdown now portals via base-ui `Popover` so it isn't clipped by the modal's overflow.
- **Create/Load Safe** (`/new-safe/*`) — restored Container gutters, removed stray top margin, centered the Load card, and matched "Name"/"Select networks" heading sizes.

## How to test it

Look at every finding in the related ticket.
Open each surface above and compare against `feat/shadcn-migration`: Trusted Safes modal, a toast of each severity, the staking promo banner, `/swap` (disclaimer), Settings › Signers (narrow width), Spaces Address Book → Add contact (network dropdown), `/new-safe/create` and `/new-safe/load`.

## Affected flows

- Trusted Safes account list management
- App notifications (all toasts, app-wide)
- Promo banners (dashboard, balances, staking)
- Widget disclaimers (swap / earn / stake / bridge)
- Settings › Signers
- Spaces Address Book — add/edit contact + network selection
- Create Safe / Add existing Safe

## Blast radius

- **Shared components:** `Notifications` (all toasts), `Disclaimer` (4 flows), `PromoBanner` (dashboard/balances/hypernative/no-fee/stake), `SecurityBanner` (trusted modal + spaces), `NetworkMultiSelectorInput` (safe creation + add/edit contact). `CopyTooltip` was **not** changed (a trial revert was undone).
- **Scoped only:** `NameInput` label styling via a per-instance `className` (no shared change); address-book icon sizing via a cell-scoped selector.
- No API/hook/slice/flag/route changes. CSS/markup only.

## Risks / not checked

- `NetworkMultiSelectorInput` now uses base-ui `Popover`; Cypress `create_wallet` selectors are preserved (global `network-checkbox` / `li[role=option]` / `input`), but open/focus timing under Cypress wasn't run.
- Dark mode not exhaustively verified (toasts/banners use theme vars).
- Pixel-exact parity with the pre-migration MUI flows not verified in a running browser.

## Visual summary

UI-only change — attach before/after screenshots for: Trusted Safes modal, error/success/info toasts, staking promo banner, swap disclaimer, Settings › Signers, Address Book add-contact network dropdown, `/new-safe/create` + `/new-safe/load`.

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
