### PR TITLE
fix: Sidebar regression in TX Builder

### DIFF
--- a/apps/web/src/components/common/Disclaimer/__snapshots__/index.stories.test.tsx.snap
+++ b/apps/web/src/components/common/Disclaimer/__snapshots__/index.stories.test.tsx.snap
@@ -134,7 +134,7 @@ exports[`./index.stories LegalDisclaimer 1`] = `
                   I have read and understood the
                    
                   <a
-                    class="underline-offset-4 transition-colors outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary decoration-primary/40 hover:decoration-current no-underline hover:no-underline"
+                    class="underline-offset-4 transition-colors outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary decoration-primary/40 hover:decoration-current font-bold no-underline hover:text-muted-foreground hover:no-underline"
                     data-slot="link"
                     data-variant="default"
                     href="/terms"

--- a/apps/web/src/components/common/LegalDisclaimerContent/index.tsx
+++ b/apps/web/src/components/common/LegalDisclaimerContent/index.tsx
@@ -31,7 +31,10 @@ const LegalDisclaimerContent = ({
 
       <Typography>
         I have read and understood the{' '}
-        <ExternalLink href={AppRoutes.terms} className="no-underline hover:no-underline">
+        <ExternalLink
+          href={AppRoutes.terms}
+          className="font-bold no-underline hover:text-muted-foreground hover:no-underline"
+        >
           Terms
         </ExternalLink>{' '}
         and this Disclaimer, and agree to be bound by them.

--- a/apps/web/src/components/common/PageLayout/SideDrawer.tsx
+++ b/apps/web/src/components/common/PageLayout/SideDrawer.tsx
@@ -17,9 +17,15 @@ type SideDrawerProps = {
   isOpen: boolean
   onToggle: (isOpen: boolean) => void
   onSidebarOpenChange?: (open: boolean) => void
+  isSidebarExpanded?: boolean
 }
 
-const SideDrawer = ({ isOpen, onToggle, onSidebarOpenChange }: SideDrawerProps): ReactElement => {
+const SideDrawer = ({
+  isOpen,
+  onToggle,
+  onSidebarOpenChange,
+  isSidebarExpanded = true,
+}: SideDrawerProps): ReactElement => {
   const isSmallScreen = useIsBelowMd()
   const isTabletDrawer = useMediaQuery('(min-width:768px) and (max-width:899.95px)')
   const [, isSafeAppRoute] = useIsSidebarRoute()
@@ -102,7 +108,12 @@ const SideDrawer = ({ isOpen, onToggle, onSidebarOpenChange }: SideDrawerProps):
       )}
 
       {showSidebarToggle && (
-        <div className={classnames(css.sidebarTogglePosition, isOpen && css.sidebarOpen)}>
+        <div
+          className={classnames(
+            css.sidebarTogglePosition,
+            isOpen && (isSidebarExpanded ? css.sidebarOpen : css.sidebarCollapsed),
+          )}
+        >
           <div className={css.sidebarToggle} role="button" onClick={() => onToggle(!isOpen)}>
             <Button variant="ghost" size="icon-sm" aria-label="collapse sidebar">
               {isOpen ? <ChevronsLeft className="size-5" /> : <ChevronsRight className="size-5" />}

--- a/apps/web/src/components/common/PageLayout/index.tsx
+++ b/apps/web/src/components/common/PageLayout/index.tsx
@@ -84,7 +84,12 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
       )}
 
       {isSidebarRoute ? (
-        <SideDrawer isOpen={isSidebarVisible} onToggle={setSidebarOpen} onSidebarOpenChange={setSidebarExpanded} />
+        <SideDrawer
+          isOpen={isSidebarVisible}
+          onToggle={setSidebarOpen}
+          onSidebarOpenChange={setSidebarExpanded}
+          isSidebarExpanded={isSidebarExpanded}
+        />
       ) : null}
 
       <div

--- a/apps/web/src/components/common/PageLayout/styles.module.css
+++ b/apps/web/src/components/common/PageLayout/styles.module.css
@@ -162,12 +162,18 @@
   z-index: 4;
   left: 0;
   top: 0;
-  /* mimics MUI drawer animation */
-  transition: transform 225ms cubic-bezier(0, 0, 0.2, 1) 0ms;
+  /* Matches the sidebar's own transition; anything slower makes the strip trail its edge. */
+  transition: transform 200ms linear 0ms;
 }
 
 .sidebarTogglePosition.sidebarOpen {
   transform: translateX(230px);
+}
+
+/* Tracks the sidebar's icon-rail width, the same offset `.mainSidebarCollapsed` and
+   `.topbarCollapsed` use — otherwise the strip strands itself out over the page content. */
+.sidebarTogglePosition.sidebarCollapsed {
+  transform: translateX(52px);
 }
 
 .sidebarToggle {

--- a/apps/web/src/components/common/PageLayout/styles.test.ts
+++ b/apps/web/src/components/common/PageLayout/styles.test.ts
@@ -100,6 +100,26 @@ describe('PageLayout topbar elevation', () => {
   })
 })
 
+// The toggle strip restates the sidebar offset as a transform rather than inheriting it, so both
+// widths have to stay in step with the page offsets or the strip strands itself over the content.
+describe('PageLayout sidebar toggle offset', () => {
+  it.each([
+    ['.sidebarTogglePosition.sidebarOpen', '.main', 'padding-left'],
+    ['.sidebarTogglePosition.sidebarCollapsed', '.mainSidebarCollapsed', 'padding-left'],
+  ])('offsets %s by the same width as %s', (toggleSelector, mainSelector, mainProp) => {
+    const offset = declOf(findRule(mainSelector), mainProp)
+
+    expect(offset).toBeDefined()
+    expect(declOf(findRule(toggleSelector), 'transform')).toBe(`translateX(${offset})`)
+  })
+
+  it('keeps the collapsed toggle aligned with the collapsed topbar', () => {
+    expect(declOf(findRule('.sidebarTogglePosition.sidebarCollapsed'), 'transform')).toBe(
+      `translateX(${declOf(findRule('.topbarCollapsed'), '--topbar-offset')})`,
+    )
+  })
+})
+
 describe('PageLayout responsive spacing', () => {
   it('emits the tablet top-bar reset after the desktop height reserve', () => {
     const root = postcss.parse(styles)

--- a/apps/web/src/components/safe-apps/AppFrame/TransactionQueueBar/TransactionQueueBar.stories.test.tsx
+++ b/apps/web/src/components/safe-apps/AppFrame/TransactionQueueBar/TransactionQueueBar.stories.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * Auto-generated snapshot tests for Storybook stories
+ * Run "yarn generate:storybook-tests" to regenerate
+ */
+import '../../../../tests/storybook-setup'
+import { composeStories } from '@storybook/react'
+import { render } from '@testing-library/react'
+import type { ComponentType } from 'react'
+
+import * as stories from './TransactionQueueBar.stories'
+
+const composedStories = composeStories(stories)
+
+describe('./TransactionQueueBar.stories', () => {
+  Object.entries(composedStories).forEach(([storyName, Story]) => {
+    test(storyName, () => {
+      const StoryComponent = Story as ComponentType
+      const { container } = render(<StoryComponent />)
+      expect(container.firstChild).toMatchSnapshot()
+    })
+  })
+})

--- a/apps/web/src/components/safe-apps/AppFrame/TransactionQueueBar/TransactionQueueBar.stories.tsx
+++ b/apps/web/src/components/safe-apps/AppFrame/TransactionQueueBar/TransactionQueueBar.stories.tsx
@@ -1,0 +1,149 @@
+import type { ReactElement } from 'react'
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
+import { mswLoader } from 'msw-storybook-addon'
+import type { QueuedItemPage } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import {
+  ConflictType,
+  DetailedExecutionInfoType,
+  TransactionInfoType,
+  TransactionListItemType,
+  TransactionStatus,
+} from '@safe-global/store/gateway/types'
+import { createMockStory } from '@/stories/mocks'
+import { RouterDecorator } from '@/stories/routerDecorator'
+import { AppRoutes } from '@/config/routes'
+import TransactionQueueBar from './index'
+
+const SAFE_ADDRESS = '0x1111111111111111111111111111111111111111'
+const SIGNER_ADDRESS = '0x2222222222222222222222222222222222222222'
+
+// Fixed so the rows render absolute dates rather than drifting "N days ago" labels in snapshots.
+const TIMESTAMP = Date.UTC(2024, 0, 15, 12, 0, 0)
+
+const makeQueuedTx = (nonce: number): QueuedItemPage['results'][number] => ({
+  type: TransactionListItemType.TRANSACTION,
+  transaction: {
+    id: `multisig_${SAFE_ADDRESS}_0x${nonce.toString(16).padStart(8, '0')}`,
+    timestamp: TIMESTAMP + nonce * 60_000,
+    txStatus: TransactionStatus.AWAITING_CONFIRMATIONS,
+    txInfo: {
+      type: TransactionInfoType.CUSTOM,
+      to: { value: SAFE_ADDRESS },
+      dataSize: '0',
+      value: '0',
+      isCancellation: false,
+    },
+    executionInfo: {
+      type: DetailedExecutionInfoType.MULTISIG,
+      nonce,
+      confirmationsRequired: 2,
+      confirmationsSubmitted: 1,
+      missingSigners: [{ value: SIGNER_ADDRESS }],
+    },
+    txHash: null,
+  },
+  conflictType: ConflictType.NONE,
+})
+
+const makeQueue = (count: number): QueuedItemPage => ({
+  results: Array.from({ length: count }, (_, index) => makeQueuedTx(index + 1)),
+})
+
+const SHORT_QUEUE = makeQueue(3)
+const LONG_QUEUE = makeQueue(30)
+
+/**
+ * The bar is `position: absolute; bottom: 0`, so it needs a positioned, full-height host — inside
+ * the app that is the Safe App frame wrapper.
+ */
+const withAppFrame = (Story: () => ReactElement) => (
+  <div className="bg-background relative h-dvh w-full overflow-hidden">
+    <Story />
+  </div>
+)
+
+/**
+ * `createMockStory`'s `parameters.nextjs.router` only reaches the story inside Storybook; the
+ * snapshot tests compose these with `.storybook/preview` alone, where `PaginatedTxns`' `useTxFilter`
+ * would find no router. Providing the context explicitly renders the same in both.
+ */
+const withRouter: Decorator = (Story) => (
+  <RouterDecorator
+    router={{
+      pathname: AppRoutes.apps.open,
+      route: AppRoutes.apps.open,
+      asPath: AppRoutes.apps.open,
+      query: { safe: `eth:${SAFE_ADDRESS}` },
+    }}
+  >
+    <Story />
+  </RouterDecorator>
+)
+
+/**
+ * `PaginatedTxns` reads the first queue page from the store rather than the network, so seeding
+ * `txQueue` is what puts real rows in the bar.
+ */
+const setupWithQueue = (queue: QueuedItemPage) =>
+  createMockStory({
+    scenario: 'efSafe',
+    wallet: 'owner',
+    layout: 'none',
+    store: { txQueue: { data: queue, loading: false, loaded: true } },
+  })
+
+const shortQueueSetup = setupWithQueue(SHORT_QUEUE)
+const longQueueSetup = setupWithQueue(LONG_QUEUE)
+
+// Decorators live on the stories, not on meta: story-level decorators stack with meta-level ones,
+// so a per-story store override would render the frame and providers twice.
+const meta = {
+  title: 'Components/SafeApps/TransactionQueueBar',
+  component: TransactionQueueBar,
+  loaders: [mswLoader],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    visible: true,
+    setExpanded: () => {},
+    onDismiss: () => {},
+  },
+} satisfies Meta<typeof TransactionQueueBar>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Collapsed, the bar is just its 64px header. The chevron points up: it expands upward. */
+export const Collapsed: Story = {
+  parameters: shortQueueSetup.parameters,
+  decorators: [withAppFrame, withRouter, shortQueueSetup.decorator],
+  args: {
+    expanded: false,
+    transactions: SHORT_QUEUE,
+  },
+}
+
+/** Short enough to fit under the 70vh cap, so the bar sizes to its content. */
+export const Expanded: Story = {
+  parameters: shortQueueSetup.parameters,
+  decorators: [withAppFrame, withRouter, shortQueueSetup.decorator],
+  args: {
+    expanded: true,
+    transactions: SHORT_QUEUE,
+  },
+}
+
+/**
+ * The regression case: a queue taller than the 70vh cap. The rows have to stay inside the bar's
+ * own surface and scroll within it — with a visible overflow they render past the background and
+ * over the dimmed backdrop.
+ */
+export const LongQueue: Story = {
+  parameters: longQueueSetup.parameters,
+  decorators: [withAppFrame, withRouter, longQueueSetup.decorator],
+  args: {
+    expanded: true,
+    transactions: LONG_QUEUE,
+  },
+}

--- a/apps/web/src/components/safe-apps/AppFrame/TransactionQueueBar/__snapshots__/TransactionQueueBar.stories.test.tsx.snap
+++ b/apps/web/src/components/safe-apps/AppFrame/TransactionQueueBar/__snapshots__/TransactionQueueBar.stories.test.tsx.snap
@@ -1,0 +1,6881 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`./TransactionQueueBar.stories Collapsed 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 0px;"
+>
+  <div
+    class="shadcn-scope"
+  >
+    <div
+      class="bg-background min-h-screen [&>main]:p-6"
+    >
+      <main>
+        <div
+          class="bg-background relative h-dvh w-full overflow-hidden"
+        >
+          <div
+            class="barWrapper"
+          >
+            <div
+              class="flex w-full flex-col rounded-bl-none rounded-br-none"
+              data-orientation="vertical"
+              data-slot="accordion"
+              dir="ltr"
+              role="region"
+            >
+              <div
+                class="not-last:border-b relative border-b-0"
+                data-closed=""
+                data-index="0"
+                data-orientation="vertical"
+                data-slot="accordion-item"
+              >
+                <h3
+                  class="flex"
+                  data-closed=""
+                  data-index="0"
+                  data-orientation="vertical"
+                >
+                  <button
+                    aria-disabled="false"
+                    aria-expanded="false"
+                    aria-label="expand transaction queue bar"
+                    class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground cursor-pointer rounded-md py-4 text-left text-sm font-medium hover:underline focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 items-center pl-4 pr-12 **:data-[slot=accordion-trigger-icon]:rotate-180"
+                    data-orientation="vertical"
+                    data-slot="accordion-trigger"
+                    data-value=""
+                    id="base-ui-_r_2_"
+                    style="height: 64px;"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <p
+                      class="m-0 text-base leading-6 font-semibold mr-auto text-[var(--color-primary-main)]"
+                      data-slot="typography"
+                      data-variant="paragraph-bold"
+                    >
+                      (3) Transaction queue
+                    </p>
+                    <svg
+                      aria-hidden="true"
+                      class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                      data-slot="accordion-trigger-icon"
+                      fill="none"
+                      height="24"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="m6 9 6 6 6-6"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden="true"
+                      class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                      data-slot="accordion-trigger-icon"
+                      fill="none"
+                      height="24"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="m18 15-6-6-6 6"
+                      />
+                    </svg>
+                  </button>
+                </h3>
+                <button
+                  aria-label="dismiss transaction queue bar"
+                  class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground size-8 in-data-[slot=button-group]:rounded-sm absolute right-2 -translate-y-1/2"
+                  data-slot="button"
+                  style="top: calc(64px / 2);"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="lucide lucide-x"
+                    fill="none"
+                    height="24"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18 6 6 18"
+                    />
+                    <path
+                      d="m6 6 12 12"
+                    />
+                  </svg>
+                </button>
+                <div
+                  aria-labelledby="base-ui-_r_2_"
+                  class="data-open:animate-accordion-down data-closed:animate-accordion-up text-sm overflow-hidden"
+                  data-closed=""
+                  data-index="0"
+                  data-orientation="vertical"
+                  data-slot="accordion-content"
+                  hidden=""
+                  id="base-ui-_r_1_"
+                  role="region"
+                  style="--accordion-panel-height: auto; --accordion-panel-width: auto;"
+                >
+                  <div
+                    class="pt-0 pb-4 [&_a]:hover:text-foreground h-(--accordion-panel-height) data-ending-style:h-0 data-starting-style:h-0 [&_a]:underline [&_a]:underline-offset-3 [&_p:not(:last-child)]:mb-4 px-4"
+                  >
+                    <div
+                      class="flex flex-col items-end"
+                    >
+                      <span
+                        data-slot="tooltip-trigger"
+                        id="base-ui-_r_4_"
+                      >
+                        <button
+                          class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-2 px-6 [&_svg:not([class*='size-'])]:size-5"
+                          data-disabled=""
+                          data-slot="button"
+                          disabled=""
+                          tabindex="0"
+                          type="button"
+                        >
+                          Bulk execute
+                        </button>
+                      </span>
+                    </div>
+                    <div
+                      class="relative"
+                    >
+                      <div
+                        class="container"
+                      >
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_7_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000001"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    1
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:01:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_9_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_c_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000002"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    2
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:02:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_e_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_h_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000003"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    3
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:03:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_j_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`./TransactionQueueBar.stories Expanded 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 0px;"
+>
+  <div
+    class="shadcn-scope"
+  >
+    <div
+      class="bg-background min-h-screen [&>main]:p-6"
+    >
+      <main>
+        <div
+          class="bg-background relative h-dvh w-full overflow-hidden"
+        >
+          <div
+            class="barWrapper"
+          >
+            <div
+              class="flex w-full flex-col rounded-bl-none rounded-br-none"
+              data-orientation="vertical"
+              data-slot="accordion"
+              dir="ltr"
+              role="region"
+            >
+              <div
+                class="not-last:border-b relative border-b-0"
+                data-index="0"
+                data-open=""
+                data-orientation="vertical"
+                data-slot="accordion-item"
+              >
+                <h3
+                  class="flex"
+                  data-index="0"
+                  data-open=""
+                  data-orientation="vertical"
+                >
+                  <button
+                    aria-controls="base-ui-_r_l_"
+                    aria-disabled="false"
+                    aria-expanded="true"
+                    aria-label="expand transaction queue bar"
+                    class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground cursor-pointer rounded-md py-4 text-left text-sm font-medium hover:underline focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 items-center pl-4 pr-12 **:data-[slot=accordion-trigger-icon]:rotate-180"
+                    data-orientation="vertical"
+                    data-panel-open=""
+                    data-slot="accordion-trigger"
+                    data-value="queue"
+                    id="base-ui-_r_m_"
+                    style="height: 64px;"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <p
+                      class="m-0 text-base leading-6 font-semibold mr-auto text-[var(--color-primary-main)]"
+                      data-slot="typography"
+                      data-variant="paragraph-bold"
+                    >
+                      (3) Transaction queue
+                    </p>
+                    <svg
+                      aria-hidden="true"
+                      class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                      data-slot="accordion-trigger-icon"
+                      fill="none"
+                      height="24"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="m6 9 6 6 6-6"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden="true"
+                      class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                      data-slot="accordion-trigger-icon"
+                      fill="none"
+                      height="24"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="m18 15-6-6-6 6"
+                      />
+                    </svg>
+                  </button>
+                </h3>
+                <button
+                  aria-label="dismiss transaction queue bar"
+                  class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground size-8 in-data-[slot=button-group]:rounded-sm absolute right-2 -translate-y-1/2"
+                  data-slot="button"
+                  style="top: calc(64px / 2);"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="lucide lucide-x"
+                    fill="none"
+                    height="24"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18 6 6 18"
+                    />
+                    <path
+                      d="m6 6 12 12"
+                    />
+                  </svg>
+                </button>
+                <div
+                  aria-labelledby="base-ui-_r_m_"
+                  class="data-open:animate-accordion-down data-closed:animate-accordion-up text-sm overflow-hidden"
+                  data-index="0"
+                  data-open=""
+                  data-orientation="vertical"
+                  data-slot="accordion-content"
+                  id="base-ui-_r_l_"
+                  role="region"
+                  style="--accordion-panel-height: auto; --accordion-panel-width: auto;"
+                >
+                  <div
+                    class="pt-0 pb-4 [&_a]:hover:text-foreground h-(--accordion-panel-height) data-ending-style:h-0 data-starting-style:h-0 [&_a]:underline [&_a]:underline-offset-3 [&_p:not(:last-child)]:mb-4 px-4"
+                  >
+                    <div
+                      class="flex flex-col items-end"
+                    >
+                      <span
+                        data-slot="tooltip-trigger"
+                        id="base-ui-_r_o_"
+                      >
+                        <button
+                          class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-2 px-6 [&_svg:not([class*='size-'])]:size-5"
+                          data-disabled=""
+                          data-slot="button"
+                          disabled=""
+                          tabindex="0"
+                          type="button"
+                        >
+                          Bulk execute
+                        </button>
+                      </span>
+                    </div>
+                    <div
+                      class="relative"
+                    >
+                      <div
+                        class="container"
+                      >
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_r_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000001"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    1
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:01:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_t_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_10_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000002"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    2
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:02:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_12_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_15_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000003"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    3
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:03:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_17_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="backdrop"
+            data-testid="queue-bar-backdrop"
+          />
+        </div>
+      </main>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`./TransactionQueueBar.stories LongQueue 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 0px;"
+>
+  <div
+    class="shadcn-scope"
+  >
+    <div
+      class="bg-background min-h-screen [&>main]:p-6"
+    >
+      <main>
+        <div
+          class="bg-background relative h-dvh w-full overflow-hidden"
+        >
+          <div
+            class="barWrapper"
+          >
+            <div
+              class="flex w-full flex-col rounded-bl-none rounded-br-none"
+              data-orientation="vertical"
+              data-slot="accordion"
+              dir="ltr"
+              role="region"
+            >
+              <div
+                class="not-last:border-b relative border-b-0"
+                data-index="0"
+                data-open=""
+                data-orientation="vertical"
+                data-slot="accordion-item"
+              >
+                <h3
+                  class="flex"
+                  data-index="0"
+                  data-open=""
+                  data-orientation="vertical"
+                >
+                  <button
+                    aria-controls="base-ui-_r_19_"
+                    aria-disabled="false"
+                    aria-expanded="true"
+                    aria-label="expand transaction queue bar"
+                    class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground cursor-pointer rounded-md py-4 text-left text-sm font-medium hover:underline focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 items-center pl-4 pr-12 **:data-[slot=accordion-trigger-icon]:rotate-180"
+                    data-orientation="vertical"
+                    data-panel-open=""
+                    data-slot="accordion-trigger"
+                    data-value="queue"
+                    id="base-ui-_r_1a_"
+                    style="height: 64px;"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <p
+                      class="m-0 text-base leading-6 font-semibold mr-auto text-[var(--color-primary-main)]"
+                      data-slot="typography"
+                      data-variant="paragraph-bold"
+                    >
+                      (30) Transaction queue
+                    </p>
+                    <svg
+                      aria-hidden="true"
+                      class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                      data-slot="accordion-trigger-icon"
+                      fill="none"
+                      height="24"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="m6 9 6 6 6-6"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden="true"
+                      class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                      data-slot="accordion-trigger-icon"
+                      fill="none"
+                      height="24"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="m18 15-6-6-6 6"
+                      />
+                    </svg>
+                  </button>
+                </h3>
+                <button
+                  aria-label="dismiss transaction queue bar"
+                  class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground size-8 in-data-[slot=button-group]:rounded-sm absolute right-2 -translate-y-1/2"
+                  data-slot="button"
+                  style="top: calc(64px / 2);"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="lucide lucide-x"
+                    fill="none"
+                    height="24"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18 6 6 18"
+                    />
+                    <path
+                      d="m6 6 12 12"
+                    />
+                  </svg>
+                </button>
+                <div
+                  aria-labelledby="base-ui-_r_1a_"
+                  class="data-open:animate-accordion-down data-closed:animate-accordion-up text-sm overflow-hidden"
+                  data-index="0"
+                  data-open=""
+                  data-orientation="vertical"
+                  data-slot="accordion-content"
+                  id="base-ui-_r_19_"
+                  role="region"
+                  style="--accordion-panel-height: auto; --accordion-panel-width: auto;"
+                >
+                  <div
+                    class="pt-0 pb-4 [&_a]:hover:text-foreground h-(--accordion-panel-height) data-ending-style:h-0 data-starting-style:h-0 [&_a]:underline [&_a]:underline-offset-3 [&_p:not(:last-child)]:mb-4 px-4"
+                  >
+                    <div
+                      class="flex flex-col items-end"
+                    >
+                      <span
+                        data-slot="tooltip-trigger"
+                        id="base-ui-_r_1c_"
+                      >
+                        <button
+                          class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-2 px-6 [&_svg:not([class*='size-'])]:size-5"
+                          data-disabled=""
+                          data-slot="button"
+                          disabled=""
+                          tabindex="0"
+                          type="button"
+                        >
+                          Bulk execute
+                        </button>
+                      </span>
+                    </div>
+                    <div
+                      class="relative"
+                    >
+                      <div
+                        class="container"
+                      >
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_1f_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000001"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    1
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:01:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_1h_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_1k_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000002"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    2
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:02:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_1m_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_1p_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000003"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    3
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:03:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_1r_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_1u_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000004"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    4
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:04:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_20_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_23_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000005"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    5
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:05:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_25_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_28_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000006"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    6
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:06:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_2a_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_2d_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000007"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    7
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:07:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_2f_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_2i_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000008"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    8
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:08:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_2k_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_2n_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000009"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    9
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:09:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_2p_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_2s_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x0000000a"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    10
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:10:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_2u_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_31_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x0000000b"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    11
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:11:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_33_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_36_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x0000000c"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    12
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:12:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_38_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_3b_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x0000000d"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    13
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:13:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_3d_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_3g_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x0000000e"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    14
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:14:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_3i_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_3l_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x0000000f"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    15
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:15:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_3n_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_3q_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000010"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    16
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:16:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_3s_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_3v_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000011"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    17
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:17:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_41_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_44_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000012"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    18
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:18:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_46_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_49_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000013"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    19
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:19:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_4b_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_4e_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000014"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    20
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:20:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_4g_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_4j_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000015"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    21
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:21:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_4l_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_4o_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000016"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    22
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:22:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_4q_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_4t_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000017"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    23
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:23:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_4v_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_52_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000018"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    24
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:24:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_54_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_57_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x00000019"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    25
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:25:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_59_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_5c_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x0000001a"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    26
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:26:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_5e_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_5h_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x0000001b"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    27
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:27:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_5j_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_5m_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x0000001c"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    28
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:28:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_5o_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_5r_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x0000001d"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    29
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:29:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_5t_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                        <div
+                          class="flex w-full flex-col"
+                          data-orientation="vertical"
+                          data-slot="accordion"
+                          dir="ltr"
+                          role="region"
+                        >
+                          <div
+                            class="not-last:border-b listItem"
+                            data-closed=""
+                            data-index="0"
+                            data-orientation="vertical"
+                            data-slot="accordion-item"
+                          >
+                            <h3
+                              class="flex"
+                              data-closed=""
+                              data-index="0"
+                              data-orientation="vertical"
+                            >
+                              <div
+                                aria-expanded="false"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                data-orientation="vertical"
+                                data-slot="accordion-trigger"
+                                data-value=""
+                                id="base-ui-_r_60_"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="gridContainer queue"
+                                  data-testid="transaction-item"
+                                  id="multisig_0x1111111111111111111111111111111111111111_0x0000001e"
+                                >
+                                  <div
+                                    class="nonce"
+                                    data-testid="nonce"
+                                    style="grid-area: nonce;"
+                                  >
+                                    30
+                                  </div>
+                                  <div
+                                    class="type"
+                                    data-testid="tx-type"
+                                    style="grid-area: type;"
+                                  >
+                                    <div
+                                      class="typeRow"
+                                    >
+                                      <div
+                                        class="txType"
+                                      >
+                                        <img
+                                          alt="Contract interaction"
+                                          height="16"
+                                          src="/images/transactions/custom.svg"
+                                          width="16"
+                                        />
+                                      </div>
+                                      <span
+                                        class="typeLabel"
+                                      >
+                                        Contract interaction
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="info"
+                                    data-testid="tx-info"
+                                    style="grid-area: info;"
+                                  >
+                                    <div
+                                      class="txInfo"
+                                    />
+                                  </div>
+                                  <div
+                                    class="date"
+                                    data-testid="tx-date"
+                                    style="grid-area: date;"
+                                  >
+                                    <span>
+                                      Jan 15, 2024 - 12:30:00 PM
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="confirmations"
+                                    style="grid-area: confirmations;"
+                                  >
+                                    <span
+                                      class="gap-1 border border-transparent transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 h-6 px-2.5 py-0 text-sm rounded-4xl font-bold"
+                                      data-slot="badge"
+                                      data-variant="secondary"
+                                    >
+                                      <mock-icon
+                                        class="size-5"
+                                      />
+                                      <span
+                                        class="text-xs font-bold tracking-[1px]"
+                                      >
+                                        1
+                                        /
+                                        2
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="actions"
+                                    style="grid-area: actions;"
+                                  >
+                                    <div
+                                      class="mr-4 flex justify-center"
+                                      data-testid="tx-actions"
+                                    >
+                                      <span
+                                        data-slot="tooltip-trigger"
+                                        id="base-ui-_r_62_"
+                                      >
+                                        <span
+                                          data-track="tx-list: Confirm transaction"
+                                        >
+                                          <button
+                                            class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none border-border bg-transparent hover:bg-foreground/[0.06] hover:text-foreground dark:border-border aria-expanded:bg-foreground/[0.06] aria-expanded:text-foreground shadow-xs h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+                                            data-disabled=""
+                                            data-slot="button"
+                                            disabled=""
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            Confirm
+                                          </button>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-up pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                                  data-slot="accordion-trigger-icon"
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m18 15-6-6-6 6"
+                                  />
+                                </svg>
+                              </div>
+                            </h3>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="backdrop"
+            data-testid="queue-bar-backdrop"
+          />
+        </div>
+      </main>
+    </div>
+  </div>
+</div>
+`;

--- a/apps/web/src/components/safe-apps/AppFrame/TransactionQueueBar/index.test.tsx
+++ b/apps/web/src/components/safe-apps/AppFrame/TransactionQueueBar/index.test.tsx
@@ -64,12 +64,20 @@ const renderBar = (expanded: boolean, setExpanded = jest.fn()) => {
   return setExpanded
 }
 
-const getZIndex = (className: string): number => {
+const getDeclaration = (className: string, prop: string): string | undefined => {
   const css = readFileSync(join(__dirname, 'styles.module.css'), 'utf-8')
   const rule = new RegExp(`\\.${className}\\s*\\{([^}]*)\\}`).exec(css)?.[1]
-  const zIndex = rule && /z-index:\s*(\d+)/.exec(rule)?.[1]
 
-  return zIndex ? Number(zIndex) : NaN
+  return rule ? new RegExp(`(?<![\\w-])${prop}:\\s*([^;]+)`).exec(rule)?.[1].trim() : undefined
+}
+
+const getZIndex = (className: string): number => Number(getDeclaration(className, 'z-index') ?? NaN)
+
+/** Resolves the vertical axis out of the `overflow` shorthand, with the longhand taking precedence. */
+const getOverflowY = (className: string): string | undefined => {
+  const [x, y = x] = getDeclaration(className, 'overflow')?.split(/\s+/) ?? []
+
+  return getDeclaration(className, 'overflow-y') ?? y
 }
 
 describe('TransactionQueueBar', () => {
@@ -92,5 +100,15 @@ describe('TransactionQueueBar', () => {
     fireEvent.click(screen.getByTestId('queue-bar-backdrop'))
 
     expect(setExpanded).toHaveBeenCalledWith(false)
+  })
+})
+
+// The element painting the background is the one capped, so it has to be the one that scrolls or a
+// long queue renders past it. jsdom has no layout, so only the pairing is asserted here.
+describe('TransactionQueueBar surface', () => {
+  it('scrolls the queue rather than letting rows render past its background', () => {
+    expect(getDeclaration('barWrapper', 'background-color')).toBeDefined()
+    expect(getDeclaration('barWrapper', 'max-height')).toBeDefined()
+    expect(['auto', 'scroll']).toContain(getOverflowY('barWrapper'))
   })
 })

--- a/apps/web/src/components/safe-apps/AppFrame/TransactionQueueBar/index.tsx
+++ b/apps/web/src/components/safe-apps/AppFrame/TransactionQueueBar/index.tsx
@@ -49,7 +49,7 @@ const TransactionQueueBar = ({
                 chevron inside this fixed-height bar instead of centring them on it. */}
             <AccordionTrigger
               aria-label="expand transaction queue bar"
-              className="items-center pl-4 pr-12"
+              className="items-center pl-4 pr-12 **:data-[slot=accordion-trigger-icon]:rotate-180"
               style={{ height: TRANSACTION_BAR_HEIGHT }}
             >
               <Typography variant="paragraph-bold" className="mr-auto text-[var(--color-primary-main)]">

--- a/apps/web/src/components/safe-apps/AppFrame/TransactionQueueBar/styles.module.css
+++ b/apps/web/src/components/safe-apps/AppFrame/TransactionQueueBar/styles.module.css
@@ -8,7 +8,9 @@
   z-index: 1200;
 
   /*this rule is needed to prevent the bar from being expanded outside the screen without scrolling on mobile devices*/
-  max-height: 90vh;
+  max-height: 70vh;
+
+  overflow: hidden auto;
 
   /* The bar's own surface. It never needed one here before: MUI's <Accordion> rendered as a Paper,
      which brought its background with it. The shadcn Accordion is an unstyled div, so the bar came

--- a/apps/web/src/components/safe-apps/PermissionsPrompt.tsx
+++ b/apps/web/src/components/safe-apps/PermissionsPrompt.tsx
@@ -38,7 +38,7 @@ const PermissionsPrompt = ({
           <Typography>
             <b>{origin}</b> is requesting permissions for:
           </Typography>
-          <ul>
+          <ul className="mt-4 flex list-disc flex-col gap-1 pl-10">
             {permissions.map((permission, index) => (
               <li key={index}>
                 <Typography>{getSafePermissionDisplayValues(Object.keys(permission)[0]).description}</Typography>

--- a/apps/web/src/components/safe-apps/SafeAppsInfoModal/Domain.tsx
+++ b/apps/web/src/components/safe-apps/SafeAppsInfoModal/Domain.tsx
@@ -13,7 +13,7 @@ type DomainProps = {
 const Domain: React.FC<DomainProps> = ({ url, showInOneLine }): React.ReactElement => {
   return (
     <Typography className={cn(styles.domainText, { 'overflow-y-hidden whitespace-nowrap': showInOneLine })}>
-      <Check className={cn(styles.domainIcon, 'text-[var(--color-success-main)]')} /> {url}
+      <Check className={cn(styles.domainIcon, 'shrink-0 text-[var(--color-success-main)]')} /> {url}
     </Typography>
   )
 }

--- a/apps/web/src/components/safe-apps/SafeAppsInfoModal/Slider.tsx
+++ b/apps/web/src/components/safe-apps/SafeAppsInfoModal/Slider.tsx
@@ -68,7 +68,7 @@ const Slider: React.FC<SliderProps> = ({ onSlideChange, children, initialStep })
           ))}
         </div>
       </div>
-      <div className="mt-4 flex w-full gap-2 border-t border-border pt-4">
+      <div className="mt-4 flex w-full gap-2 border-border pt-4">
         <Button variant="outline" size="sm" className="min-w-0 flex-1" onClick={prevSlide}>
           {isFirstStep ? 'Cancel' : 'Back'}
         </Button>

--- a/apps/web/src/components/safe-apps/SafeAppsInfoModal/UnknownAppWarning.tsx
+++ b/apps/web/src/components/safe-apps/SafeAppsInfoModal/UnknownAppWarning.tsx
@@ -20,7 +20,7 @@ const UnknownAppWarning = ({ url, onHideWarning }: UnknownAppWarningProps): Reac
 
   return (
     <div className="flex h-full flex-col items-center">
-      <div className="mt-12 block items-center">
+      <div className="mt-12 flex flex-col items-center">
         <TriangleAlert className="size-9 text-[var(--color-warning-main)]" />
         <Typography variant="h3" className="mt-4 text-[var(--color-warning-main)]">
           Warning

--- a/apps/web/src/components/safe-apps/SafeAppsInfoModal/styles.module.css
+++ b/apps/web/src/components/safe-apps/SafeAppsInfoModal/styles.module.css
@@ -25,18 +25,16 @@
 }
 
 .domainIcon {
-  position: relative;
-  top: 6px;
   padding-right: 4px;
 }
 
 .domainText {
-  display: block;
+  display: flex;
   font-size: 12px;
   font-weight: bold;
   overflow-wrap: anywhere;
   background-color: var(--color-background-light);
-  padding: 0 15px 10px 10px;
+  padding: 10px 15px;
   border-radius: 8px;
   max-width: 75%;
 }


### PR DESCRIPTION
## What it solves

Resolves: [WA-3178](https://linear.app/safe-global/issue/WA-3178/sidebar-regression-in-tx-builder)

A batch of visual regressions in the Safe Apps surface left over from the MUI/Emotion → shadcn/ui + Tailwind migration (#8040). Each one is a case where the migration faithfully carried over markup that depended on MUI or browser defaults that Tailwind's preflight or the shadcn primitives no longer provide.

**Sidebar (Safe App routes)**

- The collapse toggle strip is `position: fixed` at `left: 0` and reaches the sidebar edge via `translateX(230px)`, keyed only off whether the drawer is open. When the sidebar itself is collapsed to its icon rail, the strip stayed at `230px` and stranded itself — line and button floating ~180px out over the app content.
- The strip animated at MUI's `225ms cubic-bezier(0, 0, 0.2, 1)` while the shadcn sidebar animates at `200ms ease-linear`, so it visibly trailed the sidebar edge.

**Transaction queue bar**

- Chevron pointed the wrong way. The bar is anchored to the viewport bottom and expands *upward*, so the shared accordion's convention (`v` collapsed, `^` expanded) is inverted here. The pre-migration component handled this with `<ExpandLessIcon />` rotated 180° when expanded.
- Scrolling the expanded queue ran the rows off the bar's background onto the dimmed backdrop. `.barWrapper` is capped at `max-height` but had no `overflow` rule. Pre-migration the background sat on the MUI `Paper` — a *child*, which grew with the content; the migration moved it onto the capped wrapper.
- Expanded bar took most of the viewport.

**Safe App info modal**

- The "Warning" screen's icon sat left of its label: the wrapper was `block items-center`, and `items-center` is a no-op on a block container.
- The domain pill's green checkmark collapsed to zero width once the pill became a flex container.

**Permissions prompt**

- The requested-permissions list lost its bullets and indent. It was a bare `<ul>` relying on browser defaults; Tailwind's preflight resets `list-style`, `padding-inline-start`, and the block margin.

**Legal disclaimer**

- The Terms link had no weight distinction and no hover feedback.

## How this PR fixes it

| Fix | Change |
| --- | --- |
| Toggle strip position | `SideDrawer` takes an optional `isSidebarExpanded` prop and picks between `.sidebarOpen` (`230px`) and a new `.sidebarCollapsed` (`52px`) — the same offset `.mainSidebarCollapsed` and `.topbarCollapsed` already use. `PageLayout` passes down the state it already owns; no new state, `SidebarStateReporter` stays the single source of truth. |
| Toggle strip timing | `transition: transform 200ms linear`, matching the sidebar's `duration-200 ease-linear`. |
| Queue bar chevron | `**:data-[slot=accordion-trigger-icon]:rotate-180` on the trigger. Rotating both icons swaps them exactly (a chevron-down at 180° *is* a chevron-up), so the shared `AccordionTrigger` is untouched and every other accordion keeps the standard direction. |
| Queue bar overflow | `overflow: hidden auto` on `.barWrapper`, plus `max-height: 70vh`. `hidden` on the x-axis is deliberate: `overflow-y: auto` alone makes `overflow-x` compute to `auto` and adds a stray horizontal scrollbar. |
| Warning icon | Wrapper `block items-center` → `flex flex-col items-center`. |
| Domain checkmark | `shrink-0` on the icon; `.domainIcon` drops the `position: relative; top: 6px` nudge that was tuned for the old inline layout. |
| Permissions list | `mt-4 flex list-disc flex-col gap-1 pl-10`, matching the `list-disc` + padding convention used by `field.tsx` and the design-system stories. |
| Terms link | `font-bold` with `hover:text-muted-foreground`. Doesn't fight the link's `default` variant `text-primary` — different modifier, so twMerge keeps both. |

## How to test it

Run a Safe App and exercise each surface.

1. **Info modal** — with consent not yet accepted, the disclaimer slide shows a bold "Terms" link that dims on hover. Advance to the warning slide: the triangle is centred over "Warning", and the domain pill keeps its green checkmark with a long URL.
2. **Permissions prompt** — trigger a permission request (e.g. address book access). The list renders with bullets and indentation.
3. **Sidebar** — on the Safe App route, collapse the sidebar to its icon rail. The toggle strip should sit flush against the rail edge, not out over the app. Expand/collapse repeatedly: the strip tracks the sidebar edge without lagging.
4. **Queue bar** — use a Safe with 20+ queued transactions. Collapsed shows `^`, expanded shows `v`. Expanded, the bar occupies ~70% of the viewport and the queue scrolls *inside* it; rows never render past the bar's surface onto the backdrop.

## Affected flows

- Opening a Safe App — consent disclaimer, browser-permissions review, and unknown-app warning slides
- Granting/rejecting a Safe App permission request
- Collapsing and expanding the sidebar on Safe App routes
- Viewing and paging the transaction queue from inside the Safe App frame

## Blast radius

- **`PageLayout` / `SideDrawer`** — shared layout for every sidebar route. `isSidebarExpanded` is optional and defaults to `true`, and `PageLayout` is the only production consumer, so no other caller changes behaviour. The new `.sidebarCollapsed` rule is additive; `.sidebarOpen` is untouched.
- **`.sidebarTogglePosition` timing** — scoped to the toggle strip, which only renders on Safe App routes (`showSidebarToggle = isSafeAppRoute && !isSmallScreen`). `.mainAnimated` still animates page padding at `225ms cubic-bezier(0, 0, 0.2, 1)`; deliberately left alone, as changing it touches every sidebar route.
- **Shared UI primitives** — none modified. `AccordionTrigger` keeps its default chevron direction; the inversion is a call-site class. The shadcn sidebar's `ease-linear` is unchanged.
- **`LegalDisclaimerContent`** — one production consumer (`SafeAppsInfoModal`) plus a Storybook story.
- **No changes** to Redux slices, RTK Query endpoints, API contracts, feature flags, chain configs, persisted state, routes, or shared `packages/**` — so no mobile impact.

## Risks / not checked

- Transition smoothing was considered and explicitly declined; the strip and sidebar are both `200ms linear`, which is synchronised but mechanical.
- The 225ms/200ms mismatch between `.mainAnimated` (page content padding) and the sidebar still exists. Pre-existing, out of scope, and visible as a slight content lag on collapse.
- Tablet drawer range (`768px–899.95px`) not exercised; the toggle strip is suppressed below `md`, but the bespoke transparent overlay path was not visually checked.
- Queue bar infinite scroll past the first page not verified end-to-end. The `InfiniteScroll` sentinel needs a real scroll container to intersect, which `overflow: hidden auto` now provides, but paging with a 20+ item queue was not confirmed in-browser.
- Not tested on mobile or in dark mode.
- No test covers chevron direction or the queue bar's scroll behaviour — both are visual properties.
- Other bare `<ul>`/`<ol>` elements elsewhere in the app likely lost their markers to the same preflight reset. Not swept in this PR.

## Visual summary

**Sidebar toggle offset — the strip restates the sidebar width instead of inheriting it**

```mermaid
flowchart TB
  subgraph Before
    A1[isSidebarOpen] --> B1[".sidebarOpen<br/>translateX(230px)"]
    B1 --> C1["Icon rail is 52px wide<br/>→ strip strands 178px out"]
  end
  subgraph After
    A2[isSidebarOpen] --> D{isSidebarExpanded}
    D -->|true| E[".sidebarOpen<br/>translateX(230px)"]
    D -->|false| F[".sidebarCollapsed<br/>translateX(52px)"]
    E --> G[Strip hugs sidebar edge]
    F --> G
  end
```

`52px` is now asserted against `.mainSidebarCollapsed` and `.topbarCollapsed` in `styles.test.ts`, so the three offsets cannot drift apart again.

**Before / after**
<img width="84" height="828" alt="Screenshot 2026-08-14 at 1 22 02 PM" src="https://github.com/user-attachments/assets/2a7bf8d8-91ba-4094-a3a6-0a89d193a74e" />
<img width="1512" height="593" alt="Screenshot 2026-08-14 at 1 21 44 PM" src="https://github.com/user-attachments/assets/d70e8e13-b3a5-478f-98a8-39839e17a6b8" />
<img width="497" height="593" alt="Screenshot 2026-08-14 at 1 21 31 PM" src="https://github.com/user-attachments/assets/314b0388-e97e-420e-b818-a3e968786fda" />

| Surface | Before | After |
| --- | --- | --- |
| Sidebar toggle (collapsed rail) | _screenshot_ | _screenshot_ |
| Queue bar, scrolled | _screenshot_ | _screenshot_ |
| Warning slide | _screenshot_ | _screenshot_ |
| Permissions list | _screenshot_ | _screenshot_ |

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
