### PR TITLE
chore: update @safe-global/protocol-kit to ^8.0.6

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -73,7 +73,7 @@
     "@reown/appkit-ethers-react-native": "^2.0.3",
     "@reown/appkit-react-native": "^2.0.3",
     "@reown/walletkit": "^1.2.7",
-    "@safe-global/protocol-kit": "^8.0.5",
+    "@safe-global/protocol-kit": "^8.0.6",
     "@safe-global/store": "workspace:^",
     "@safe-global/theme": "workspace:^",
     "@safe-global/utils": "workspace:^",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -71,7 +71,7 @@
     "@reduxjs/toolkit": "^2.11.0",
     "@reown/walletkit": "^1.2.7",
     "@safe-global/api-kit": "^5.0.2",
-    "@safe-global/protocol-kit": "^8.0.5",
+    "@safe-global/protocol-kit": "^8.0.6",
     "@safe-global/safe-apps-sdk": "^9.1.0",
     "@safe-global/safe-deployments": "^1.37.62",
     "@safe-global/safe-modules-deployments": "^3.0.9",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -36,7 +36,7 @@
     "ts-node": "^10.9.2"
   },
   "peerDependencies": {
-    "@safe-global/protocol-kit": "^8.0.4",
+    "@safe-global/protocol-kit": "^8.0.6",
     "@safe-global/store": "*",
     "@safe-global/types-kit": "^3.1.x"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13316,7 +13316,7 @@ __metadata:
     "@reown/appkit-react-native": "npm:^2.0.3"
     "@reown/walletkit": "npm:^1.2.7"
     "@rtk-query/codegen-openapi": "npm:^2.0.0"
-    "@safe-global/protocol-kit": "npm:^8.0.5"
+    "@safe-global/protocol-kit": "npm:^8.0.6"
     "@safe-global/store": "workspace:^"
     "@safe-global/test": "workspace:^"
     "@safe-global/theme": "workspace:^"
@@ -13441,13 +13441,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@safe-global/protocol-kit@npm:^8.0.5":
-  version: 8.0.5
-  resolution: "@safe-global/protocol-kit@npm:8.0.5"
+"@safe-global/protocol-kit@npm:^8.0.5, @safe-global/protocol-kit@npm:^8.0.6":
+  version: 8.0.6
+  resolution: "@safe-global/protocol-kit@npm:8.0.6"
   dependencies:
     "@noble/curves": "npm:^1.6.0"
     "@peculiar/asn1-schema": "npm:^2.3.13"
-    "@safe-global/safe-deployments": "npm:^1.37.61"
+    "@safe-global/safe-deployments": "npm:^1.37.62"
     "@safe-global/safe-modules-deployments": "npm:^3.0.9"
     "@safe-global/types-kit": "npm:^4.0.1"
     abitype: "npm:^1.2.3"
@@ -13458,7 +13458,7 @@ __metadata:
       optional: true
     "@peculiar/asn1-schema":
       optional: true
-  checksum: 10/d0fe001350377db09a03ce33f2906e10f452fb19535bbde507147aaf6dfde9c26e337fd72a87d4f1f74e2b4ff8e353d475ea5727c78f131b536ca01c43270b5d
+  checksum: 10/0aa846c498e9ef741b2fa101faed28be60be7b55bcb4672a553b49b272291354be0322ab726af29ca7e712df8e3cebc99ce3cffff2471a4b8c91f580ad481eda
   languageName: node
   linkType: hard
 
@@ -13493,7 +13493,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@safe-global/safe-deployments@npm:^1.37.61, @safe-global/safe-deployments@npm:^1.37.62":
+"@safe-global/safe-deployments@npm:^1.37.62":
   version: 1.37.62
   resolution: "@safe-global/safe-deployments@npm:1.37.62"
   dependencies:
@@ -13707,7 +13707,7 @@ __metadata:
     typescript: "npm:~5.9.2"
     typescript-eslint: "npm:^8.31.1"
   peerDependencies:
-    "@safe-global/protocol-kit": ^8.0.4
+    "@safe-global/protocol-kit": ^8.0.6
     "@safe-global/store": "*"
     "@safe-global/types-kit": ^3.1.x
   languageName: unknown
@@ -13792,7 +13792,7 @@ __metadata:
     "@reown/walletkit": "npm:^1.2.7"
     "@rspack/plugin-react-refresh": "npm:^1.0.0"
     "@safe-global/api-kit": "npm:^5.0.2"
-    "@safe-global/protocol-kit": "npm:^8.0.5"
+    "@safe-global/protocol-kit": "npm:^8.0.6"
     "@safe-global/safe-apps-sdk": "npm:^9.1.0"
     "@safe-global/safe-deployments": "npm:^1.37.62"
     "@safe-global/safe-modules-deployments": "npm:^3.0.9"


### PR DESCRIPTION
## What it solves

Resolves: WA-3113

Aligns the monorepo's declared `@safe-global/protocol-kit` range with the latest upstream release. protocol-kit `8.0.6` raises its `@safe-global/safe-deployments` floor to `^1.37.62`, matching the version the monorepo already resolves directly (#8470). Dependency hygiene only — no functional change: the deployments data was already deduped to `1.37.62` in `yarn.lock`, and `8.0.6` contains no code changes beyond the dependency floor bump ([changelog](https://github.com/safe-global/safe-core-sdk/blob/main/packages/protocol-kit/CHANGELOG.md#806)).

## How this PR fixes it

- Bumps `@safe-global/protocol-kit` to `^8.0.6` in `apps/web`, `apps/mobile` (from `^8.0.5`) and `packages/utils` (from `^8.0.4`).
- Refreshes `yarn.lock` and dedupes so `protocol-kit` resolves to a single `8.0.6` entry everywhere, including transitively via `@safe-global/api-kit@5.0.2` (whose `^8.0.5` range now resolves to `8.0.6`).

## How to test it

- `yarn why @safe-global/protocol-kit` → single resolution `8.0.6` (web + mobile direct, api-kit transitive).
- `yarn why @safe-global/safe-deployments` → still a single entry at `1.37.62`.
- CI green; no runtime behaviour to exercise (resolved deployments data is unchanged).

## Affected flows

- None intentionally — lockfile/range alignment only.

## Blast radius

- `@safe-global/protocol-kit` consumers across `apps/web`, `apps/mobile`, `packages/utils` (Safe deployment lookups, tx building/signing). Resolved code delta between `8.0.5` and `8.0.6` is limited to the `safe-deployments` dependency floor; the resolved `safe-deployments` version (`1.37.62`) is identical before and after.
- No API contracts, feature flags, persistence, or routes touched.

## Risks / not checked

- Did not manually exercise transaction creation / gas-estimation flows: the resolved dependency tree is byte-identical apart from protocol-kit's own version bump, so behaviour is expected to be unchanged. Type-check passes for `web`, `mobile`, and `utils`.

## Visual summary

```mermaid
graph LR
  web["apps/web<br/>^8.0.6"] --> pk["protocol-kit 8.0.6"]
  mobile["apps/mobile<br/>^8.0.6"] --> pk
  utils["packages/utils<br/>^8.0.6"] --> pk
  apikit["api-kit 5.0.2<br/>(^8.0.5, deduped)"] --> pk
  pk --> sd["safe-deployments 1.37.62<br/>(single resolution, unchanged)"]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — not applicable, dependency bump
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).