### PR TITLE
feat(errors): block execution with GS026 pre-checks before broadcast

### DIFF
--- a/apps/web/src/components/tx-flow/actions/ComboSubmit.tsx
+++ b/apps/web/src/components/tx-flow/actions/ComboSubmit.tsx
@@ -69,9 +69,7 @@ export const ComboSubmit = (props: SlotComponentProps<SlotName.Submit>) => {
         </div>
       )}
 
-      {validationError !== undefined && (
-        <ErrorMessage error={validationError}>Error validating transaction data</ErrorMessage>
-      )}
+      {validationError !== undefined && <ErrorMessage error={validationError}>{validationError.message}</ErrorMessage>}
 
       {showLastSignerWarning && (
         <div className="mt-2">

--- a/apps/web/src/components/tx/TxSubmitError/__tests__/TxSubmitError.test.tsx
+++ b/apps/web/src/components/tx/TxSubmitError/__tests__/TxSubmitError.test.tsx
@@ -1,9 +1,42 @@
 import { render } from '@/tests/test-utils'
 import type { EthersError } from '@/utils/ethers-utils'
 import type { TransactionReceipt } from 'ethers'
+import { Gs026PreCheckError } from '@/services/tx/executionPreChecks'
 import TxSubmitError from '..'
 
 describe('TxSubmitError', () => {
+  it('shows the cause-specific message for a failed GS026 pre-check', () => {
+    const { getByText, queryByText } = render(<TxSubmitError error={new Gs026PreCheckError('STALE_NONCE')} />)
+
+    expect(getByText('Another transaction used this nonce. Refresh to get the current one.')).toBeInTheDocument()
+    expect(queryByText(/Could not submit/)).not.toBeInTheDocument()
+  })
+
+  it('shows the always-visible GS026 code reference for a failed pre-check', () => {
+    const { getByText, getByTestId, queryByText } = render(
+      <TxSubmitError error={new Gs026PreCheckError('STALE_NONCE')} />,
+    )
+
+    // GS errors show the code-only reference inline — no Details toggle
+    expect(getByTestId('error-details')).toBeInTheDocument()
+    expect(getByText('GS026')).toBeInTheDocument()
+    expect(queryByText('Details')).not.toBeInTheDocument()
+  })
+
+  it('shows the stale-nonce message for a wallet (EOA) nonce-too-low rejection', () => {
+    // viem wraps the RPC rejection as a contract revert — must not be
+    // classified as one (no gas was spent, nothing was mined)
+    const error = new Error(
+      'The contract function "execTransaction" reverted with the following reason:\nRPC 0xaa36a7 Infura eth_sendRawTransaction: nonce too low: next nonce 42, tx nonce 41',
+    )
+
+    const { getByText, queryByText } = render(<TxSubmitError error={error} />)
+
+    expect(getByText('Another transaction used this nonce. Refresh to get the current one.')).toBeInTheDocument()
+    expect(queryByText(/Gas was spent/)).not.toBeInTheDocument()
+    expect(queryByText(/Could not submit/)).not.toBeInTheDocument()
+  })
+
   it('claims gas was spent only for a mined revert (receipt status 0)', () => {
     const error = Object.assign(new Error('execution reverted'), {
       reason: 'GS013',

--- a/apps/web/src/components/tx/TxSubmitError/index.tsx
+++ b/apps/web/src/components/tx/TxSubmitError/index.tsx
@@ -1,7 +1,14 @@
 import type { ReactElement } from 'react'
 import { useCurrentChain } from '@/hooks/useChains'
-import { isRateLimitError, isRevertError, RATE_LIMIT_USER_MESSAGE } from '@/utils/transaction-errors'
+import { getGs026Message } from '@safe-global/utils/services/exceptions/contractErrors'
+import {
+  isNonceTooLowError,
+  isRateLimitError,
+  isRevertError,
+  RATE_LIMIT_USER_MESSAGE,
+} from '@/utils/transaction-errors'
 import { didRevert, type EthersError } from '@/utils/ethers-utils'
+import { isGs026PreCheckError } from '@/services/tx/executionPreChecks'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 
 export const COULD_NOT_SUBMIT_MESSAGE = 'Could not submit the transaction.'
@@ -27,6 +34,28 @@ const TxSubmitError = ({
   context?: 'estimation' | 'execution'
 }): ReactElement => {
   const chain = useCurrentChain()
+
+  // A failed GS026 pre-check blocked the broadcast — show its specific,
+  // cause-aware message (stale nonce / not a signer / bad signature).
+  if (isGs026PreCheckError(error)) {
+    return (
+      <ErrorMessage error={error} level="error" context={context}>
+        {error.message}
+      </ErrorMessage>
+    )
+  }
+
+  // The signer wallet's own Ethereum nonce advanced before broadcast (e.g. it
+  // executed another tx meanwhile). Same user story as a stale Safe nonce, so
+  // show the same message. Must be checked before the revert classification:
+  // viem misleadingly wraps this RPC rejection as a contract revert.
+  if (isNonceTooLowError(error)) {
+    return (
+      <ErrorMessage error={error} level="error" context={context}>
+        {getGs026Message('STALE_NONCE')}
+      </ErrorMessage>
+    )
+  }
 
   if (isRateLimitError(error)) {
     return (

--- a/apps/web/src/components/tx/shared/__tests__/hooks.test.ts
+++ b/apps/web/src/components/tx/shared/__tests__/hooks.test.ts
@@ -32,6 +32,14 @@ import { SafeTxContext, type SafeTxContextParams } from '@/components/tx-flow/Sa
 
 const chainInfo = chainBuilder().with({ chainId: '1' }).build()
 
+// The GS026 pre-checks have their own suite (services/tx/__tests__/executionPreChecks.test.ts);
+// these tests exercise the dispatch orchestration, where the mocked wallet is not
+// an owner of the mocked Safe and would otherwise be blocked by NOT_SIGNER.
+jest.mock('@/services/tx/executionPreChecks', () => ({
+  ...jest.requireActual('@/services/tx/executionPreChecks'),
+  runExecutionPreChecks: jest.fn(() => Promise.resolve()),
+}))
+
 describe('SignOrExecute hooks', () => {
   const extendedSafeInfo = extendedSafeInfoBuilder().build()
 
@@ -389,6 +397,46 @@ describe('SignOrExecute hooks', () => {
       expect(proposeSpy).not.toHaveBeenCalled()
       expect(executeSpy).toHaveBeenCalled()
       expect(id).toEqual('455')
+    })
+
+    it('should block the broadcast when a GS026 pre-check fails', async () => {
+      jest.spyOn(useSafeInfoHook, 'default').mockImplementation(() => ({
+        safe: {
+          ...extendedSafeInfo,
+          version: '1.3.0',
+          address: { value: zeroPadValue('0x0000', 20) },
+          nonce: 100,
+          threshold: 2,
+          owners: [{ value: zeroPadValue('0x0123', 20) }, { value: zeroPadValue('0x0456', 20) }],
+          chainId: '1',
+        },
+        safeAddress: '0x123',
+        safeError: undefined,
+        safeLoading: false,
+        safeLoaded: true,
+      }))
+
+      const { runExecutionPreChecks } = jest.requireMock('@/services/tx/executionPreChecks')
+      const { Gs026PreCheckError } = jest.requireActual('@/services/tx/executionPreChecks')
+      runExecutionPreChecks.mockRejectedValueOnce(new Gs026PreCheckError('STALE_NONCE'))
+
+      const proposeSpy = jest
+        .spyOn(txSender, 'dispatchTxProposal')
+        .mockImplementation((() => Promise.resolve({ txId: '123' })) as unknown as typeof txSender.dispatchTxProposal)
+      const executeSpy = jest
+        .spyOn(txSender, 'dispatchTxExecution')
+        .mockImplementation((() => Promise.resolve(createSafeTx())) as unknown as typeof txSender.dispatchTxExecution)
+
+      const { result } = renderHook(() => useTxActions())
+      const { executeTx } = result.current
+
+      await expect(executeTx({ gasPrice: 1 }, createSafeTx(), '455')).rejects.toThrow(
+        'Another transaction used this nonce. Refresh to get the current one.',
+      )
+
+      // Nothing was proposed or broadcast
+      expect(proposeSpy).not.toHaveBeenCalled()
+      expect(executeSpy).not.toHaveBeenCalled()
     })
 
     it('should throw an error if the tx is undefined', async () => {

--- a/apps/web/src/components/tx/shared/hooks.ts
+++ b/apps/web/src/components/tx/shared/hooks.ts
@@ -24,6 +24,7 @@ import {
   dispatchTxSigning,
 } from '@/services/tx/tx-sender'
 import { useHasPendingTxs } from '@/hooks/usePendingTxs'
+import { runExecutionPreChecks } from '@/services/tx/executionPreChecks'
 import { getSafeTxGas, getNonces } from '@/services/tx/tx-sender/recommendedNonce'
 import useAsync from '@safe-global/utils/hooks/useAsync'
 import { useUpdateBatch } from '@/features/batching'
@@ -178,6 +179,11 @@ export const useTxActions = (): TxActions => {
       assertProvider(signer?.provider)
       assertOnboard(onboard)
       assertChainInfo(chain)
+
+      // Catch the three GS026 causes (stale nonce, non-signer executor, bad
+      // signature) before anything is signed or broadcast — an on-chain GS026
+      // revert would cost the user gas for a guaranteed failure (WA-3005).
+      await runExecutionPreChecks({ safeTx, safe, signerAddress: signer.address })
 
       let tx: TransactionDetails | undefined
       let rePropose = false

--- a/apps/web/src/hooks/__tests__/useValidateTxData.test.tsx
+++ b/apps/web/src/hooks/__tests__/useValidateTxData.test.tsx
@@ -1,0 +1,113 @@
+import type { ReactNode } from 'react'
+import type Safe from '@safe-global/protocol-kit'
+import type { SafeTransaction } from '@safe-global/types-kit'
+import { faker } from '@faker-js/faker'
+import { renderHook, waitFor } from '@/tests/test-utils'
+import { createMockSafeTransaction } from '@/tests/transactions'
+import { SafeTxContext, type SafeTxContextParams } from '@/components/tx-flow/SafeTxProvider'
+import * as safeCoreSDK from '@/hooks/coreSDK/safeCoreSDK'
+import * as executionPreChecks from '@/services/tx/executionPreChecks'
+import { useValidateTxData } from '../useValidateTxData'
+
+const SAFE_TX_HASH = `0x${'ab'.repeat(32)}`
+
+const createWrapper = (safeTx?: SafeTransaction) => {
+  const value: SafeTxContextParams = {
+    safeTx,
+    setSafeTx: () => {},
+    setSafeMessage: () => {},
+    setSafeMessageHash: () => {},
+    setSafeTxError: () => {},
+    setNonce: () => {},
+    setNonceNeeded: () => {},
+    setSafeTxGas: () => {},
+    setTxOrigin: () => {},
+    isReadOnly: false,
+    gtfPaymentMode: 'safe',
+    setGtfPaymentMode: () => {},
+    setGtfSelectedGasToken: () => {},
+  }
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <SafeTxContext.Provider value={value}>{children}</SafeTxContext.Provider>
+  }
+}
+
+describe('useValidateTxData', () => {
+  const safeTx = createMockSafeTransaction({ to: faker.finance.ethereumAddress(), data: '0x' })
+  let validateTxSignaturesSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    jest.spyOn(safeCoreSDK, 'useSafeSDK').mockReturnValue({
+      getTransactionHash: jest.fn().mockResolvedValue(SAFE_TX_HASH),
+    } as unknown as Safe)
+
+    validateTxSignaturesSpy = jest.spyOn(executionPreChecks, 'validateTxSignatures').mockReturnValue(undefined)
+  })
+
+  it('returns undefined while the SDK is not initialized', async () => {
+    jest.spyOn(safeCoreSDK, 'useSafeSDK').mockReturnValue(undefined)
+
+    const { result } = renderHook(() => useValidateTxData(), { wrapper: createWrapper(safeTx) })
+
+    await waitFor(() => {
+      expect(result.current).toEqual([undefined, undefined, false])
+    })
+    expect(validateTxSignaturesSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns undefined when there is no safeTx in the context', async () => {
+    const { result } = renderHook(() => useValidateTxData(), { wrapper: createWrapper(undefined) })
+
+    await waitFor(() => {
+      expect(result.current).toEqual([undefined, undefined, false])
+    })
+    expect(validateTxSignaturesSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns an error message when the txId does not match the computed safeTxHash', async () => {
+    const txId = `multisig_0x123_0x${'ff'.repeat(32)}`
+
+    const { result } = renderHook(() => useValidateTxData(txId), { wrapper: createWrapper(safeTx) })
+
+    await waitFor(() => {
+      expect(result.current[0]).toBe('The transaction data does not match its safeTxHash')
+      expect(result.current[2]).toBe(false)
+    })
+    expect(validateTxSignaturesSpy).not.toHaveBeenCalled()
+  })
+
+  it('validates signatures when the txId matches the computed safeTxHash', async () => {
+    const txId = `multisig_0x123_${SAFE_TX_HASH}`
+
+    const { result } = renderHook(() => useValidateTxData(txId), { wrapper: createWrapper(safeTx) })
+
+    await waitFor(() => {
+      expect(result.current).toEqual([undefined, undefined, false])
+    })
+    expect(validateTxSignaturesSpy).toHaveBeenCalledWith(safeTx, SAFE_TX_HASH)
+  })
+
+  it('returns the signature validation message when a signature does not verify', async () => {
+    const badSignatureMessage = 'Could not verify your signature. Sign the transaction again.'
+    validateTxSignaturesSpy.mockReturnValue(badSignatureMessage)
+
+    const { result } = renderHook(() => useValidateTxData(), { wrapper: createWrapper(safeTx) })
+
+    await waitFor(() => {
+      expect(result.current[0]).toBe(badSignatureMessage)
+      expect(result.current[2]).toBe(false)
+    })
+    expect(validateTxSignaturesSpy).toHaveBeenCalledWith(safeTx, SAFE_TX_HASH)
+  })
+
+  it('validates signatures without a txId', async () => {
+    const { result } = renderHook(() => useValidateTxData(), { wrapper: createWrapper(safeTx) })
+
+    await waitFor(() => {
+      expect(result.current).toEqual([undefined, undefined, false])
+    })
+    expect(validateTxSignaturesSpy).toHaveBeenCalledWith(safeTx, SAFE_TX_HASH)
+  })
+})

--- a/apps/web/src/hooks/useTxNotifications.ts
+++ b/apps/web/src/hooks/useTxNotifications.ts
@@ -15,7 +15,13 @@ import { isWalletRejection } from '@/utils/wallets'
 import { getTxLink } from '@/utils/tx-link'
 import { useLazyTransactionsGetTransactionByIdV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { getExplorerLink } from '@safe-global/utils/utils/gateway'
-import { getGuardErrorInfo, isRateLimitError, RATE_LIMIT_USER_MESSAGE } from '@/utils/transaction-errors'
+import {
+  getGuardErrorInfo,
+  isNonceTooLowError,
+  isRateLimitError,
+  RATE_LIMIT_USER_MESSAGE,
+} from '@/utils/transaction-errors'
+import { getGs026Message } from '@safe-global/utils/services/exceptions/contractErrors'
 
 const TxNotifications = {
   [TxEvent.SIGN_FAILED]: 'Failed to sign. Please try again.',
@@ -74,6 +80,11 @@ const useTxNotifications = (): void => {
           message = `Transaction reverted on ${chain.chainName}. Gas was spent.`
         } else if (guardErrorName) {
           message = `Guard reverted the transaction (${guardErrorName}).`
+        } else if (isError && isNonceTooLowError(detail.error)) {
+          // The signer wallet's Ethereum nonce advanced before broadcast — the
+          // RPC rejected it pre-mining (no gas spent). Same user story as a
+          // stale Safe nonce, so show the same message.
+          message = getGs026Message('STALE_NONCE')
         } else if (isError && isRateLimitError(detail.error)) {
           // Translate transient RPC rate-limit failures into friendly copy.
           // The raw error from viem looks like a contract revert ("Request is

--- a/apps/web/src/hooks/useValidateTxData.ts
+++ b/apps/web/src/hooks/useValidateTxData.ts
@@ -1,9 +1,7 @@
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { useSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import useAsync from '@safe-global/utils/hooks/useAsync'
-import { logError } from '@/services/exceptions'
-import ErrorCodes from '@safe-global/utils/services/exceptions/ErrorCodes'
-import { ethers } from 'ethers'
+import { validateTxSignatures } from '@/services/tx/executionPreChecks'
 import { useContext } from 'react'
 
 export const useValidateTxData = (txId?: string) => {
@@ -22,44 +20,7 @@ export const useValidateTxData = (txId?: string) => {
       return 'The transaction data does not match its safeTxHash'
     }
 
-    // Validate non 1271 signatures
-    for (const signature of safeTx.signatures.values()) {
-      if (signature.isContractSignature) {
-        continue
-      }
-
-      const sig = signature.staticPart()
-      const v = parseInt(sig.slice(-2), 16)
-
-      if (v === 0 || v === 1) {
-        // We ignore pre-validated sigs and EIP1271 for now
-        continue
-      }
-      // ECDSA signature
-      if (v === 27 || v === 28) {
-        try {
-          const recoveredAddress = ethers.recoverAddress(computedSafeTxHash, sig)
-          if (recoveredAddress !== signature.signer) {
-            return `The signature for the signer ${signature.signer} is invalid`
-          }
-        } catch (e) {
-          logError(ErrorCodes._818, e)
-          return `The signature for the signer ${signature.signer} could not be validated`
-        }
-      }
-      // ETH_SIGN signature
-      if (v === 31 || v === 32) {
-        try {
-          const modifiedSig = `${sig.slice(0, -2)}${(v - 4).toString(16)}`
-          const recoveredAddress = ethers.verifyMessage(ethers.getBytes(computedSafeTxHash), modifiedSig)
-          if (recoveredAddress !== signature.signer) {
-            return `The signature for the signer ${signature.signer} is invalid`
-          }
-        } catch (e) {
-          logError(ErrorCodes._818, e)
-          return `The signature for the signer ${signature.signer} could not be validated`
-        }
-      }
-    }
+    // Validate non-1271 signatures locally (shared with the GS026 pre-checks)
+    return validateTxSignatures(safeTx, computedSafeTxHash)
   }, [sdk, safeTx, txId])
 }

--- a/apps/web/src/services/tx/__tests__/executionPreChecks.test.ts
+++ b/apps/web/src/services/tx/__tests__/executionPreChecks.test.ts
@@ -1,0 +1,188 @@
+import { ethers } from 'ethers'
+import type { SafeTransaction, SafeSignature } from '@safe-global/types-kit'
+import { GS026_MESSAGES } from '@safe-global/utils/services/exceptions/contractErrors'
+import {
+  Gs026PreCheckError,
+  isGs026PreCheckError,
+  runExecutionPreChecks,
+  validateTxSignatures,
+} from '../executionPreChecks'
+import { getNonces } from '@/services/tx/tx-sender/recommendedNonce'
+import { getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
+
+jest.mock('@/services/tx/tx-sender/recommendedNonce', () => ({
+  getNonces: jest.fn(),
+}))
+
+jest.mock('@/hooks/coreSDK/safeCoreSDK', () => ({
+  getSafeSDK: jest.fn(),
+}))
+
+jest.mock('@/services/exceptions', () => ({
+  logError: jest.fn(),
+}))
+
+const mockGetNonces = getNonces as jest.MockedFunction<typeof getNonces>
+const mockGetSafeSDK = getSafeSDK as jest.MockedFunction<typeof getSafeSDK>
+
+// A real key pair so ECDSA recovery genuinely round-trips
+const signerWallet = new ethers.Wallet('0x0123456789012345678901234567890123456789012345678901234567890123')
+const SAFE_TX_HASH = ethers.keccak256(ethers.toUtf8Bytes('safeTxHash'))
+
+const validSignature = (): SafeSignature => {
+  const sig = signerWallet.signingKey.sign(SAFE_TX_HASH)
+  return {
+    signer: signerWallet.address,
+    data: sig.serialized,
+    isContractSignature: false,
+    staticPart: () => sig.serialized,
+    dynamicPart: () => '',
+  }
+}
+
+const wrongSignerSignature = (): SafeSignature => ({
+  ...validSignature(),
+  // Claims to be from a different address than the one that signed
+  signer: '0x000000000000000000000000000000000000dEaD',
+})
+
+const contractSignature = (): SafeSignature => ({
+  signer: '0x000000000000000000000000000000000000bEEF',
+  data: '0x',
+  isContractSignature: true,
+  staticPart: () => '0x',
+  dynamicPart: () => '',
+})
+
+const createSafeTx = (nonce: number, signatures: SafeSignature[]): SafeTransaction =>
+  ({
+    data: { nonce },
+    signatures: new Map(signatures.map((sig) => [sig.signer.toLowerCase(), sig])),
+  }) as unknown as SafeTransaction
+
+const createSafe = ({ threshold = 1, owners = [signerWallet.address], deployed = true } = {}) => ({
+  chainId: '1',
+  address: { value: '0x0000000000000000000000000000000000005AFE' },
+  owners: owners.map((value) => ({ value })),
+  threshold,
+  deployed,
+})
+
+describe('executionPreChecks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetNonces.mockResolvedValue(undefined)
+    mockGetSafeSDK.mockReturnValue(undefined)
+  })
+
+  describe('validateTxSignatures', () => {
+    it('passes a signature that recovers to its claimed signer', () => {
+      const safeTx = createSafeTx(0, [validSignature()])
+      expect(validateTxSignatures(safeTx, SAFE_TX_HASH)).toBeUndefined()
+    })
+
+    it('fails a signature claiming to be from a different signer', () => {
+      const safeTx = createSafeTx(0, [wrongSignerSignature()])
+      expect(validateTxSignatures(safeTx, SAFE_TX_HASH)).toBe(GS026_MESSAGES.BAD_SIGNATURE)
+    })
+
+    it('fails a malformed signature instead of throwing', () => {
+      const broken: SafeSignature = {
+        ...validSignature(),
+        staticPart: () => '0x1b', // v=27 but not a real signature
+      }
+      const safeTx = createSafeTx(0, [broken])
+      expect(validateTxSignatures(safeTx, SAFE_TX_HASH)).toBe(GS026_MESSAGES.BAD_SIGNATURE)
+    })
+
+    it('skips contract (EIP-1271) signatures', () => {
+      const safeTx = createSafeTx(0, [contractSignature()])
+      expect(validateTxSignatures(safeTx, SAFE_TX_HASH)).toBeUndefined()
+    })
+  })
+
+  describe('runExecutionPreChecks', () => {
+    it('throws STALE_NONCE when another transaction already used the nonce', async () => {
+      mockGetNonces.mockResolvedValue({ currentNonce: 5, recommendedNonce: 5 })
+      const safeTx = createSafeTx(3, [validSignature()])
+
+      const promise = runExecutionPreChecks({ safeTx, safe: createSafe(), signerAddress: signerWallet.address })
+
+      await expect(promise).rejects.toThrow(GS026_MESSAGES.STALE_NONCE)
+      await expect(promise).rejects.toBeInstanceOf(Gs026PreCheckError)
+    })
+
+    it('skips the nonce check when the fresh nonce cannot be fetched', async () => {
+      mockGetNonces.mockResolvedValue(undefined)
+      const safeTx = createSafeTx(3, [validSignature()])
+
+      await expect(
+        runExecutionPreChecks({ safeTx, safe: createSafe(), signerAddress: signerWallet.address }),
+      ).resolves.toBeUndefined()
+    })
+
+    it('does not fetch the nonce for an undeployed Safe', async () => {
+      const safeTx = createSafeTx(0, [validSignature()])
+
+      await runExecutionPreChecks({
+        safeTx,
+        safe: createSafe({ deployed: false }),
+        signerAddress: signerWallet.address,
+      })
+
+      expect(mockGetNonces).not.toHaveBeenCalled()
+    })
+
+    it('throws NOT_SIGNER when an under-signed tx is executed by a non-owner', async () => {
+      // 1 signature, threshold 2 -> the executor's own signature is counted
+      const safeTx = createSafeTx(0, [validSignature()])
+      const safe = createSafe({ threshold: 2 })
+
+      await expect(
+        runExecutionPreChecks({ safeTx, safe, signerAddress: '0x000000000000000000000000000000000000dEaD' }),
+      ).rejects.toThrow(GS026_MESSAGES.NOT_SIGNER)
+    })
+
+    it('allows a non-owner to execute a fully signed tx', async () => {
+      const safeTx = createSafeTx(0, [validSignature()])
+      const safe = createSafe({ threshold: 1 })
+
+      await expect(
+        runExecutionPreChecks({ safeTx, safe, signerAddress: '0x000000000000000000000000000000000000dEaD' }),
+      ).resolves.toBeUndefined()
+    })
+
+    it('throws BAD_SIGNATURE when a collected signature does not verify', async () => {
+      mockGetSafeSDK.mockReturnValue({
+        getTransactionHash: jest.fn().mockResolvedValue(SAFE_TX_HASH),
+      } as unknown as ReturnType<typeof getSafeSDK>)
+
+      const safeTx = createSafeTx(0, [wrongSignerSignature()])
+
+      await expect(
+        runExecutionPreChecks({ safeTx, safe: createSafe(), signerAddress: signerWallet.address }),
+      ).rejects.toThrow(GS026_MESSAGES.BAD_SIGNATURE)
+    })
+
+    it('resolves when nonce, signer and signatures are all valid', async () => {
+      mockGetNonces.mockResolvedValue({ currentNonce: 3, recommendedNonce: 4 })
+      mockGetSafeSDK.mockReturnValue({
+        getTransactionHash: jest.fn().mockResolvedValue(SAFE_TX_HASH),
+      } as unknown as ReturnType<typeof getSafeSDK>)
+
+      const safeTx = createSafeTx(3, [validSignature()])
+
+      await expect(
+        runExecutionPreChecks({ safeTx, safe: createSafe(), signerAddress: signerWallet.address }),
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  describe('isGs026PreCheckError', () => {
+    it('identifies pre-check errors and rejects others', () => {
+      expect(isGs026PreCheckError(new Gs026PreCheckError('STALE_NONCE'))).toBe(true)
+      expect(isGs026PreCheckError(new Error(GS026_MESSAGES.STALE_NONCE))).toBe(false)
+      expect(isGs026PreCheckError(undefined)).toBe(false)
+    })
+  })
+})

--- a/apps/web/src/services/tx/__tests__/executionPreChecks.test.ts
+++ b/apps/web/src/services/tx/__tests__/executionPreChecks.test.ts
@@ -54,6 +54,33 @@ const contractSignature = (): SafeSignature => ({
   dynamicPart: () => '',
 })
 
+// Safe's eth_sign encoding: an EIP-191 personal_sign over the safeTxHash bytes,
+// with v shifted by +4 (27/28 -> 31/32)
+const ethSignSignature = (): SafeSignature => {
+  const sig = signerWallet.signMessageSync(ethers.getBytes(SAFE_TX_HASH))
+  const shiftedV = parseInt(sig.slice(-2), 16) + 4
+  const shiftedSig = `${sig.slice(0, -2)}${shiftedV.toString(16)}`
+  return {
+    signer: signerWallet.address,
+    data: shiftedSig,
+    isContractSignature: false,
+    staticPart: () => shiftedSig,
+    dynamicPart: () => '',
+  }
+}
+
+// Pre-validated signature: r = padded owner address, s = 0, v = 1
+const preValidatedSignature = (): SafeSignature => {
+  const staticPart = `0x${'00'.repeat(12)}${signerWallet.address.slice(2)}${'00'.repeat(32)}01`
+  return {
+    signer: signerWallet.address,
+    data: staticPart,
+    isContractSignature: false,
+    staticPart: () => staticPart,
+    dynamicPart: () => '',
+  }
+}
+
 const createSafeTx = (nonce: number, signatures: SafeSignature[]): SafeTransaction =>
   ({
     data: { nonce },
@@ -98,6 +125,36 @@ describe('executionPreChecks', () => {
     it('skips contract (EIP-1271) signatures', () => {
       const safeTx = createSafeTx(0, [contractSignature()])
       expect(validateTxSignatures(safeTx, SAFE_TX_HASH)).toBeUndefined()
+    })
+
+    it('skips pre-validated signatures — they can only be verified on-chain', () => {
+      // Recovery is impossible for a pre-validated signature, so returning
+      // undefined proves it was skipped rather than flagged as bad
+      const safeTx = createSafeTx(0, [preValidatedSignature()])
+      expect(validateTxSignatures(safeTx, SAFE_TX_HASH)).toBeUndefined()
+    })
+
+    it('passes an eth_sign signature that recovers to its claimed signer', () => {
+      const safeTx = createSafeTx(0, [ethSignSignature()])
+      expect(validateTxSignatures(safeTx, SAFE_TX_HASH)).toBeUndefined()
+    })
+
+    it('fails an eth_sign signature claiming to be from a different signer', () => {
+      const badEthSign: SafeSignature = {
+        ...ethSignSignature(),
+        signer: '0x000000000000000000000000000000000000dEaD',
+      }
+      const safeTx = createSafeTx(0, [badEthSign])
+      expect(validateTxSignatures(safeTx, SAFE_TX_HASH)).toBe(GS026_MESSAGES.BAD_SIGNATURE)
+    })
+
+    it('fails a malformed eth_sign signature instead of throwing', () => {
+      const broken: SafeSignature = {
+        ...ethSignSignature(),
+        staticPart: () => '0x1f', // v=31 but not a real signature
+      }
+      const safeTx = createSafeTx(0, [broken])
+      expect(validateTxSignatures(safeTx, SAFE_TX_HASH)).toBe(GS026_MESSAGES.BAD_SIGNATURE)
     })
   })
 

--- a/apps/web/src/services/tx/executionPreChecks.ts
+++ b/apps/web/src/services/tx/executionPreChecks.ts
@@ -1,0 +1,139 @@
+/**
+ * Pre-broadcast checks for the three causes hidden behind the GS026 on-chain
+ * revert ("Invalid owner provided"): a stale nonce, a non-signer executor, and
+ * a signature that does not verify. Each is detectable client-side, so we block
+ * submission with a specific message instead of letting the transaction revert
+ * on-chain and cost the user gas (WA-3005).
+ */
+import { ethers } from 'ethers'
+import type { SafeTransaction } from '@safe-global/types-kit'
+import type { ExtendedSafeInfo } from '@safe-global/store/slices/SafeInfo/types'
+import { getGs026Message, type Gs026Reason } from '@safe-global/utils/services/exceptions/contractErrors'
+import ErrorCodes from '@safe-global/utils/services/exceptions/ErrorCodes'
+import { logError } from '@/services/exceptions'
+import { getNonces } from '@/services/tx/tx-sender/recommendedNonce'
+import { getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
+import { isOwner } from '@/utils/transaction-guards'
+
+export class Gs026PreCheckError extends Error {
+  /** The GS code this pre-check prevents — lets the Details panel show it. */
+  code = 'GS026' as const
+  reason: Gs026Reason
+
+  constructor(reason: Gs026Reason) {
+    super(getGs026Message(reason))
+    this.name = 'Gs026PreCheckError'
+    this.reason = reason
+  }
+}
+
+export const isGs026PreCheckError = (error: unknown): error is Gs026PreCheckError => error instanceof Gs026PreCheckError
+
+/**
+ * A Safe signature's last byte is the ECDSA `v` value, which Safe overloads to
+ * encode HOW the signature must be verified:
+ * https://docs.safe.global/advanced/smart-account-signatures
+ *
+ * - 0: contract (EIP-1271) signature
+ * - 1: pre-validated signature (hash approved on-chain / msg.sender)
+ * - 27/28: standard ECDSA signature over the safeTxHash
+ * - 31/32: eth_sign — ECDSA over the EIP-191-prefixed safeTxHash, with v shifted by +4
+ */
+const SIG_TYPE_CONTRACT = 0
+const SIG_TYPE_PRE_VALIDATED = 1
+const SIG_TYPE_ECDSA = [27, 28]
+const SIG_TYPE_ETH_SIGN = [31, 32]
+const ETH_SIGN_V_OFFSET = 4
+
+const getSignatureType = (staticPart: string): number => parseInt(staticPart.slice(-2), 16)
+
+/**
+ * Locally recover every collected ECDSA/eth_sign signature against the
+ * transaction hash. Contract (EIP-1271) and pre-validated signatures are
+ * skipped — they cannot be verified client-side. Returns the user-facing
+ * message when a signature does not verify, undefined when all pass.
+ */
+export const validateTxSignatures = (safeTx: SafeTransaction, safeTxHash: string): string | undefined => {
+  for (const signature of safeTx.signatures.values()) {
+    if (signature.isContractSignature) {
+      continue
+    }
+
+    const sig = signature.staticPart()
+    const signatureType = getSignatureType(sig)
+
+    if (signatureType === SIG_TYPE_CONTRACT || signatureType === SIG_TYPE_PRE_VALIDATED) {
+      // Verified on-chain only; nothing to recover locally
+      continue
+    }
+
+    if (SIG_TYPE_ECDSA.includes(signatureType)) {
+      try {
+        const recoveredAddress = ethers.recoverAddress(safeTxHash, sig)
+        if (recoveredAddress !== signature.signer) {
+          return getGs026Message('BAD_SIGNATURE')
+        }
+      } catch (e) {
+        logError(ErrorCodes._818, e)
+        return getGs026Message('BAD_SIGNATURE')
+      }
+    }
+
+    if (SIG_TYPE_ETH_SIGN.includes(signatureType)) {
+      try {
+        // Undo Safe's +4 offset to get a standard v, then verify as an
+        // EIP-191 personal_sign message over the safeTxHash
+        const standardV = signatureType - ETH_SIGN_V_OFFSET
+        const standardSig = `${sig.slice(0, -2)}${standardV.toString(16)}`
+        const recoveredAddress = ethers.verifyMessage(ethers.getBytes(safeTxHash), standardSig)
+        if (recoveredAddress !== signature.signer) {
+          return getGs026Message('BAD_SIGNATURE')
+        }
+      } catch (e) {
+        logError(ErrorCodes._818, e)
+        return getGs026Message('BAD_SIGNATURE')
+      }
+    }
+  }
+}
+
+/**
+ * Run all GS026 pre-checks before broadcasting an execution. Throws a
+ * `Gs026PreCheckError` carrying the cause-specific message on the first
+ * failed check. Checks are best-effort: when the data needed for a check is
+ * unavailable (nonce fetch failed, SDK not initialised) the check is skipped
+ * rather than blocking a potentially valid transaction — the on-chain
+ * validation remains the final safety net.
+ */
+export const runExecutionPreChecks = async ({
+  safeTx,
+  safe,
+  signerAddress,
+}: {
+  safeTx: SafeTransaction
+  safe: Pick<ExtendedSafeInfo, 'chainId' | 'address' | 'owners' | 'threshold' | 'deployed'>
+  signerAddress: string
+}): Promise<void> => {
+  // STALE_NONCE: another transaction already consumed this nonce
+  if (safe.deployed) {
+    const nonces = await getNonces(safe.chainId, safe.address.value)
+    if (nonces && safeTx.data.nonce < nonces.currentNonce) {
+      throw new Gs026PreCheckError('STALE_NONCE')
+    }
+  }
+
+  // NOT_SIGNER: an under-signed transaction counts the executor's own
+  // pre-validated signature, so the executor must be an owner
+  if (safeTx.signatures.size < safe.threshold && !isOwner(safe.owners, signerAddress)) {
+    throw new Gs026PreCheckError('NOT_SIGNER')
+  }
+
+  // BAD_SIGNATURE: a collected signature does not recover to its claimed signer
+  const sdk = getSafeSDK()
+  if (sdk) {
+    const safeTxHash = await sdk.getTransactionHash(safeTx)
+    if (validateTxSignatures(safeTx, safeTxHash)) {
+      throw new Gs026PreCheckError('BAD_SIGNATURE')
+    }
+  }
+}

--- a/apps/web/src/utils/__tests__/transaction-errors.test.ts
+++ b/apps/web/src/utils/__tests__/transaction-errors.test.ts
@@ -4,12 +4,46 @@ import {
   extractGuardErrorCode,
   getGuardErrorInfo,
   getGuardErrorName,
+  isNonceTooLowError,
   isRateLimitError,
   isRevertError,
   GUARD_ERROR_CODES,
 } from '../transaction-errors'
 
 describe('transaction-errors', () => {
+  describe('isNonceTooLowError', () => {
+    it('detects the RPC "nonce too low" text, even wrapped as a viem revert', () => {
+      // Real shape: viem wraps the RPC rejection as a contract revert
+      const viemWrapped = new Error(
+        'The contract function "execTransaction" reverted with the following reason:\nRPC 0xaa36a7 Infura eth_sendRawTransaction: nonce too low: next nonce 42, tx nonce 41',
+      )
+      expect(isNonceTooLowError(viemWrapped)).toBe(true)
+    })
+
+    it('detects a pending same-nonce conflict ("replacement transaction underpriced")', () => {
+      const viemWrapped = new Error(
+        'The contract function "execTransaction" reverted with the following reason:\nRPC 0xaa36a7 Infura eth_sendRawTransaction: replacement transaction underpriced',
+      )
+      expect(isNonceTooLowError(viemWrapped)).toBe(true)
+      expect(isNonceTooLowError(new Error('already known'))).toBe(true)
+    })
+
+    it('detects the structured ethers nonce-conflict codes', () => {
+      expect(
+        isNonceTooLowError(Object.assign(new Error('nonce has already been used'), { code: 'NONCE_EXPIRED' })),
+      ).toBe(true)
+      expect(
+        isNonceTooLowError(Object.assign(new Error('replacement fee too low'), { code: 'REPLACEMENT_UNDERPRICED' })),
+      ).toBe(true)
+    })
+
+    it('returns false for unrelated errors', () => {
+      expect(isNonceTooLowError(new Error('execution reverted: GS026'))).toBe(false)
+      expect(isNonceTooLowError(null)).toBe(false)
+      expect(isNonceTooLowError(undefined)).toBe(false)
+    })
+  })
+
   describe('isRevertError', () => {
     it('treats a GS revert reason as a revert', () => {
       expect(isRevertError(Object.assign(new Error('execution reverted'), { reason: 'GS013' }))).toBe(true)

--- a/apps/web/src/utils/transaction-errors.ts
+++ b/apps/web/src/utils/transaction-errors.ts
@@ -104,6 +104,28 @@ export const isRateLimitError = (error: unknown): boolean => {
 }
 
 /**
+ * Detects a wallet-level (EOA) nonce conflict rejected by the RPC pre-mining
+ * (no gas spent): the signer account's Ethereum nonce was already consumed
+ * ("nonce too low" — another tx from the same wallet mined first) or is still
+ * occupied by a pending tx that the new one doesn't outbid ("replacement
+ * transaction underpriced" / "already known"). Matched on the RPC error text
+ * (viem wraps these misleadingly as contract reverts) plus ethers' structured
+ * codes.
+ */
+export const isNonceTooLowError = (error: unknown): boolean => {
+  if (!error) return false
+
+  const err = error as { code?: unknown; message?: string }
+
+  if (err.code === 'NONCE_EXPIRED' || err.code === 'REPLACEMENT_UNDERPRICED') return true
+
+  return (
+    typeof err.message === 'string' &&
+    /nonce too low|nonce has already been used|replacement transaction underpriced|already known/i.test(err.message)
+  )
+}
+
+/**
  * Detects whether an error is a genuine on-chain revert — i.e. a node told us
  * the transaction reverts — as opposed to an infrastructure failure (RPC down,
  * timeout, rate-limit) where we simply could not complete the check.

--- a/packages/utils/src/services/exceptions/__tests__/contractErrors.test.ts
+++ b/packages/utils/src/services/exceptions/__tests__/contractErrors.test.ts
@@ -109,6 +109,16 @@ describe('contractErrors', () => {
   })
 
   describe('getGsCodeFromError', () => {
+    it('extracts a GS code from an explicit code property', () => {
+      // e.g. a pre-check error that identifies its GS code directly, with a clean message
+      expect(getGsCodeFromError({ code: 'GS026', message: 'Another transaction used this nonce.' })).toBe('GS026')
+    })
+
+    it('ignores non-GS code properties', () => {
+      expect(getGsCodeFromError({ code: 'CALL_EXCEPTION', message: 'no gs here' })).toBeUndefined()
+      expect(getGsCodeFromError({ code: -32005, message: 'no gs here' })).toBeUndefined()
+    })
+
     it('extracts a GS code from the reason', () => {
       expect(getGsCodeFromError({ reason: 'GS026', message: 'anything' })).toBe('GS026')
     })

--- a/packages/utils/src/services/exceptions/contractErrors.ts
+++ b/packages/utils/src/services/exceptions/contractErrors.ts
@@ -152,12 +152,18 @@ export const isGsCode = (code: unknown): code is GsCode =>
 const GS_CODE_RE = /\bGS\d{3}\b/
 
 /**
- * Extract a known GS code from an error's `reason`/`message`, if present.
- * Lets the UI tell an on-chain (GS) error apart from any other error so the
- * code-only support reference is shown for GS errors only.
+ * Extract a known GS code from an error, if present: an explicit `code`
+ * property (e.g. a pre-check error that identifies its GS code directly), or a
+ * code embedded in `reason`/`message`. Lets the UI tell an on-chain (GS) error
+ * apart from any other error so the code-only support reference is shown for
+ * GS errors only.
  */
-export const getGsCodeFromError = (error?: { message?: string; reason?: string } | null): GsCode | undefined => {
+export const getGsCodeFromError = (
+  error?: { message?: string; reason?: string; code?: unknown } | null,
+): GsCode | undefined => {
   if (!error) return undefined
+
+  if (isGsCode(error.code)) return error.code
 
   const reason = typeof error.reason === 'string' ? error.reason : ''
   const message = typeof error.message === 'string' ? error.message : ''


### PR DESCRIPTION
## What it solves

Resolves: the GS026 slice of WA-3005. A GS026 on-chain revert ("Invalid owner provided") costs the user gas for a failure that is fully predictable client-side. This PR detects its three causes before anything is signed or broadcast and blocks submission with a cause-specific message.

## How this PR fixes it

- **New `services/tx/executionPreChecks.ts`**: `runExecutionPreChecks` runs before `executeTx` dispatches anything and throws a `Gs026PreCheckError` (carrying `code: 'GS026'` and the cause) on:
  - **STALE_NONCE** — the Safe nonce was already consumed by another transaction
  - **NOT_SIGNER** — an under-signed tx would count the executor's pre-validated signature, but the executor isn't an owner
  - **BAD_SIGNATURE** — a collected ECDSA/eth_sign signature doesn't recover to its claimed signer (EIP-1271 and pre-validated sigs are skipped; checks are best-effort and skip when their data is unavailable — on-chain validation remains the final safety net)
- The signature-recovery logic was extracted from `useValidateTxData` into the shared `validateTxSignatures`, so both consumers use one implementation.
- **New `isNonceTooLowError`** in `utils/transaction-errors.ts`: detects wallet-level (EOA) nonce conflicts ("nonce too low", "replacement transaction underpriced", "already known", ethers' `NONCE_EXPIRED`/`REPLACEMENT_UNDERPRICED`) that viem misleadingly wraps as contract reverts. `TxSubmitError` and `useTxNotifications` show the stale-nonce copy for these instead of "Transaction reverted... Gas was spent."
- `getGsCodeFromError` now also honors an explicit `code` property, so the pre-check error shows the GS026 code-only support reference in the alert.
- Also restores the `SidebarSeparator` mock in two sidebar tests that was lost in the last dev merge (they failed with "Element type is invalid").

## How to test it

1. Queue a transaction, execute the same nonce from another tab/wallet, then execute the stale one → blocked with "Another transaction used this nonce. Refresh to get the current one." — no wallet prompt, no gas.
2. Connect a non-owner wallet to an under-signed tx (signatures < threshold) and execute → blocked with the NOT_SIGNER message.
3. Execute normally → no behavior change.
4. From an EOA, broadcast a competing tx so the wallet nonce advances mid-flow → the notification/toast shows the stale-nonce copy, not "Gas was spent".

## Affected flows

- Execute transaction (all entry points that go through `useTxActions.executeTx`)
- Execute batch / combo submit error display (`TxSubmitError`)
- Transaction failure notifications (`useTxNotifications`)
- Transaction data validation (`useValidateTxData`, now delegating signature recovery)

## Blast radius

- `useTxActions.executeTx` (shared hook) — every execution path now runs the pre-checks; they are best-effort and skip on missing data, so they can block but not falsely pass
- `getGsCodeFromError` in `packages/utils` — shared with mobile; parity tests pass (`contractErrorsParity`)
- `TxSubmitError` / `useTxNotifications` — new nonce-conflict branch ordered before the revert classification

## Risks / not checked

- Not tested on mobile (packages/utils change is covered by parity unit tests only)
- The nonce-conflict detection is text-matching on RPC error messages plus ethers codes; an RPC with unusual wording will fall through to the generic copy (safe fallback)
- Did not manually exercise the BAD_SIGNATURE path against a real malformed signature — covered by unit tests only

## Visual summary

```mermaid
flowchart TB
  A[executeTx] --> B{runExecutionPreChecks}
  B -->|Safe nonce consumed| C[STALE_NONCE message - blocked, no gas]
  B -->|executor not an owner| D[NOT_SIGNER message - blocked, no gas]
  B -->|signature does not recover| E[BAD_SIGNATURE message - blocked, no gas]
  B -->|all pass| F[sign / propose / broadcast]
  F -->|RPC: nonce too low| G[isNonceTooLowError -> stale-nonce copy, no 'gas was spent' claim]
  F -->|mined revert, status 0| H[Reverted on-chain - gas was spent]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
