### PR TITLE
fix(UI): WalletConnect popup issues after Shadcn migration

### DIFF
--- a/apps/web/src/components/common/NavTabs/index.tsx
+++ b/apps/web/src/components/common/NavTabs/index.tsx
@@ -14,11 +14,7 @@ const NavTabs = ({ tabs }: { tabs: NavItem[] }) => {
 
   return (
     <Tabs value={activeHref}>
-      <TabsList
-        variant="underline"
-        tone="brand"
-        className="max-sm:h-auto! max-sm:flex-wrap max-sm:justify-start max-sm:gap-y-2 sm:overflow-x-auto sm:overflow-y-hidden"
-      >
+      <TabsList variant="underline" tone="brand" className="overflow-x-auto overflow-y-hidden">
         {tabs.map((tab) => (
           <TabsTrigger
             key={tab.href}

--- a/apps/web/src/components/common/NavTabs/index.tsx
+++ b/apps/web/src/components/common/NavTabs/index.tsx
@@ -14,7 +14,11 @@ const NavTabs = ({ tabs }: { tabs: NavItem[] }) => {
 
   return (
     <Tabs value={activeHref}>
-      <TabsList variant="underline" tone="brand" className="overflow-x-auto overflow-y-hidden">
+      <TabsList
+        variant="underline"
+        tone="brand"
+        className="max-sm:h-auto! max-sm:flex-wrap max-sm:justify-start max-sm:gap-y-2 sm:overflow-x-auto sm:overflow-y-hidden"
+      >
         {tabs.map((tab) => (
           <TabsTrigger
             key={tab.href}

--- a/apps/web/src/components/common/Popup/index.tsx
+++ b/apps/web/src/components/common/Popup/index.tsx
@@ -33,7 +33,8 @@ const Popup = ({ children, open, onClose, anchorEl, modal = true }: PopupProps):
         align="center"
         side="bottom"
         sideOffset={12}
-        className="max-h-[calc(100vh-var(--header-height))] w-[454px] overflow-y-auto rounded-3xl"
+        collisionAvoidance={{ fallbackAxisSide: 'none' }}
+        className="max-h-[var(--available-height)] w-[454px] overflow-y-auto rounded-3xl"
       >
         {children}
       </PopoverContent>

--- a/apps/web/src/components/common/Popup/index.tsx
+++ b/apps/web/src/components/common/Popup/index.tsx
@@ -34,7 +34,7 @@ const Popup = ({ children, open, onClose, anchorEl, modal = true }: PopupProps):
         side="bottom"
         sideOffset={12}
         collisionAvoidance={{ fallbackAxisSide: 'none' }}
-        className="max-h-[var(--available-height)] w-[454px] overflow-y-auto rounded-3xl"
+        className="max-h-[var(--available-height)] w-[454px] max-w-[calc(100vw-1rem)] overflow-y-auto rounded-3xl"
       >
         {children}
       </PopoverContent>

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -42,9 +42,13 @@ function PopoverContent({
   side = 'bottom',
   sideOffset = 4,
   anchor,
+  collisionAvoidance,
   ...props
 }: PopoverPrimitive.Popup.Props &
-  Pick<PopoverPrimitive.Positioner.Props, 'align' | 'alignOffset' | 'side' | 'sideOffset' | 'anchor'>) {
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    'align' | 'alignOffset' | 'side' | 'sideOffset' | 'anchor' | 'collisionAvoidance'
+  >) {
   const portalContainer = usePortalContainer()
   return (
     <PopoverPrimitive.Portal container={portalContainer}>
@@ -54,6 +58,7 @@ function PopoverContent({
         side={side}
         sideOffset={sideOffset}
         anchor={anchor}
+        collisionAvoidance={collisionAvoidance}
         className="isolate z-[var(--z-overlay)]"
       >
         <PopoverPrimitive.Popup

--- a/apps/web/src/features/walletconnect/components/WcConnectionForm/index.test.tsx
+++ b/apps/web/src/features/walletconnect/components/WcConnectionForm/index.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, within } from '@/tests/test-utils'
+import userEvent from '@testing-library/user-event'
+import local from '@/services/local-storage/local'
+import WcConnectionForm from '.'
+
+describe('WcConnectionForm', () => {
+  it('shows the hints by default and hides them via the info button', async () => {
+    local.setItem('wcHints', true)
+    render(<WcConnectionForm sessions={[]} uri="" />)
+
+    expect(screen.getByText('How do I connect to a dApp?')).toBeInTheDocument()
+
+    const trigger = document.querySelector('span.infoIcon')
+    expect(trigger).not.toBeNull()
+    await userEvent.click(within(trigger as HTMLElement).getByRole('button'))
+
+    expect(screen.queryByText('How do I connect to a dApp?')).not.toBeInTheDocument()
+  })
+
+  // The tooltip anchors to its trigger element, so the trigger itself must carry the absolute
+  // positioning that places the icon in the popup corner — otherwise the tooltip opens where the
+  // collapsed trigger sits in normal flow, in the middle of the popup.
+  it('positions the tooltip trigger with the info icon', () => {
+    render(<WcConnectionForm sessions={[]} uri="" />)
+
+    const trigger = document.querySelector('span.infoIcon')
+    expect(trigger).not.toBeNull()
+    expect(within(trigger as HTMLElement).getByRole('button')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/walletconnect/components/WcConnectionForm/index.tsx
+++ b/apps/web/src/features/walletconnect/components/WcConnectionForm/index.tsx
@@ -38,9 +38,9 @@ const WcConnectionForm = ({ sessions, uri }: { sessions: SessionTypes.Struct[]; 
         <Tooltip>
           <TooltipTrigger
             render={
-              <span className="inline-flex">
+              <span className={`inline-flex ${css.infoIcon}`}>
                 <Track {...(showHints ? WALLETCONNECT_EVENTS.HINTS_HIDE : WALLETCONNECT_EVENTS.HINTS_SHOW)}>
-                  <Button variant="ghost" size="icon" onClick={onToggle} className={css.infoIcon}>
+                  <Button variant="ghost" size="icon" onClick={onToggle}>
                     <InfoIcon className="size-6 text-[var(--color-border-main)]" />
                   </Button>
                 </Track>

--- a/apps/web/src/features/walletconnect/components/WcConnectionForm/styles.module.css
+++ b/apps/web/src/features/walletconnect/components/WcConnectionForm/styles.module.css
@@ -1,5 +1,8 @@
+/* Span the same 50px row as the WalletConnect logo and center the button in it */
 .infoIcon {
   position: absolute;
-  top: var(--space-3);
+  top: 0;
   right: var(--space-3);
+  height: 50px;
+  align-items: center;
 }

--- a/apps/web/src/features/walletconnect/components/WcInput/index.tsx
+++ b/apps/web/src/features/walletconnect/components/WcInput/index.tsx
@@ -118,7 +118,7 @@ const WcInput = ({ uri }: { uri: string }) => {
             placeholder="wc:"
             spellCheck={false}
           />
-          <InputGroupAddon align="inline-end">
+          <InputGroupAddon align="inline-end" className="pr-0">
             <Track {...WALLETCONNECT_EVENTS.PASTE_CLICK}>
               <Button variant="default" size="sm" onClick={onPaste} disabled={!!loading}>
                 {loading === WCLoadingState.CONNECT || loading === WCLoadingState.APPROVE ? (

--- a/apps/web/src/features/walletconnect/components/WcLogoHeader/index.tsx
+++ b/apps/web/src/features/walletconnect/components/WcLogoHeader/index.tsx
@@ -8,7 +8,7 @@ import { BRAND_NAME } from '@/config/constants'
 const WcLogoHeader = ({ errorMessage }: { errorMessage?: string }): ReactElement => {
   return (
     <>
-      <div>
+      <div className="flex items-end justify-center">
         <WalletConnect data-testid="wc-icon" className={`size-[50px] ${css.icon}`} />
         {errorMessage && <Alert data-testid="wc-alert" className={`size-5 ${css.errorBadge}`} />}
       </div>


### PR DESCRIPTION
## What it solves

Resolves: [WA-3197](https://linear.app/safe-global/issue/WA-3197/walletconnect-logo-alignment-and-cta-specifications)

UI bugs in the WalletConnect popup — the WC logo was left-aligned, the "How does WalletConnect work?" tooltip appeared in the middle of the popup instead of on the Info icon (which was also misaligned with the logo), and the popup jumped to the left when expanding the hint accordions.

## How this PR fixes it

- **Logo centering**: the scoped Tailwind preflight makes `svg` a block element, defeating `text-center` — the logo wrapper in `WcLogoHeader` is now `flex items-end justify-center` (keeps the error-badge overlap).
- **Tooltip anchor + icon alignment**: the tooltip anchors to its trigger, but the trigger span sat in normal flow while the button was absolutely positioned — the `infoIcon` positioning now lives on the trigger span, which spans the logo's 50px row and vertically centers the button.
- **Popup jump**: Base UI's popover defaults to `collisionAvoidance: { fallbackAxisSide: 'end' }`, relocating the popup to a perpendicular side when it outgrows the space below/above the anchor. `Popup` now passes `fallbackAxisSide: 'none'` and caps height with Base UI's `var(--available-height)`, so content scrolls in place. `PopoverContent` gained an optional `collisionAvoidance` pass-through (default unchanged).

## How to test it

1. Open the WalletConnect popup from the header — the logo is centered and the Info icon is vertically aligned with it.
2. Hover the Info icon — the tooltip appears on the icon.
3. Click the info icon - expand "How do I connect to a dApp?" / "How do I interact with a dApp?" — the popup stays in place and scrolls if needed.

## Affected flows

- User opens the WalletConnect popup and toggles/expands the connection hints.

## Blast radius

- `components/ui/popover.tsx` (`PopoverContent`) — shared shadcn wrapper; new prop is optional with unchanged defaults, other consumers unaffected.
- `components/common/Popup` — single consumer (`WcHeaderWidget`).
- `WcLogoHeader` — also rendered by `WcProposalForm` and `WcErrorMessage` (error badge overlap preserved).

## Risks / not checked

- Pixel-exact rendering only spot-checked visually; jsdom can't assert positioning/collision behavior.
- Pre-existing quirk left as-is: with no stored `wcHints` value, the first Info-icon click is a visual no-op (`!undefined === true`).


## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics changes; hint show/hide/expand events unchanged
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — added `WcConnectionForm/index.test.tsx` (hints toggle + tooltip-trigger positioning contract)
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
