### PR TITLE
feat: disable adding a Safe as a proposer

### DIFF
--- a/apps/web/src/components/settings/ProposersList/index.tsx
+++ b/apps/web/src/components/settings/ProposersList/index.tsx
@@ -25,7 +25,6 @@ import { FEATURES } from '@safe-global/utils/utils/chains'
 import { HelpCenterArticle } from '@safe-global/utils/config/constants'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import NamedAddressInfo from '@/components/common/NamedAddressInfo'
-import SettingsCard from '@/components/settings/SettingsCard'
 
 const headCells = [
   {
@@ -123,29 +122,25 @@ const ProposersList = () => {
   }
 
   return (
-    <SettingsCard
-      title="Proposers"
-      className="mt-4"
-      contentClassName="flex flex-col gap-4"
-      data-testid="proposer-section"
-    >
-      <div>
-        <Typography className="mb-4">
-          Proposers can suggest transactions but cannot approve or execute them. Signers should review and approve
-          transactions first. <ExternalLink href={HelpCenterArticle.PROPOSERS}>Learn more</ExternalLink>
-        </Typography>
+    <div data-testid="proposer-section">
+      <Typography variant="paragraph-bold" className="mb-4">
+        Proposers
+      </Typography>
+      <Typography className="mb-4">
+        Proposers can suggest transactions but cannot approve or execute them. Signers should review and approve
+        transactions first. <ExternalLink href={HelpCenterArticle.PROPOSERS}>Learn more</ExternalLink>
+      </Typography>
 
-        {showPendingDelegations && <PendingDelegationsList />}
+      {showPendingDelegations && <PendingDelegationsList />}
 
-        {isEnabled && <AddProposerButton onAdd={onAdd} isUndeployedSafe={isUndeployedSafe} />}
+      {isEnabled && <AddProposerButton onAdd={onAdd} isUndeployedSafe={isUndeployedSafe} />}
 
-        {rows.length > 0 && <EnhancedTable rows={rows} headCells={headCells} />}
-      </div>
+      {rows.length > 0 && <EnhancedTable rows={rows} headCells={headCells} />}
 
       {isAddDialogOpen && (
         <UpsertProposer onClose={() => setIsAddDialogOpen(false)} onSuccess={() => setIsAddDialogOpen(false)} />
       )}
-    </SettingsCard>
+    </div>
   )
 }
 

--- a/apps/web/src/features/proposers/components/UpsertProposer.test.tsx
+++ b/apps/web/src/features/proposers/components/UpsertProposer.test.tsx
@@ -1,8 +1,10 @@
 import type { ReactElement } from 'react'
 import { faker } from '@faker-js/faker'
 import { render, fakerChecksummedAddress } from '@/tests/test-utils'
+import { SMART_CONTRACT_PROPOSER_ERROR } from '@/features/proposers/constants'
 import { act, fireEvent, waitFor } from '@testing-library/react'
 import * as proposerUtils from '@/features/proposers/utils/utils'
+import * as walletUtils from '@/utils/wallets'
 import UpsertProposer from './UpsertProposer'
 import useWallet from '@/hooks/wallets/useWallet'
 import { useDelegatorSelection } from '../hooks/useDelegatorSelection'
@@ -82,6 +84,7 @@ describe('UpsertProposer signing logic', () => {
       })
 
       mockGetSigner.mockResolvedValue({} as Awaited<ReturnType<typeof getAssertedChainSigner>>)
+      jest.spyOn(walletUtils, 'isSmartContractWallet').mockResolvedValue(false)
       jest.spyOn(proposerUtils, 'signProposerTypedData').mockResolvedValue('0xsignature')
 
       mockUseAddDelegateV2.mockReturnValue([addDelegateV2, {} as never])
@@ -132,6 +135,73 @@ describe('UpsertProposer signing logic', () => {
       await waitFor(() => expect(addDelegateV2).toHaveBeenCalled())
       const label = addDelegateV2.mock.calls[0][0].createDelegateDto.label
       expect(label).toBe(label.trim())
+    })
+  })
+
+  describe('smart contract address validation', () => {
+    const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>
+    const mockUseDelegatorSelection = useDelegatorSelection as jest.MockedFunction<typeof useDelegatorSelection>
+    const mockUseAddDelegateV2 = useDelegatesPostDelegateV2Mutation as jest.MockedFunction<
+      typeof useDelegatesPostDelegateV2Mutation
+    >
+
+    const addDelegateV2 = jest.fn().mockReturnValue({ unwrap: () => Promise.resolve() })
+
+    beforeEach(() => {
+      mockUseWallet.mockReturnValue({
+        address: fakerChecksummedAddress(),
+        chainId: '1',
+        label: 'MetaMask',
+        provider: MockEip1193Provider,
+      })
+
+      mockUseDelegatorSelection.mockReturnValue({
+        delegatorOptions: [],
+        setSelectedDelegator: jest.fn(),
+        effectiveDelegator: undefined,
+        parentSafeAddress: undefined,
+        parentThreshold: undefined,
+        parentOwners: undefined,
+        isMultiSigRequired: false,
+        isParentLoading: false,
+        canEdit: true,
+      })
+
+      mockUseAddDelegateV2.mockReturnValue([addDelegateV2, {} as never])
+      useDelegatesPostDelegateV1Mutation.mockReturnValue([jest.fn(), {}])
+    })
+
+    it('shows an error and keeps submit disabled when the address is a smart contract', async () => {
+      jest.spyOn(walletUtils, 'isSmartContractWallet').mockResolvedValue(true)
+
+      const { getByLabelText, getByTestId, findByText } = render(
+        <UpsertProposer onClose={jest.fn()} onSuccess={jest.fn()} />,
+      )
+
+      act(() => {
+        fireEvent.change(getByLabelText(/Address/i), { target: { value: fakerChecksummedAddress() } })
+        fireEvent.change(getByLabelText(/Name/i), { target: { value: 'My other Safe' } })
+      })
+
+      await findByText(SMART_CONTRACT_PROPOSER_ERROR, {}, { timeout: 3000 })
+      expect(getByTestId('submit-proposer-btn')).toBeDisabled()
+      expect(addDelegateV2).not.toHaveBeenCalled()
+    })
+
+    it('allows an EOA address', async () => {
+      jest.spyOn(walletUtils, 'isSmartContractWallet').mockResolvedValue(false)
+
+      const { getByLabelText, getByTestId, queryByText } = render(
+        <UpsertProposer onClose={jest.fn()} onSuccess={jest.fn()} />,
+      )
+
+      act(() => {
+        fireEvent.change(getByLabelText(/Address/i), { target: { value: fakerChecksummedAddress() } })
+        fireEvent.change(getByLabelText(/Name/i), { target: { value: 'An EOA' } })
+      })
+
+      await waitFor(() => expect(getByTestId('submit-proposer-btn')).not.toBeDisabled())
+      expect(queryByText(SMART_CONTRACT_PROPOSER_ERROR)).toBeNull()
     })
   })
 })

