### PR TITLE
chore: tx-builder E2E fix

### DIFF
--- a/apps/web/cypress/e2e/pages/safeapps.pages.js
+++ b/apps/web/cypress/e2e/pages/safeapps.pages.js
@@ -356,3 +356,11 @@ export function uncheckAllPermissions(element) {
 export function checkAllPermissions(element) {
   cy.wrap(element).findByText(allowAllPermissions).click()
 }
+
+export function getSafeAppIframeSelector(appUrl) {
+  return `iframe[id="iframe-${encodeURIComponent(appUrl)}"]`
+}
+
+export function verifySafeAppIframeVisible(appUrl) {
+  cy.get(getSafeAppIframeSelector(appUrl), { timeout: 30000 }).should('be.visible')
+}

--- a/apps/web/cypress/e2e/safe-apps/tx-builder.cy.js
+++ b/apps/web/cypress/e2e/safe-apps/tx-builder.cy.js
@@ -1,8 +1,10 @@
 import * as constants from '../../support/constants.js'
 import * as safeapps from '../pages/safeapps.pages.js'
 import * as navigation from '../pages/navigation.page.js'
+import * as main from '../pages/main.page.js'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 import * as utils from '../../support/utils/checkers.js'
+import * as ls from '../../support/localstorage_data.js'
 
 let safeAppSafes = []
 let iframeSelector
@@ -14,21 +16,13 @@ describe('Transaction Builder tests', { defaultCommandTimeout: 20000 }, () => {
 
   beforeEach(() => {
     const appUrl = constants.TX_Builder_url
-    iframeSelector = `iframe[id="iframe-${encodeURIComponent(appUrl)}"]`
+    iframeSelector = safeapps.getSafeAppIframeSelector(appUrl)
     const visitUrl = `/apps/open?safe=${safeAppSafes.SEP_SAFEAPP_SAFE_1}&appUrl=${encodeURIComponent(appUrl)}`
-    cy.visit(visitUrl, {
-      onBeforeLoad(win) {
-        // Pre-grant address book access: the permissions prompt is a modal dialog, and Base UI
-        // marks everything behind it inert, hiding the tx modal from Cypress
-        win.localStorage.setItem(
-          constants.SAFE_PERMISSIONS_KEY,
-          JSON.stringify({
-            [appUrl]: [{ invoker: appUrl, parentCapability: 'requestAddressBook', date: 1111111111111, caveats: [] }],
-          }),
-        )
-      },
-    })
-    cy.get(iframeSelector, { timeout: 30000 }).should('be.visible')
+    // tx-builder keeps its form disabled until the address book permission prompt is answered:
+    // pre-grant it before the visit
+    main.addToLocalStorage(constants.SAFE_PERMISSIONS_KEY, ls.safeAppSafePermissions(appUrl))
+    cy.visit(visitUrl)
+    safeapps.verifySafeAppIframeVisible(appUrl)
   })
 
   it('Verify a simple batch can be created', () => {

--- a/apps/web/cypress/e2e/safe-apps/tx-builder_2.cy.js
+++ b/apps/web/cypress/e2e/safe-apps/tx-builder_2.cy.js
@@ -1,8 +1,10 @@
 import * as constants from '../../support/constants.js'
 import * as safeapps from '../pages/safeapps.pages.js'
+import * as main from '../pages/main.page.js'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 import * as utils from '../../support/utils/checkers.js'
 import { getMockAddress } from '../../support/utils/ethers.js'
+import * as ls from '../../support/localstorage_data.js'
 
 let safeAppSafes = []
 let iframeSelector
@@ -14,20 +16,12 @@ describe('Transaction Builder 2 tests', { defaultCommandTimeout: 20000 }, () => 
 
   beforeEach(() => {
     const appUrl = constants.TX_Builder_url
-    iframeSelector = `iframe[id="iframe-${encodeURIComponent(appUrl)}"]`
+    iframeSelector = safeapps.getSafeAppIframeSelector(appUrl)
     const visitUrl = `/apps/open?safe=${safeAppSafes.SEP_SAFEAPP_SAFE_1}&appUrl=${encodeURIComponent(appUrl)}`
-    cy.visit(visitUrl, {
-      onBeforeLoad(win) {
-        // Pre-grant address book access: the permissions prompt is a modal dialog, and Base UI
-        // marks everything behind it (including the app iframe) inert
-        win.localStorage.setItem(
-          constants.SAFE_PERMISSIONS_KEY,
-          JSON.stringify({
-            [appUrl]: [{ invoker: appUrl, parentCapability: 'requestAddressBook', date: 1111111111111, caveats: [] }],
-          }),
-        )
-      },
-    })
+    // tx-builder keeps its form disabled until the address book permission prompt is answered:
+    // pre-grant it before the visit
+    main.addToLocalStorage(constants.SAFE_PERMISSIONS_KEY, ls.safeAppSafePermissions(appUrl))
+    cy.visit(visitUrl)
   })
 
   it('Verify a batch cannot be created without method data', () => {

--- a/apps/web/cypress/e2e/safe-apps/tx-builder_3.cy.js
+++ b/apps/web/cypress/e2e/safe-apps/tx-builder_3.cy.js
@@ -3,6 +3,7 @@ import * as safeapps from '../pages/safeapps.pages.js'
 import * as main from '../pages/main.page.js'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 import { txAccordionDetails } from '../pages/create_tx.pages'
+import * as ls from '../../support/localstorage_data.js'
 let staticSafes = []
 let iframeSelector
 
@@ -13,9 +14,13 @@ describe('Transaction Builder 3 tests', { defaultCommandTimeout: 20000 }, () => 
 
   beforeEach(() => {
     const appUrl = constants.TX_Builder_url
-    iframeSelector = `iframe[id="iframe-${encodeURIComponent(appUrl)}"]`
+    iframeSelector = safeapps.getSafeAppIframeSelector(appUrl)
     const visitUrl = `/apps/open?safe=${staticSafes.SEP_STATIC_SAFE_43}&appUrl=${encodeURIComponent(appUrl)}`
+    // tx-builder keeps its form disabled until the address book permission prompt is answered:
+    // pre-grant it before the visit
+    main.addToLocalStorage(constants.SAFE_PERMISSIONS_KEY, ls.safeAppSafePermissions(appUrl))
     cy.visit(visitUrl)
+    safeapps.verifySafeAppIframeVisible(appUrl)
   })
 
   it('Verify that no error for the COWSwap fallbackhandler on confirm tx screen', () => {

--- a/apps/web/cypress/support/localstorage_data.js
+++ b/apps/web/cypress/support/localstorage_data.js
@@ -944,6 +944,11 @@ export const appPermissions = (url) => ({
   infoModalAccepted: JSON.stringify(infoModalAccepted),
 })
 
+// Safe (SDK) permissions payload for SAFE_PERMISSIONS_KEY, as stored after accepting the prompt
+export const safeAppSafePermissions = (appUrl) => ({
+  [appUrl]: [{ invoker: appUrl, parentCapability: 'requestAddressBook', date: 1111111111111, caveats: [] }],
+})
+
 export const cookies = {
   acceptedCookies: JSON.stringify(cookieState),
   acceptedTokenListOnboarding: true,

--- a/apps/web/src/features/feature-flag-overrides/components/FeatureFlagEditorDialog.tsx
+++ b/apps/web/src/features/feature-flag-overrides/components/FeatureFlagEditorDialog.tsx
@@ -5,6 +5,7 @@ import {
   DialogClose,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
@@ -25,8 +26,8 @@ export const FeatureFlagEditorDialog = ({ open, onOpenChange }: FeatureFlagEdito
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[90vh] w-full max-w-[min(900px,calc(100vw-2rem))] flex-col gap-0 p-0">
-        <DialogHeader className="shrink-0 border-b border-border px-6 pb-4 pt-6">
+      <DialogContent size="md" className="flex max-h-[90vh] flex-col">
+        <DialogHeader divided className="shrink-0">
           <DialogTitle className="font-bold">Feature flags</DialogTitle>
           <DialogDescription>
             Override the feature flags delivered by the config service. Changes apply instantly across all chains — no
@@ -34,22 +35,22 @@ export const FeatureFlagEditorDialog = ({ open, onOpenChange }: FeatureFlagEdito
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex min-h-0 flex-1 flex-col px-6 pb-6 pt-4">
+        <div className="flex min-h-0 flex-1 flex-col p-4">
           <FeatureFlagEditor />
-
-          <div className="mt-4 flex shrink-0 flex-row items-center gap-3 border-t border-border pt-4">
-            <Button
-              variant="destructive"
-              size="lg"
-              onClick={() => dispatch(clearAllOverrides())}
-              disabled={overridden.length === 0}
-            >
-              <RotateCcw />
-              Reset all overrides
-            </Button>
-            <DialogClose render={<Button size="lg" className="ml-auto" />}>Done</DialogClose>
-          </div>
         </div>
+
+        <DialogFooter divided className="shrink-0 flex-row items-center">
+          <Button
+            variant="destructive"
+            size="lg"
+            onClick={() => dispatch(clearAllOverrides())}
+            disabled={overridden.length === 0}
+          >
+            <RotateCcw />
+            Reset all overrides
+          </Button>
+          <DialogClose render={<Button size="lg" className="ml-auto" />}>Done</DialogClose>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   )

--- a/apps/web/src/features/feature-flag-overrides/components/FeatureFlagSection.tsx
+++ b/apps/web/src/features/feature-flag-overrides/components/FeatureFlagSection.tsx
@@ -22,7 +22,7 @@ export const FeatureFlagSection = ({
         <Badge variant="secondary">{rows.length}</Badge>
       </div>
 
-      <Card className="gap-0 p-0">
+      <Card size="none">
         <div
           className={cn(
             GRID,

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarContent/__tests__/SafeSidebarContent.developerAction.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarContent/__tests__/SafeSidebarContent.developerAction.test.tsx
@@ -84,6 +84,7 @@ jest.mock('@/components/ui/sidebar', () => ({
   SidebarGroupContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SidebarMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SidebarMenuItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SidebarSeparator: () => null,
   // Mirrors the real primitive's two shapes so NavItem's link-vs-button decision stays observable.
   SidebarMenuButton: ({
     children,

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SpacesSidebarContent/__tests__/SpacesSidebarContent.developerAction.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SpacesSidebarContent/__tests__/SpacesSidebarContent.developerAction.test.tsx
@@ -59,6 +59,7 @@ jest.mock('@/components/ui/sidebar', () => ({
   SidebarGroupContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SidebarMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SidebarMenuItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SidebarSeparator: () => null,
   // Mirrors the real primitive's two shapes so NavItem's link-vs-button decision stays observable.
   SidebarMenuButton: ({
     children,


### PR DESCRIPTION
## What it solves

Resolves:

Two follow-ups from the shadcn/ui migration (#8040):

1. The tx-builder Cypress suites were broken: tx-builder keeps its form disabled until the address book permission prompt is answered, and since the prompt is now a Base UI modal, everything behind it (including the app iframe) is marked inert and unreachable for Cypress. This cherry-picks the fix from #8492.
2. The developer feature-flag editor dialog (#8288) still styled its layout with hand-rolled padding/border classes instead of the migrated Dialog/Card component APIs.

## How this PR fixes it

**Cypress tx-builder fixes (cherry-pick of #8492):**

- Pre-grants the `requestAddressBook` permission in localStorage before visiting the app, so the permission prompt never opens and the form is enabled from the start (all three tx-builder suites).
- Extracts shared helpers instead of duplicating inline logic:
  - `safeapps.getSafeAppIframeSelector(appUrl)` / `safeapps.verifySafeAppIframeVisible(appUrl)` in `safeapps.pages.js`
  - `ls.safeAppSafePermissions(appUrl)` fixture in `localstorage_data.js`, applied via `main.addToLocalStorage`

**Feature-flag editor post-migration cleanup:**

- `FeatureFlagEditorDialog` now uses `DialogContent size="md"`, `DialogHeader divided`, and `DialogFooter divided` instead of manual `px-6/pb-4/border-b` classes and a hand-built footer row.
- `FeatureFlagSection` uses `Card size="none"` instead of `className="gap-0 p-0"`.

## How to test it

- Run the tx-builder Cypress suites: `tx-builder.cy.js`, `tx-builder_2.cy.js`, `tx-builder_3.cy.js` — all specs should pass without the permission prompt blocking interactions.
- Open the app with the developer feature-flag editor enabled and verify the "Feature flags" dialog renders with correct header/footer dividers, spacing, and the "Reset all overrides" / "Done" footer actions.

## Affected flows

- Cypress E2E: Transaction Builder safe-app suites (test-only).
- Developer-only feature flag editor dialog (dev tooling, behind developer flag).

## Blast radius

- `safeapps.pages.js` and `localstorage_data.js` gain new exports — no existing helpers changed, other suites unaffected.
- `FeatureFlagEditorDialog` / `FeatureFlagSection` are only consumed within the `feature-flag-overrides` feature; no shared components, hooks, or endpoints touched.
- No production user-facing flows, no mobile impact, no persisted-state changes.

## Risks / not checked

- Did not run the full Cypress suite, only the tx-builder specs.
- Dialog restyle verified visually in light mode only; dark mode relies on token-based Dialog/Card variants.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1[tx-builder.cy.js] --> I1[inline onBeforeLoad<br/>localStorage permission JSON]
    A2[tx-builder_2.cy.js] --> I2[inline onBeforeLoad<br/>localStorage permission JSON]
    A3[tx-builder_3.cy.js] --> X[no permission pre-grant<br/>prompt blocks form]
  end
  subgraph After
    B1[tx-builder.cy.js] --> H[ls.safeAppSafePermissions<br/>+ main.addToLocalStorage]
    B2[tx-builder_2.cy.js] --> H
    B3[tx-builder_3.cy.js] --> H
    H --> V[safeapps.verifySafeAppIframeVisible]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
