### PR TITLE
fix: double-navigation in usePreventNavigation

### DIFF
--- a/apps/web/src/components/tx-flow/__tests__/TxModalProvider.test.tsx
+++ b/apps/web/src/components/tx-flow/__tests__/TxModalProvider.test.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react'
-import { render, screen, waitFor } from '@/tests/test-utils'
+import { fireEvent, render, screen, waitFor } from '@/tests/test-utils'
 import userEvent from '@testing-library/user-event'
 import { TxModalContext, TxModalProvider } from '..'
 
@@ -8,6 +8,7 @@ jest.mock('@/hooks/useTopbarElevation', () => ({
 }))
 
 const FLOW_TEXT = 'Flow content'
+const LINK_HREF = '/target'
 
 /** Opens a flow via the context, mirroring how real call sites do it. */
 const Opener = ({ shouldWarn }: { shouldWarn?: boolean }) => {
@@ -108,5 +109,92 @@ describe('TxModalProvider close gate', () => {
     await user.click(screen.getByRole('button', { name: 'Discard' }))
 
     await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+  })
+})
+
+/** Opens a flow containing an internal link, mirroring the success screens that link back into the app. */
+const LinkOpener = ({ shouldWarn }: { shouldWarn?: boolean }) => {
+  const { setTxFlow } = useContext(TxModalContext)
+
+  return (
+    <button
+      onClick={() =>
+        setTxFlow(
+          <>
+            <div>{FLOW_TEXT}</div>
+            <a href={LINK_HREF}>go</a>
+          </>,
+          undefined,
+          shouldWarn,
+        )
+      }
+    >
+      open
+    </button>
+  )
+}
+
+describe('TxModalProvider navigation gate', () => {
+  const renderWithLink = (push: jest.Mock, shouldWarn?: boolean) =>
+    render(
+      <TxModalProvider>
+        <LinkOpener shouldWarn={shouldWarn} />
+      </TxModalProvider>,
+      { routerProps: { push } },
+    )
+
+  const clickLink = () => fireEvent.mouseDown(screen.getByRole('link', { name: 'go' }))
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('routes exactly once when the flow opted out of the warning', async () => {
+    const user = userEvent.setup()
+    const push = jest.fn()
+    renderWithLink(push, false)
+    await openFlow(user)
+
+    clickLink()
+
+    // Both the hook and the discard gate used to route, so this landed twice
+    expect(push).toHaveBeenCalledTimes(1)
+    expect(push).toHaveBeenCalledWith(LINK_HREF)
+    await waitFor(() => expect(screen.queryByText(FLOW_TEXT)).not.toBeInTheDocument())
+    expect(screen.queryByText('Discard this transaction?')).not.toBeInTheDocument()
+  })
+
+  it('holds the navigation until the discard is confirmed', async () => {
+    const user = userEvent.setup()
+    const push = jest.fn()
+    renderWithLink(push)
+    await openFlow(user)
+
+    clickLink()
+
+    expect(push).not.toHaveBeenCalled()
+    expect(await screen.findByText('Discard this transaction?')).toBeInTheDocument()
+    expect(screen.getByText(FLOW_TEXT)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Discard' }))
+
+    await waitFor(() => expect(push).toHaveBeenCalledTimes(1))
+    expect(push).toHaveBeenCalledWith(LINK_HREF)
+  })
+
+  it('keeps the flow open and does not route when the discard is declined', async () => {
+    const user = userEvent.setup()
+    const push = jest.fn()
+    renderWithLink(push)
+    await openFlow(user)
+
+    clickLink()
+    await screen.findByText('Discard this transaction?')
+
+    await user.click(screen.getByRole('button', { name: 'Keep editing' }))
+
+    await waitFor(() => expect(screen.queryByText('Discard this transaction?')).not.toBeInTheDocument())
+    expect(screen.getByText(FLOW_TEXT)).toBeInTheDocument()
+    expect(push).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/components/tx-flow/index.tsx
+++ b/apps/web/src/components/tx-flow/index.tsx
@@ -47,14 +47,14 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
 
   /**
    * Runs `action` now when there is no unsaved progress, otherwise parks it behind the discard
-   * dialog. Returns whether it ran, because `usePreventNavigation` needs a synchronous answer.
+   * dialog. Returns whether it ran; `action` is told whether it was parked.
    */
-  const requestDiscard = useCallback((action: () => void): boolean => {
+  const requestDiscard = useCallback((action: (wasParked: boolean) => void): boolean => {
     if (!shouldWarn.current) {
-      action()
+      action(false)
       return true
     }
-    setPendingDiscard(() => action)
+    setPendingDiscard(() => () => action(true))
     return false
   }, [])
 
@@ -104,9 +104,9 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
   usePreventNavigation(
     txFlow
       ? (proceed) =>
-          requestDiscard(() => {
+          requestDiscard((wasParked) => {
             closeFlow()
-            proceed()
+            if (wasParked) proceed()
           })
       : undefined,
   )

--- a/apps/web/src/hooks/__tests__/usePreventNavigation.test.ts
+++ b/apps/web/src/hooks/__tests__/usePreventNavigation.test.ts
@@ -1,0 +1,150 @@
+import type { NextRouter } from 'next/router'
+import { faker } from '@faker-js/faker'
+import { fireEvent, renderHook } from '@/tests/test-utils'
+import { usePreventNavigation } from '../usePreventNavigation'
+
+type PopStateHandler = Parameters<NextRouter['beforePopState']>[0]
+
+const CURRENT_PATH = '/current'
+const TARGET_PATH = '/target'
+
+describe('usePreventNavigation', () => {
+  const push = jest.fn()
+  const replace = jest.fn()
+  const beforePopState = jest.fn()
+  const elements: HTMLElement[] = []
+
+  const renderGuard = (onNavigate?: (proceed: () => void) => boolean) =>
+    renderHook(() => usePreventNavigation(onNavigate), {
+      routerProps: { asPath: CURRENT_PATH, push, replace, beforePopState },
+    })
+
+  const addElement = (tag: string, attributes: Record<string, string> = {}) => {
+    const element = document.createElement(tag)
+    Object.entries(attributes).forEach(([name, value]) => element.setAttribute(name, value))
+    document.body.appendChild(element)
+    elements.push(element)
+    return element
+  }
+
+  /** Fires a `mousedown` and reports whether a listener cancelled it. */
+  const mouseDown = (element: HTMLElement): boolean => !fireEvent.mouseDown(element)
+
+  const getPopStateHandler = () => beforePopState.mock.calls.at(-1)?.[0] as PopStateHandler
+
+  const popState = (url: string) => getPopStateHandler()({ url, as: url, options: {} })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    elements.splice(0).forEach((element) => element.remove())
+  })
+
+  describe('link clicks', () => {
+    it('routes an allowed navigation exactly once', () => {
+      const onNavigate = jest.fn(() => true)
+      renderGuard(onNavigate)
+
+      const wasPrevented = mouseDown(addElement('a', { href: TARGET_PATH }))
+
+      expect(onNavigate).toHaveBeenCalledTimes(1)
+      expect(push).toHaveBeenCalledTimes(1)
+      expect(push).toHaveBeenCalledWith(TARGET_PATH)
+      // The guard may close whatever the link lives in, so the anchor must not navigate as well
+      expect(wasPrevented).toBe(true)
+    })
+
+    it('does not route a blocked navigation until the guard replays it', () => {
+      let parked: (() => void) | undefined
+      renderGuard((proceed) => {
+        parked = proceed
+        return false
+      })
+
+      const wasPrevented = mouseDown(addElement('a', { href: TARGET_PATH }))
+
+      expect(wasPrevented).toBe(true)
+      expect(push).not.toHaveBeenCalled()
+
+      parked?.()
+
+      expect(push).toHaveBeenCalledTimes(1)
+      expect(push).toHaveBeenCalledWith(TARGET_PATH)
+    })
+
+    it('ignores links that open in a new tab', () => {
+      const onNavigate = jest.fn(() => true)
+      renderGuard(onNavigate)
+
+      const wasPrevented = mouseDown(addElement('a', { href: TARGET_PATH, target: '_blank' }))
+
+      expect(onNavigate).not.toHaveBeenCalled()
+      expect(push).not.toHaveBeenCalled()
+      expect(wasPrevented).toBe(false)
+    })
+
+    it.each([
+      ['a mailto', `mailto:${faker.internet.email()}`],
+      ['an external URL', faker.internet.url()],
+      ['a hash', '#anchor'],
+    ])('ignores %s href', (_, href) => {
+      const onNavigate = jest.fn(() => true)
+      renderGuard(onNavigate)
+
+      const wasPrevented = mouseDown(addElement('a', { href }))
+
+      expect(onNavigate).not.toHaveBeenCalled()
+      expect(push).not.toHaveBeenCalled()
+      expect(wasPrevented).toBe(false)
+    })
+
+    it('ignores clicks that are not on a link', () => {
+      const onNavigate = jest.fn(() => true)
+      renderGuard(onNavigate)
+
+      const wasPrevented = mouseDown(addElement('div'))
+
+      expect(onNavigate).not.toHaveBeenCalled()
+      expect(wasPrevented).toBe(false)
+    })
+
+    it('does nothing without a guard', () => {
+      renderGuard(undefined)
+
+      const wasPrevented = mouseDown(addElement('a', { href: TARGET_PATH }))
+
+      expect(push).not.toHaveBeenCalled()
+      expect(wasPrevented).toBe(false)
+    })
+  })
+
+  describe('back/forward', () => {
+    it('lets an allowed navigation through untouched', () => {
+      renderGuard(() => true)
+
+      expect(popState(TARGET_PATH)).toBe(true)
+      // popstate has already moved the URL, so routing again would only add a history entry
+      expect(push).not.toHaveBeenCalled()
+      expect(replace).not.toHaveBeenCalled()
+    })
+
+    it('rewinds a blocked navigation until the guard replays it', () => {
+      let parked: (() => void) | undefined
+      renderGuard((proceed) => {
+        parked = proceed
+        return false
+      })
+
+      expect(popState(TARGET_PATH)).toBe(false)
+      expect(replace).toHaveBeenCalledWith(CURRENT_PATH)
+      expect(push).not.toHaveBeenCalled()
+
+      parked?.()
+
+      expect(push).toHaveBeenCalledTimes(1)
+      expect(push).toHaveBeenCalledWith(TARGET_PATH)
+    })
+  })
+})

--- a/apps/web/src/hooks/usePreventNavigation.ts
+++ b/apps/web/src/hooks/usePreventNavigation.ts
@@ -8,6 +8,9 @@ import { useRouter } from 'next/router'
  * and a `false` from `beforePopState` are both only honoured in the same tick, so the guard cannot
  * await a user's answer. It instead returns `false` to block now and receives `proceed`, the
  * navigation it blocked, to run later once the user has confirmed.
+ *
+ * `proceed` belongs to whoever blocked the navigation: a guard that returns `true` must never call
+ * it, or the route change happens twice.
  */
 export function usePreventNavigation(onNavigate?: (proceed: () => void) => boolean): void {
   const router = useRouter()
@@ -32,16 +35,18 @@ export function usePreventNavigation(onNavigate?: (proceed: () => void) => boole
       const href = link?.getAttribute('href')
       const targetAttr = link?.getAttribute('target')
 
-      if (!link || !href || targetAttr?.toLowerCase() === '_blank') return
+      // Only in-app paths are ours to route; new tabs, `mailto:` and external URLs stay the anchor's.
+      if (!link || !href?.startsWith('/') || targetAttr?.toLowerCase() === '_blank') return
 
       const proceed = () => {
         router.push(href)
       }
 
+      e.preventDefault()
+
       if (onNavigate(proceed)) {
         proceed()
       } else {
-        e.preventDefault()
         e.stopImmediatePropagation()
         e.stopPropagation()
       }


### PR DESCRIPTION
## What it solves

Resolves: [WA-3116](https://linear.app/safe-global/issue/WA-3116/fix-double-navigation-in-usepreventnavigation)

`usePreventNavigation` and its only consumer both claimed ownership of `proceed`, the handle that replays a navigation the discard guard blocked. `requestDiscard` runs its action immediately when a flow opted out of the discard warning, and that action called `proceed()` — then the hook called `proceed()` again because the guard returned `true`.

On any flow opened with `shouldWarn: false` (success screens, `ConfirmTxFlow`, `ReplaceTxFlow`, `ExecuteBatchFlow`, and every sidebar/dashboard "New transaction" entry point) this produced:

1. **Link click** → `router.push(href)` twice.
2. **Back/Forward** → the guard pushed `url` *and* the hook returned `true`, so Next also completed the popstate. That left a duplicate history entry, making the back button appear to need two presses.

The second one is not in the ticket. It has the same root cause and is fixed by the same change.

## How this PR fixes it

Restores the contract the hook's own JSDoc already described: **`proceed` belongs to whoever blocked the navigation.** A guard that returns `true` must never touch it.

| Case | Who navigates |
| --- | --- |
| Link click, allowed | the hook — `router.push` |
| Link click, blocked | the guard, replaying `proceed` after "Discard" |
| Back/Forward, allowed | nobody — the hook returns `true` and Next finishes the popstate |
| Back/Forward, blocked | the guard, replaying `proceed` after "Discard" |

- `usePreventNavigation` now calls `preventDefault()` on every intercepted link before consulting the guard. This is needed because the guard closes the flow the link lives in: React flushes that unmount before the `click` that follows `mousedown`, so the anchor cannot be relied on to navigate, and a surviving anchor would otherwise add a second route change. `stopImmediatePropagation`/`stopPropagation` stay in the blocked branch only.
- Interception is narrowed to in-app (`/…`) hrefs, so the new unconditional `preventDefault` cannot swallow a `mailto:`, external, or hash link.
- `requestDiscard` tells its action whether it was parked, so the navigation guard replays `proceed` only when it actually blocked something. The warn condition stays single-sourced — splitting it into a separate guard would let the two copies desync silently and reintroduce this exact bug class.
- `beforePopState` needed no change; it became correct once the consumer stopped pushing.

## How to test it

Fastest repro — **New transaction** from the sidebar opens `NewTxFlow` with `shouldWarn: false` and contains the in-app "Transaction Builder" link:

1. Sidebar → **New transaction** → click **Transaction Builder**. Lands on `/apps/open?…` once. On `dev` this routes twice.
2. Reopen the same modal and press **Back**. Goes back exactly one entry. On `dev` it takes two presses.
3. Start a **New transaction**, fill in a recipient (`shouldWarn: true`), then click an in-app link → discard dialog appears, flow stays open, URL unchanged. Confirm **Discard** → navigates once. Choose **Keep editing** → stays put, no navigation.
4. An `ExternalLink` inside a flow still opens in a new tab.

```bash
yarn workspace @safe-global/web test --testPathPattern "usePreventNavigation|TxModalProvider"
```

## Affected flows

- Clicking an in-app link inside a tx flow that opted out of the discard warning
- Browser Back/Forward while such a flow is open
- Clicking an in-app link inside a flow *with* unsaved progress — discard dialog, then confirm or cancel

## Blast radius

- **`usePreventNavigation`** — single consumer, `TxModalProvider`. Both the `mousedown` interception and the `beforePopState` guard are touched.
- **`TxModalProvider.requestDiscard`** — signature gains a `wasParked` argument. Its other two callers (`handleModalClose`, and the superseding-flow branch of `setTxFlow`) pass zero-arg functions and are unaffected.
- **Indirect** — every `setTxFlow(…, false)` call site: success screens, `ConfirmTxFlow`, `ReplaceTxFlow`, `ExecuteBatchFlow`, batch sidebar, spaces/dashboard send buttons, `NewTxFlow`.
- **Behaviour change beyond the ticket:** links inside a flow whose href is not an in-app path (`mailto:`, external without `target="_blank"`, `#hash`) are no longer routed through `router.push` — they now behave as plain anchors. None exist inside a flow today; `ExternalLink` always sets `target="_blank"`.
- No API contracts, feature flags, persisted state, analytics, or shared packages touched. No mobile impact.

## Risks / not checked

- **Not verified: whether cancelling `mousedown` actually blocks a Next `<Link>` in a real browser.** Per spec `preventDefault()` on `mousedown` does not cancel the subsequent `click`, so the *blocked* branch likely works only because `closeFlow()` unmounts the anchor first. This is pre-existing and untouched here; jsdom cannot settle it. If manual step 3 shows the URL changing behind the discard dialog, that is a separate ticket — the fix there is intercepting `click` in the capture phase.
- Not tested on mobile.
- No E2E test added — the behaviour is unit-testable, and Playwright is the wrong layer for it.
- `onNavigate` is still an inline arrow in `TxModalProvider`, so the hook's effects re-register on every provider render. Pre-existing; not addressed.

## Visual summary

```mermaid
flowchart TB
  subgraph Before["Before — 2 route changes"]
    direction TB
    B1["mousedown on in-app link"] --> B2["onNavigate(proceed)"]
    B2 --> B3["requestDiscard: no warning, run now"]
    B3 --> B4["closeFlow + proceed"]
    B4 --> B5["router.push — 1st"]
    B2 -.->|"returned true"| B6["hook calls proceed"]
    B6 --> B7["router.push — 2nd"]
  end

  subgraph After["After — 1 route change"]
    direction TB
    A1["mousedown on in-app link"] --> A2["preventDefault"]
    A2 --> A3["onNavigate(proceed)"]
    A3 --> A4["requestDiscard: no warning, run now, wasParked = false"]
    A4 --> A5["closeFlow only"]
    A3 -.->|"returned true"| A6["hook calls proceed"]
    A6 --> A7["router.push — once"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