--- a/apps/web/src/features/proposers/components/UpsertProposer.test.tsx
+++ b/apps/web/src/features/proposers/components/UpsertProposer.test.tsx
@@ -1,7 +1,11 @@
 import type { ReactElement, ReactNode } from 'react'
 import { faker } from '@faker-js/faker'
 import { render, fakerChecksummedAddress } from '@/tests/test-utils'
-import { SMART_CONTRACT_PROPOSER_ERROR, SMART_CONTRACT_PROPOSER_INFO } from '@/features/proposers/constants'
+import {
+  SMART_CONTRACT_PROPOSER_EDIT_ERROR,
+  SMART_CONTRACT_PROPOSER_ERROR,
+  SMART_CONTRACT_PROPOSER_INFO,
+} from '@/features/proposers/constants'
 import { act, fireEvent, waitFor } from '@testing-library/react'
 import * as proposerUtils from '@/features/proposers/utils/utils'
 import * as walletUtils from '@/utils/wallets'
@@ -238,6 +242,91 @@ describe('UpsertProposer signing logic', () => {
 
       await waitFor(() => expect(getByTestId('submit-proposer-btn')).not.toBeDisabled())
       expect(queryByText(SMART_CONTRACT_PROPOSER_INFO)).toBeNull()
+    })
+  })
+
+  describe('smart contract guard on submit (edit flow)', () => {
+    const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>
+    const mockUseDelegatorSelection = useDelegatorSelection as jest.MockedFunction<typeof useDelegatorSelection>
+    const mockGetSigner = getAssertedChainSigner as jest.MockedFunction<typeof getAssertedChainSigner>
+    const mockUseAddDelegateV2 = useDelegatesPostDelegateV2Mutation as jest.MockedFunction<
+      typeof useDelegatesPostDelegateV2Mutation
+    >
+
+    const addDelegateV2 = jest.fn().mockReturnValue({ unwrap: () => Promise.resolve() })
+
+    const proposer = {
+      delegate: fakerChecksummedAddress(),
+      delegator: fakerChecksummedAddress(),
+      safe: fakerChecksummedAddress(),
+      label: 'Existing proposer',
+    }
+
+    beforeEach(() => {
+      mockUseWallet.mockReturnValue({
+        address: fakerChecksummedAddress(),
+        chainId: '1',
+        label: 'MetaMask',
+        provider: MockEip1193Provider,
+      })
+
+      mockUseDelegatorSelection.mockReturnValue({
+        delegatorOptions: [],
+        setSelectedDelegator: jest.fn(),
+        effectiveDelegator: undefined,
+        parentSafeAddress: undefined,
+        parentThreshold: undefined,
+        parentOwners: undefined,
+        isMultiSigRequired: false,
+        isParentLoading: false,
+        canEdit: true,
+      })
+
+      mockGetSigner.mockResolvedValue({} as Awaited<ReturnType<typeof getAssertedChainSigner>>)
+      jest.spyOn(proposerUtils, 'signProposerTypedData').mockResolvedValue('0xsignature')
+
+      mockUseAddDelegateV2.mockReturnValue([addDelegateV2, {} as never])
+      useDelegatesPostDelegateV1Mutation.mockReturnValue([jest.fn(), {}])
+    })
+
+    it('blocks submitting an edit when the existing proposer is a smart contract', async () => {
+      jest.spyOn(walletUtils, 'isSmartContractWallet').mockResolvedValue(true)
+
+      const { getByTestId, findByText } = render(
+        <UpsertProposer onClose={jest.fn()} onSuccess={jest.fn()} proposer={proposer} />,
+      )
+
+      await waitFor(() => expect(getByTestId('submit-proposer-btn')).not.toBeDisabled())
+
+      act(() => {
+        fireEvent.click(getByTestId('submit-proposer-btn'))
+      })
+
+      expect(await findByText(SMART_CONTRACT_PROPOSER_EDIT_ERROR)).toBeInTheDocument()
+      expect(addDelegateV2).not.toHaveBeenCalled()
+    })
+
+    it('submits an edit when the existing proposer is an EOA', async () => {
+      jest.spyOn(walletUtils, 'isSmartContractWallet').mockResolvedValue(false)
+
+      const { getByTestId, queryByText } = render(
+        <UpsertProposer onClose={jest.fn()} onSuccess={jest.fn()} proposer={proposer} />,
+      )
+
+      await waitFor(() => expect(getByTestId('submit-proposer-btn')).not.toBeDisabled())
+
+      act(() => {
+        fireEvent.click(getByTestId('submit-proposer-btn'))
+      })
+
+      await waitFor(() =>
+        expect(addDelegateV2).toHaveBeenCalledWith(
+          expect.objectContaining({
+            createDelegateDto: expect.objectContaining({ delegate: proposer.delegate }),
+          }),
+        ),
+      )
+      expect(queryByText(SMART_CONTRACT_PROPOSER_EDIT_ERROR)).toBeNull()
     })
   })
 })

