### PR TITLE
fix(proposers): keep proposer names on the device, never send them to…

### DIFF
--- a/apps/web/src/components/settings/ProposersList/index.stories.tsx
+++ b/apps/web/src/components/settings/ProposersList/index.stories.tsx
@@ -3,6 +3,7 @@ import { http, HttpResponse } from 'msw'
 import { mswLoader } from 'msw-storybook-addon'
 import type { DelegatePage } from '@safe-global/store/gateway/AUTO_GENERATED/delegates'
 import { createMockStory } from '@/stories/mocks'
+import { PROPOSER_LABEL_PLACEHOLDER } from '@/features/proposers/constants'
 import ProposersList from './index'
 
 const setup = createMockStory({
@@ -34,6 +35,16 @@ const proposersPage: DelegatePage = {
 
 const withProposersHandler = http.get(/\/v[12]\/chains\/\d+\/delegates$/, () => HttpResponse.json(proposersPage))
 
+// What a proposer added after names became device-local looks like from the API
+const placeholderProposersPage: DelegatePage = {
+  ...proposersPage,
+  results: proposersPage.results.map((proposer) => ({ ...proposer, label: PROPOSER_LABEL_PLACEHOLDER })),
+}
+
+const withPlaceholderProposersHandler = http.get(/\/v[12]\/chains\/\d+\/delegates$/, () =>
+  HttpResponse.json(placeholderProposersPage),
+)
+
 const meta = {
   title: 'Features/Proposers/ProposersList',
   component: ProposersList,
@@ -55,6 +66,15 @@ export const Default: Story = {
       // The custom proposers handler must come first so it wins over the
       // default empty delegates handler included in setup.parameters
       handlers: [withProposersHandler, ...setup.handlers],
+    },
+  },
+}
+
+/** No local address book entry, so only the address shows — names never come from the backend. */
+export const AddressOnly: Story = {
+  parameters: {
+    msw: {
+      handlers: [withPlaceholderProposersHandler, ...setup.handlers],
     },
   },
 }

--- a/apps/web/src/components/settings/ProposersList/index.tsx
+++ b/apps/web/src/components/settings/ProposersList/index.tsx
@@ -3,10 +3,11 @@ import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 import CheckWallet from '@/components/common/CheckWallet'
 import Track from '@/components/common/Track'
 import {
-  UpsertProposer,
+  AddProposer,
   DeleteProposerDialog,
   EditProposerDialog,
   PendingDelegationsList,
+  useMigrateProposerLabels,
   useParentSafeThreshold,
 } from '@/features/proposers'
 import { useHasFeature } from '@/hooks/useChains'
@@ -76,6 +77,7 @@ const ProposersList = () => {
   const [isAddDialogOpen, setIsAddDialogOpen] = useState<boolean>()
   const proposers = useProposers()
   const isEnabled = useHasFeature(FEATURES.PROPOSERS)
+  useMigrateProposerLabels()
   const { safe } = useSafeInfo()
   const isUndeployedSafe = !safe.deployed
   const isNestedSafeOwner = useIsNestedSafeOwner()
@@ -91,15 +93,7 @@ const ProposersList = () => {
         cells: {
           proposer: {
             rawValue: proposer.delegate,
-            content: (
-              <NamedAddressInfo
-                address={proposer.delegate}
-                showCopyButton
-                hasExplorer
-                name={proposer.label || undefined}
-                shortAddress
-              />
-            ),
+            content: <NamedAddressInfo address={proposer.delegate} showCopyButton hasExplorer shortAddress />,
           },
 
           creator: {
@@ -147,7 +141,7 @@ const ProposersList = () => {
       {rows.length > 0 && <EnhancedTable rows={rows} headCells={headCells} />}
 
       {isAddDialogOpen && (
-        <UpsertProposer onClose={() => setIsAddDialogOpen(false)} onSuccess={() => setIsAddDialogOpen(false)} />
+        <AddProposer onClose={() => setIsAddDialogOpen(false)} onSuccess={() => setIsAddDialogOpen(false)} />
       )}
     </div>
   )

--- a/apps/web/src/features/proposers/components/AddProposer.test.tsx
+++ b/apps/web/src/features/proposers/components/AddProposer.test.tsx
@@ -2,20 +2,21 @@ import type { ReactElement, ReactNode } from 'react'
 import { faker } from '@faker-js/faker'
 import { render, fakerChecksummedAddress } from '@/tests/test-utils'
 import {
-  SMART_CONTRACT_PROPOSER_EDIT_ERROR,
+  PROPOSER_LABEL_PLACEHOLDER,
   SMART_CONTRACT_PROPOSER_ERROR,
   SMART_CONTRACT_PROPOSER_INFO,
 } from '@/features/proposers/constants'
 import { act, fireEvent, waitFor } from '@testing-library/react'
 import * as proposerUtils from '@/features/proposers/utils/utils'
 import * as walletUtils from '@/utils/wallets'
-import UpsertProposer from './UpsertProposer'
+import AddProposer from './AddProposer'
 import useWallet from '@/hooks/wallets/useWallet'
 import { useDelegatorSelection } from '../hooks/useDelegatorSelection'
 import { getAssertedChainSigner } from '@/services/tx/tx-sender/sdk'
 import { useDelegatesPostDelegateV2Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/delegates'
 import { MockEip1193Provider } from '@/tests/mocks/providers'
 import { ZERO_ADDRESS, SENTINEL_ADDRESS } from '@safe-global/utils/utils/constants'
+import { getStoreInstance } from '@/store'
 
 jest.mock('@/hooks/wallets/useWallet')
 jest.mock('../hooks/useDelegatorSelection')
@@ -38,9 +39,28 @@ jest.mock('@/components/ui/tooltip', () => ({
 
 const { useDelegatesPostDelegateV1Mutation } = jest.requireMock('@safe-global/store/gateway/AUTO_GENERATED/delegates')
 
-describe('UpsertProposer signing logic', () => {
+// Chain-agnostic so the assertions need no useChainId mock
+const addressBookName = (address: string): string | undefined =>
+  Object.values(getStoreInstance().getState().addressBook)
+    .map((book) => book[address])
+    .find(Boolean)
+
+const mockDelegatorSelection = (): ReturnType<typeof useDelegatorSelection> => ({
+  delegatorOptions: [],
+  setSelectedDelegator: jest.fn(),
+  effectiveDelegator: undefined,
+  parentSafeAddress: undefined,
+  parentThreshold: undefined,
+  parentOwners: undefined,
+  isMultiSigRequired: false,
+  isParentLoading: false,
+})
+
+describe('AddProposer signing logic', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    // test-utils hydrates the store from localStorage, and the address book is persisted there
+    localStorage.clear()
   })
 
   describe('signProposerTypedDataForSafe', () => {
@@ -64,7 +84,7 @@ describe('UpsertProposer signing logic', () => {
     })
   })
 
-  describe('name sanitization on submit', () => {
+  describe('the name stays on the device', () => {
     const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>
     const mockUseDelegatorSelection = useDelegatorSelection as jest.MockedFunction<typeof useDelegatorSelection>
     const mockGetSigner = getAssertedChainSigner as jest.MockedFunction<typeof getAssertedChainSigner>
@@ -82,17 +102,7 @@ describe('UpsertProposer signing logic', () => {
         provider: MockEip1193Provider,
       })
 
-      mockUseDelegatorSelection.mockReturnValue({
-        delegatorOptions: [],
-        setSelectedDelegator: jest.fn(),
-        effectiveDelegator: undefined,
-        parentSafeAddress: undefined,
-        parentThreshold: undefined,
-        parentOwners: undefined,
-        isMultiSigRequired: false,
-        isParentLoading: false,
-        canEdit: true,
-      })
+      mockUseDelegatorSelection.mockReturnValue(mockDelegatorSelection())
 
       mockGetSigner.mockResolvedValue({} as Awaited<ReturnType<typeof getAssertedChainSigner>>)
       jest.spyOn(walletUtils, 'isSmartContractWallet').mockResolvedValue(false)
@@ -102,8 +112,8 @@ describe('UpsertProposer signing logic', () => {
       useDelegatesPostDelegateV1Mutation.mockReturnValue([jest.fn(), {}])
     })
 
-    it('sends a sanitized label to the delegate API when the raw name has smart punctuation', async () => {
-      const { getByLabelText, getByTestId } = render(<UpsertProposer onClose={jest.fn()} onSuccess={jest.fn()} />)
+    it('sends a placeholder label to the delegate API, never the entered name', async () => {
+      const { getByLabelText, getByTestId } = render(<AddProposer onClose={jest.fn()} onSuccess={jest.fn()} />)
 
       const address = fakerChecksummedAddress()
 
@@ -118,23 +128,21 @@ describe('UpsertProposer signing logic', () => {
         fireEvent.click(getByTestId('submit-proposer-btn'))
       })
 
-      await waitFor(() =>
-        expect(addDelegateV2).toHaveBeenCalledWith(
-          expect.objectContaining({
-            createDelegateDto: expect.objectContaining({ label: 'Foo-Bar' }),
-          }),
-        ),
-      )
+      await waitFor(() => expect(addDelegateV2).toHaveBeenCalled())
+
+      const { label } = addDelegateV2.mock.calls[0][0].createDelegateDto
+      expect(label).toBe(PROPOSER_LABEL_PLACEHOLDER)
+      expect(label).not.toContain('Foo')
     })
 
-    it('trims surrounding whitespace from the label before calling the delegate API', async () => {
-      const { getByLabelText, getByTestId } = render(<UpsertProposer onClose={jest.fn()} onSuccess={jest.fn()} />)
+    it('saves the sanitized name to the local address book instead', async () => {
+      const { getByLabelText, getByTestId } = render(<AddProposer onClose={jest.fn()} onSuccess={jest.fn()} />)
 
       const address = fakerChecksummedAddress()
 
       act(() => {
         fireEvent.change(getByLabelText(/Address/i), { target: { value: address } })
-        fireEvent.change(getByLabelText(/Name/i), { target: { value: `  ${faker.person.firstName()}  ` } })
+        fireEvent.change(getByLabelText(/Name/i), { target: { value: '  Foo—Bar  ' } })
       })
 
       await waitFor(() => expect(getByTestId('submit-proposer-btn')).not.toBeDisabled())
@@ -144,8 +152,34 @@ describe('UpsertProposer signing logic', () => {
       })
 
       await waitFor(() => expect(addDelegateV2).toHaveBeenCalled())
-      const label = addDelegateV2.mock.calls[0][0].createDelegateDto.label
-      expect(label).toBe(label.trim())
+      await waitFor(() => expect(addressBookName(address)).toBe('Foo-Bar'))
+    })
+
+    it('does not save the name locally when the delegate request fails', async () => {
+      const failingAddDelegate = jest
+        .fn()
+        .mockReturnValue({ unwrap: () => Promise.reject(new Error('delegate rejected')) })
+      mockUseAddDelegateV2.mockReturnValue([failingAddDelegate, {} as never])
+
+      const { getByLabelText, getByTestId, findByText } = render(
+        <AddProposer onClose={jest.fn()} onSuccess={jest.fn()} />,
+      )
+
+      const address = fakerChecksummedAddress()
+
+      act(() => {
+        fireEvent.change(getByLabelText(/Address/i), { target: { value: address } })
+        fireEvent.change(getByLabelText(/Name/i), { target: { value: faker.person.firstName() } })
+      })
+
+      await waitFor(() => expect(getByTestId('submit-proposer-btn')).not.toBeDisabled())
+
+      act(() => {
+        fireEvent.click(getByTestId('submit-proposer-btn'))
+      })
+
+      expect(await findByText('Error adding proposer')).toBeInTheDocument()
+      expect(addressBookName(address)).toBeUndefined()
     })
   })
 
@@ -166,17 +200,7 @@ describe('UpsertProposer signing logic', () => {
         provider: MockEip1193Provider,
       })
 
-      mockUseDelegatorSelection.mockReturnValue({
-        delegatorOptions: [],
-        setSelectedDelegator: jest.fn(),
-        effectiveDelegator: undefined,
-        parentSafeAddress: undefined,
-        parentThreshold: undefined,
-        parentOwners: undefined,
-        isMultiSigRequired: false,
-        isParentLoading: false,
-        canEdit: true,
-      })
+      mockUseDelegatorSelection.mockReturnValue(mockDelegatorSelection())
 
       mockUseAddDelegateV2.mockReturnValue([addDelegateV2, {} as never])
       useDelegatesPostDelegateV1Mutation.mockReturnValue([jest.fn(), {}])
@@ -191,7 +215,7 @@ describe('UpsertProposer signing logic', () => {
       jest.spyOn(walletUtils, 'isSmartContractWallet').mockResolvedValue(false)
 
       const { getByLabelText, getByTestId, findByText } = render(
-        <UpsertProposer onClose={jest.fn()} onSuccess={jest.fn()} />,
+        <AddProposer onClose={jest.fn()} onSuccess={jest.fn()} />,
       )
 
       act(() => {
@@ -208,7 +232,7 @@ describe('UpsertProposer signing logic', () => {
       jest.spyOn(walletUtils, 'isSmartContractWallet').mockResolvedValue(true)
 
       const { getByLabelText, getByTestId, findByText } = render(
-        <UpsertProposer onClose={jest.fn()} onSuccess={jest.fn()} />,
+        <AddProposer onClose={jest.fn()} onSuccess={jest.fn()} />,
       )
 
       act(() => {
@@ -225,7 +249,7 @@ describe('UpsertProposer signing logic', () => {
       jest.spyOn(walletUtils, 'isSmartContractWallet').mockResolvedValue(false)
 
       const { getByLabelText, getByTestId, queryByText } = render(
-        <UpsertProposer onClose={jest.fn()} onSuccess={jest.fn()} />,
+        <AddProposer onClose={jest.fn()} onSuccess={jest.fn()} />,
       )
 
       act(() => {
@@ -240,7 +264,7 @@ describe('UpsertProposer signing logic', () => {
     it('explains on the disabled button why a smart contract cannot be a proposer', async () => {
       jest.spyOn(walletUtils, 'isSmartContractWallet').mockResolvedValue(true)
 
-      const { getByLabelText, findByText } = render(<UpsertProposer onClose={jest.fn()} onSuccess={jest.fn()} />)
+      const { getByLabelText, findByText } = render(<AddProposer onClose={jest.fn()} onSuccess={jest.fn()} />)
 
       act(() => {
         fireEvent.change(getByLabelText(/Address/i), { target: { value: fakerChecksummedAddress() } })
@@ -255,7 +279,7 @@ describe('UpsertProposer signing logic', () => {
       jest.spyOn(walletUtils, 'isSmartContractWallet').mockResolvedValue(false)
 
       const { getByLabelText, getByTestId, queryByText } = render(
-        <UpsertProposer onClose={jest.fn()} onSuccess={jest.fn()} />,
+        <AddProposer onClose={jest.fn()} onSuccess={jest.fn()} />,
       )
 
       act(() => {
@@ -265,91 +289,6 @@ describe('UpsertProposer signing logic', () => {
 
       await waitFor(() => expect(getByTestId('submit-proposer-btn')).not.toBeDisabled())
       expect(queryByText(SMART_CONTRACT_PROPOSER_INFO)).toBeNull()
-    })
-  })
-
-  describe('smart contract guard on submit (edit flow)', () => {
-    const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>
-    const mockUseDelegatorSelection = useDelegatorSelection as jest.MockedFunction<typeof useDelegatorSelection>
-    const mockGetSigner = getAssertedChainSigner as jest.MockedFunction<typeof getAssertedChainSigner>
-    const mockUseAddDelegateV2 = useDelegatesPostDelegateV2Mutation as jest.MockedFunction<
-      typeof useDelegatesPostDelegateV2Mutation
-    >
-
-    const addDelegateV2 = jest.fn().mockReturnValue({ unwrap: () => Promise.resolve() })
-
-    const proposer = {
-      delegate: fakerChecksummedAddress(),
-      delegator: fakerChecksummedAddress(),
-      safe: fakerChecksummedAddress(),
-      label: 'Existing proposer',
-    }
-
-    beforeEach(() => {
-      mockUseWallet.mockReturnValue({
-        address: fakerChecksummedAddress(),
-        chainId: '1',
-        label: 'MetaMask',
-        provider: MockEip1193Provider,
-      })
-
-      mockUseDelegatorSelection.mockReturnValue({
-        delegatorOptions: [],
-        setSelectedDelegator: jest.fn(),
-        effectiveDelegator: undefined,
-        parentSafeAddress: undefined,
-        parentThreshold: undefined,
-        parentOwners: undefined,
-        isMultiSigRequired: false,
-        isParentLoading: false,
-        canEdit: true,
-      })
-
-      mockGetSigner.mockResolvedValue({} as Awaited<ReturnType<typeof getAssertedChainSigner>>)
-      jest.spyOn(proposerUtils, 'signProposerTypedData').mockResolvedValue('0xsignature')
-
-      mockUseAddDelegateV2.mockReturnValue([addDelegateV2, {} as never])
-      useDelegatesPostDelegateV1Mutation.mockReturnValue([jest.fn(), {}])
-    })
-
-    it('blocks submitting an edit when the existing proposer is a smart contract', async () => {
-      jest.spyOn(walletUtils, 'isSmartContractWallet').mockResolvedValue(true)
-
-      const { getByTestId, findByText } = render(
-        <UpsertProposer onClose={jest.fn()} onSuccess={jest.fn()} proposer={proposer} />,
-      )
-
-      await waitFor(() => expect(getByTestId('submit-proposer-btn')).not.toBeDisabled())
-
-      act(() => {
-        fireEvent.click(getByTestId('submit-proposer-btn'))
-      })
-
-      expect(await findByText(SMART_CONTRACT_PROPOSER_EDIT_ERROR)).toBeInTheDocument()
-      expect(addDelegateV2).not.toHaveBeenCalled()
-    })
-
-    it('submits an edit when the existing proposer is an EOA', async () => {
-      jest.spyOn(walletUtils, 'isSmartContractWallet').mockResolvedValue(false)
-
-      const { getByTestId, queryByText } = render(
-        <UpsertProposer onClose={jest.fn()} onSuccess={jest.fn()} proposer={proposer} />,
-      )
-
-      await waitFor(() => expect(getByTestId('submit-proposer-btn')).not.toBeDisabled())
-
-      act(() => {
-        fireEvent.click(getByTestId('submit-proposer-btn'))
-      })
-
-      await waitFor(() =>
-        expect(addDelegateV2).toHaveBeenCalledWith(
-          expect.objectContaining({
-            createDelegateDto: expect.objectContaining({ delegate: proposer.delegate }),
-          }),
-        ),
-      )
-      expect(queryByText(SMART_CONTRACT_PROPOSER_EDIT_ERROR)).toBeNull()
     })
   })
 })

--- a/apps/web/src/features/proposers/components/AddProposer.tsx
+++ b/apps/web/src/features/proposers/components/AddProposer.tsx
@@ -1,6 +1,5 @@
 import AddressBookInput from '@/components/common/AddressBookInput'
 import DialogActions from '@/components/common/DialogActions'
-import EthHashInfo from '@/components/common/EthHashInfo'
 import NameInput from '@/components/common/NameInput'
 import NetworkWarning from '@/components/new-safe/create/NetworkWarning'
 import ErrorMessage from '@/components/tx/ErrorMessage'
@@ -12,7 +11,7 @@ import {
   signProposerTypedDataForSafe,
 } from '@/features/proposers/utils/utils'
 import {
-  SMART_CONTRACT_PROPOSER_EDIT_ERROR,
+  PROPOSER_LABEL_PLACEHOLDER,
   SMART_CONTRACT_PROPOSER_ERROR,
   SMART_CONTRACT_PROPOSER_INFO,
 } from '@/features/proposers/constants'
@@ -24,6 +23,7 @@ import useWallet from '@/hooks/wallets/useWallet'
 import { SETTINGS_EVENTS, trackEvent } from '@/services/analytics'
 import { getAssertedChainSigner } from '@/services/tx/tx-sender/sdk'
 import { useAppDispatch } from '@/store'
+import { upsertAddressBookEntries } from '@/store/addressBookSlice'
 import { showNotification } from '@/store/notificationsSlice'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
 import { shortenAddress } from '@safe-global/utils/utils/formatters'
@@ -41,7 +41,6 @@ import {
   useDelegatesPostDelegateV1Mutation,
   useDelegatesPostDelegateV2Mutation,
   type CreateDelegateDto,
-  type Delegate,
 } from '@safe-global/store/gateway/AUTO_GENERATED/delegates'
 import { getDelegateTypedData } from '@safe-global/utils/services/delegates'
 import { type BaseSyntheticEvent, useCallback, useMemo, useState } from 'react'
@@ -52,10 +51,9 @@ import InfoIcon from '@/public/images/notifications/info.svg'
 import SignatureIcon from '@/public/images/transactions/signature.svg'
 import type { TypedData } from '@safe-global/store/gateway/AUTO_GENERATED/messages'
 
-type UpsertProposerProps = {
+type AddProposerProps = {
   onClose: () => void
   onSuccess: () => void
-  proposer?: Delegate
 }
 
 enum ProposerEntryFields {
@@ -68,7 +66,7 @@ type ProposerEntry = {
   [ProposerEntryFields.address]: string
 }
 
-const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) => {
+const AddProposer = ({ onClose, onSuccess }: AddProposerProps) => {
   const [error, setError] = useState<Error>()
   const [blockedReason, setBlockedReason] = useState<string>()
   const [isLoading, setIsLoading] = useState<boolean>(false)
@@ -82,8 +80,6 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
   const safeAddress = useSafeAddress()
   const { safe } = useSafeInfo()
 
-  const isEditing = !!proposer
-
   const {
     delegatorOptions,
     setSelectedDelegator,
@@ -93,13 +89,12 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
     parentOwners,
     isMultiSigRequired,
     isParentLoading,
-    canEdit,
-  } = useDelegatorSelection(proposer)
+  } = useDelegatorSelection()
 
   const methods = useForm<ProposerEntry>({
     defaultValues: {
-      [ProposerEntryFields.address]: proposer?.delegate,
-      [ProposerEntryFields.name]: proposer?.label,
+      [ProposerEntryFields.address]: '',
+      [ProposerEntryFields.name]: '',
     },
     mode: 'onChange',
   })
@@ -128,15 +123,19 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
 
     const name = sanitizeName(data.name)
 
+    // The name is deliberately never sent to the backend; it lives only in this device's address book.
+    const saveNameLocally = () =>
+      dispatch(upsertAddressBookEntries({ chainIds: [chainId], address: data.address, name }))
+
     setError(undefined)
     setBlockedReason(undefined)
     setIsLoading(true)
 
     try {
-      // Backstop for the edit flow, where the address field (and its validator) is not rendered
+      // Backstop in case the field validator has not settled by the time the form is submitted
       const smartContractError = await addressIsNotSmartContract(chainId, SMART_CONTRACT_PROPOSER_ERROR)(data.address)
       if (smartContractError) {
-        setBlockedReason(isEditing ? SMART_CONTRACT_PROPOSER_EDIT_ERROR : smartContractError)
+        setBlockedReason(smartContractError)
         return
       }
 
@@ -151,10 +150,11 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
           // Multi-sig flow: create off-chain message on parent Safe for signature collection
           const eoaSignature = await signProposerTypedDataForSafe(chainId, data.address, parentSafeAddress, signer)
           const delegateTypedData = getDelegateTypedData(chainId, data.address) as TypedData
-          const origin = buildDelegationOrigin(proposer ? 'edit' : 'add', data.address, safeAddress, name)
+          const origin = buildDelegationOrigin('add', data.address, safeAddress)
 
           await createDelegationMessage(dispatch, chainId, parentSafeAddress, delegateTypedData, eoaSignature, origin)
 
+          saveNameLocally()
           setMultiSigInitiated(true)
           trackEvent(SETTINGS_EVENTS.PROPOSERS.SUBMIT_ADD_PROPOSER)
           setIsLoading(false)
@@ -177,7 +177,7 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
       const createDelegateDto: CreateDelegateDto = {
         delegate: data.address,
         delegator,
-        label: name,
+        label: PROPOSER_LABEL_PLACEHOLDER,
         signature,
         safe: safeAddress,
       }
@@ -188,9 +188,9 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
         await addDelegateV2({ chainId, createDelegateDto }).unwrap()
       }
 
-      trackEvent(
-        isEditing ? SETTINGS_EVENTS.PROPOSERS.SUBMIT_EDIT_PROPOSER : SETTINGS_EVENTS.PROPOSERS.SUBMIT_ADD_PROPOSER,
-      )
+      saveNameLocally()
+
+      trackEvent(SETTINGS_EVENTS.PROPOSERS.SUBMIT_ADD_PROPOSER)
 
       dispatch(
         showNotification({
@@ -216,9 +216,7 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
   }
 
   const onCancel = () => {
-    trackEvent(
-      isEditing ? SETTINGS_EVENTS.PROPOSERS.CANCEL_EDIT_PROPOSER : SETTINGS_EVENTS.PROPOSERS.CANCEL_ADD_PROPOSER,
-    )
+    trackEvent(SETTINGS_EVENTS.PROPOSERS.CANCEL_ADD_PROPOSER)
     onClose()
   }
 
@@ -269,7 +267,7 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
         <FormProvider {...methods}>
           <form onSubmit={onSubmit}>
             <DialogHeader className="flex-row items-center justify-between">
-              <DialogTitle data-testid="untrusted-token-warning">{isEditing ? 'Edit' : 'Add'} proposer</DialogTitle>
+              <DialogTitle data-testid="untrusted-token-warning">Add proposer</DialogTitle>
 
               <Button variant="ghost" size="icon-sm" aria-label="close" onClick={onCancel}>
                 <XIcon />
@@ -298,24 +296,20 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
 
               <Alert variant="info">
                 <AlertSeverityIcon variant="info" />
-                <AlertDescription>Proposer&apos;s name and address are publicly visible.</AlertDescription>
+                <AlertDescription>
+                  The proposer&apos;s address is publicly visible. The name is saved on this device only.
+                </AlertDescription>
               </Alert>
 
               <div className="my-4">
-                {isEditing ? (
-                  <div className="mb-6 text-sm [&_svg]:size-4">
-                    <EthHashInfo address={proposer?.delegate} showCopyButton hasExplorer shortAddress={false} />
-                  </div>
-                ) : (
-                  <AddressBookInput
-                    name="address"
-                    label="Address"
-                    validate={validateAddress}
-                    variant="outlined"
-                    fullWidth
-                    required
-                  />
-                )}
+                <AddressBookInput
+                  name="address"
+                  label="Address"
+                  validate={validateAddress}
+                  variant="outlined"
+                  fullWidth
+                  required
+                />
               </div>
 
               <div className="mb-4">
@@ -336,7 +330,7 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
 
               <NetworkWarning action="sign" />
 
-              {!isEditing && delegatorOptions.length > 1 && (
+              {delegatorOptions.length > 1 && (
                 <div className="mt-4">
                   <Typography variant="h4" className="mb-2 flex items-center gap-2">
                     <SignatureIcon className="size-4" />
@@ -376,7 +370,7 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
                 confirmTestId="submit-proposer-btn"
                 confirmType="submit"
                 confirmLoading={isLoading}
-                confirmDisabled={isParentLoading || (isEditing && !canEdit) || !formState.isValid}
+                confirmDisabled={isParentLoading || !formState.isValid}
                 confirmCheckWallet={{ checkNetwork: !isLoading, allowProposer: false }}
                 confirmTooltip={isSmartContractError ? SMART_CONTRACT_PROPOSER_INFO : undefined}
               />
@@ -388,4 +382,4 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
   )
 }
 
-export default UpsertProposer
+export default AddProposer

--- a/apps/web/src/features/proposers/components/DeleteProposerDialog.tsx
+++ b/apps/web/src/features/proposers/components/DeleteProposerDialog.tsx
@@ -88,7 +88,7 @@ const InternalDeleteProposer = ({ wallet, safeAddress, chainId, proposer }: Dele
         // Multi-sig flow: create off-chain message on parent Safe for signature collection
         const eoaSignature = await signProposerTypedDataForSafe(chainId, proposer.delegate, parentSafeAddress, signer)
         const delegateTypedData = getDelegateTypedData(chainId, proposer.delegate) as TypedData
-        const origin = buildDelegationOrigin('remove', proposer.delegate, safeAddress, proposer.label)
+        const origin = buildDelegationOrigin('remove', proposer.delegate, safeAddress)
 
         await createDelegationMessage(dispatch, chainId, parentSafeAddress, delegateTypedData, eoaSignature, origin)
 

--- a/apps/web/src/features/proposers/components/EditProposerDialog.tsx
+++ b/apps/web/src/features/proposers/components/EditProposerDialog.tsx
@@ -1,62 +1,43 @@
-import CheckWallet from '@/components/common/CheckWallet'
 import Track from '@/components/common/Track'
-import UpsertProposer from './UpsertProposer'
-import useWallet from '@/hooks/wallets/useWallet'
-import { useNestedSafeOwners } from '@/hooks/useNestedSafeOwners'
-import { sameAddress } from '@safe-global/utils/utils/addresses'
+import EntryDialog from '@/components/address-book/EntryDialog'
+import { useAddressBookItem } from '@/hooks/useAllAddressBooks'
+import useChainId from '@/hooks/useChainId'
 import EditIcon from '@/public/images/common/edit.svg'
 import { SETTINGS_EVENTS } from '@/services/analytics'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type { Delegate } from '@safe-global/store/gateway/AUTO_GENERATED/delegates'
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 const EditProposerDialog = ({ proposer }: { proposer: Delegate }) => {
   const [open, setOpen] = useState<boolean>(false)
-  const wallet = useWallet()
-  const nestedSafeOwners = useNestedSafeOwners()
-
-  const canEdit =
-    sameAddress(wallet?.address, proposer.delegator) ||
-    (nestedSafeOwners?.some((addr) => sameAddress(addr, proposer.delegator)) ?? false)
+  const chainId = useChainId()
+  const contact = useAddressBookItem(proposer.delegate, chainId)
 
   return (
     <>
-      <CheckWallet allowProposer={false}>
-        {(isOk) => {
-          const tooltipTitle =
-            isOk && canEdit ? 'Edit proposer' : isOk && !canEdit ? 'Only the owner of this proposer can edit them' : ''
+      <Track {...SETTINGS_EVENTS.PROPOSERS.EDIT_PROPOSER}>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <span tabIndex={0}>
+                <Button variant="ghost" size="icon-sm" data-testid="edit-proposer-btn" onClick={() => setOpen(true)}>
+                  <EditIcon className="size-4 text-[var(--color-border-main)]" />
+                </Button>
+              </span>
+            }
+          />
+          <TooltipContent>Rename proposer</TooltipContent>
+        </Tooltip>
+      </Track>
 
-          const button = (
-            <span tabIndex={0}>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                data-testid="edit-proposer-btn"
-                onClick={() => setOpen(true)}
-                disabled={!isOk || !canEdit}
-              >
-                <EditIcon className="size-4 text-[var(--color-border-main)]" />
-              </Button>
-            </span>
-          )
-
-          return (
-            <Track {...SETTINGS_EVENTS.PROPOSERS.EDIT_PROPOSER}>
-              {tooltipTitle ? (
-                <Tooltip>
-                  <TooltipTrigger render={button} />
-                  <TooltipContent>{tooltipTitle}</TooltipContent>
-                </Tooltip>
-              ) : (
-                button
-              )}
-            </Track>
-          )
-        }}
-      </CheckWallet>
-
-      {open && <UpsertProposer onClose={() => setOpen(false)} onSuccess={() => setOpen(false)} proposer={proposer} />}
+      {open && (
+        <EntryDialog
+          handleClose={() => setOpen(false)}
+          defaultValues={{ address: proposer.delegate, name: contact?.name ?? '' }}
+          disableAddressInput
+        />
+      )}
     </>
   )
 }

--- a/apps/web/src/features/proposers/components/PendingDelegation.tsx
+++ b/apps/web/src/features/proposers/components/PendingDelegation.tsx
@@ -109,7 +109,7 @@ function PendingDelegation({ delegation, onRefetch }: PendingDelegationProps): R
         showNotification({
           variant: 'success',
           groupKey: 'delegation-submitted',
-          title: `Proposer ${delegation.action === 'add' ? 'added' : delegation.action === 'edit' ? 'updated' : 'removed'} successfully!`,
+          title: `Proposer ${delegation.action === 'add' ? 'added' : 'removed'} successfully!`,
           message: '',
         }),
       )
@@ -156,20 +156,10 @@ function PendingDelegation({ delegation, onRefetch }: PendingDelegationProps): R
       <div className="rounded-lg bg-[var(--color-border-background)] p-4">
         <div className="flex items-center gap-6">
           <Typography variant="paragraph-small" className="whitespace-nowrap">
-            {delegation.action === 'remove'
-              ? 'Remove proposer:'
-              : delegation.action === 'edit'
-                ? 'Edit proposer:'
-                : 'New proposer:'}
+            {delegation.action === 'remove' ? 'Remove proposer:' : 'New proposer:'}
           </Typography>
           <div className="[&_.ethHashInfo-name]:font-bold">
-            <EthHashInfo
-              address={delegation.delegateAddress}
-              showCopyButton
-              shortAddress={false}
-              name={delegation.delegateLabel}
-              hasExplorer
-            />
+            <EthHashInfo address={delegation.delegateAddress} showCopyButton shortAddress={false} hasExplorer />
           </div>
         </div>
       </div>

--- a/apps/web/src/features/proposers/constants.ts
+++ b/apps/web/src/features/proposers/constants.ts
@@ -4,12 +4,11 @@ export const TOTP_INTERVAL_SECONDS = 3600
 /** Polling interval for pending delegations (milliseconds) */
 export const DELEGATION_POLLING_INTERVAL_MS = 5000
 
+/** Sent instead of the user's name. Not `''` — the Transaction Service requires a label and we can't observe whether it accepts a blank one. */
+export const PROPOSER_LABEL_PLACEHOLDER = 'Proposer'
+
 /** Validation error for the proposer address field */
 export const SMART_CONTRACT_PROPOSER_ERROR = 'Cannot add a smart contract account as proposer'
-
-/** Shown when submitting an edit of an existing smart contract proposer */
-export const SMART_CONTRACT_PROPOSER_EDIT_ERROR =
-  'This proposer is a smart contract account, which cannot sign transaction proposals. Remove it instead.'
 
 /** Explanation shown on the disabled confirm button */
 export const SMART_CONTRACT_PROPOSER_INFO =

--- a/apps/web/src/features/proposers/hooks/__tests__/useDelegatorSelection.test.ts
+++ b/apps/web/src/features/proposers/hooks/__tests__/useDelegatorSelection.test.ts
@@ -2,11 +2,9 @@ import { renderHook } from '@/tests/test-utils'
 import { useDelegatorSelection } from '../useDelegatorSelection'
 import {
   buildDelegatorOptions,
-  resolveEffectiveDelegator,
   resolveParentSafeAddress,
   isWalletDirectOwner,
   checkMultiSigRequired,
-  checkCanEdit,
 } from '../useDelegatorSelection'
 import * as useWalletModule from '@/hooks/wallets/useWallet'
 import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
@@ -18,41 +16,20 @@ import { checksumAddress } from '@safe-global/utils/utils/addresses'
 
 describe('useDelegatorSelection pure functions', () => {
   describe('buildDelegatorOptions', () => {
-    it('should return empty array when editing', () => {
-      expect(buildDelegatorOptions(true, true, '0xWallet', ['0xNested'])).toEqual([])
-    })
-
     it('should include wallet address when direct owner', () => {
-      expect(buildDelegatorOptions(false, true, '0xWallet', null)).toEqual(['0xWallet'])
+      expect(buildDelegatorOptions(true, '0xWallet', null)).toEqual(['0xWallet'])
     })
 
     it('should include nested owners', () => {
-      expect(buildDelegatorOptions(false, false, '0xWallet', ['0xNested1', '0xNested2'])).toEqual([
-        '0xNested1',
-        '0xNested2',
-      ])
+      expect(buildDelegatorOptions(false, '0xWallet', ['0xNested1', '0xNested2'])).toEqual(['0xNested1', '0xNested2'])
     })
 
     it('should include both wallet and nested owners', () => {
-      expect(buildDelegatorOptions(false, true, '0xWallet', ['0xNested'])).toEqual(['0xWallet', '0xNested'])
+      expect(buildDelegatorOptions(true, '0xWallet', ['0xNested'])).toEqual(['0xWallet', '0xNested'])
     })
 
     it('should not include wallet when not direct owner', () => {
-      expect(buildDelegatorOptions(false, false, '0xWallet', null)).toEqual([])
-    })
-  })
-
-  describe('resolveEffectiveDelegator', () => {
-    it('should return proposer delegator when editing', () => {
-      expect(resolveEffectiveDelegator(true, '0xProposer', '0xSelected', '0xDefault')).toBe('0xProposer')
-    })
-
-    it('should return selected delegator when not editing', () => {
-      expect(resolveEffectiveDelegator(false, undefined, '0xSelected', '0xDefault')).toBe('0xSelected')
-    })
-
-    it('should fall back to default when no selection', () => {
-      expect(resolveEffectiveDelegator(false, undefined, undefined, '0xDefault')).toBe('0xDefault')
+      expect(buildDelegatorOptions(false, '0xWallet', null)).toEqual([])
     })
   })
 
@@ -103,24 +80,6 @@ describe('useDelegatorSelection pure functions', () => {
       expect(checkMultiSigRequired('0xParent', 2)).toBe(true)
     })
   })
-
-  describe('checkCanEdit', () => {
-    const wallet = checksumAddress(faker.finance.ethereumAddress())
-    const nested = checksumAddress(faker.finance.ethereumAddress())
-
-    it('should return true when wallet matches delegator', () => {
-      expect(checkCanEdit(wallet, wallet, null)).toBe(true)
-    })
-
-    it('should return true when delegator is a nested owner', () => {
-      expect(checkCanEdit(wallet, nested, [nested])).toBe(true)
-    })
-
-    it('should return false otherwise', () => {
-      const other = checksumAddress(faker.finance.ethereumAddress())
-      expect(checkCanEdit(wallet, other, null)).toBe(false)
-    })
-  })
 })
 
 describe('useDelegatorSelection hook', () => {
@@ -162,7 +121,7 @@ describe('useDelegatorSelection hook', () => {
       isLoading: false,
     })
 
-    const { result } = renderHook(() => useDelegatorSelection(undefined))
+    const { result } = renderHook(() => useDelegatorSelection())
 
     expect(result.current.isParentLoading).toBe(false)
     expect(result.current.isMultiSigRequired).toBe(false)
@@ -182,7 +141,7 @@ describe('useDelegatorSelection hook', () => {
       isLoading: true,
     })
 
-    const { result } = renderHook(() => useDelegatorSelection(undefined))
+    const { result } = renderHook(() => useDelegatorSelection())
 
     expect(result.current.isParentLoading).toBe(true)
     // Key: isMultiSigRequired is false while loading, so consumers must
@@ -207,7 +166,7 @@ describe('useDelegatorSelection hook', () => {
       isLoading: false,
     })
 
-    const { result } = renderHook(() => useDelegatorSelection(undefined))
+    const { result } = renderHook(() => useDelegatorSelection())
 
     expect(result.current.isParentLoading).toBe(false)
     expect(result.current.isMultiSigRequired).toBe(true)
@@ -228,7 +187,7 @@ describe('useDelegatorSelection hook', () => {
       isLoading: false,
     })
 
-    const { result } = renderHook(() => useDelegatorSelection(undefined))
+    const { result } = renderHook(() => useDelegatorSelection())
 
     expect(result.current.isParentLoading).toBe(false)
     expect(result.current.isMultiSigRequired).toBe(false)

--- a/apps/web/src/features/proposers/hooks/__tests__/useMigrateProposerLabels.test.ts
+++ b/apps/web/src/features/proposers/hooks/__tests__/useMigrateProposerLabels.test.ts
@@ -1,0 +1,91 @@
+import { renderHook, fakerChecksummedAddress } from '@/tests/test-utils'
+import { useMigrateProposerLabels } from '../useMigrateProposerLabels'
+import { PROPOSER_LABEL_PLACEHOLDER } from '@/features/proposers/constants'
+import * as useChainIdModule from '@/hooks/useChainId'
+import * as useIsSafeOwnerModule from '@/hooks/useIsSafeOwner'
+import * as useIsNestedSafeOwnerModule from '@/hooks/useIsNestedSafeOwner'
+import * as useProposersModule from '@/hooks/useProposers'
+import * as spacesModule from '@/features/spaces'
+import { getStoreInstance } from '@/store'
+import type { Delegate } from '@safe-global/store/gateway/AUTO_GENERATED/delegates'
+
+const chainId = '1'
+
+const mockProposers = (results: Delegate[]) => {
+  jest.spyOn(useProposersModule, 'default').mockReturnValue({
+    data: { results },
+    isLoading: false,
+    refetch: jest.fn(),
+  } as unknown as ReturnType<typeof useProposersModule.default>)
+}
+
+const addressBookName = (address: string): string | undefined =>
+  getStoreInstance().getState().addressBook[chainId]?.[address]
+
+describe('useMigrateProposerLabels', () => {
+  const delegate = fakerChecksummedAddress()
+  const delegator = fakerChecksummedAddress()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    localStorage.clear()
+    jest.spyOn(useChainIdModule, 'default').mockReturnValue(chainId)
+    jest.spyOn(useIsSafeOwnerModule, 'default').mockReturnValue(true)
+    jest.spyOn(useIsNestedSafeOwnerModule, 'useIsNestedSafeOwner').mockReturnValue(false)
+    jest.spyOn(spacesModule, 'useGetSpaceAddressBook').mockReturnValue([])
+  })
+
+  it('copies a server-held name into the local address book for a signer', () => {
+    mockProposers([{ delegate, delegator, label: 'Alice' }])
+
+    renderHook(() => useMigrateProposerLabels())
+
+    expect(addressBookName(delegate)).toBe('Alice')
+  })
+
+  it('migrates for a nested Safe owner, who set the name on the parent Safe', () => {
+    jest.spyOn(useIsSafeOwnerModule, 'default').mockReturnValue(false)
+    jest.spyOn(useIsNestedSafeOwnerModule, 'useIsNestedSafeOwner').mockReturnValue(true)
+    mockProposers([{ delegate, delegator, label: 'Alice' }])
+
+    renderHook(() => useMigrateProposerLabels())
+
+    expect(addressBookName(delegate)).toBe('Alice')
+  })
+
+  it('does not persist a name for a viewer who is not a signer', () => {
+    jest.spyOn(useIsSafeOwnerModule, 'default').mockReturnValue(false)
+    jest.spyOn(useIsNestedSafeOwnerModule, 'useIsNestedSafeOwner').mockReturnValue(false)
+    mockProposers([{ delegate, delegator, label: 'Alice' }])
+
+    renderHook(() => useMigrateProposerLabels())
+
+    expect(addressBookName(delegate)).toBeUndefined()
+  })
+
+  it('leaves an existing local entry untouched', () => {
+    mockProposers([{ delegate, delegator, label: 'Server Name' }])
+
+    renderHook(() => useMigrateProposerLabels(), {
+      initialReduxState: { addressBook: { [chainId]: { [delegate]: 'My Own Name' } } },
+    })
+
+    expect(addressBookName(delegate)).toBe('My Own Name')
+  })
+
+  it('skips the placeholder label, which carries no name', () => {
+    mockProposers([{ delegate, delegator, label: PROPOSER_LABEL_PLACEHOLDER }])
+
+    renderHook(() => useMigrateProposerLabels())
+
+    expect(addressBookName(delegate)).toBeUndefined()
+  })
+
+  it('skips an empty label', () => {
+    mockProposers([{ delegate, delegator, label: '' }])
+
+    renderHook(() => useMigrateProposerLabels())
+
+    expect(addressBookName(delegate)).toBeUndefined()
+  })
+})

--- a/apps/web/src/features/proposers/hooks/__tests__/usePendingDelegations.test.ts
+++ b/apps/web/src/features/proposers/hooks/__tests__/usePendingDelegations.test.ts
@@ -19,9 +19,10 @@ describe('usePendingDelegations', () => {
 
   const createMessageItem = (
     overrides: Partial<{
-      action: 'add' | 'remove' | 'edit'
+      action: 'add' | 'remove'
       delegate: string
       nestedSafe: string
+      /** Only for simulating messages created before names became device-local. */
       label: string
       totp: number
       confirmationsSubmitted: number
@@ -33,7 +34,7 @@ describe('usePendingDelegations', () => {
     const action = overrides.action ?? 'add'
     const delegate = overrides.delegate ?? delegateAddress
     const nestedSafe = overrides.nestedSafe ?? safeAddress
-    const label = overrides.label ?? 'Test Proposer'
+    const label = overrides.label
     const totp = overrides.totp ?? currentTotp
 
     return {
@@ -193,7 +194,6 @@ describe('usePendingDelegations', () => {
     expect(result.current.pendingDelegations).toHaveLength(1)
     expect(result.current.pendingDelegations[0].action).toBe('remove')
     expect(result.current.pendingDelegations[0].delegateAddress).toBe(delegate)
-    expect(result.current.pendingDelegations[0].delegateLabel).toBe('Test Proposer')
     expect(result.current.pendingDelegations[0].nestedSafeAddress).toBe(safeAddress)
     expect(result.current.pendingDelegations[0].parentSafeAddress).toBe(parentSafeAddress)
   })
@@ -401,31 +401,8 @@ describe('usePendingDelegations', () => {
     expect(result.current.pendingDelegations[0].messageHash).toBe(validMessage.messageHash)
   })
 
-  it('should keep edit delegation when delegate exists and label is different', () => {
-    const existingDelegate = checksumAddress(faker.finance.ethereumAddress())
-    jest.spyOn(useNestedSafeOwnersModule, 'useNestedSafeOwners').mockReturnValue([parentSafeAddress])
-    jest.spyOn(useProposersModule, 'default').mockReturnValue({
-      data: { results: [{ delegate: existingDelegate, label: 'Old Label' }] },
-      isLoading: false,
-      refetch: jest.fn(),
-    } as unknown as ReturnType<typeof useProposersModule.default>)
-
-    const editMessage = createMessageItem({ delegate: existingDelegate, action: 'edit', label: 'New Label' })
-
-    jest.spyOn(messagesQueries, 'useMessagesGetMessagesBySafeV1Query').mockReturnValue({
-      data: { results: [editMessage] },
-      isLoading: false,
-      refetch: mockRefetch,
-    } as ReturnType<typeof messagesQueries.useMessagesGetMessagesBySafeV1Query>)
-
-    const { result } = renderHook(() => usePendingDelegations())
-
-    expect(result.current.pendingDelegations).toHaveLength(1)
-    expect(result.current.pendingDelegations[0].action).toBe('edit')
-  })
-
-  it('should filter out edit delegation when delegate does not exist', () => {
-    const nonExistentDelegate = checksumAddress(faker.finance.ethereumAddress())
+  it('should still parse an in-flight origin created before names became device-local', () => {
+    const newDelegate = checksumAddress(faker.finance.ethereumAddress())
     jest.spyOn(useNestedSafeOwnersModule, 'useNestedSafeOwners').mockReturnValue([parentSafeAddress])
     jest.spyOn(useProposersModule, 'default').mockReturnValue({
       data: { results: [] },
@@ -433,39 +410,18 @@ describe('usePendingDelegations', () => {
       refetch: jest.fn(),
     } as unknown as ReturnType<typeof useProposersModule.default>)
 
-    const editMessage = createMessageItem({ delegate: nonExistentDelegate, action: 'edit', label: 'New Label' })
+    const legacyMessage = createMessageItem({ delegate: newDelegate, action: 'add', label: 'Old Label' })
 
     jest.spyOn(messagesQueries, 'useMessagesGetMessagesBySafeV1Query').mockReturnValue({
-      data: { results: [editMessage] },
+      data: { results: [legacyMessage] },
       isLoading: false,
       refetch: mockRefetch,
     } as ReturnType<typeof messagesQueries.useMessagesGetMessagesBySafeV1Query>)
 
     const { result } = renderHook(() => usePendingDelegations())
 
-    expect(result.current.pendingDelegations).toHaveLength(0)
-  })
-
-  it('should filter out edit delegation when label already matches (edit was applied)', () => {
-    const existingDelegate = checksumAddress(faker.finance.ethereumAddress())
-    jest.spyOn(useNestedSafeOwnersModule, 'useNestedSafeOwners').mockReturnValue([parentSafeAddress])
-    jest.spyOn(useProposersModule, 'default').mockReturnValue({
-      data: { results: [{ delegate: existingDelegate, label: 'Updated Label' }] },
-      isLoading: false,
-      refetch: jest.fn(),
-    } as unknown as ReturnType<typeof useProposersModule.default>)
-
-    // Pending edit with same label as current - means edit was already applied
-    const editMessage = createMessageItem({ delegate: existingDelegate, action: 'edit', label: 'Updated Label' })
-
-    jest.spyOn(messagesQueries, 'useMessagesGetMessagesBySafeV1Query').mockReturnValue({
-      data: { results: [editMessage] },
-      isLoading: false,
-      refetch: mockRefetch,
-    } as ReturnType<typeof messagesQueries.useMessagesGetMessagesBySafeV1Query>)
-
-    const { result } = renderHook(() => usePendingDelegations())
-
-    expect(result.current.pendingDelegations).toHaveLength(0)
+    expect(result.current.pendingDelegations).toHaveLength(1)
+    expect(result.current.pendingDelegations[0].action).toBe('add')
+    expect(result.current.pendingDelegations[0].delegateAddress).toBe(newDelegate)
   })
 })

--- a/apps/web/src/features/proposers/hooks/__tests__/useSubmitDelegation.test.ts
+++ b/apps/web/src/features/proposers/hooks/__tests__/useSubmitDelegation.test.ts
@@ -7,6 +7,7 @@ import * as utilsModule from '@/features/proposers/utils/utils'
 import { faker } from '@faker-js/faker'
 import { checksumAddress } from '@safe-global/utils/utils/addresses'
 import type { PendingDelegation } from '@/features/proposers/types'
+import { PROPOSER_LABEL_PLACEHOLDER } from '@/features/proposers/constants'
 
 describe('useSubmitDelegation', () => {
   const chainId = '1'
@@ -20,7 +21,6 @@ describe('useSubmitDelegation', () => {
     messageHash: `0x${faker.string.hexadecimal({ length: 64 })}`,
     action: 'add',
     delegateAddress,
-    delegateLabel: 'Test Proposer',
     nestedSafeAddress: safeAddress,
     parentSafeAddress,
     totp: Math.floor(Date.now() / 1000 / 3600),
@@ -84,7 +84,7 @@ describe('useSubmitDelegation', () => {
         delegate: delegateAddress,
         delegator: parentSafeAddress,
         signature: encodedSignature,
-        label: 'Test Proposer',
+        label: PROPOSER_LABEL_PLACEHOLDER,
       },
     })
     expect(mockDeleteDelegateV2).not.toHaveBeenCalled()

--- a/apps/web/src/features/proposers/hooks/useDelegatorSelection.ts
+++ b/apps/web/src/features/proposers/hooks/useDelegatorSelection.ts
@@ -4,29 +4,16 @@ import { useNestedSafeOwners } from '@/hooks/useNestedSafeOwners'
 import useWallet from '@/hooks/wallets/useWallet'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
-import type { Delegate } from '@safe-global/store/gateway/AUTO_GENERATED/delegates'
 
 export const buildDelegatorOptions = (
-  isEditing: boolean,
   isDirectOwner: boolean,
   walletAddress: string | undefined,
   nestedSafeOwners: string[] | null | undefined,
 ): string[] => {
-  if (isEditing) return []
   const options: string[] = []
   if (isDirectOwner && walletAddress) options.push(walletAddress)
   if (nestedSafeOwners) options.push(...nestedSafeOwners)
   return options
-}
-
-export const resolveEffectiveDelegator = (
-  isEditing: boolean,
-  proposerDelegator: string | undefined,
-  selectedDelegator: string | undefined,
-  defaultOption: string | undefined,
-): string | undefined => {
-  if (isEditing) return proposerDelegator
-  return selectedDelegator ?? defaultOption
 }
 
 export const resolveParentSafeAddress = (
@@ -45,37 +32,27 @@ export const checkMultiSigRequired = (
   parentThreshold: number | undefined,
 ): boolean => !!parentSafeAddress && parentThreshold !== undefined && parentThreshold > 1
 
-export const checkCanEdit = (
-  walletAddress: string | undefined,
-  proposerDelegator: string | undefined,
-  nestedSafeOwners: string[] | null | undefined,
-): boolean =>
-  sameAddress(walletAddress, proposerDelegator) ||
-  (nestedSafeOwners?.some((addr) => sameAddress(addr, proposerDelegator)) ?? false)
-
 /**
- * Encapsulates all delegator selection logic for the proposer add/edit flow.
+ * Encapsulates all delegator selection logic for adding a proposer.
  * Determines the effective delegator address, whether a nested Safe is involved,
  * and whether multi-sig signing is required.
  */
-export const useDelegatorSelection = (proposer: Delegate | undefined) => {
+export const useDelegatorSelection = () => {
   const wallet = useWallet()
   const { safe } = useSafeInfo()
   const nestedSafeOwners = useNestedSafeOwners()
-  const isEditing = !!proposer
   const isDirectOwner = isWalletDirectOwner(safe.owners, wallet?.address)
 
   const delegatorOptions = useMemo(
-    () => buildDelegatorOptions(isEditing, isDirectOwner, wallet?.address, nestedSafeOwners),
-    [isEditing, isDirectOwner, wallet?.address, nestedSafeOwners],
+    () => buildDelegatorOptions(isDirectOwner, wallet?.address, nestedSafeOwners),
+    [isDirectOwner, wallet?.address, nestedSafeOwners],
   )
 
   const [selectedDelegator, setSelectedDelegator] = useState<string | undefined>(undefined)
 
-  const effectiveDelegator = useMemo(
-    () => resolveEffectiveDelegator(isEditing, proposer?.delegator, selectedDelegator, delegatorOptions[0]),
-    [isEditing, proposer?.delegator, selectedDelegator, delegatorOptions],
-  )
+  // `.at(0)` rather than `[0]`: delegatorOptions is empty when the wallet owns neither this Safe
+  // nor a parent, and only `.at` types that absence honestly
+  const effectiveDelegator = selectedDelegator ?? delegatorOptions.at(0)
 
   const parentSafeAddress = resolveParentSafeAddress(nestedSafeOwners, effectiveDelegator)
   const {
@@ -84,7 +61,6 @@ export const useDelegatorSelection = (proposer: Delegate | undefined) => {
     isLoading: isParentLoading,
   } = useParentSafeThreshold(parentSafeAddress)
   const isMultiSigRequired = checkMultiSigRequired(parentSafeAddress, parentThreshold)
-  const canEdit = checkCanEdit(wallet?.address, proposer?.delegator, nestedSafeOwners)
 
   return {
     delegatorOptions,
@@ -95,6 +71,5 @@ export const useDelegatorSelection = (proposer: Delegate | undefined) => {
     parentOwners,
     isMultiSigRequired,
     isParentLoading,
-    canEdit,
   }
 }

--- a/apps/web/src/features/proposers/hooks/useMigrateProposerLabels.ts
+++ b/apps/web/src/features/proposers/hooks/useMigrateProposerLabels.ts
@@ -1,0 +1,41 @@
+import { useEffect } from 'react'
+import { sanitizeName } from '@safe-global/utils/validation/names'
+import { PROPOSER_LABEL_PLACEHOLDER } from '@/features/proposers/constants'
+import { useMergedAddressBooks } from '@/hooks/useAllAddressBooks'
+import useChainId from '@/hooks/useChainId'
+import { useIsNestedSafeOwner } from '@/hooks/useIsNestedSafeOwner'
+import useIsSafeOwner from '@/hooks/useIsSafeOwner'
+import useProposers from '@/hooks/useProposers'
+import { upsertAddressBookEntries } from '@/store/addressBookSlice'
+import { useAppDispatch } from '@/store'
+
+/**
+ * Copies proposer names still held by the Transaction Service into the local address book so they
+ * survive the move to local-only names. Signers only — an anonymous viewer must not end up
+ * persisting someone else's name to disk.
+ *
+ * ponytail: no "already migrated" flag, so deleting a migrated contact brings it back on the next
+ * load. Add the flag if that bites before Platform purges the stored labels.
+ */
+export const useMigrateProposerLabels = () => {
+  const dispatch = useAppDispatch()
+  const chainId = useChainId()
+  const isSafeOwner = useIsSafeOwner()
+  const isNestedSafeOwner = useIsNestedSafeOwner()
+  const proposers = useProposers()
+  const { has } = useMergedAddressBooks(chainId)
+
+  const isSigner = isSafeOwner || isNestedSafeOwner
+
+  useEffect(() => {
+    if (!isSigner) return
+
+    for (const { delegate, label } of proposers.data?.results ?? []) {
+      const name = sanitizeName(label ?? '')
+      if (!name || name === PROPOSER_LABEL_PLACEHOLDER) continue
+      if (has(delegate, chainId)) continue
+
+      dispatch(upsertAddressBookEntries({ chainIds: [chainId], address: delegate, name }))
+    }
+  }, [chainId, dispatch, has, isSigner, proposers.data?.results])
+}

--- a/apps/web/src/features/proposers/hooks/usePendingDelegations.ts
+++ b/apps/web/src/features/proposers/hooks/usePendingDelegations.ts
@@ -43,14 +43,10 @@ export function usePendingDelegations(): UsePendingDelegationsResult {
     },
   )
 
-  // Map of lowercase address -> label for current delegates
-  const currentDelegatesMap = useMemo(() => {
-    const map = new Map<string, string>()
-    for (const p of proposers.data?.results ?? []) {
-      map.set(p.delegate.toLowerCase(), p.label)
-    }
-    return map
-  }, [proposers.data?.results])
+  const currentDelegates = useMemo(
+    () => new Set((proposers.data?.results ?? []).map((p) => p.delegate.toLowerCase())),
+    [proposers.data?.results],
+  )
 
   const pendingDelegations = useMemo(() => {
     if (!messagesPage?.results || !parentSafeAddress) return []
@@ -61,8 +57,8 @@ export function usePendingDelegations(): UsePendingDelegationsResult {
       .filter((d): d is DelegationWithTimestamp => d !== null)
 
     const latestByDelegate = keepLatestPerDelegate(allDelegations)
-    return filterActedUponDelegations(latestByDelegate, currentDelegatesMap)
-  }, [messagesPage, parentSafeAddress, safeAddress, currentDelegatesMap])
+    return filterActedUponDelegations(latestByDelegate, currentDelegates)
+  }, [messagesPage, parentSafeAddress, safeAddress, currentDelegates])
 
   return { pendingDelegations, isLoading, refetch }
 }

--- a/apps/web/src/features/proposers/hooks/useSubmitDelegation.ts
+++ b/apps/web/src/features/proposers/hooks/useSubmitDelegation.ts
@@ -6,6 +6,7 @@ import {
 import { asError } from '@safe-global/utils/services/exceptions/utils'
 import { encodeEIP1271Signature } from '@/features/proposers/utils/utils'
 import { isTotpValid } from '@/features/proposers/utils/totp'
+import { PROPOSER_LABEL_PLACEHOLDER } from '@/features/proposers/constants'
 import useChainId from '@/hooks/useChainId'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import type { PendingDelegation } from '@/features/proposers/types'
@@ -41,7 +42,7 @@ export const useSubmitDelegation = () => {
           delegation.preparedSignature,
         )
 
-        if (delegation.action === 'add' || delegation.action === 'edit') {
+        if (delegation.action === 'add') {
           await addDelegateV2({
             chainId,
             createDelegateDto: {
@@ -49,7 +50,7 @@ export const useSubmitDelegation = () => {
               delegate: delegation.delegateAddress,
               delegator: delegation.parentSafeAddress,
               signature: eip1271Signature,
-              label: delegation.delegateLabel,
+              label: PROPOSER_LABEL_PLACEHOLDER,
             },
           }).unwrap()
         } else if (delegation.action === 'remove') {

--- a/apps/web/src/features/proposers/index.ts
+++ b/apps/web/src/features/proposers/index.ts
@@ -1,7 +1,8 @@
-export { default as UpsertProposer } from './components/UpsertProposer'
+export { default as AddProposer } from './components/AddProposer'
 export { default as DeleteProposerDialog } from './components/DeleteProposerDialog'
 export { default as EditProposerDialog } from './components/EditProposerDialog'
 export { default as PendingDelegationsList } from './components/PendingDelegationsList'
 export { default as TxProposalChip } from './components/TxProposalChip'
 
 export { useParentSafeThreshold } from './hooks/useParentSafeThreshold'
+export { useMigrateProposerLabels } from './hooks/useMigrateProposerLabels'

--- a/apps/web/src/features/proposers/services/__tests__/delegationMessages.test.ts
+++ b/apps/web/src/features/proposers/services/__tests__/delegationMessages.test.ts
@@ -21,7 +21,7 @@ describe('delegationMessages', () => {
 
   describe('buildDelegationOrigin', () => {
     it('should build correct JSON string for add action', () => {
-      const result = buildDelegationOrigin('add', delegateAddress, nestedSafeAddress, 'Test Label')
+      const result = buildDelegationOrigin('add', delegateAddress, nestedSafeAddress)
 
       const parsed = JSON.parse(result)
       expect(parsed).toEqual({
@@ -29,12 +29,11 @@ describe('delegationMessages', () => {
         action: 'add',
         delegate: delegateAddress,
         nestedSafe: nestedSafeAddress,
-        label: 'Test Label',
       })
     })
 
     it('should build correct JSON string for remove action', () => {
-      const result = buildDelegationOrigin('remove', delegateAddress, nestedSafeAddress, 'Remove Label')
+      const result = buildDelegationOrigin('remove', delegateAddress, nestedSafeAddress)
 
       const parsed = JSON.parse(result)
       expect(parsed).toEqual({
@@ -42,25 +41,24 @@ describe('delegationMessages', () => {
         action: 'remove',
         delegate: delegateAddress,
         nestedSafe: nestedSafeAddress,
-        label: 'Remove Label',
       })
     })
 
-    it('should include all required fields for proper delegation origin', () => {
-      const result = buildDelegationOrigin('add', delegateAddress, nestedSafeAddress, 'My Label')
+    it('should never carry a proposer name, which must stay on the device', () => {
+      const result = buildDelegationOrigin('add', delegateAddress, nestedSafeAddress)
 
       const parsed = JSON.parse(result)
       expect(parsed.type).toBe('proposer-delegation')
       expect(parsed.action).toBeDefined()
       expect(parsed.delegate).toBeDefined()
       expect(parsed.nestedSafe).toBeDefined()
-      expect(parsed.label).toBeDefined()
+      expect(parsed.label).toBeUndefined()
     })
   })
 
   describe('createDelegationMessage', () => {
     const typedData = createTypedData()
-    const origin = buildDelegationOrigin('add', delegateAddress, nestedSafeAddress, 'Test')
+    const origin = buildDelegationOrigin('add', delegateAddress, nestedSafeAddress)
 
     it('should successfully create message by dispatching correct action', async () => {
       const mockUnwrap = jest.fn().mockResolvedValue({})

--- a/apps/web/src/features/proposers/services/delegationMessages.ts
+++ b/apps/web/src/features/proposers/services/delegationMessages.ts
@@ -9,18 +9,12 @@ import type { AppDispatch } from '@/store'
 /**
  * Builds the origin metadata JSON string for a delegation off-chain message.
  */
-export function buildDelegationOrigin(
-  action: 'add' | 'remove' | 'edit',
-  delegate: string,
-  nestedSafe: string,
-  label: string,
-): string {
+export function buildDelegationOrigin(action: 'add' | 'remove', delegate: string, nestedSafe: string): string {
   const origin: DelegationOrigin = {
     type: 'proposer-delegation',
     action,
     delegate,
     nestedSafe,
-    label,
   }
   return JSON.stringify(origin)
 }

--- a/apps/web/src/features/proposers/types.ts
+++ b/apps/web/src/features/proposers/types.ts
@@ -2,17 +2,15 @@ import type { AddressInfo, MessageConfirmation } from '@safe-global/store/gatewa
 
 export interface DelegationOrigin {
   type: 'proposer-delegation'
-  action: 'add' | 'remove' | 'edit'
+  action: 'add' | 'remove'
   delegate: string
   nestedSafe: string
-  label: string
 }
 
 export interface PendingDelegation {
   messageHash: string
-  action: 'add' | 'remove' | 'edit'
+  action: 'add' | 'remove'
   delegateAddress: string
-  delegateLabel: string
   nestedSafeAddress: string
   parentSafeAddress: string
   totp: number

--- a/apps/web/src/features/proposers/utils/delegationFilters.ts
+++ b/apps/web/src/features/proposers/utils/delegationFilters.ts
@@ -22,27 +22,20 @@ export function keepLatestPerDelegate(delegations: DelegationWithTimestamp[]): M
 /**
  * Filters out delegations that have already been acted upon.
  * - "add" delegations are filtered if the delegate is already in currentDelegates
- * - "edit" delegations are filtered if the delegate doesn't exist OR the label already matches (edit applied)
  * - "remove" delegations are filtered if the delegate is not in currentDelegates
  *
- * @param currentDelegates Map of lowercase delegate address -> current label
+ * @param currentDelegates Set of lowercase delegate addresses
  */
 export function filterActedUponDelegations(
   delegations: Map<string, DelegationWithTimestamp>,
-  currentDelegates: Map<string, string>,
+  currentDelegates: Set<string>,
 ): PendingDelegation[] {
   const result: PendingDelegation[] = []
 
   for (const delegation of delegations.values()) {
-    const delegateLower = delegation.delegateAddress.toLowerCase()
-    const currentLabel = currentDelegates.get(delegateLower)
-    const isAlreadyDelegate = currentLabel !== undefined
+    const isAlreadyDelegate = currentDelegates.has(delegation.delegateAddress.toLowerCase())
 
     if (delegation.action === 'add' && isAlreadyDelegate) continue
-    if (delegation.action === 'edit') {
-      // Filter if delegate doesn't exist OR if label already matches (edit was applied)
-      if (!isAlreadyDelegate || currentLabel === delegation.delegateLabel) continue
-    }
     if (delegation.action === 'remove' && !isAlreadyDelegate) continue
 
     const { _timestamp: _, ...cleanDelegation } = delegation

--- a/apps/web/src/features/proposers/utils/delegationParsing.ts
+++ b/apps/web/src/features/proposers/utils/delegationParsing.ts
@@ -15,12 +15,11 @@ export function parseDelegationOrigin(originStr: string | null | undefined): Del
     const parsed = JSON.parse(originStr)
     if (
       parsed?.type === 'proposer-delegation' &&
-      (parsed.action === 'add' || parsed.action === 'remove' || parsed.action === 'edit') &&
+      (parsed.action === 'add' || parsed.action === 'remove') &&
       typeof parsed.delegate === 'string' &&
       isAddress(parsed.delegate) &&
       typeof parsed.nestedSafe === 'string' &&
-      isAddress(parsed.nestedSafe) &&
-      typeof parsed.label === 'string'
+      isAddress(parsed.nestedSafe)
     ) {
       return parsed as DelegationOrigin
     }
@@ -78,7 +77,6 @@ export function parseMessageToDelegation(
     messageHash: message.messageHash,
     action: origin.action,
     delegateAddress: origin.delegate,
-    delegateLabel: origin.label,
     nestedSafeAddress: origin.nestedSafe,
     parentSafeAddress,
     totp: messageTotp,


### PR DESCRIPTION
## What it solves

Resolves [WA-3114](https://linear.app/safe-global/issue/WA-3114/store-proposer-names-locally-in-the-address-book-and-never-send-them)

Proposer names were stored in the Transaction Service `label` field and returned by the public `delegates` endpoint, so the Settings → Setup page exposed them to **anyone**, including anonymous visitors. That ties a real-world identity to a wallet role, which is a personal-safety risk in some jurisdictions rather than just a data-hygiene one. Reported by Morpho.

## How this PR fixes it

The name never leaves the device. It goes to the local address book; the backend stores address-only.

The backend requires a name field, and the gateway hides its error messages, so we can't tell whether it would reject an empty one. A fixed word always works, which is what lets this ship without a backend change.

**Showing names got simpler.** We deleted the one line that displayed the backend's name. Nothing replaced it: the address book already supplies names for every address in the app, so it now does the same job here. "Proposed by" already worked this way and needed no change.

**Renaming no longer touches the backend.** The edit button opens the normal address book dialog, no signature, no request. Anyone can rename, because it only changes their own device.

**The old "edit proposer" approval flow is gone.** It figured out whether a rename was still pending by comparing the old and new names, which is meaningless once every name is the same placeholder. Removing it deleted more code than it added.

**Existing names aren't lost.** The first time a signer opens the page, any name already on the backend is copied into their local address book. Signers only, so a random visitor never ends up storing someone else's name.


## How to test it

1. **Nothing is sent.** Settings → Setup → Add proposer, enter an address and a name. In DevTools, inspect `POST …/v2/chains/<id>/delegates` → body has `"label":"Proposer"` and no trace of what you typed. The name renders in the list, sourced from the address book.
2. **Anonymous viewers see nothing.** Open the same Safe in an incognito window → the proposer shows **address only**.
3. **Renaming writes nothing.** Click the edit (pencil) icon, change the name, save. Filter DevTools Network by `method:POST` → **empty**. (You *will* see GETs; see Blast radius.)
4. **Renaming needs no wallet.** Disconnect entirely, the edit icon is still available and still works.
5. **Removal still works** and its `origin` carries no label.
6. **Migration.** On a Safe with a pre-existing named proposer, connect as an owner → the name migrates into the address book and still renders. Reload as a non-owner → address only.

## Affected flows

- Owner adds a proposer from Settings → Setup — name now saved locally, placeholder sent to the backend, alert copy changed
- Owner renames a proposer — now a local address book edit with no signature and no backend call; shows the standard "contact updated" toast
- **Any** viewer renames a proposer — previously blocked to the delegator, now permitted (local data)
- Nested-Safe owner adds a proposer via multi-sig signature collection — `origin` no longer carries the name
- Owner removes a proposer — `origin` no longer carries the name; the address book entry is intentionally **kept** (it's the user's own contact data)
- Anonymous / non-signer views Settings → Setup — sees addresses only
- Signer opens Settings → Setup on a Safe with legacy named proposers — one-time silent migration into the local address book
- Address book page and CSV export — proposer names now appear there, because they are ordinary local contacts

## Visual summary

Where the name is written and read, before and after:

```mermaid
flowchart LR
  subgraph Before
    F1[Add proposer form] -->|"label: name"| TS1[("Transaction Service<br/>delegates.label")]
    F1 -->|"origin JSON: label"| TS2[("Transaction Service<br/>off-chain message")]
    TS1 -->|public GET| S1[Setup page]
    TS1 -->|public GET| A1["Anonymous visitor<br/>sees the name"]
    TS2 -->|public GET| A1
  end

  subgraph After
    F2[Add proposer form] -->|"label: 'Proposer'"| TS3[("Transaction Service<br/>address-only")]
    F2 -->|"name"| AB["Local address book<br/>(localStorage)"]
    AB --> S2[Setup page]
    TS3 -->|public GET| A2["Anonymous visitor<br/>sees address only"]
    R[Rename] -->|no network write| AB
  end
```

The migration gate, which is the subtlest new logic:

```mermaid
flowchart TD
  P[Proposer from delegates endpoint] --> Q1{Viewer is owner<br/>or nested-Safe owner?}
  Q1 -->|No| SKIP1["Skip — never persist<br/>a stranger's name"]
  Q1 -->|Yes| Q2{"label empty or<br/>== 'Proposer'?"}
  Q2 -->|Yes| SKIP2[Skip — carries no name]
  Q2 -->|No| Q3{Address book entry<br/>already exists?}
  Q3 -->|Yes| SKIP3["Skip — don't clobber<br/>the user's own name"]
  Q3 -->|No| WRITE[Write sanitized name<br/>to local address book]
```

## Checklist

- [x] I've tested the branch on mobile 📱 — n/a, mobile has no proposer-management UI and no shared package is touched
- [x] I've documented how it affects the analytics (if at all) 📊 — see Blast radius: two edit events stop firing, definitions retained
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — 7246/7246 web tests pass; new coverage for the placeholder label, address-book write **only on success**, the migration gate, and legacy-origin parsing. Cypress **not** updated, see Risks
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
