### PR TITLE
fix: update multichain help article link

### DIFF
--- a/apps/web/src/config/constants.ts
+++ b/apps/web/src/config/constants.ts
@@ -147,7 +147,7 @@ export const SAFE_GLOBAL_DOMAIN = 'https://safe.global'
 
 export const ECOSYSTEM_ID_ADDRESS =
   process.env.NEXT_PUBLIC_ECOSYSTEM_ID_ADDRESS || '0x0000000000000000000000000000000000000000'
-export const MULTICHAIN_HELP_ARTICLE = `${HELP_CENTER_URL}/en/articles/222612-multi-chain-safe`
+export const MULTICHAIN_HELP_ARTICLE = `${HELP_CENTER_URL}/articles/9317165368-deploying-a-multi-chain-safe`
 
 export const WORKSPACE_ANNOUNCEMENT_URL = `${SAFE_GLOBAL_DOMAIN}/blog/introducing-workspace-the-onchain-operating-environment-for-treasury-teams`
 


### PR DESCRIPTION
## Summary
- update the multi-chain Safe help article URL used by the app constants
- point the "Read more" link to the current Help Center article

## Testing
- Not run; URL-only change.