--- a/apps/web/src/features/proposers/components/UpsertProposer.test.tsx
+++ b/apps/web/src/features/proposers/components/UpsertProposer.test.tsx
@@ -1,7 +1,7 @@
-import type { ReactElement } from 'react'
+import type { ReactElement, ReactNode } from 'react'
 import { faker } from '@faker-js/faker'
 import { render, fakerChecksummedAddress } from '@/tests/test-utils'
-import { SMART_CONTRACT_PROPOSER_ERROR } from '@/features/proposers/constants'
+import { SMART_CONTRACT_PROPOSER_ERROR, SMART_CONTRACT_PROPOSER_INFO } from '@/features/proposers/constants'
 import { act, fireEvent, waitFor } from '@testing-library/react'
 import * as proposerUtils from '@/features/proposers/utils/utils'
 import * as walletUtils from '@/utils/wallets'
@@ -23,6 +23,12 @@ jest.mock('@safe-global/store/gateway/AUTO_GENERATED/delegates', () => ({
 jest.mock('@/components/common/CheckWallet', () => ({
   __esModule: true,
   default: ({ children }: { children: (ok: boolean) => ReactElement }) => children(true),
+}))
+
+jest.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
 }))
 
 const { useDelegatesPostDelegateV1Mutation } = jest.requireMock('@safe-global/store/gateway/AUTO_GENERATED/delegates')
