### PR TITLE
fix: e2e tests for tx-builder

### DIFF
--- a/apps/web/cypress/e2e/pages/safeapps.pages.js
+++ b/apps/web/cypress/e2e/pages/safeapps.pages.js
@@ -1,5 +1,4 @@
 import * as constants from '../../support/constants'
-import * as ls from '../../support/localstorage_data.js'
 import { accordionActionItem } from '../pages/nfts.pages'
 
 const searchAppInput = 'input[id="search-by-name"]'
@@ -344,8 +343,10 @@ export function checkAllPermissions(element) {
   cy.wrap(element).findByText(allowAllPermissions).click()
 }
 
-// tx-builder requests address book access on load and keeps its form disabled until the
-// prompt is answered: pre-grant the permission before the page loads (visit onBeforeLoad)
-export function preGrantAddressBookPermission(win, appUrl) {
-  win.localStorage.setItem(constants.SAFE_PERMISSIONS_KEY, JSON.stringify(ls.safeAppSafePermissions(appUrl)))
+export function getSafeAppIframeSelector(appUrl) {
+  return `iframe[id="iframe-${encodeURIComponent(appUrl)}"]`
+}
+
+export function verifySafeAppIframeVisible(appUrl) {
+  cy.get(getSafeAppIframeSelector(appUrl), { timeout: 30000 }).should('be.visible')
 }

--- a/apps/web/cypress/e2e/pages/safeapps.pages.js
+++ b/apps/web/cypress/e2e/pages/safeapps.pages.js
@@ -1,4 +1,5 @@
 import * as constants from '../../support/constants'
+import * as ls from '../../support/localstorage_data.js'
 import { accordionActionItem } from '../pages/nfts.pages'
 
 const searchAppInput = 'input[id="search-by-name"]'
@@ -341,4 +342,10 @@ export function uncheckAllPermissions(element) {
 
 export function checkAllPermissions(element) {
   cy.wrap(element).findByText(allowAllPermissions).click()
+}
+
+// tx-builder requests address book access on load and keeps its form disabled until the
+// prompt is answered: pre-grant the permission before the page loads (visit onBeforeLoad)
+export function preGrantAddressBookPermission(win, appUrl) {
+  win.localStorage.setItem(constants.SAFE_PERMISSIONS_KEY, JSON.stringify(ls.safeAppSafePermissions(appUrl)))
 }

--- a/apps/web/cypress/e2e/safe-apps/tx-builder.cy.js
+++ b/apps/web/cypress/e2e/safe-apps/tx-builder.cy.js
@@ -16,7 +16,11 @@ describe('Transaction Builder tests', { defaultCommandTimeout: 20000 }, () => {
     const appUrl = constants.TX_Builder_url
     iframeSelector = `iframe[id="iframe-${encodeURIComponent(appUrl)}"]`
     const visitUrl = `/apps/open?safe=${safeAppSafes.SEP_SAFEAPP_SAFE_1}&appUrl=${encodeURIComponent(appUrl)}`
-    cy.visit(visitUrl)
+    cy.visit(visitUrl, {
+      onBeforeLoad(win) {
+        safeapps.preGrantAddressBookPermission(win, appUrl)
+      },
+    })
     cy.get(iframeSelector, { timeout: 30000 }).should('be.visible')
   })
 

--- a/apps/web/cypress/e2e/safe-apps/tx-builder.cy.js
+++ b/apps/web/cypress/e2e/safe-apps/tx-builder.cy.js
@@ -1,8 +1,10 @@
 import * as constants from '../../support/constants.js'
 import * as safeapps from '../pages/safeapps.pages.js'
 import * as navigation from '../pages/navigation.page.js'
+import * as main from '../pages/main.page.js'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 import * as utils from '../../support/utils/checkers.js'
+import * as ls from '../../support/localstorage_data.js'
 
 let safeAppSafes = []
 let iframeSelector
@@ -14,14 +16,13 @@ describe('Transaction Builder tests', { defaultCommandTimeout: 20000 }, () => {
 
   beforeEach(() => {
     const appUrl = constants.TX_Builder_url
-    iframeSelector = `iframe[id="iframe-${encodeURIComponent(appUrl)}"]`
+    iframeSelector = safeapps.getSafeAppIframeSelector(appUrl)
     const visitUrl = `/apps/open?safe=${safeAppSafes.SEP_SAFEAPP_SAFE_1}&appUrl=${encodeURIComponent(appUrl)}`
-    cy.visit(visitUrl, {
-      onBeforeLoad(win) {
-        safeapps.preGrantAddressBookPermission(win, appUrl)
-      },
-    })
-    cy.get(iframeSelector, { timeout: 30000 }).should('be.visible')
+    // tx-builder keeps its form disabled until the address book permission prompt is answered:
+    // pre-grant it before the visit
+    main.addToLocalStorage(constants.SAFE_PERMISSIONS_KEY, ls.safeAppSafePermissions(appUrl))
+    cy.visit(visitUrl)
+    safeapps.verifySafeAppIframeVisible(appUrl)
   })
 
   it('Verify a simple batch can be created', () => {

--- a/apps/web/cypress/e2e/safe-apps/tx-builder_2.cy.js
+++ b/apps/web/cypress/e2e/safe-apps/tx-builder_2.cy.js
@@ -1,8 +1,10 @@
 import * as constants from '../../support/constants.js'
 import * as safeapps from '../pages/safeapps.pages.js'
+import * as main from '../pages/main.page.js'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 import * as utils from '../../support/utils/checkers.js'
 import { getMockAddress } from '../../support/utils/ethers.js'
+import * as ls from '../../support/localstorage_data.js'
 
 let safeAppSafes = []
 let iframeSelector
@@ -14,13 +16,12 @@ describe('Transaction Builder 2 tests', { defaultCommandTimeout: 20000 }, () => 
 
   beforeEach(() => {
     const appUrl = constants.TX_Builder_url
-    iframeSelector = `iframe[id="iframe-${encodeURIComponent(appUrl)}"]`
+    iframeSelector = safeapps.getSafeAppIframeSelector(appUrl)
     const visitUrl = `/apps/open?safe=${safeAppSafes.SEP_SAFEAPP_SAFE_1}&appUrl=${encodeURIComponent(appUrl)}`
-    cy.visit(visitUrl, {
-      onBeforeLoad(win) {
-        safeapps.preGrantAddressBookPermission(win, appUrl)
-      },
-    })
+    // tx-builder keeps its form disabled until the address book permission prompt is answered:
+    // pre-grant it before the visit
+    main.addToLocalStorage(constants.SAFE_PERMISSIONS_KEY, ls.safeAppSafePermissions(appUrl))
+    cy.visit(visitUrl)
   })
 
   it('Verify a batch cannot be created without method data', () => {

--- a/apps/web/cypress/e2e/safe-apps/tx-builder_2.cy.js
+++ b/apps/web/cypress/e2e/safe-apps/tx-builder_2.cy.js
@@ -16,7 +16,11 @@ describe('Transaction Builder 2 tests', { defaultCommandTimeout: 20000 }, () => 
     const appUrl = constants.TX_Builder_url
     iframeSelector = `iframe[id="iframe-${encodeURIComponent(appUrl)}"]`
     const visitUrl = `/apps/open?safe=${safeAppSafes.SEP_SAFEAPP_SAFE_1}&appUrl=${encodeURIComponent(appUrl)}`
-    cy.visit(visitUrl)
+    cy.visit(visitUrl, {
+      onBeforeLoad(win) {
+        safeapps.preGrantAddressBookPermission(win, appUrl)
+      },
+    })
   })
 
   it('Verify a batch cannot be created without method data', () => {
@@ -47,6 +51,15 @@ describe('Transaction Builder 2 tests', { defaultCommandTimeout: 20000 }, () => 
       getBody().findAllByText(safeapps.confirmDeleteBtnStr).should('not.be.disabled').click()
       getBody().findByText(safeapps.noSavedBatchesStr).should('be.visible')
       getBody().findByText(safeapps.backToTransactionStr).should('be.visible')
+
+      // Clear the uploaded draft: the app persists it in its own localStorage, and with
+      // testIsolation off the next tests would land on the batch view instead of the dropzone
+      getBody().findByText(safeapps.backToTransactionStr).click()
+      getBody().findByText(safeapps.createBatchStr).click()
+      getBody().findByRole('button', { name: safeapps.cancelBtnStr }).click()
+      getBody().findByText(safeapps.clearTransactionListStr)
+      getBody().findByRole('button', { name: safeapps.confirmClearTransactionListStr }).click()
+      getBody().findAllByText('choose a file').should('be.visible')
     })
     cy.readFile('cypress/downloads/E2E test.json').should('exist')
   })

--- a/apps/web/cypress/e2e/safe-apps/tx-builder_3.cy.js
+++ b/apps/web/cypress/e2e/safe-apps/tx-builder_3.cy.js
@@ -3,6 +3,7 @@ import * as safeapps from '../pages/safeapps.pages.js'
 import * as main from '../pages/main.page.js'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 import { txAccordionDetails } from '../pages/create_tx.pages'
+import * as ls from '../../support/localstorage_data.js'
 let staticSafes = []
 let iframeSelector
 
@@ -13,14 +14,13 @@ describe('Transaction Builder 3 tests', { defaultCommandTimeout: 20000 }, () => 
 
   beforeEach(() => {
     const appUrl = constants.TX_Builder_url
-    iframeSelector = `iframe[id="iframe-${encodeURIComponent(appUrl)}"]`
+    iframeSelector = safeapps.getSafeAppIframeSelector(appUrl)
     const visitUrl = `/apps/open?safe=${staticSafes.SEP_STATIC_SAFE_43}&appUrl=${encodeURIComponent(appUrl)}`
-    cy.visit(visitUrl, {
-      onBeforeLoad(win) {
-        safeapps.preGrantAddressBookPermission(win, appUrl)
-      },
-    })
-    cy.get(iframeSelector, { timeout: 30000 }).should('be.visible')
+    // tx-builder keeps its form disabled until the address book permission prompt is answered:
+    // pre-grant it before the visit
+    main.addToLocalStorage(constants.SAFE_PERMISSIONS_KEY, ls.safeAppSafePermissions(appUrl))
+    cy.visit(visitUrl)
+    safeapps.verifySafeAppIframeVisible(appUrl)
   })
 
   it('Verify that no error for the COWSwap fallbackhandler on confirm tx screen', () => {

--- a/apps/web/cypress/e2e/safe-apps/tx-builder_3.cy.js
+++ b/apps/web/cypress/e2e/safe-apps/tx-builder_3.cy.js
@@ -15,7 +15,12 @@ describe('Transaction Builder 3 tests', { defaultCommandTimeout: 20000 }, () => 
     const appUrl = constants.TX_Builder_url
     iframeSelector = `iframe[id="iframe-${encodeURIComponent(appUrl)}"]`
     const visitUrl = `/apps/open?safe=${staticSafes.SEP_STATIC_SAFE_43}&appUrl=${encodeURIComponent(appUrl)}`
-    cy.visit(visitUrl)
+    cy.visit(visitUrl, {
+      onBeforeLoad(win) {
+        safeapps.preGrantAddressBookPermission(win, appUrl)
+      },
+    })
+    cy.get(iframeSelector, { timeout: 30000 }).should('be.visible')
   })
 
   it('Verify that no error for the COWSwap fallbackhandler on confirm tx screen', () => {

--- a/apps/web/cypress/support/localstorage_data.js
+++ b/apps/web/cypress/support/localstorage_data.js
@@ -944,6 +944,11 @@ export const appPermissions = (url) => ({
   infoModalAccepted: JSON.stringify(infoModalAccepted),
 })
 
+// Safe (SDK) permissions payload for SAFE_PERMISSIONS_KEY, as stored after accepting the prompt
+export const safeAppSafePermissions = (appUrl) => ({
+  [appUrl]: [{ invoker: appUrl, parentCapability: 'requestAddressBook', date: 1111111111111, caveats: [] }],
+})
+
 export const cookies = {
   acceptedCookies: JSON.stringify(cookieState),
   acceptedTokenListOnboarding: true,


### PR DESCRIPTION
## What it solves
Adjusts e2e tests to pre-seed the address book permission

## How this PR fixes it

## How to test it

## Affected flows

<!-- The primary user journey(s) this PR intentionally changes. One bullet per flow. Example: "Owner adds a new signer from Settings > Signers". -->

## Blast radius

<!--
List the surfaces touched by this change and who else depends on them. Think in dependency terms, not files.
Include where relevant:
- Shared hooks / components / selectors / slices touched and their known consumers
- RTK Query endpoints / API contracts
- Feature flags / chain configs
- Persistence / cache / migration implications
- Routes or layouts affected indirectly
- Mobile impact (shared packages)
-->

## Risks / not checked

<!--
Be explicit about what you did NOT verify. This exposes false confidence and helps reviewers target their attention.
Example:
- Did not verify behavior with feature flag X disabled
- Did not test on mobile
- Did not exercise the retry / error path manually
-->

## Visual summary

<!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
