### PR TITLE
fix: Post shadcn migration changes

### DIFF
--- a/apps/mobile/src/components/FiatChange/FiatChange.tsx
+++ b/apps/mobile/src/components/FiatChange/FiatChange.tsx
@@ -2,13 +2,17 @@ import React from 'react'
 import { Text, View } from 'tamagui'
 import { type Balance } from '@safe-global/store/gateway/AUTO_GENERATED/balances'
 import { formatPercentage } from '@safe-global/utils/utils/formatters'
+import { getFiatChangeDirection, parseFiatChange } from '@safe-global/utils/utils/fiatChange'
+import { getFiatChangeColor, getFiatChangeSign } from '@/src/utils/fiatChange'
 
 interface FiatChangeProps {
   balanceItem: Balance
 }
 
 export const FiatChange = ({ balanceItem }: FiatChangeProps) => {
-  if (!balanceItem.fiatBalance24hChange) {
+  const changeAsNumber = parseFiatChange(balanceItem.fiatBalance24hChange)
+
+  if (changeAsNumber === null) {
     return (
       <Text fontSize="$3" color="$colorSecondary" opacity={0.7}>
         0%
@@ -16,37 +20,13 @@ export const FiatChange = ({ balanceItem }: FiatChangeProps) => {
     )
   }
 
-  const changeAsNumber = Number(balanceItem.fiatBalance24hChange) / 100
-  const changeLabel = formatPercentage(changeAsNumber)
-  const direction = changeAsNumber < 0 ? 'down' : changeAsNumber > 0 ? 'up' : 'none'
-
-  const getColor = () => {
-    switch (direction) {
-      case 'down':
-        return '$error'
-      case 'up':
-        return '$success'
-      default:
-        return '$colorSecondary'
-    }
-  }
-
-  const changeSign = () => {
-    switch (direction) {
-      case 'down':
-        return '-'
-      case 'up':
-        return '+'
-      default:
-        return ''
-    }
-  }
+  const direction = getFiatChangeDirection(changeAsNumber)
 
   return (
     <View flexDirection="row" alignItems="center" gap="$1">
-      <Text fontSize="$3" color={getColor()} fontWeight="500">
-        {changeSign()}
-        {changeLabel}
+      <Text fontSize="$3" color={getFiatChangeColor(direction)} fontWeight="500">
+        {getFiatChangeSign(direction)}
+        {formatPercentage(changeAsNumber)}
       </Text>
     </View>
   )

--- a/apps/mobile/src/components/FiatChange/__tests__/FiatChange.test.tsx
+++ b/apps/mobile/src/components/FiatChange/__tests__/FiatChange.test.tsx
@@ -4,13 +4,32 @@ import { FiatChange } from '../FiatChange'
 import { type Balance } from '@safe-global/store/gateway/AUTO_GENERATED/balances'
 
 describe('FiatChange', () => {
-  it('renders "n/a" when fiatBalance24hChange is not present', () => {
+  it('renders "0%" when fiatBalance24hChange is not present', () => {
     const mockBalance: Balance = {
       fiatBalance24hChange: undefined,
     } as Balance
 
     const { getByText } = render(<FiatChange balanceItem={mockBalance} />)
     expect(getByText('0%')).toBeTruthy()
+  })
+
+  it('renders "0%" when fiatBalance24hChange is an empty string', () => {
+    const mockBalance: Balance = {
+      fiatBalance24hChange: '',
+    } as Balance
+
+    const { getByText } = render(<FiatChange balanceItem={mockBalance} />)
+    expect(getByText('0%')).toBeTruthy()
+  })
+
+  it('renders "0%" instead of "NaN%" when fiatBalance24hChange is not numeric', () => {
+    const mockBalance: Balance = {
+      fiatBalance24hChange: 'not-a-number',
+    } as Balance
+
+    const { getByText, queryByText } = render(<FiatChange balanceItem={mockBalance} />)
+    expect(getByText('0%')).toBeTruthy()
+    expect(queryByText('NaN%')).toBeNull()
   })
 
   it('renders positive change with success color and plus sign', () => {

--- a/apps/mobile/src/features/Assets/components/Positions/PositionItem/PositionFiatChange.test.tsx
+++ b/apps/mobile/src/features/Assets/components/Positions/PositionItem/PositionFiatChange.test.tsx
@@ -21,6 +21,13 @@ describe('PositionFiatChange', () => {
     expect(screen.queryByText(/NaN/)).toBeNull()
   })
 
+  it('keeps the percentage but drops the amount when fiatBalance is not numeric', () => {
+    render(<PositionFiatChange fiatBalance="not-a-number" currency="usd" fiatBalance24hChange="5.0" />)
+
+    expect(screen.getByText(/5\.00%/)).toBeTruthy()
+    expect(screen.queryByText(/NaN/)).toBeNull()
+  })
+
   it('renders a genuine zero change as 0.00%', () => {
     render(<PositionFiatChange {...defaultProps} fiatBalance24hChange="0" />)
 

--- a/apps/mobile/src/features/Assets/components/Positions/PositionItem/PositionFiatChange.test.tsx
+++ b/apps/mobile/src/features/Assets/components/Positions/PositionItem/PositionFiatChange.test.tsx
@@ -14,6 +14,19 @@ describe('PositionFiatChange', () => {
     expect(screen.getByText('0%')).toBeTruthy()
   })
 
+  it('renders 0% instead of a NaN percentage and amount when fiatBalance24hChange is not numeric', () => {
+    render(<PositionFiatChange {...defaultProps} fiatBalance24hChange="not-a-number" />)
+
+    expect(screen.getByText('0%')).toBeTruthy()
+    expect(screen.queryByText(/NaN/)).toBeNull()
+  })
+
+  it('renders a genuine zero change as 0.00%', () => {
+    render(<PositionFiatChange {...defaultProps} fiatBalance24hChange="0" />)
+
+    expect(screen.getByText(/0\.00%/)).toBeTruthy()
+  })
+
   it('renders positive change with plus sign', () => {
     const { toJSON } = render(<PositionFiatChange {...defaultProps} fiatBalance24hChange="5.0" />)
 

--- a/apps/mobile/src/features/Assets/components/Positions/PositionItem/PositionFiatChange.tsx
+++ b/apps/mobile/src/features/Assets/components/Positions/PositionItem/PositionFiatChange.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { Text, View } from 'tamagui'
 import { formatPercentage } from '@safe-global/utils/utils/formatters'
 import { formatCurrencyPrecise } from '@safe-global/utils/utils/formatNumber'
+import { getFiatChangeDirection, parseFiatChange } from '@safe-global/utils/utils/fiatChange'
+import { getFiatChangeColor, getFiatChangeSign } from '@/src/utils/fiatChange'
 import { InfoSheet } from '@/src/components/InfoSheet'
 
 interface PositionFiatChangeProps {
@@ -15,7 +17,9 @@ const INFO_SHEET_DESCRIPTION =
   'This shows how much the value of this position has changed in the last 24 hours, based on token price movements.'
 
 export const PositionFiatChange = ({ fiatBalance24hChange, fiatBalance, currency }: PositionFiatChangeProps) => {
-  if (!fiatBalance24hChange) {
+  const changeAsNumber = parseFiatChange(fiatBalance24hChange)
+
+  if (changeAsNumber === null) {
     return (
       <InfoSheet title={INFO_SHEET_TITLE} info={INFO_SHEET_DESCRIPTION}>
         <Text fontSize="$3" color="$colorSecondary" opacity={0.7}>
@@ -25,42 +29,16 @@ export const PositionFiatChange = ({ fiatBalance24hChange, fiatBalance, currency
     )
   }
 
-  const changeAsNumber = Number(fiatBalance24hChange) / 100
-  const changeLabel = formatPercentage(changeAsNumber)
-  const direction = changeAsNumber < 0 ? 'down' : changeAsNumber > 0 ? 'up' : 'none'
-
-  const fiatBalanceNumber = Number(fiatBalance)
-  const changeAmount = fiatBalanceNumber * changeAsNumber
+  const direction = getFiatChangeDirection(changeAsNumber)
+  const changeAmount = Number(fiatBalance) * changeAsNumber
   const formattedChangeAmount = formatCurrencyPrecise(Math.abs(changeAmount).toString(), currency)
-
-  const getColor = () => {
-    switch (direction) {
-      case 'down':
-        return '$error'
-      case 'up':
-        return '$success'
-      default:
-        return '$colorSecondary'
-    }
-  }
-
-  const changeSign = () => {
-    switch (direction) {
-      case 'down':
-        return '-'
-      case 'up':
-        return '+'
-      default:
-        return ''
-    }
-  }
 
   return (
     <InfoSheet title={INFO_SHEET_TITLE} info={INFO_SHEET_DESCRIPTION}>
       <View flexDirection="row" alignItems="center" gap="$1">
-        <Text fontSize="$3" color={getColor()} fontWeight={400}>
-          {changeSign()}
-          {changeLabel} ({formattedChangeAmount})
+        <Text fontSize="$3" color={getFiatChangeColor(direction)} fontWeight={400}>
+          {getFiatChangeSign(direction)}
+          {formatPercentage(changeAsNumber)} ({formattedChangeAmount})
         </Text>
       </View>
     </InfoSheet>

--- a/apps/mobile/src/features/Assets/components/Positions/PositionItem/PositionFiatChange.tsx
+++ b/apps/mobile/src/features/Assets/components/Positions/PositionItem/PositionFiatChange.tsx
@@ -31,14 +31,18 @@ export const PositionFiatChange = ({ fiatBalance24hChange, fiatBalance, currency
 
   const direction = getFiatChangeDirection(changeAsNumber)
   const changeAmount = Number(fiatBalance) * changeAsNumber
-  const formattedChangeAmount = formatCurrencyPrecise(Math.abs(changeAmount).toString(), currency)
+  // The percentage stands on its own, so an unusable balance drops the amount rather than the row.
+  const changeAmountLabel = Number.isFinite(changeAmount)
+    ? ` (${formatCurrencyPrecise(Math.abs(changeAmount).toString(), currency)})`
+    : ''
 
   return (
     <InfoSheet title={INFO_SHEET_TITLE} info={INFO_SHEET_DESCRIPTION}>
       <View flexDirection="row" alignItems="center" gap="$1">
         <Text fontSize="$3" color={getFiatChangeColor(direction)} fontWeight={400}>
           {getFiatChangeSign(direction)}
-          {formatPercentage(changeAsNumber)} ({formattedChangeAmount})
+          {formatPercentage(changeAsNumber)}
+          {changeAmountLabel}
         </Text>
       </View>
     </InfoSheet>

--- a/apps/mobile/src/features/Assets/components/Positions/PositionItem/__snapshots__/PositionFiatChange.test.tsx.snap
+++ b/apps/mobile/src/features/Assets/components/Positions/PositionItem/__snapshots__/PositionFiatChange.test.tsx.snap
@@ -42,9 +42,7 @@ exports[`PositionFiatChange renders negative change with minus sign 1`] = `
         >
           -
           3.50%
-           (
-          $ 35.00
-          )
+           ($ 35.00)
         </Text>
       </View>
     </View>
@@ -94,9 +92,7 @@ exports[`PositionFiatChange renders positive change with plus sign 1`] = `
         >
           +
           5.00%
-           (
-          $ 50.00
-          )
+           ($ 50.00)
         </Text>
       </View>
     </View>

--- a/apps/mobile/src/features/Assets/components/Positions/ProtocolDetailSheet/ProtocolDetailSheetHeader.tsx
+++ b/apps/mobile/src/features/Assets/components/Positions/ProtocolDetailSheet/ProtocolDetailSheetHeader.tsx
@@ -6,6 +6,7 @@ import { formatPercentage } from '@safe-global/utils/utils/formatters'
 import { splitCurrencyParts } from '@/src/utils/formatters'
 import type { Protocol } from '@safe-global/store/gateway/AUTO_GENERATED/positions'
 import { calculateProtocolFiatChange } from './utils'
+import { ProtocolFiatChange } from '../ProtocolFiatChange'
 
 interface ProtocolDetailSheetHeaderProps {
   protocol: Protocol
@@ -79,17 +80,7 @@ export const ProtocolDetailSheetHeader = ({ protocol, percentageRatio, currency 
               </Text>
             )}
           </View>
-          {fiatChange !== null && (
-            <Text
-              fontSize="$4"
-              fontWeight={400}
-              color={fiatChange > 0 ? '$success' : fiatChange < 0 ? '$error' : '$colorSecondary'}
-              lineHeight={20}
-            >
-              {fiatChange > 0 ? '+' : fiatChange < 0 ? '-' : ''}
-              {formatPercentage(fiatChange)}
-            </Text>
-          )}
+          <ProtocolFiatChange fiatChange={fiatChange} />
         </View>
       </View>
 

--- a/apps/mobile/src/features/Assets/components/Positions/ProtocolDetailSheet/utils.test.ts
+++ b/apps/mobile/src/features/Assets/components/Positions/ProtocolDetailSheet/utils.test.ts
@@ -45,6 +45,17 @@ describe('calculateProtocolFiatChange', () => {
     expect(calculateProtocolFiatChange(protocol)).toBeNull()
   })
 
+  it('returns null rather than NaN when fiatTotal is not numeric', () => {
+    const protocol = createMockProtocol({ fiatTotal: 'not-a-number' })
+    expect(calculateProtocolFiatChange(protocol)).toBeNull()
+  })
+
+  it('returns null rather than NaN when a position 24h change is not numeric', () => {
+    const protocol = createMockProtocol()
+    protocol.items[0].items[0].fiatBalance24hChange = 'not-a-number'
+    expect(calculateProtocolFiatChange(protocol)).toBeNull()
+  })
+
   it('returns null when all positions have null 24h change', () => {
     const protocol = createMockProtocol({
       items: [

--- a/apps/mobile/src/features/Assets/components/Positions/ProtocolDetailSheet/utils.test.ts
+++ b/apps/mobile/src/features/Assets/components/Positions/ProtocolDetailSheet/utils.test.ts
@@ -50,9 +50,15 @@ describe('calculateProtocolFiatChange', () => {
     expect(calculateProtocolFiatChange(protocol)).toBeNull()
   })
 
-  it('returns null rather than NaN when a position 24h change is not numeric', () => {
+  it('returns null when the only position 24h change is not numeric', () => {
     const protocol = createMockProtocol()
     protocol.items[0].items[0].fiatBalance24hChange = 'not-a-number'
+    expect(calculateProtocolFiatChange(protocol)).toBeNull()
+  })
+
+  it('treats an empty 24h change as absent', () => {
+    const protocol = createMockProtocol()
+    protocol.items[0].items[0].fiatBalance24hChange = ''
     expect(calculateProtocolFiatChange(protocol)).toBeNull()
   })
 
@@ -174,5 +180,22 @@ describe('calculateProtocolFiatChange', () => {
     const result = calculateProtocolFiatChange(protocol)
     // Only first position counted: 60 / 2000 = 0.03
     expect(result).toBeCloseTo(0.03)
+  })
+
+  it('skips an unparseable position instead of discarding the whole total', () => {
+    const protocol = createMockProtocol({ fiatTotal: '2000.00' })
+    const [good] = protocol.items[0].items
+    protocol.items[0].items.push({ ...good, fiatBalance24hChange: 'not-a-number' })
+
+    // 1000 * 0.05 = 50 from the parseable position only, 50 / 2000 = 0.025
+    expect(calculateProtocolFiatChange(protocol)).toBeCloseTo(0.025)
+  })
+
+  it('skips a position whose fiat balance is not numeric', () => {
+    const protocol = createMockProtocol({ fiatTotal: '2000.00' })
+    const [good] = protocol.items[0].items
+    protocol.items[0].items.push({ ...good, fiatBalance: 'not-a-number' })
+
+    expect(calculateProtocolFiatChange(protocol)).toBeCloseTo(0.025)
   })
 })

--- a/apps/mobile/src/features/Assets/components/Positions/ProtocolDetailSheet/utils.ts
+++ b/apps/mobile/src/features/Assets/components/Positions/ProtocolDetailSheet/utils.ts
@@ -24,5 +24,7 @@ export const calculateProtocolFiatChange = (protocol: Protocol): number | null =
     return null
   }
 
-  return totalChange / totalFiat
+  const ratio = totalChange / totalFiat
+
+  return Number.isFinite(ratio) ? ratio : null
 }

--- a/apps/mobile/src/features/Assets/components/Positions/ProtocolDetailSheet/utils.ts
+++ b/apps/mobile/src/features/Assets/components/Positions/ProtocolDetailSheet/utils.ts
@@ -1,4 +1,5 @@
 import type { Protocol } from '@safe-global/store/gateway/AUTO_GENERATED/positions'
+import { parseFiatChange } from '@safe-global/utils/utils/fiatChange'
 
 export const calculateProtocolFiatChange = (protocol: Protocol): number | null => {
   const totalFiat = Number(protocol.fiatTotal)
@@ -9,14 +10,17 @@ export const calculateProtocolFiatChange = (protocol: Protocol): number | null =
   let totalChange = 0
   let hasAnyChange = false
 
+  // A position we cannot parse is skipped, not fatal — one bad row must not hide the protocol total.
   for (const group of protocol.items) {
     for (const position of group.items) {
-      if (position.fiatBalance24hChange != null) {
-        hasAnyChange = true
-        const fiatBalance = Number(position.fiatBalance)
-        const changePercent = Number(position.fiatBalance24hChange) / 100
-        totalChange += fiatBalance * changePercent
+      const changePercent = parseFiatChange(position.fiatBalance24hChange)
+      const fiatBalance = Number(position.fiatBalance)
+      if (changePercent === null || !Number.isFinite(fiatBalance)) {
+        continue
       }
+
+      hasAnyChange = true
+      totalChange += fiatBalance * changePercent
     }
   }
 

--- a/apps/mobile/src/features/Assets/components/Positions/ProtocolFiatChange/ProtocolFiatChange.test.tsx
+++ b/apps/mobile/src/features/Assets/components/Positions/ProtocolFiatChange/ProtocolFiatChange.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { render, screen } from '@/src/tests/test-utils'
+import { ProtocolFiatChange } from './ProtocolFiatChange'
+
+describe('ProtocolFiatChange', () => {
+  it('renders nothing when there is no change to show', () => {
+    render(<ProtocolFiatChange fiatChange={null} />)
+
+    expect(screen.queryByText(/%/)).toBeNull()
+  })
+
+  it('prefixes a positive change with a plus sign', () => {
+    render(<ProtocolFiatChange fiatChange={0.05} />)
+
+    expect(screen.getByText('+5.00%')).toBeTruthy()
+  })
+
+  it('prefixes a negative change with a minus sign', () => {
+    render(<ProtocolFiatChange fiatChange={-0.03} />)
+
+    expect(screen.getByText('-3.00%')).toBeTruthy()
+  })
+
+  it('renders a zero change without a sign', () => {
+    render(<ProtocolFiatChange fiatChange={0} />)
+
+    expect(screen.getByText('0.00%')).toBeTruthy()
+  })
+})

--- a/apps/mobile/src/features/Assets/components/Positions/ProtocolFiatChange/ProtocolFiatChange.tsx
+++ b/apps/mobile/src/features/Assets/components/Positions/ProtocolFiatChange/ProtocolFiatChange.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { Text } from 'tamagui'
+import { formatPercentage } from '@safe-global/utils/utils/formatters'
+import { getFiatChangeDirection } from '@safe-global/utils/utils/fiatChange'
+import { getFiatChangeColor, getFiatChangeSign } from '@/src/utils/fiatChange'
+
+interface ProtocolFiatChangeProps {
+  fiatChange: number | null
+}
+
+export const ProtocolFiatChange = ({ fiatChange }: ProtocolFiatChangeProps) => {
+  if (fiatChange === null) {
+    return null
+  }
+
+  const direction = getFiatChangeDirection(fiatChange)
+
+  return (
+    <Text fontSize="$4" fontWeight={400} color={getFiatChangeColor(direction)} lineHeight={20}>
+      {getFiatChangeSign(direction)}
+      {formatPercentage(fiatChange)}
+    </Text>
+  )
+}

--- a/apps/mobile/src/features/Assets/components/Positions/ProtocolFiatChange/index.ts
+++ b/apps/mobile/src/features/Assets/components/Positions/ProtocolFiatChange/index.ts
@@ -1,0 +1,1 @@
+export { ProtocolFiatChange } from './ProtocolFiatChange'

--- a/apps/mobile/src/features/Assets/components/Positions/ProtocolSection/ProtocolSection.tsx
+++ b/apps/mobile/src/features/Assets/components/Positions/ProtocolSection/ProtocolSection.tsx
@@ -9,6 +9,7 @@ import { formatPercentage } from '@safe-global/utils/utils/formatters'
 import { calculateProtocolPercentage } from '@safe-global/utils/features/positions'
 import type { Protocol } from '@safe-global/store/gateway/AUTO_GENERATED/positions'
 import { calculateProtocolFiatChange } from '../ProtocolDetailSheet/utils'
+import { ProtocolFiatChange } from '../ProtocolFiatChange'
 
 interface ProtocolSectionProps {
   protocol: Protocol
@@ -81,17 +82,7 @@ export const ProtocolSection = ({ protocol, totalFiatValue, currency }: Protocol
             >
               {formattedFiatTotal}
             </Text>
-            {fiatChange !== null && (
-              <Text
-                fontSize="$4"
-                fontWeight={400}
-                color={fiatChange > 0 ? '$success' : fiatChange < 0 ? '$error' : '$colorSecondary'}
-                lineHeight={20}
-              >
-                {fiatChange > 0 ? '+' : fiatChange < 0 ? '-' : ''}
-                {formatPercentage(fiatChange)}
-              </Text>
-            )}
+            <ProtocolFiatChange fiatChange={fiatChange} />
           </View>
           <SafeFontIcon name="chevron-right" size={24} color="$colorSecondary" />
         </View>

--- a/apps/mobile/src/utils/fiatChange.test.ts
+++ b/apps/mobile/src/utils/fiatChange.test.ts
@@ -1,0 +1,17 @@
+import { getFiatChangeColor, getFiatChangeSign } from './fiatChange'
+
+describe('getFiatChangeColor', () => {
+  it('maps direction to a theme colour token', () => {
+    expect(getFiatChangeColor('up')).toBe('$success')
+    expect(getFiatChangeColor('down')).toBe('$error')
+    expect(getFiatChangeColor('none')).toBe('$colorSecondary')
+  })
+})
+
+describe('getFiatChangeSign', () => {
+  it('maps direction to a sign prefix', () => {
+    expect(getFiatChangeSign('up')).toBe('+')
+    expect(getFiatChangeSign('down')).toBe('-')
+    expect(getFiatChangeSign('none')).toBe('')
+  })
+})

--- a/apps/mobile/src/utils/fiatChange.ts
+++ b/apps/mobile/src/utils/fiatChange.ts
@@ -1,0 +1,24 @@
+import type { FiatChangeDirection } from '@safe-global/utils/utils/fiatChange'
+
+export const getFiatChangeColor = (direction: FiatChangeDirection) => {
+  switch (direction) {
+    case 'up':
+      return '$success'
+    case 'down':
+      return '$error'
+    default:
+      return '$colorSecondary'
+  }
+}
+
+/** formatPercentage uses signDisplay: 'never', so the sign is rendered separately. */
+export const getFiatChangeSign = (direction: FiatChangeDirection) => {
+  switch (direction) {
+    case 'up':
+      return '+'
+    case 'down':
+      return '-'
+    default:
+      return ''
+  }
+}

--- a/apps/web/src/components/balances/AssetsTable/FiatChange.test.tsx
+++ b/apps/web/src/components/balances/AssetsTable/FiatChange.test.tsx
@@ -12,6 +12,20 @@ describe('FiatChange', () => {
     expect(screen.getByText('n/a')).toBeInTheDocument()
   })
 
+  it('renders "n/a" when the change is an empty string', () => {
+    const mockBalance: Balance = {
+      fiatBalance24hChange: '',
+    } as Balance
+
+    render(<FiatChange balanceItem={mockBalance} />)
+    expect(screen.getByText('n/a')).toBeInTheDocument()
+  })
+
+  it('renders "n/a" when the change is not numeric', () => {
+    render(<FiatChange change="not-a-number" />)
+    expect(screen.getByText('n/a')).toBeInTheDocument()
+  })
+
   it('renders a negative change as a positive percentage', () => {
     const mockBalance: Balance = {
       fiatBalance24hChange: '-3.00', // 3% decrease

--- a/apps/web/src/components/balances/AssetsTable/FiatChange.test.tsx
+++ b/apps/web/src/components/balances/AssetsTable/FiatChange.test.tsx
@@ -26,6 +26,11 @@ describe('FiatChange', () => {
     expect(screen.getByText('n/a')).toBeInTheDocument()
   })
 
+  it('renders "n/a" when the change is not finite', () => {
+    render(<FiatChange change="Infinity" />)
+    expect(screen.getByText('n/a')).toBeInTheDocument()
+  })
+
   it('renders a negative change as a positive percentage', () => {
     const mockBalance: Balance = {
       fiatBalance24hChange: '-3.00', // 3% decrease

--- a/apps/web/src/components/balances/AssetsTable/FiatChange.tsx
+++ b/apps/web/src/components/balances/AssetsTable/FiatChange.tsx
@@ -3,6 +3,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Typography } from '@/components/ui/typography'
 import { type Balance } from '@safe-global/store/gateway/AUTO_GENERATED/balances'
 import { formatPercentage } from '@safe-global/utils/utils/formatters'
+import { getFiatChangeDirection, parseFiatChange } from '@safe-global/utils/utils/fiatChange'
 import ArrowDown from '@/public/images/balances/change-down.svg'
 import ArrowUp from '@/public/images/balances/change-up.svg'
 
@@ -19,11 +20,9 @@ interface FiatChangeProps {
  * @param inline - Inline display variant
  */
 export const FiatChange = ({ balanceItem, change, inline = false }: FiatChangeProps) => {
-  const fiatChange = change ?? balanceItem?.fiatBalance24hChange ?? null
-  // The backend emits null for missing data and "0" for a genuine zero change
-  const changeAsNumber = fiatChange === null || fiatChange === '' ? NaN : Number(fiatChange) / 100
+  const changeAsNumber = parseFiatChange(change ?? balanceItem?.fiatBalance24hChange)
 
-  if (Number.isNaN(changeAsNumber)) {
+  if (changeAsNumber === null) {
     return (
       <Typography variant="paragraph-mini" color="muted" className="block pl-6">
         n/a
@@ -32,7 +31,7 @@ export const FiatChange = ({ balanceItem, change, inline = false }: FiatChangePr
   }
 
   const changeLabel = formatPercentage(changeAsNumber)
-  const direction = changeAsNumber < 0 ? 'down' : changeAsNumber > 0 ? 'up' : 'none'
+  const direction = getFiatChangeDirection(changeAsNumber)
 
   return (
     <Tooltip>

--- a/apps/web/src/components/balances/AssetsTable/FiatChange.tsx
+++ b/apps/web/src/components/balances/AssetsTable/FiatChange.tsx
@@ -20,8 +20,10 @@ interface FiatChangeProps {
  */
 export const FiatChange = ({ balanceItem, change, inline = false }: FiatChangeProps) => {
   const fiatChange = change ?? balanceItem?.fiatBalance24hChange ?? null
+  // The backend emits null for missing data and "0" for a genuine zero change
+  const changeAsNumber = fiatChange === null || fiatChange === '' ? NaN : Number(fiatChange) / 100
 
-  if (!fiatChange) {
+  if (Number.isNaN(changeAsNumber)) {
     return (
       <Typography variant="paragraph-mini" color="muted" className="block pl-6">
         n/a
@@ -29,7 +31,6 @@ export const FiatChange = ({ balanceItem, change, inline = false }: FiatChangePr
     )
   }
 
-  const changeAsNumber = Number(fiatChange) / 100
   const changeLabel = formatPercentage(changeAsNumber)
   const direction = changeAsNumber < 0 ? 'down' : changeAsNumber > 0 ? 'up' : 'none'
 

--- a/apps/web/src/components/safe-apps/AddCustomAppModal/index.test.tsx
+++ b/apps/web/src/components/safe-apps/AddCustomAppModal/index.test.tsx
@@ -1,19 +1,41 @@
-import { act, fireEvent, render, screen, waitFor } from '@/tests/test-utils'
+import { act, fireEvent, render, screen } from '@/tests/test-utils'
 import type { SafeApp as SafeAppData } from '@safe-global/store/gateway/AUTO_GENERATED/safe-apps'
+import { fetchSafeAppFromManifest } from '@/services/safe-apps/manifest'
 import { AddCustomAppModal } from '.'
 
 jest.mock('@/services/safe-apps/manifest', () => ({
-  fetchSafeAppFromManifest: jest.fn(() => Promise.resolve(undefined)),
+  fetchSafeAppFromManifest: jest.fn(),
 }))
+
+const mockFetchSafeAppFromManifest = jest.mocked(fetchSafeAppFromManifest)
+
+const listedApp: SafeAppData = {
+  id: 1,
+  url: 'https://listed-app.com',
+  name: 'Listed App',
+  description: 'A Safe App fixture',
+  iconUrl: 'https://listed-app.com/icon.png',
+  chainIds: ['1'],
+  accessControl: { type: 'NO_RESTRICTIONS' },
+  tags: [],
+  features: [],
+  socialProfiles: [],
+  featured: false,
+}
 
 const defaultProps = {
   open: true,
   onClose: jest.fn(),
   onSave: jest.fn(),
-  safeAppsList: [{ url: 'https://listed-app.com' } as SafeAppData],
+  safeAppsList: [listedApp],
 }
 
 describe('AddCustomAppModal', () => {
+  beforeEach(() => {
+    // No manifest by default, so the app preview stays absent unless a test opts in
+    mockFetchSafeAppFromManifest.mockReset()
+  })
+
   it('shows an error message when the URL is invalid', async () => {
     render(<AddCustomAppModal {...defaultProps} />)
 
@@ -34,14 +56,24 @@ describe('AddCustomAppModal', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent('URL is required')
   })
 
-  it('does not show a field error when the app is already in the list', async () => {
+  it('confirms the app is already registered instead of showing a field error', async () => {
+    mockFetchSafeAppFromManifest.mockResolvedValue({ ...listedApp, safeAppsPermissions: [] })
     render(<AddCustomAppModal {...defaultProps} />)
 
-    fireEvent.change(screen.getByLabelText(/Safe App URL/i), { target: { value: 'https://listed-app.com' } })
+    fireEvent.change(screen.getByLabelText(/Safe App URL/i), { target: { value: listedApp.url } })
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled()
-    })
+    expect(await screen.findByText(/already registered/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled()
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('does not offer the risk acknowledgement for an app that is already registered', async () => {
+    mockFetchSafeAppFromManifest.mockResolvedValue({ ...listedApp, safeAppsPermissions: [] })
+    render(<AddCustomAppModal {...defaultProps} />)
+
+    fireEvent.change(screen.getByLabelText(/Safe App URL/i), { target: { value: listedApp.url } })
+
+    await screen.findByText(/already registered/i)
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/safe-apps/AddCustomAppModal/index.test.tsx
+++ b/apps/web/src/components/safe-apps/AddCustomAppModal/index.test.tsx
@@ -1,0 +1,47 @@
+import { act, fireEvent, render, screen, waitFor } from '@/tests/test-utils'
+import type { SafeApp as SafeAppData } from '@safe-global/store/gateway/AUTO_GENERATED/safe-apps'
+import { AddCustomAppModal } from '.'
+
+jest.mock('@/services/safe-apps/manifest', () => ({
+  fetchSafeAppFromManifest: jest.fn(() => Promise.resolve(undefined)),
+}))
+
+const defaultProps = {
+  open: true,
+  onClose: jest.fn(),
+  onSave: jest.fn(),
+  safeAppsList: [{ url: 'https://listed-app.com' } as SafeAppData],
+}
+
+describe('AddCustomAppModal', () => {
+  it('shows an error message when the URL is invalid', async () => {
+    render(<AddCustomAppModal {...defaultProps} />)
+
+    fireEvent.change(screen.getByLabelText(/Safe App URL/i), { target: { value: 'not-a-url' } })
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('The url is invalid')
+  })
+
+  it('shows an error message when the URL is cleared', async () => {
+    render(<AddCustomAppModal {...defaultProps} />)
+
+    const input = screen.getByLabelText(/Safe App URL/i)
+    fireEvent.change(input, { target: { value: 'https://example.com' } })
+    // Flush the async validation of the first change before clearing, as a user typing would
+    await act(async () => {})
+    fireEvent.change(input, { target: { value: '' } })
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('URL is required')
+  })
+
+  it('does not show a field error when the app is already in the list', async () => {
+    render(<AddCustomAppModal {...defaultProps} />)
+
+    fireEvent.change(screen.getByLabelText(/Safe App URL/i), { target: { value: 'https://listed-app.com' } })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled()
+    })
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/safe-apps/AddCustomAppModal/index.tsx
+++ b/apps/web/src/components/safe-apps/AddCustomAppModal/index.tsx
@@ -98,10 +98,10 @@ export const AddCustomAppModal = ({ open, onClose, onSave, safeAppsList }: Props
               <Label htmlFor="appUrl">Safe App URL</Label>
               <Input
                 id="appUrl"
-                error={errors?.appUrl?.type === 'validUrl' ? errors?.appUrl?.message : undefined}
+                error={errors?.appUrl?.type !== 'alreadyExists' ? errors?.appUrl?.message : undefined}
                 autoComplete="off"
                 {...register('appUrl', {
-                  required: true,
+                  required: 'URL is required',
                   validate: {
                     validUrl: (val: string) => (isValidURL(val) ? undefined : INVALID_URL_ERROR),
                     alreadyExists: (val: string) =>

--- a/apps/web/src/components/safe-apps/AddCustomAppModal/index.tsx
+++ b/apps/web/src/components/safe-apps/AddCustomAppModal/index.tsx
@@ -98,6 +98,7 @@ export const AddCustomAppModal = ({ open, onClose, onSave, safeAppsList }: Props
               <Label htmlFor="appUrl">Safe App URL</Label>
               <Input
                 id="appUrl"
+                // show all validation errors except alreadyExists, which renders as its own confirmation panel below
                 error={errors?.appUrl?.type !== 'alreadyExists' ? errors?.appUrl?.message : undefined}
                 autoComplete="off"
                 {...register('appUrl', {

--- a/apps/web/src/components/tx-flow/__tests__/TxModalProvider.test.tsx
+++ b/apps/web/src/components/tx-flow/__tests__/TxModalProvider.test.tsx
@@ -30,7 +30,7 @@ const openFlow = async (user: ReturnType<typeof userEvent.setup>) => {
 }
 
 const clickClose = (user: ReturnType<typeof userEvent.setup>) =>
-  user.click(screen.getByRole('button', { name: 'close' }))
+  user.click(screen.getByRole('button', { name: /close/i }))
 
 describe('TxModalProvider close gate', () => {
   beforeEach(() => {

--- a/apps/web/src/components/tx-flow/__tests__/TxModalProvider.test.tsx
+++ b/apps/web/src/components/tx-flow/__tests__/TxModalProvider.test.tsx
@@ -1,4 +1,5 @@
 import { useContext } from 'react'
+import { fireEvent } from '@testing-library/react'
 import { render, screen, waitFor } from '@/tests/test-utils'
 import userEvent from '@testing-library/user-event'
 import { TxModalContext, TxModalProvider } from '..'
@@ -83,6 +84,53 @@ describe('TxModalProvider close gate', () => {
     await user.click(screen.getByRole('button', { name: 'Discard' }))
 
     await waitFor(() => expect(screen.queryByText(FLOW_TEXT)).not.toBeInTheDocument())
+  })
+
+  it('navigates exactly once when a link is clicked and the flow opted out of the warning', async () => {
+    const user = userEvent.setup()
+    const push = jest.fn(() => Promise.resolve(true))
+
+    render(
+      <TxModalProvider>
+        <Opener shouldWarn={false} />
+        <a href="/queue">queue</a>
+      </TxModalProvider>,
+      { routerProps: { push } },
+    )
+    await openFlow(user)
+
+    fireEvent.mouseDown(screen.getByText('queue'))
+
+    await waitFor(() => expect(screen.queryByText(FLOW_TEXT)).not.toBeInTheDocument())
+    expect(screen.queryByText('Discard this transaction?')).not.toBeInTheDocument()
+    expect(push).toHaveBeenCalledTimes(1)
+    expect(push).toHaveBeenCalledWith('/queue')
+  })
+
+  it('blocks link navigation until the discard is confirmed, then navigates once', async () => {
+    const user = userEvent.setup()
+    const push = jest.fn(() => Promise.resolve(true))
+
+    render(
+      <TxModalProvider>
+        <Opener />
+        <a href="/queue">queue</a>
+      </TxModalProvider>,
+      { routerProps: { push } },
+    )
+    await openFlow(user)
+
+    fireEvent.mouseDown(screen.getByText('queue'))
+
+    expect(await screen.findByText('Discard this transaction?')).toBeInTheDocument()
+    expect(screen.getByText(FLOW_TEXT)).toBeInTheDocument()
+    expect(push).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: 'Discard' }))
+
+    await waitFor(() => expect(screen.queryByText(FLOW_TEXT)).not.toBeInTheDocument())
+    expect(push).toHaveBeenCalledTimes(1)
+    expect(push).toHaveBeenCalledWith('/queue')
   })
 
   it('runs the flow onClose callback only once the discard is confirmed', async () => {

--- a/apps/web/src/components/tx-flow/index.tsx
+++ b/apps/web/src/components/tx-flow/index.tsx
@@ -29,6 +29,14 @@ export const TxModalContext = createContext<TxModalContextType>({
   setFullWidth: noop,
 })
 
+type DiscardHandlers = {
+  /** Runs synchronously when there is nothing to lose. */
+  immediate: () => void
+  /** Runs once the user confirms the discard; defaults to `immediate`. A navigation the guard
+      blocked has to be replayed here, since nothing else is left to perform it. */
+  deferred?: () => void
+}
+
 export const TxModalProvider = ({ children }: { children: ReactNode }): ReactElement => {
   const [txFlow, setFlow] = useState<TxModalContextType['txFlow']>(undefined)
   const [fullWidth, setFullWidth] = useState<boolean>(false)
@@ -46,21 +54,18 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
   flowRef.current = txFlow
 
   /**
-   * Runs `action` now when there is no unsaved progress, otherwise parks it behind the discard
-   * dialog; `deferred` tells the action which of the two happened. Returns whether it ran,
-   * because `usePreventNavigation` needs a synchronous answer. The return is always the inverse of
-   * the action's `deferred`, so a caller owning a side effect must place it on one side only.
+   * Runs `immediate` when there is no unsaved progress, otherwise parks `deferred` behind the
+   * discard dialog. Returns whether it ran now, because `beforePopState` in `usePreventNavigation`
+   * needs a synchronous verdict.
    */
-  const requestDiscard = useCallback((action: (deferred: boolean) => void): boolean => {
-    const deferred = shouldWarn.current
-
-    if (deferred) {
-      setPendingDiscard(() => () => action(deferred))
-    } else {
-      action(deferred)
+  const requestDiscard = useCallback(({ immediate, deferred }: DiscardHandlers): boolean => {
+    if (shouldWarn.current) {
+      setPendingDiscard(() => deferred ?? immediate)
+      return false
     }
 
-    return !deferred
+    immediate()
+    return true
   }, [])
 
   const closeFlow = useCallback(() => {
@@ -71,7 +76,7 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
     setSignerAddress?.(undefined)
   }, [setSignerAddress])
 
-  const handleModalClose = useCallback(() => requestDiscard(closeFlow), [requestDiscard, closeFlow])
+  const handleModalClose = useCallback(() => requestDiscard({ immediate: closeFlow }), [requestDiscard, closeFlow])
 
   const applyFlow = useCallback(
     (newTxFlow: TxModalContextType['txFlow'], newOnClose?: () => void, newShouldWarn?: boolean) => {
@@ -94,9 +99,11 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
         !!prev && !!newTxFlow && newTxFlow.type !== SuccessScreenFlow && newTxFlow.type !== NestedTxSuccessScreenFlow
 
       if (isSuperseding) {
-        requestDiscard(() => {
-          onClose.current()
-          applyFlow(newTxFlow, newOnClose, newShouldWarn)
+        requestDiscard({
+          immediate: () => {
+            onClose.current()
+            applyFlow(newTxFlow, newOnClose, newShouldWarn)
+          },
         })
         return
       }
@@ -109,10 +116,13 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
   usePreventNavigation(
     txFlow
       ? (proceed) =>
-          requestDiscard((deferred) => {
-            closeFlow()
-            // The hook navigates itself when the guard allows synchronously — only a blocked navigation is replayed.
-            if (deferred) proceed()
+          requestDiscard({
+            // The hook navigates itself once this returns true, so `proceed` belongs to the blocked branch only.
+            immediate: closeFlow,
+            deferred: () => {
+              closeFlow()
+              proceed()
+            },
           })
       : undefined,
   )

--- a/apps/web/src/components/tx-flow/index.tsx
+++ b/apps/web/src/components/tx-flow/index.tsx
@@ -47,14 +47,15 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
 
   /**
    * Runs `action` now when there is no unsaved progress, otherwise parks it behind the discard
-   * dialog. Returns whether it ran, because `usePreventNavigation` needs a synchronous answer.
+   * dialog; `deferred` tells the action which of the two happened. Returns whether it ran,
+   * because `usePreventNavigation` needs a synchronous answer.
    */
-  const requestDiscard = useCallback((action: () => void): boolean => {
+  const requestDiscard = useCallback((action: (deferred: boolean) => void): boolean => {
     if (!shouldWarn.current) {
-      action()
+      action(false)
       return true
     }
-    setPendingDiscard(() => action)
+    setPendingDiscard(() => () => action(true))
     return false
   }, [])
 
@@ -104,9 +105,10 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
   usePreventNavigation(
     txFlow
       ? (proceed) =>
-          requestDiscard(() => {
+          requestDiscard((deferred) => {
             closeFlow()
-            proceed()
+            // The hook navigates itself when the guard allows synchronously — only a blocked navigation is replayed.
+            if (deferred) proceed()
           })
       : undefined,
   )

--- a/apps/web/src/components/tx-flow/index.tsx
+++ b/apps/web/src/components/tx-flow/index.tsx
@@ -48,15 +48,19 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
   /**
    * Runs `action` now when there is no unsaved progress, otherwise parks it behind the discard
    * dialog; `deferred` tells the action which of the two happened. Returns whether it ran,
-   * because `usePreventNavigation` needs a synchronous answer.
+   * because `usePreventNavigation` needs a synchronous answer. The return is always the inverse of
+   * the action's `deferred`, so a caller owning a side effect must place it on one side only.
    */
   const requestDiscard = useCallback((action: (deferred: boolean) => void): boolean => {
-    if (!shouldWarn.current) {
-      action(false)
-      return true
+    const deferred = shouldWarn.current
+
+    if (deferred) {
+      setPendingDiscard(() => () => action(deferred))
+    } else {
+      action(deferred)
     }
-    setPendingDiscard(() => () => action(true))
-    return false
+
+    return !deferred
   }, [])
 
   const closeFlow = useCallback(() => {

--- a/apps/web/src/hooks/__tests__/usePreventNavigation.test.ts
+++ b/apps/web/src/hooks/__tests__/usePreventNavigation.test.ts
@@ -1,0 +1,179 @@
+import type { NextRouter } from 'next/router'
+import { fireEvent, renderHook } from '@/tests/test-utils'
+import { usePreventNavigation } from '@/hooks/usePreventNavigation'
+
+type PopStateHandler = Parameters<NextRouter['beforePopState']>[0]
+type Guard = (proceed: () => void) => boolean
+
+const CURRENT_PATH = '/current'
+const DESTINATION = '/queue'
+
+const appendedLinks: HTMLAnchorElement[] = []
+
+const appendLink = (href: string, target?: string): HTMLAnchorElement => {
+  const link = document.createElement('a')
+  link.setAttribute('href', href)
+  if (target) link.setAttribute('target', target)
+  document.body.append(link)
+  appendedLinks.push(link)
+  return link
+}
+
+const renderGuardedHook = (onNavigate?: Guard) => {
+  const push = jest.fn(() => Promise.resolve(true))
+  const replace = jest.fn(() => Promise.resolve(true))
+  let popStateHandler: PopStateHandler | undefined
+  const beforePopState = jest.fn((cb: PopStateHandler) => {
+    popStateHandler = cb
+  })
+
+  const { unmount } = renderHook(() => usePreventNavigation(onNavigate), {
+    routerProps: { asPath: CURRENT_PATH, push, replace, beforePopState },
+  })
+
+  return {
+    push,
+    replace,
+    unmount,
+    popState: (url = DESTINATION) => popStateHandler?.({ url, as: url, options: {} }),
+  }
+}
+
+/** Parks the `proceed` it is handed so the test can replay the blocked navigation later. */
+const blockingGuard = () => {
+  let parked: (() => void) | undefined
+  const guard = jest.fn((proceed: () => void) => {
+    parked = proceed
+    return false
+  })
+  return { guard, replay: () => parked?.() }
+}
+
+afterEach(() => {
+  appendedLinks.splice(0).forEach((link) => link.remove())
+})
+
+describe('usePreventNavigation', () => {
+  describe('link clicks', () => {
+    it('navigates exactly once when the guard allows', () => {
+      const onNavigate = jest.fn(() => true)
+      const { push } = renderGuardedHook(onNavigate)
+
+      fireEvent.mouseDown(appendLink(DESTINATION))
+
+      expect(onNavigate).toHaveBeenCalledTimes(1)
+      expect(push).toHaveBeenCalledTimes(1)
+      expect(push).toHaveBeenCalledWith(DESTINATION)
+    })
+
+    it('blocks the click and does not navigate when the guard denies', () => {
+      const { guard } = blockingGuard()
+      const { push } = renderGuardedHook(guard)
+
+      const defaultAllowed = fireEvent.mouseDown(appendLink(DESTINATION))
+
+      expect(defaultAllowed).toBe(false)
+      expect(push).not.toHaveBeenCalled()
+    })
+
+    it('navigates exactly once when a blocked click is replayed later', () => {
+      const { guard, replay } = blockingGuard()
+      const { push } = renderGuardedHook(guard)
+
+      fireEvent.mouseDown(appendLink(DESTINATION))
+      expect(push).not.toHaveBeenCalled()
+
+      replay()
+
+      expect(push).toHaveBeenCalledTimes(1)
+      expect(push).toHaveBeenCalledWith(DESTINATION)
+    })
+
+    it('ignores links that open in a new tab', () => {
+      const onNavigate = jest.fn(() => true)
+      const { push } = renderGuardedHook(onNavigate)
+
+      const defaultAllowed = fireEvent.mouseDown(appendLink('https://safe.global', '_blank'))
+
+      expect(defaultAllowed).toBe(true)
+      expect(onNavigate).not.toHaveBeenCalled()
+      expect(push).not.toHaveBeenCalled()
+    })
+
+    it('ignores clicks outside of a link', () => {
+      const onNavigate = jest.fn(() => true)
+      const { push } = renderGuardedHook(onNavigate)
+
+      fireEvent.mouseDown(document.body)
+
+      expect(onNavigate).not.toHaveBeenCalled()
+      expect(push).not.toHaveBeenCalled()
+    })
+
+    it('does not intercept clicks when no guard is passed', () => {
+      const { push } = renderGuardedHook(undefined)
+
+      const defaultAllowed = fireEvent.mouseDown(appendLink(DESTINATION))
+
+      expect(defaultAllowed).toBe(true)
+      expect(push).not.toHaveBeenCalled()
+    })
+
+    it('stops intercepting clicks after unmount', () => {
+      const onNavigate = jest.fn(() => true)
+      const { push, unmount } = renderGuardedHook(onNavigate)
+
+      unmount()
+      fireEvent.mouseDown(appendLink(DESTINATION))
+
+      expect(onNavigate).not.toHaveBeenCalled()
+      expect(push).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('back/forward navigation', () => {
+    it('lets the popstate navigation through without pushing when the guard allows', () => {
+      const onNavigate = jest.fn(() => true)
+      const { push, replace, popState } = renderGuardedHook(onNavigate)
+
+      expect(popState()).toBe(true)
+
+      expect(onNavigate).toHaveBeenCalledTimes(1)
+      // popstate has already navigated; a push on top of it would be the second navigation
+      expect(push).not.toHaveBeenCalled()
+      expect(replace).not.toHaveBeenCalled()
+    })
+
+    it('rewinds to the current path and does not navigate when the guard denies', () => {
+      const { guard } = blockingGuard()
+      const { push, replace, popState } = renderGuardedHook(guard)
+
+      expect(popState()).toBe(false)
+
+      expect(replace).toHaveBeenCalledTimes(1)
+      expect(replace).toHaveBeenCalledWith(CURRENT_PATH)
+      expect(push).not.toHaveBeenCalled()
+    })
+
+    it('navigates exactly once to the requested URL when a blocked popstate is replayed later', () => {
+      const { guard, replay } = blockingGuard()
+      const { push, popState } = renderGuardedHook(guard)
+
+      popState()
+      expect(push).not.toHaveBeenCalled()
+
+      replay()
+
+      expect(push).toHaveBeenCalledTimes(1)
+      expect(push).toHaveBeenCalledWith(DESTINATION)
+    })
+
+    it('allows popstate when no guard is passed', () => {
+      const { push, replace, popState } = renderGuardedHook(undefined)
+
+      expect(popState()).toBe(true)
+      expect(push).not.toHaveBeenCalled()
+      expect(replace).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/web/src/hooks/usePreventNavigation.ts
+++ b/apps/web/src/hooks/usePreventNavigation.ts
@@ -7,7 +7,8 @@ import { useRouter } from 'next/router'
  * `onNavigate` decides synchronously — `preventDefault`/`stopImmediatePropagation` on a `mousedown`
  * and a `false` from `beforePopState` are both only honoured in the same tick, so the guard cannot
  * await a user's answer. It instead returns `false` to block now and receives `proceed`, the
- * navigation it blocked, to run later once the user has confirmed.
+ * navigation it blocked, to run later once the user has confirmed. A guard that returns `true`
+ * must not call `proceed` itself — the hook owns the navigation in that case.
  */
 export function usePreventNavigation(onNavigate?: (proceed: () => void) => boolean): void {
   const router = useRouter()

--- a/packages/utils/src/utils/__tests__/fiatChange.test.ts
+++ b/packages/utils/src/utils/__tests__/fiatChange.test.ts
@@ -1,0 +1,42 @@
+import { getFiatChangeDirection, parseFiatChange } from '../fiatChange'
+
+describe('parseFiatChange', () => {
+  it('converts a percentage string into a decimal fraction', () => {
+    expect(parseFiatChange('5.00')).toBe(0.05)
+    expect(parseFiatChange('-3.00')).toBe(-0.03)
+    expect(parseFiatChange('1.23456789')).toBeCloseTo(0.0123456789)
+  })
+
+  it('treats "0" as a genuine zero change', () => {
+    expect(parseFiatChange('0')).toBe(0)
+    expect(parseFiatChange('0.00')).toBe(0)
+  })
+
+  it('returns null when the backend has no data', () => {
+    expect(parseFiatChange(null)).toBeNull()
+    expect(parseFiatChange(undefined)).toBeNull()
+    expect(parseFiatChange('')).toBeNull()
+  })
+
+  it('returns null for non-numeric values instead of NaN', () => {
+    expect(parseFiatChange('not-a-number')).toBeNull()
+    expect(parseFiatChange('1.5abc')).toBeNull()
+  })
+
+  it('returns null for non-finite values', () => {
+    expect(parseFiatChange('Infinity')).toBeNull()
+    expect(parseFiatChange('-Infinity')).toBeNull()
+  })
+})
+
+describe('getFiatChangeDirection', () => {
+  it('maps sign to direction', () => {
+    expect(getFiatChangeDirection(0.05)).toBe('up')
+    expect(getFiatChangeDirection(-0.03)).toBe('down')
+    expect(getFiatChangeDirection(0)).toBe('none')
+  })
+
+  it('treats negative zero as no change', () => {
+    expect(getFiatChangeDirection(-0)).toBe('none')
+  })
+})

--- a/packages/utils/src/utils/fiatChange.ts
+++ b/packages/utils/src/utils/fiatChange.ts
@@ -1,0 +1,13 @@
+export type FiatChangeDirection = 'up' | 'down' | 'none'
+
+/** Backend 24h change string ("-3.00" = -3%) → decimal fraction. Null when absent or non-finite; "0" is a genuine zero. */
+export const parseFiatChange = (value: string | null | undefined): number | null => {
+  if (!value) return null
+
+  const change = Number(value) / 100
+
+  return Number.isFinite(change) ? change : null
+}
+
+export const getFiatChangeDirection = (change: number): FiatChangeDirection =>
+  change < 0 ? 'down' : change > 0 ? 'up' : 'none'


### PR DESCRIPTION
## What it solves

Resolves: four post-migration defects found while auditing recently migrated components, plus the shared `FiatChange` duplication they exposed.

1. **Double navigation in `usePreventNavigation`** — when a tx flow opted out of the discard warning, clicking a link navigated twice: the hook performed the navigation itself *and* the guard called `proceed()`.
2. **`AddCustomAppModal` swallowed validation messages** — `Input.error` was wired to `errors.appUrl.type === 'validUrl'`, so the `required` error never surfaced (and `required: true` had no message to show in the first place).
3. **`FiatChange` treated `"0"` inconsistently** — the falsy check `if (!fiatChange)` rendered "n/a" for a genuine zero change, while `"0.00"` (truthy) rendered "0%". Same bug in the mobile copies.
4. **Four near-identical `FiatChange` implementations** — web + three mobile components each re-derived direction, colour, sign and parsing inline.

## How this PR fixes it

**1. Navigation guard contract**

`requestDiscard` now tells its action *how* it was invoked. `usePreventNavigation` owns the navigation when the guard returns `true` synchronously, so the guard replays `proceed()` only when the navigation was actually blocked and later confirmed:

```ts
requestDiscard((deferred) => {
  closeFlow()
  if (deferred) proceed()
})
```

The hook's JSDoc now states the contract explicitly: a guard returning `true` must not call `proceed` itself.

**2. `AddCustomAppModal` errors**

`required: true` → `required: 'URL is required'`, and the `error` prop inverted to `type !== 'alreadyExists'`. `alreadyExists` stays excluded on purpose — it renders as a positive "This Safe App is already registered" confirmation with a share URL, not as an error.

**3 + 4. Shared fiat-change helpers**

New `packages/utils/src/utils/fiatChange.ts`:

- `parseFiatChange(value)` — backend string (`"-3.00"` = -3%) → decimal fraction; `null` only when absent or non-finite, so `"0"` is preserved as a real zero
- `getFiatChangeDirection(change)` → `'up' | 'down' | 'none'`

Platform styling stays platform-local: `apps/mobile/src/utils/fiatChange.ts` maps direction → Tamagui token + sign. Each call site drops its inline `getColor()` / `changeSign()` closures. The protocol total in `ProtocolSection` was extracted into a `ProtocolFiatChange` component, and `calculateProtocolFiatChange` now guards against a non-finite ratio.

## How to test it

**Double navigation**

1. Open a tx flow that opts out of the discard warning (`shouldWarn: false`), e.g. a flow with no unsaved input.
2. Click any sidebar link. → Navigates once, no discard dialog.
3. Repeat with a flow that has unsaved progress. → "Discard this transaction?" appears, the flow stays mounted, nothing navigates until you confirm; then it navigates exactly once.

**AddCustomAppModal**

1. Apps → My custom apps → Add custom Safe App.
2. Focus and blur the URL field empty. → "URL is required".
3. Enter garbage (`not-a-url`). → invalid-URL error.
4. Enter a URL already in the default list. → no red error; the "already registered" confirmation with share link shows instead.

**FiatChange zero**

1. Web assets table and mobile assets list with a token whose `fiatBalance24hChange` is `"0"`. → renders `0%` in the neutral colour, not "n/a".
2. Non-numeric / missing change → still "n/a" (web) / `0%` placeholder (mobile).

**Unit tests**

```bash
yarn workspace @safe-global/web test src/hooks/__tests__/usePreventNavigation.test.ts src/components/tx-flow src/components/safe-apps/AddCustomAppModal src/components/balances/AssetsTable/FiatChange.test.tsx
yarn workspace @safe-global/mobile test fiatChange FiatChange ProtocolFiatChange ProtocolDetailSheet
yarn workspace @safe-global/utils test fiatChange
```

## Affected flows

- Closing a tx flow via the dialog close button (with and without unsaved progress)
- Navigating away from an open tx flow via an in-app link or browser back
- Adding a custom Safe App (validation feedback on the URL field)
- Reading 24h fiat change on the web assets table, the mobile assets list, mobile position rows, and mobile protocol sections/detail sheet

## Blast radius

**Shared packages (web + mobile):**

- `packages/utils/src/utils/fiatChange.ts` — new module, no pre-existing consumers. Consumed by 4 components across both apps.

**Web:**

- `usePreventNavigation` — sole consumer is `TxModalProvider`; the JSDoc change codifies the `proceed`-ownership contract for future callers.
- `TxModalProvider.requestDiscard` — signature widened to `(deferred: boolean) => void`. Internal to `components/tx-flow/index.tsx`; the `setTxFlow` / `TxModalContext` public API is unchanged, so no call site of the ~dozens of tx flows needs touching.
- `AssetsTable/FiatChange` — used by the assets table and inline balance displays.
- `AddCustomAppModal` — self-contained; no shared form utilities changed.

**Mobile:**

- `apps/mobile/src/utils/fiatChange.ts` — new, Tamagui-token-only.
- `ProtocolFiatChange` — new component; `ProtocolSection` and `ProtocolDetailSheetHeader` now render it instead of inlining the markup.
- `calculateProtocolFiatChange` — now returns `null` instead of `NaN`/`Infinity` for degenerate totals; consumers already handled `null`.

**Not touched:** no RTK Query endpoints, slices, feature flags, chain configs, persisted state, or routes.

## Risks / not checked

- The mobile changes are covered by unit tests but were **not** run on a device or simulator — no visual confirmation of the Tamagui colour tokens.
- Did not verify the `beforePopState` (browser back) path manually in a browser; it is covered by the `usePreventNavigation` unit tests only.
- Did not verify `beforeunload` / tab-close behaviour — unchanged by this PR, but it shares the guard.
- No E2E test added for the tx-flow discard gate; coverage is unit-level.
- `AddCustomAppModal` error copy was not reviewed by design.
- Did not audit remaining migrated components for the same falsy-`"0"` pattern beyond the four fiat-change call sites.

## Visual summary

Navigation guard — the double-navigation fix:

```mermaid
sequenceDiagram
    participant U as User
    participant H as usePreventNavigation
    participant P as TxModalProvider
    participant R as Router

    Note over U,R: Before — flow opted out of the warning
    U->>H: mousedown on link
    H->>P: guard(proceed)
    P->>P: closeFlow()
    P->>R: proceed() ❌
    P-->>H: true
    H->>R: router.push() ❌
    Note over R: navigated twice

    Note over U,R: After
    U->>H: mousedown on link
    H->>P: guard(proceed)
    P->>P: closeFlow()
    P-->>H: true (deferred = false, no proceed)
    H->>R: router.push() ✅
    Note over R: navigated once
```

Fiat change — before/after structure:

```mermaid
flowchart TB
  subgraph Before
    W1[web FiatChange] --> I1["inline: Number(v)/100<br/>falsy check, direction,<br/>getColor, changeSign"]
    M1[mobile FiatChange] --> I2[same inline logic]
    M2[PositionFiatChange] --> I3[same inline logic]
    M3[ProtocolSection] --> I4[inline ternaries]
  end
  subgraph After
    W2[web FiatChange] --> S[parseFiatChange<br/>getFiatChangeDirection<br/>packages/utils]
    M4[mobile FiatChange] --> S
    M5[PositionFiatChange] --> S
    M6[ProtocolSection] --> PC[ProtocolFiatChange]
    PC --> S
    M4 --> T[getFiatChangeColor / Sign<br/>mobile, Tamagui tokens]
    M5 --> T
    PC --> T
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