@@ -202,6 +208,36 @@ describe('UpsertProposer signing logic', () => {
 
       await waitFor(() => expect(getByTestId('submit-proposer-btn')).not.toBeDisabled())
       expect(queryByText(SMART_CONTRACT_PROPOSER_ERROR)).toBeNull()
+    })
+
+    it('explains on the disabled button why a smart contract cannot be a proposer', async () => {
+      jest.spyOn(walletUtils, 'isSmartContractWallet').mockResolvedValue(true)
+
+      const { getByLabelText, findByText } = render(<UpsertProposer onClose={jest.fn()} onSuccess={jest.fn()} />)
+
+      act(() => {
+        fireEvent.change(getByLabelText(/Address/i), { target: { value: fakerChecksummedAddress() } })
+        fireEvent.change(getByLabelText(/Name/i), { target: { value: 'My other Safe' } })
+      })
+
+      await findByText(SMART_CONTRACT_PROPOSER_ERROR, {}, { timeout: 3000 })
+      expect(await findByText(SMART_CONTRACT_PROPOSER_INFO)).toBeInTheDocument()
+    })
+
+    it('does not show the smart contract info for a valid EOA address', async () => {
+      jest.spyOn(walletUtils, 'isSmartContractWallet').mockResolvedValue(false)
+
+      const { getByLabelText, getByTestId, queryByText } = render(
+        <UpsertProposer onClose={jest.fn()} onSuccess={jest.fn()} />,
+      )
+
+      act(() => {
+        fireEvent.change(getByLabelText(/Address/i), { target: { value: fakerChecksummedAddress() } })
+        fireEvent.change(getByLabelText(/Name/i), { target: { value: 'An EOA' } })
+      })
+
+      await waitFor(() => expect(getByTestId('submit-proposer-btn')).not.toBeDisabled())
+      expect(queryByText(SMART_CONTRACT_PROPOSER_INFO)).toBeNull()
     })
   })
 })

--- a/apps/web/src/features/proposers/components/UpsertProposer.tsx
+++ b/apps/web/src/features/proposers/components/UpsertProposer.tsx
@@ -296,7 +296,7 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
 
               <div className="my-4">
                 {isEditing ? (
-                  <div className="mb-6">
+                  <div className="mb-6 text-sm [&_svg]:size-4">
                     <EthHashInfo address={proposer?.delegate} showCopyButton hasExplorer shortAddress={false} />
                   </div>
                 ) : (

--- a/apps/web/src/features/proposers/components/UpsertProposer.tsx
+++ b/apps/web/src/features/proposers/components/UpsertProposer.tsx
@@ -11,7 +11,11 @@ import {
   signProposerTypedData,
   signProposerTypedDataForSafe,
 } from '@/features/proposers/utils/utils'
-import { SMART_CONTRACT_PROPOSER_ERROR, SMART_CONTRACT_PROPOSER_INFO } from '@/features/proposers/constants'
+import {
+  SMART_CONTRACT_PROPOSER_EDIT_ERROR,
+  SMART_CONTRACT_PROPOSER_ERROR,
+  SMART_CONTRACT_PROPOSER_INFO,
+} from '@/features/proposers/constants'
 import { useDelegatorSelection } from '../hooks/useDelegatorSelection'
 import { buildDelegationOrigin, createDelegationMessage } from '../services/delegationMessages'
 import useChainId from '@/hooks/useChainId'
@@ -66,6 +70,7 @@ type ProposerEntry = {
 
 const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) => {
   const [error, setError] = useState<Error>()
+  const [blockedReason, setBlockedReason] = useState<string>()
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [multiSigInitiated, setMultiSigInitiated] = useState<boolean>(false)
   const [addDelegateV1] = useDelegatesPostDelegateV1Mutation()
@@ -120,9 +125,17 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
     const name = sanitizeName(data.name)
 
     setError(undefined)
+    setBlockedReason(undefined)
     setIsLoading(true)
 
     try {
+      // Backstop for the edit flow, where the address field (and its validator) is not rendered
+      const smartContractError = await addressIsNotSmartContract(chainId, SMART_CONTRACT_PROPOSER_ERROR)(data.address)
+      if (smartContractError) {
+        setBlockedReason(isEditing ? SMART_CONTRACT_PROPOSER_EDIT_ERROR : smartContractError)
+        return
+      }
+
       const shouldEthSign = isEthSignWallet(wallet)
       const signer = await getAssertedChainSigner(wallet.provider)
 
@@ -305,6 +318,12 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
               {error && (
                 <div className="mt-4">
                   <ErrorMessage error={error}>Error adding proposer</ErrorMessage>
+                </div>
+              )}
+
+              {blockedReason && (
+                <div className="mt-4">
+                  <ErrorMessage>{blockedReason}</ErrorMessage>
                 </div>
               )}
 

--- a/apps/web/src/features/proposers/components/UpsertProposer.tsx
+++ b/apps/web/src/features/proposers/components/UpsertProposer.tsx
@@ -5,11 +5,13 @@ import NameInput from '@/components/common/NameInput'
 import NetworkWarning from '@/components/new-safe/create/NetworkWarning'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import {
+  addressIsNotSmartContract,
   encodeEIP1271Signature,
   signProposerData,
   signProposerTypedData,
   signProposerTypedDataForSafe,
 } from '@/features/proposers/utils/utils'
+import { SMART_CONTRACT_PROPOSER_ERROR } from '@/features/proposers/constants'
 import { useDelegatorSelection } from '../hooks/useDelegatorSelection'
 import { buildDelegationOrigin, createDelegationMessage } from '../services/delegationMessages'
 import useChainId from '@/hooks/useChainId'
@@ -100,10 +102,11 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
   const safeOwnerAddresses = useMemo(() => safe.owners.map((owner) => owner.value), [safe.owners])
 
   const validateAddress = useCallback<Validate<string>>(
-    (value) =>
+    async (value) =>
       addressIsNotCurrentSafe(safeAddress, 'Cannot add Safe account itself as proposer')(value) ??
-      addressIsNotOwner(safeOwnerAddresses, 'Cannot add Safe Owner as proposer')(value),
-    [safeAddress, safeOwnerAddresses],
+      addressIsNotOwner(safeOwnerAddresses, 'Cannot add Safe Owner as proposer')(value) ??
+      (await addressIsNotSmartContract(chainId, SMART_CONTRACT_PROPOSER_ERROR)(value)),
+    [safeAddress, safeOwnerAddresses, chainId],
   )
 
   const { handleSubmit, formState } = methods

--- a/apps/web/src/features/proposers/components/UpsertProposer.tsx
+++ b/apps/web/src/features/proposers/components/UpsertProposer.tsx
@@ -107,10 +107,13 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
   const safeOwnerAddresses = useMemo(() => safe.owners.map((owner) => owner.value), [safe.owners])
 
   const validateAddress = useCallback<Validate<string>>(
-    async (value) =>
-      addressIsNotCurrentSafe(safeAddress, 'Cannot add Safe account itself as proposer')(value) ??
-      addressIsNotOwner(safeOwnerAddresses, 'Cannot add Safe Owner as proposer')(value) ??
-      (await addressIsNotSmartContract(chainId, SMART_CONTRACT_PROPOSER_ERROR)(value)),
+    async (value) => {
+      const notCurrentSafe = addressIsNotCurrentSafe(safeAddress, 'Cannot add Safe account itself as proposer')
+      const notOwner = addressIsNotOwner(safeOwnerAddresses, 'Cannot add Safe Owner as proposer')
+      const notSmartContract = addressIsNotSmartContract(chainId, SMART_CONTRACT_PROPOSER_ERROR)
+
+      return notCurrentSafe(value) ?? notOwner(value) ?? (await notSmartContract(value))
+    },
     [safeAddress, safeOwnerAddresses, chainId],
   )
 

--- a/apps/web/src/features/proposers/components/UpsertProposer.tsx
+++ b/apps/web/src/features/proposers/components/UpsertProposer.tsx
@@ -11,7 +11,7 @@ import {
   signProposerTypedData,
   signProposerTypedDataForSafe,
 } from '@/features/proposers/utils/utils'
-import { SMART_CONTRACT_PROPOSER_ERROR } from '@/features/proposers/constants'
+import { SMART_CONTRACT_PROPOSER_ERROR, SMART_CONTRACT_PROPOSER_INFO } from '@/features/proposers/constants'
 import { useDelegatorSelection } from '../hooks/useDelegatorSelection'
 import { buildDelegationOrigin, createDelegationMessage } from '../services/delegationMessages'
 import useChainId from '@/hooks/useChainId'
@@ -110,6 +110,9 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
   )
 
   const { handleSubmit, formState } = methods
+
+  const addressError = formState.errors[ProposerEntryFields.address]?.message
+  const isSmartContractError = addressError === SMART_CONTRACT_PROPOSER_ERROR
 
   const onConfirm = handleSubmit(async (data: ProposerEntry) => {
     if (!wallet) return
@@ -349,6 +352,7 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
                 confirmLoading={isLoading}
                 confirmDisabled={isParentLoading || (isEditing && !canEdit) || !formState.isValid}
                 confirmCheckWallet={{ checkNetwork: !isLoading, allowProposer: false }}
+                confirmTooltip={isSmartContractError ? SMART_CONTRACT_PROPOSER_INFO : undefined}
               />
             </DialogFooter>
           </form>

--- a/apps/web/src/features/proposers/constants.ts
+++ b/apps/web/src/features/proposers/constants.ts
@@ -7,6 +7,10 @@ export const DELEGATION_POLLING_INTERVAL_MS = 5000
 /** Validation error for the proposer address field */
 export const SMART_CONTRACT_PROPOSER_ERROR = 'Cannot add a smart contract account as proposer'
 
+/** Shown when submitting an edit of an existing smart contract proposer */
+export const SMART_CONTRACT_PROPOSER_EDIT_ERROR =
+  'This proposer is a smart contract account, which cannot sign transaction proposals. Remove it instead.'
+
 /** Explanation shown on the disabled confirm button */
 export const SMART_CONTRACT_PROPOSER_INFO =
   'Smart contract accounts (such as Safe accounts) cannot sign transaction proposals, so they cannot act as proposers.'

--- a/apps/web/src/features/proposers/constants.ts
+++ b/apps/web/src/features/proposers/constants.ts
@@ -3,3 +3,10 @@ export const TOTP_INTERVAL_SECONDS = 3600
 
 /** Polling interval for pending delegations (milliseconds) */
 export const DELEGATION_POLLING_INTERVAL_MS = 5000
+
+/** Validation error for the proposer address field */
+export const SMART_CONTRACT_PROPOSER_ERROR = 'Cannot add a smart contract account as proposer'
+
+/** Explanation shown on the disabled confirm button */
+export const SMART_CONTRACT_PROPOSER_INFO =
+  'Smart contract accounts (such as Safe accounts) cannot sign transaction proposals, so they cannot act as proposers.'

--- a/apps/web/src/features/proposers/utils/utils.test.ts
+++ b/apps/web/src/features/proposers/utils/utils.test.ts
@@ -1,9 +1,15 @@
-import { encodeEIP1271Signature, signProposerTypedDataForSafe } from './utils'
+import { addressIsNotSmartContract, encodeEIP1271Signature, signProposerTypedDataForSafe } from './utils'
 import { faker } from '@faker-js/faker'
 import { getAddress } from 'ethers'
 import type { JsonRpcSigner } from 'ethers'
 import * as web3Utils from '@safe-global/utils/utils/web3'
 import * as delegateUtils from '@safe-global/utils/services/delegates'
+
+jest.mock('@/utils/wallets', () => ({
+  isSmartContractWallet: jest.fn(),
+}))
+
+const { isSmartContractWallet } = jest.requireMock('@/utils/wallets')
 
 describe('encodeEIP1271Signature', () => {
   const parentSafeAddress = getAddress(faker.finance.ethereumAddress())
@@ -208,5 +214,36 @@ describe('signProposerTypedDataForSafe', () => {
         }),
       }),
     )
+  })
+})
+
+describe('addressIsNotSmartContract', () => {
+  const message = 'Cannot add a smart contract account as proposer'
+  const chainId = '1'
+
+  beforeEach(() => {
+    isSmartContractWallet.mockReset()
+  })
+
+  it('returns the message for a smart contract address', async () => {
+    isSmartContractWallet.mockResolvedValue(true)
+    const address = getAddress(faker.finance.ethereumAddress())
+
+    await expect(addressIsNotSmartContract(chainId, message)(address)).resolves.toBe(message)
+    expect(isSmartContractWallet).toHaveBeenCalledWith(chainId, address)
+  })
+
+  it('returns undefined for an EOA', async () => {
+    isSmartContractWallet.mockResolvedValue(false)
+    const address = getAddress(faker.finance.ethereumAddress())
+
+    await expect(addressIsNotSmartContract(chainId, message)(address)).resolves.toBeUndefined()
+  })
+
+  it('returns undefined when the contract check fails', async () => {
+    isSmartContractWallet.mockRejectedValue(new Error('Provider not found'))
+    const address = getAddress(faker.finance.ethereumAddress())
+
+    await expect(addressIsNotSmartContract(chainId, message)(address)).resolves.toBeUndefined()
   })
 })

--- a/apps/web/src/features/proposers/utils/utils.ts
+++ b/apps/web/src/features/proposers/utils/utils.ts
@@ -5,6 +5,7 @@ import { adjustVInSignature } from '@safe-global/protocol-kit'
 import type { JsonRpcSigner } from 'ethers'
 import { getDelegateTypedData } from '@safe-global/utils/services/delegates'
 import { TOTP_INTERVAL_SECONDS } from '@/features/proposers/constants'
+import { isSmartContractWallet } from '@/utils/wallets'
 
 export const signProposerTypedData = async (chainId: string, proposerAddress: string, signer: JsonRpcSigner) => {
   const typedData = getDelegateTypedData(chainId, proposerAddress)
@@ -85,3 +86,17 @@ export const encodeEIP1271Signature = async (parentSafeAddress: string, ownerSig
   // Encode to the final signature bytes string
   return '0x' + buildSignatureBytes([contractSig]).slice(2)
 }
+
+/**
+ * Address validator that rejects deployed smart contracts (EIP-7702 delegated EOAs are allowed).
+ * Fails open: returns undefined when the check cannot be performed, e.g. no RPC provider.
+ */
+export const addressIsNotSmartContract =
+  (chainId: string, message: string) =>
+  async (address: string): Promise<string | undefined> => {
+    try {
+      return (await isSmartContractWallet(chainId, address)) ? message : undefined
+    } catch {
+      return undefined
+    }
+  }

--- a/apps/web/src/utils/__tests__/wallets.test.ts
+++ b/apps/web/src/utils/__tests__/wallets.test.ts
@@ -188,5 +188,26 @@ describe('wallets', () => {
 
       expect(result).toBe(false)
     })
+
+    it('should memoize successful results per chainId and address', async () => {
+      getCodeMock.mockResolvedValue('0x608060405234801561001057600080fd5b5')
+
+      await isSmartContractWallet('1', toBeHex('0x1', 20))
+      await isSmartContractWallet('1', toBeHex('0x1', 20))
+
+      expect(getCodeMock).toHaveBeenCalledTimes(2) // isSmartContract + isEIP7702DelegatedAccount, once each
+    })
+
+    it('should not cache a failed check and retry on the next call', async () => {
+      getCodeMock.mockRejectedValueOnce(new Error('Provider not found'))
+
+      await expect(isSmartContractWallet('1', toBeHex('0x1', 20))).rejects.toThrow('Provider not found')
+
+      getCodeMock.mockResolvedValue('0x608060405234801561001057600080fd5b5')
+
+      const result = await isSmartContractWallet('1', toBeHex('0x1', 20))
+
+      expect(result).toBe(true)
+    })
   })
 })

--- a/apps/web/src/utils/wallets.ts
+++ b/apps/web/src/utils/wallets.ts
@@ -71,10 +71,16 @@ export const isEIP7702DelegatedAccount = async (address: string, provider?: Json
 }
 
 export const isSmartContractWallet = memoize(
-  async (_chainId: string, address: string): Promise<boolean> => {
-    const isContract = await isSmartContract(address)
-    const isEIP7702 = await isEIP7702DelegatedAccount(address)
-    return isContract && !isEIP7702
+  async (chainId: string, address: string): Promise<boolean> => {
+    try {
+      const isContract = await isSmartContract(address)
+      const isEIP7702 = await isEIP7702DelegatedAccount(address)
+      return isContract && !isEIP7702
+    } catch (error) {
+      // memoize would otherwise cache the rejected promise for the whole session
+      isSmartContractWallet.cache.delete?.(chainId + address)
+      throw error
+    }
   },
   (chainId, address) => chainId + address,
 )


### PR DESCRIPTION
## What it solves

Resolves: [WA-452](https://linear.app/safe-global/issue/WA-452/no-information-that-a-safe-can-not-be-used-as-a-proposer)

A Safe (or any smart contract) could be added as a proposer with no warning, but could never actually propose: proposer signing is ECDSA-only with the connected wallet, so the flow silently dead-ends.

## How this PR fixes it

- New async validator `addressIsNotSmartContract` (feature-scoped) chained after the existing checks in the add-proposer dialog. It reuses `isSmartContractWallet`, so EIP-7702-delegated EOAs remain allowed; it fails open on RPC errors (UX guard, not a security boundary).
- Inline field error: "Cannot add a smart contract account as proposer"; Continue stays disabled via the existing `formState.isValid` gate.
- Hovering the disabled Continue explains why, via the existing `DialogActions.confirmTooltip` prop.
- On edit the existing proposer (if a smart contract was added earlier): an error "This proposer is a smart contract account, which cannot sign transaction proposals. Remove it instead.".

## How to test it

Add new:
1. Safe → Settings → Setup → Proposers → Add proposer.
2. Paste a deployed Safe's address → spinner, inline error, Continue disabled, tooltip on hover explains why.
3. Paste an EOA → no error, flow works as before.

Change existing:
1. Add a new Safe address as a proposer (e.g. on Staging where there is no guard)
2. Go to the current branch, try to change a name of the added proposer, click "Continue"
3. An error "This proposer is a smart contract account, which cannot sign transaction proposals. Remove it instead." is shown

## Affected flows

- Owner adds a proposer from Settings → Proposers (address validation extended).

## Blast radius

- `features/proposers` only: `UpsertProposer`, feature `constants.ts`, feature `utils.ts` (additive export; signing functions untouched).
- `AddressInput` and `DialogActions` consumed as-is (async validate + `confirmTooltip` are existing APIs); no shared components modified.
- One extra `eth_getCode` per fully-valid entered address (memoized per chain+address); sync checks short-circuit it.
- No RTK Query/API contract, flag, persistence, or mobile impact.

## Risks / not checked

- Counterfactual (undeployed) Safes pass the check — no bytecode to detect.
- RPC unavailable → check silently skipped (fail-open by design).

## Visual summary

UI changes:
Before: no warning on Safe addition:
<img width="565" height="655" alt="image" src="https://github.com/user-attachments/assets/255b6139-fccc-4c5a-944e-829178e47aa2" />

<br>
After:
<img width="647" height="656" alt="image" src="https://github.com/user-attachments/assets/285e80d5-7f65-40f0-8808-a5f559f9185f" />

On edit:

<img width="582" height="625" alt="image" src="https://github.com/user-attachments/assets/dec83dc7-f418-4d8a-9932-62c6f1d5b381" />

<br>


```mermaid
flowchart LR
  A[Address entered] --> B{Sync checks:\ncurrent Safe? owner?}
  B -->|error| E[Inline error, Continue disabled]
  B -->|pass| C{eth_getCode:\nsmart contract?\nEIP-7702 excluded}
  C -->|yes| D[Inline error + tooltip on\ndisabled Continue button]
  C -->|no / RPC error| F[Valid — Continue enabled]
```

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics changes
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
