### PR TITLE
feat(safenet): queue-row status and Safe Shield check section

### DIFF
--- a/apps/web/src/components/transactions/TxSummary/index.test.tsx
+++ b/apps/web/src/components/transactions/TxSummary/index.test.tsx
@@ -11,8 +11,27 @@ import {
 } from '@safe-global/store/gateway/types'
 
 import TxSummary from '@/components/transactions/TxSummary/index'
+import { waitFor } from '@testing-library/react'
+import { CheckStatus } from '@safe-global/utils/features/safenet-checks'
+import { useSafenetCheck } from '@safe-global/utils/features/safenet-checks/hooks'
+import { buildBenignSnapshot, buildCheckView } from '@safe-global/utils/features/safenet-checks/builders'
 import * as pending from '@/hooks/useIsPending'
+import * as useChainsModule from '@/hooks/useChains'
+import { FEATURES } from '@safe-global/utils/utils/chains'
 import { render } from '@/tests/test-utils'
+
+jest.mock('@safe-global/utils/features/safenet-checks/hooks', () => ({
+  ...jest.requireActual('@safe-global/utils/features/safenet-checks/hooks'),
+  useSafenetCheck: jest.fn().mockReturnValue({
+    snapshot: undefined,
+    status: 'UNAVAILABLE',
+    publicStatus: 'UNAVAILABLE',
+    isLoading: false,
+    isFetching: false,
+    isStale: false,
+    refetch: jest.fn(),
+  }),
+}))
 
 const mockTransaction: MultisigTransaction = {
   type: TransactionListItemType.TRANSACTION,
@@ -121,5 +140,68 @@ describe('TxSummary', () => {
     const { queryByTestId } = render(<TxSummary item={mockTransaction} isConflictGroup={false} />)
 
     expect(queryByTestId('tx-status-label')).not.toBeInTheDocument()
+  })
+
+  describe('Safenet queue status', () => {
+    const safenetTxHash = `0x${'ab'.repeat(32)}`
+    const mockQueuedWithId = {
+      ...mockTransaction,
+      transaction: {
+        ...mockTransaction.transaction,
+        id: `multisig_0x0000000000000000000000000000000000000123_${safenetTxHash}`,
+        timestamp: 1_700_000_000_000,
+      },
+    }
+
+    let hasFeatureSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      hasFeatureSpy = jest
+        .spyOn(useChainsModule, 'useHasFeature')
+        .mockImplementation((feature) => feature === FEATURES.SAFENET_CHECKS)
+      const mocked = useSafenetCheck as jest.MockedFunction<typeof useSafenetCheck>
+      mocked.mockReturnValue(
+        buildCheckView({
+          snapshot: buildBenignSnapshot({ safeTxHash: safenetTxHash as `0x${string}` }),
+          status: CheckStatus.BENIGN,
+          publicStatus: CheckStatus.BENIGN,
+        }),
+      )
+    })
+
+    afterEach(() => {
+      hasFeatureSpy.mockRestore()
+    })
+
+    it('mounts the indicator for a queued transaction with the flag on', async () => {
+      const { getByTestId } = render(<TxSummary item={mockQueuedWithId} isConflictGroup={false} />)
+
+      // The feature chunk loads lazily.
+      await waitFor(() => expect(getByTestId('safenet-queue-status')).toHaveTextContent('No issues found'))
+      expect(useSafenetCheck).toHaveBeenCalledWith(safenetTxHash, 1_700_000_000_000)
+    })
+
+    it('never mounts the indicator on a history row', async () => {
+      const historyItem = {
+        ...mockQueuedWithId,
+        transaction: { ...mockQueuedWithId.transaction, txStatus: TransactionStatus.SUCCESS },
+      }
+      const { queryByTestId } = render(<TxSummary item={historyItem} isConflictGroup={false} />)
+
+      await waitFor(() => expect(queryByTestId('safenet-queue-status')).not.toBeInTheDocument())
+    })
+
+    it('never mounts the indicator with the flag off', async () => {
+      hasFeatureSpy.mockReturnValue(false)
+      const { queryByTestId } = render(<TxSummary item={mockQueuedWithId} isConflictGroup={false} />)
+
+      await waitFor(() => expect(queryByTestId('safenet-queue-status')).not.toBeInTheDocument())
+    })
+
+    it('never mounts the indicator on a bulk-group row (hidden cells must not read the chain)', async () => {
+      const { queryByTestId } = render(<TxSummary item={mockQueuedWithId} isBulkGroup />)
+
+      await waitFor(() => expect(queryByTestId('safenet-queue-status')).not.toBeInTheDocument())
+    })
   })
 })

--- a/apps/web/src/components/transactions/TxSummary/index.tsx
+++ b/apps/web/src/components/transactions/TxSummary/index.tsx
@@ -26,6 +26,7 @@ import {
   HypernativeFeature,
 } from '@/features/hypernative'
 import { getSafeTxHashFromTxId } from '@/utils/transactions'
+import { SafenetChecksFeature, useIsSafenetChecksEnabled } from '@/features/safenet-checks'
 import { useLoadFeature } from '@/features/__core__/useLoadFeature'
 
 type TxSummaryProps = {
@@ -38,6 +39,8 @@ const TxSummary = ({ item, isConflictGroup, isBulkGroup }: TxSummaryProps): Reac
   const { StatusLabel } = useLoadFeature(SwapFeature)
   const hasDefaultTokenlist = useHasFeature(FEATURES.DEFAULT_TOKENLIST)
   const { HnQueueAssessment } = useLoadFeature(HypernativeFeature)
+  const safenet = useLoadFeature(SafenetChecksFeature)
+  const isSafenetEnabled = useIsSafenetChecksEnabled()
 
   const tx = item.transaction
   const isQueue = isTxQueued(tx.txStatus)
@@ -53,6 +56,8 @@ const TxSummary = ({ item, isConflictGroup, isBulkGroup }: TxSummaryProps): Reac
   const assessment = useHnQueueAssessmentResult(safeTxHash)
   const { isAuthenticated } = useHypernativeOAuth()
   const showAssessment = useShowHypernativeAssessment() && isQueue
+  // Bulk-group rows hide the cell via CSS; skipping the mount also skips the chain read.
+  const showSafenetStatus = isSafenetEnabled && isQueue && !isBulkGroup && !!safeTxHash
 
   return (
     <div
@@ -65,6 +70,7 @@ const TxSummary = ({ item, isConflictGroup, isBulkGroup }: TxSummaryProps): Reac
         [css.bulkGroup]: isBulkGroup,
         [css.untrusted]: !isTrusted || isImitationTransaction,
         [css.withAssessment]: showAssessment,
+        [css.withSafenet]: showSafenetStatus,
       })}
       id={tx.id}
     >
@@ -125,6 +131,12 @@ const TxSummary = ({ item, isConflictGroup, isBulkGroup }: TxSummaryProps): Reac
       {showAssessment && safeTxHash && (
         <div style={{ gridArea: 'assessment' }} className={css.assessment}>
           <HnQueueAssessment safeTxHash={safeTxHash} assessment={assessment} isAuthenticated={isAuthenticated} />
+        </div>
+      )}
+
+      {showSafenetStatus && safeTxHash && (
+        <div style={{ gridArea: 'safenet' }} className={css.safenet}>
+          <safenet.SafenetQueueStatus safeTxHash={safeTxHash} timestampMs={tx.timestamp} />
         </div>
       )}
 

--- a/apps/web/src/components/transactions/TxSummary/styles.module.css
+++ b/apps/web/src/components/transactions/TxSummary/styles.module.css
@@ -13,6 +13,7 @@
   --grid-date: minmax(76px, 2fr);
   --grid-confirmations: minmax(56px, 1fr);
   --grid-assessment: 0;
+  --grid-safenet: 0;
   /* `auto`, not a fixed minimum: queue rows only render a status for pending/expired transactions, so
      a hard min reserved ~72px of dead width on every ordinary row and forced the wrap sooner. */
   --grid-status: auto;
@@ -25,13 +26,18 @@
   white-space: nowrap;
   grid-template-columns:
     var(--grid-nonce) var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-confirmations)
-    var(--grid-assessment) var(--grid-status) var(--grid-actions);
-  grid-template-areas: 'nonce type info date confirmations assessment status actions';
+    var(--grid-assessment) var(--grid-safenet) var(--grid-status) var(--grid-actions);
+  grid-template-areas: 'nonce type info date confirmations assessment safenet status actions';
 }
 
 .gridContainer.withAssessment {
   --grid-confirmations: minmax(90px, 1fr);
   --grid-assessment: minmax(80px, 1.5fr);
+}
+
+.gridContainer.withSafenet {
+  --grid-confirmations: minmax(90px, 1fr);
+  --grid-safenet: minmax(80px, 1.5fr);
 }
 
 /* min-width: 0 lets a cell shrink below its content so the row can hold one line; without it a long
@@ -65,15 +71,16 @@
   grid-template-areas: 'nonce type info date status';
 }
 
-.gridContainer.history .assessment {
+.gridContainer.history .assessment,
+.gridContainer.history .safenet {
   display: none;
 }
 
 .gridContainer.conflictGroup {
   grid-template-columns:
     var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-confirmations) var(--grid-assessment)
-    var(--grid-status) var(--grid-actions);
-  grid-template-areas: 'type info date confirmations assessment status actions';
+    var(--grid-safenet) var(--grid-status) var(--grid-actions);
+  grid-template-areas: 'type info date confirmations assessment safenet status actions';
 }
 
 .gridContainer.bulkGroup {
@@ -81,7 +88,8 @@
   grid-template-areas: 'type info date status';
 }
 
-.gridContainer.bulkGroup .assessment {
+.gridContainer.bulkGroup .assessment,
+.gridContainer.bulkGroup .safenet {
   display: none;
 }
 
@@ -163,6 +171,11 @@
 
   .gridContainer.queue .status {
     margin: 0;
+  }
+
+  /* The two-row template has no safenet area; the check state lives in the expanded panel anyway. */
+  .gridContainer.queue .safenet {
+    display: none;
   }
 
   .gridContainer.queue .nonce {

--- a/apps/web/src/features/safe-shield/__tests__/SafeShieldWidget.test.tsx
+++ b/apps/web/src/features/safe-shield/__tests__/SafeShieldWidget.test.tsx
@@ -41,6 +41,7 @@ jest.mock('@/features/__core__', () => ({
       )
     },
     HnCustomChecksCard: () => null,
+    SafenetChecksSection: () => null,
   })),
 }))
 

--- a/apps/web/src/features/safe-shield/components/SafeShieldContent/index.tsx
+++ b/apps/web/src/features/safe-shield/components/SafeShieldContent/index.tsx
@@ -18,6 +18,7 @@ import type { SafeTransaction } from '@safe-global/types-kit'
 import { analysisVisibilityDelay, calculateAnalysisDelays, useDelayedLoading } from '../../hooks/useDelayedLoading'
 import { SAFE_SHIELD_EVENTS } from '@/services/analytics'
 import { HypernativeFeature, type HypernativeAuthStatus } from '@/features/hypernative'
+import { SafenetChecksFeature } from '@/features/safenet-checks'
 import { useLoadFeature } from '@/features/__core__'
 import { ThreatAnalysis } from '../ThreatAnalysis'
 
@@ -47,6 +48,7 @@ export const SafeShieldContent = ({
   onAddToTrustedList?: () => void
 }): ReactElement => {
   const hn = useLoadFeature(HypernativeFeature)
+  const safenet = useLoadFeature(SafenetChecksFeature)
   const [recipientResults = {}, _recipientError, recipientLoading = false] = recipient
   const [contractResults = {}, _contractError, contractLoading = false] = contract
   const [threatResults = {}, _threatError, threatLoading = false] = threat
@@ -125,6 +127,8 @@ export const SafeShieldContent = ({
             highlightedSeverity={highlightedSeverity}
             hypernativeAuth={hypernativeAuth}
           />
+
+          {shouldShowContent && <safenet.SafenetChecksSection />}
 
           {!contractLoading && !threatLoading && (
             <TenderlySimulation

--- a/apps/web/src/features/safe-shield/components/__tests__/SafeShieldContent.safenet.test.tsx
+++ b/apps/web/src/features/safe-shield/components/__tests__/SafeShieldContent.safenet.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from '@/tests/test-utils'
+import { SafeShieldContent } from '../SafeShieldContent'
+import { TxFlowContext, type TxFlowContextType } from '@/components/tx-flow/TxFlowProvider'
+import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { DetailedExecutionInfoType } from '@safe-global/store/gateway/types'
+import { CheckStatus } from '@safe-global/utils/features/safenet-checks'
+import { useSafenetCheck } from '@safe-global/utils/features/safenet-checks/hooks'
+import { buildBenignSnapshot, buildCheckView } from '@safe-global/utils/features/safenet-checks/builders'
+import * as useChainsModule from '@/hooks/useChains'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+
+// The real lazy feature chunk mounts inside the widget; only the chain read is mocked.
+// A missing feature.tsx registry member cannot be caught by the stubbed widget test.
+jest.mock('@safe-global/utils/features/safenet-checks/hooks', () => ({
+  ...jest.requireActual('@safe-global/utils/features/safenet-checks/hooks'),
+  useSafenetCheck: jest.fn(),
+}))
+
+const HASH = `0x${'ef'.repeat(32)}`
+const TX_ID = `multisig_0x0000000000000000000000000000000000000123_${HASH}`
+
+const emptyAnalysis: [undefined, undefined, boolean] = [undefined, undefined, false]
+
+describe('SafeShieldContent Safenet section integration', () => {
+  let hasFeatureSpy: jest.SpyInstance
+  beforeAll(() => {
+    hasFeatureSpy = jest
+      .spyOn(useChainsModule, 'useHasFeature')
+      .mockImplementation((feature) => feature === FEATURES.SAFENET_CHECKS)
+  })
+  afterAll(() => {
+    hasFeatureSpy.mockRestore()
+  })
+
+  it('renders the check section through the lazy feature for a flow with a txId', async () => {
+    const mocked = useSafenetCheck as jest.MockedFunction<typeof useSafenetCheck>
+    mocked.mockReturnValue(
+      buildCheckView({
+        snapshot: buildBenignSnapshot({ safeTxHash: HASH as `0x${string}` }),
+        status: CheckStatus.BENIGN,
+        publicStatus: CheckStatus.BENIGN,
+      }),
+    )
+    const txDetails = {
+      detailedExecutionInfo: { type: DetailedExecutionInfoType.MULTISIG, submittedAt: 1_700_000_000_000 },
+    } as unknown as TransactionDetails
+
+    render(
+      <TxFlowContext.Provider value={{ txId: TX_ID, txDetails } as TxFlowContextType}>
+        <SafeShieldContent
+          recipient={emptyAnalysis}
+          contract={emptyAnalysis}
+          threat={emptyAnalysis}
+          deadlock={emptyAnalysis}
+        />
+      </TxFlowContext.Provider>,
+    )
+
+    // The testid alone distinguishes the real mount from the null stub. Cold
+    // CI runners can take seconds to transform the chunk's module graph.
+    await waitFor(() => expect(screen.getByTestId('safenet-checks-section')).toBeInTheDocument(), {
+      timeout: 10_000,
+    })
+  }, 15_000)
+})

--- a/apps/web/src/features/safenet-checks/components/SafenetAuditRow.tsx
+++ b/apps/web/src/features/safenet-checks/components/SafenetAuditRow.tsx
@@ -9,16 +9,9 @@ import {
   SAFENET_EXPLORER_URL,
   type PublicCheckStatus,
 } from '@safe-global/utils/features/safenet-checks'
-import { useSafenetCheck } from '@safe-global/utils/features/safenet-checks/hooks'
+import { useSafenetDisplayStatus } from '../useSafenetDisplayStatus'
+import { STATUS_PRESENTATION } from '../statusPresentation'
 import { getExplorerLink } from '@safe-global/utils/utils/gateway'
-
-const STEP_LABEL: Record<Exclude<PublicCheckStatus, CheckStatus.UNAVAILABLE>, string> = {
-  [CheckStatus.SUBMITTED]: 'Submitted',
-  [CheckStatus.IN_PROGRESS]: 'Simulating',
-  [CheckStatus.BENIGN]: 'No issues found',
-  [CheckStatus.MALICIOUS]: 'Risk detected',
-  [CheckStatus.TIMED_OUT]: 'Safenet check failed',
-}
 
 const STEP_ICON: Record<Exclude<PublicCheckStatus, CheckStatus.UNAVAILABLE>, ActionType> = {
   [CheckStatus.SUBMITTED]: 'pending',
@@ -60,12 +53,12 @@ export const SafenetAuditRow = ({
   timestampMs,
   isLast,
 }: SafenetAuditRowProps): ReactElement | null => {
-  const { publicStatus, snapshot } = useSafenetCheck(safeTxHash, timestampMs)
+  const { publicStatus, snapshot } = useSafenetDisplayStatus(safeTxHash, timestampMs)
   // The Safenet chain (the chain the attestation landed on), not the Safe's.
   const safenetChain = useChain(snapshot?.chainId ?? '')
   const isDarkMode = useDarkMode()
 
-  if (!safeTxHash || !snapshot || publicStatus === CheckStatus.UNAVAILABLE) return null
+  if (!safeTxHash || publicStatus === CheckStatus.UNAVAILABLE) return null
 
   // Link only on BENIGN: it is underivable without a FROST-verified
   // attestation, so "No issues found" and the proof link always travel together.
@@ -87,7 +80,7 @@ export const SafenetAuditRow = ({
     // animation softens the late insert instead of popping it in one frame.
     <div className="animate-in fade-in slide-in-from-top-1 duration-300">
       <AuditRow
-        label={STEP_LABEL[publicStatus]}
+        label={STATUS_PRESENTATION[publicStatus].label}
         actionType={STEP_ICON[publicStatus]}
         iconColor={isDarkMode ? DARK_STEP_COLOR[publicStatus] : undefined}
         actor={
@@ -102,7 +95,7 @@ export const SafenetAuditRow = ({
         }
         isLast={isLast}
         // Null while running or when the header read failed — column stays empty.
-        timestamp={snapshot.attestedAtMs}
+        timestamp={snapshot?.attestedAtMs ?? null}
       />
     </div>
   )

--- a/apps/web/src/features/safenet-checks/components/SafenetAuditRow.tsx
+++ b/apps/web/src/features/safenet-checks/components/SafenetAuditRow.tsx
@@ -53,12 +53,13 @@ export const SafenetAuditRow = ({
   timestampMs,
   isLast,
 }: SafenetAuditRowProps): ReactElement | null => {
-  const { publicStatus, snapshot } = useSafenetDisplayStatus(safeTxHash, timestampMs)
+  const display = useSafenetDisplayStatus(safeTxHash, timestampMs)
   // The Safenet chain (the chain the attestation landed on), not the Safe's.
-  const safenetChain = useChain(snapshot?.chainId ?? '')
+  const safenetChain = useChain(display?.snapshot.chainId ?? '')
   const isDarkMode = useDarkMode()
 
-  if (!safeTxHash || publicStatus === CheckStatus.UNAVAILABLE) return null
+  if (!safeTxHash || !display) return null
+  const { publicStatus, snapshot } = display
 
   // Link only on BENIGN: it is underivable without a FROST-verified
   // attestation, so "No issues found" and the proof link always travel together.
@@ -69,8 +70,8 @@ export const SafenetAuditRow = ({
   // verifies. The Safenet explorer's hash route is the fallback when the
   // chain config or the attested event is unavailable.
   const attested =
-    snapshot?.events.find((event) => event.type === CheckEventType.ORACLE_ATTESTED) ??
-    snapshot?.events.find((event) => event.type === CheckEventType.PLAIN_ATTESTED)
+    snapshot.events.find((event) => event.type === CheckEventType.ORACLE_ATTESTED) ??
+    snapshot.events.find((event) => event.type === CheckEventType.PLAIN_ATTESTED)
   const attestationTxLink =
     attested && safenetChain ? getExplorerLink(attested.transactionHash, safenetChain.blockExplorerUriTemplate) : null
   const href = attestationTxLink?.href ?? `${SAFENET_EXPLORER_URL}/#/safeTx?chainId=${chainId}&safeTxHash=${safeTxHash}`
@@ -95,7 +96,7 @@ export const SafenetAuditRow = ({
         }
         isLast={isLast}
         // Null while running or when the header read failed — column stays empty.
-        timestamp={snapshot?.attestedAtMs ?? null}
+        timestamp={snapshot.attestedAtMs ?? null}
       />
     </div>
   )

--- a/apps/web/src/features/safenet-checks/components/SafenetChecksSection.tsx
+++ b/apps/web/src/features/safenet-checks/components/SafenetChecksSection.tsx
@@ -5,7 +5,6 @@ import { SeverityIcon } from '@/features/safe-shield/components/SeverityIcon'
 import { TxFlowContext } from '@/components/tx-flow/TxFlowProvider'
 import { getSafeTxHashFromTxId } from '@/utils/transactions'
 import { isMultisigDetailedExecutionInfo } from '@/utils/transaction-guards'
-import { CheckStatus } from '@safe-global/utils/features/safenet-checks'
 import { useSafenetDisplayStatus } from '../useSafenetDisplayStatus'
 import { STATUS_PRESENTATION } from '../statusPresentation'
 
@@ -25,9 +24,10 @@ export const SafenetChecksSection = (): ReactElement | null => {
       ? txDetails.detailedExecutionInfo.submittedAt
       : undefined
 
-  const { publicStatus } = useSafenetDisplayStatus(submittedAt !== undefined ? safeTxHash : undefined, submittedAt)
-  if (publicStatus === CheckStatus.UNAVAILABLE) return null
+  const display = useSafenetDisplayStatus(submittedAt !== undefined ? safeTxHash : undefined, submittedAt)
+  if (!display) return null
 
+  const { publicStatus } = display
   const { severity, copy } = STATUS_PRESENTATION[publicStatus]
 
   return (

--- a/apps/web/src/features/safenet-checks/components/SafenetChecksSection.tsx
+++ b/apps/web/src/features/safenet-checks/components/SafenetChecksSection.tsx
@@ -1,0 +1,56 @@
+import { useContext, type ReactElement } from 'react'
+import { Typography } from '@/components/ui/typography'
+// eslint-disable-next-line no-restricted-imports -- deep import keeps this lazy chunk from pulling the whole safe-shield barrel (same as HnQueueAssessment)
+import { SeverityIcon } from '@/features/safe-shield/components/SeverityIcon'
+import { TxFlowContext } from '@/components/tx-flow/TxFlowProvider'
+import { getSafeTxHashFromTxId } from '@/utils/transactions'
+import { isMultisigDetailedExecutionInfo } from '@/utils/transaction-guards'
+import { CheckStatus } from '@safe-global/utils/features/safenet-checks'
+import { useSafenetDisplayStatus } from '../useSafenetDisplayStatus'
+import { STATUS_PRESENTATION } from '../statusPresentation'
+
+/**
+ * Safenet check state as a section in the Safe Shield widget (PRD display
+ * rule: reuse the severity components, no new banner UI). Subscribes only for
+ * confirm/execute flows of an already-proposed transaction, and only once the
+ * submission time is known — the shared cache keys by hash, so a fetch aimed
+ * without it would cache a mis-aimed read for every surface. Renders nothing
+ * until a check has been observed.
+ */
+export const SafenetChecksSection = (): ReactElement | null => {
+  const { txId, txDetails } = useContext(TxFlowContext)
+  const safeTxHash = txId ? getSafeTxHashFromTxId(txId) : undefined
+  const submittedAt =
+    txDetails && isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)
+      ? txDetails.detailedExecutionInfo.submittedAt
+      : undefined
+
+  const { publicStatus } = useSafenetDisplayStatus(submittedAt !== undefined ? safeTxHash : undefined, submittedAt)
+  if (publicStatus === CheckStatus.UNAVAILABLE) return null
+
+  const { severity, copy } = STATUS_PRESENTATION[publicStatus]
+
+  return (
+    // The section appears only once the chain read resolves; the entrance
+    // animation softens the late insert instead of popping it in one frame.
+    <div
+      data-testid="safenet-checks-section"
+      data-status={publicStatus}
+      className="animate-in fade-in slide-in-from-top-1 p-4 duration-300"
+    >
+      <div className="flex items-start gap-2">
+        <SeverityIcon severity={severity} />
+        <div>
+          <Typography variant="paragraph-small" className="font-bold leading-4">
+            Safenet check
+          </Typography>
+          <Typography variant="paragraph-small" className="text-muted-foreground">
+            {copy}
+          </Typography>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default SafenetChecksSection

--- a/apps/web/src/features/safenet-checks/components/SafenetQueueStatus.tsx
+++ b/apps/web/src/features/safenet-checks/components/SafenetQueueStatus.tsx
@@ -3,7 +3,6 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Typography } from '@/components/ui/typography'
 // eslint-disable-next-line no-restricted-imports -- deep import keeps this lazy chunk from pulling the whole safe-shield barrel (same as HnQueueAssessment)
 import { SeverityIcon } from '@/features/safe-shield/components/SeverityIcon'
-import { CheckStatus } from '@safe-global/utils/features/safenet-checks'
 import { useSafenetDisplayStatus } from '../useSafenetDisplayStatus'
 import { STATUS_PRESENTATION } from '../statusPresentation'
 
@@ -23,9 +22,10 @@ export type SafenetQueueStatusProps = {
  * check has been observed for the hash.
  */
 export const SafenetQueueStatus = ({ safeTxHash, timestampMs }: SafenetQueueStatusProps): ReactElement | null => {
-  const { publicStatus } = useSafenetDisplayStatus(safeTxHash, timestampMs)
-  if (publicStatus === CheckStatus.UNAVAILABLE) return null
+  const display = useSafenetDisplayStatus(safeTxHash, timestampMs)
+  if (!display) return null
 
+  const { publicStatus } = display
   const { severity, label, copy } = STATUS_PRESENTATION[publicStatus]
 
   return (

--- a/apps/web/src/features/safenet-checks/components/SafenetQueueStatus.tsx
+++ b/apps/web/src/features/safenet-checks/components/SafenetQueueStatus.tsx
@@ -1,0 +1,48 @@
+import type { ReactElement } from 'react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { Typography } from '@/components/ui/typography'
+// eslint-disable-next-line no-restricted-imports -- deep import keeps this lazy chunk from pulling the whole safe-shield barrel (same as HnQueueAssessment)
+import { SeverityIcon } from '@/features/safe-shield/components/SeverityIcon'
+import { CheckStatus } from '@safe-global/utils/features/safenet-checks'
+import { useSafenetDisplayStatus } from '../useSafenetDisplayStatus'
+import { STATUS_PRESENTATION } from '../statusPresentation'
+
+export type SafenetQueueStatusProps = {
+  safeTxHash: string
+  /**
+   * Submission time from the queue summary; aims the reader's block window.
+   * Required: the cache keys by hash and the last fetch's args aim every
+   * later poll, so an unaimed subscription would poison every surface.
+   */
+  timestampMs: number
+}
+
+/**
+ * Compact per-row check state for the transaction queue: severity icon plus
+ * the PRD state name, full-sentence copy on hover. Renders nothing until a
+ * check has been observed for the hash.
+ */
+export const SafenetQueueStatus = ({ safeTxHash, timestampMs }: SafenetQueueStatusProps): ReactElement | null => {
+  const { publicStatus } = useSafenetDisplayStatus(safeTxHash, timestampMs)
+  if (publicStatus === CheckStatus.UNAVAILABLE) return null
+
+  const { severity, label, copy } = STATUS_PRESENTATION[publicStatus]
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <div data-testid="safenet-queue-status" data-status={publicStatus} className="inline-flex items-center gap-1">
+            <SeverityIcon severity={severity} />
+            <Typography variant="paragraph-mini" className="text-muted-foreground">
+              {label}
+            </Typography>
+          </div>
+        }
+      />
+      <TooltipContent side="top">{copy}</TooltipContent>
+    </Tooltip>
+  )
+}
+
+export default SafenetQueueStatus

--- a/apps/web/src/features/safenet-checks/components/__tests__/SafenetChecksSection.test.tsx
+++ b/apps/web/src/features/safenet-checks/components/__tests__/SafenetChecksSection.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@/tests/test-utils'
+import { TxFlowContext, type TxFlowContextType } from '@/components/tx-flow/TxFlowProvider'
+import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { DetailedExecutionInfoType } from '@safe-global/store/gateway/types'
+import { CheckStatus, type PublicCheckStatus } from '@safe-global/utils/features/safenet-checks'
+import { useSafenetCheck } from '@safe-global/utils/features/safenet-checks/hooks'
+import { buildCheckView, buildSnapshot } from '@safe-global/utils/features/safenet-checks/builders'
+import { SafenetChecksSection } from '../SafenetChecksSection'
+
+jest.mock('@safe-global/utils/features/safenet-checks/hooks', () => ({
+  ...jest.requireActual('@safe-global/utils/features/safenet-checks/hooks'),
+  useSafenetCheck: jest.fn(),
+}))
+
+const mockUseSafenetCheck = useSafenetCheck as jest.MockedFunction<typeof useSafenetCheck>
+
+const HASH = `0x${'cd'.repeat(32)}`
+const SAFE = '0x0000000000000000000000000000000000000123'
+const TX_ID = `multisig_${SAFE}_${HASH}`
+const SUBMITTED_AT = 1_700_000_000_000
+
+const txDetails = {
+  detailedExecutionInfo: {
+    type: DetailedExecutionInfoType.MULTISIG,
+    submittedAt: SUBMITTED_AT,
+  },
+} as unknown as TransactionDetails
+
+const renderInFlow = (flow: Partial<TxFlowContextType>) =>
+  render(
+    <TxFlowContext.Provider value={flow as TxFlowContextType}>
+      <SafenetChecksSection />
+    </TxFlowContext.Provider>,
+  )
+
+describe('SafenetChecksSection', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('subscribes with the hash from the flow txId and the submission time', () => {
+    mockUseSafenetCheck.mockReturnValue(buildCheckView())
+
+    renderInFlow({ txId: TX_ID, txDetails })
+
+    expect(mockUseSafenetCheck).toHaveBeenCalledWith(HASH, SUBMITTED_AT)
+  })
+
+  it('renders nothing for a creation flow (no txId, no canonical hash)', () => {
+    mockUseSafenetCheck.mockReturnValue(buildCheckView())
+
+    const { container } = renderInFlow({})
+
+    expect(mockUseSafenetCheck).toHaveBeenCalledWith(undefined, undefined)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('never subscribes before the submission time is known (shared cache aims by the last args)', () => {
+    mockUseSafenetCheck.mockReturnValue(buildCheckView())
+
+    const { container } = renderInFlow({ txId: TX_ID })
+
+    expect(mockUseSafenetCheck).toHaveBeenCalledWith(undefined, undefined)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when no check was observed', () => {
+    mockUseSafenetCheck.mockReturnValue(buildCheckView())
+
+    const { container } = renderInFlow({ txId: TX_ID, txDetails })
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it.each<[Exclude<PublicCheckStatus, CheckStatus.UNAVAILABLE>, string]>([
+    [CheckStatus.SUBMITTED, 'Check submitted to Safenet.'],
+    [CheckStatus.IN_PROGRESS, 'Safenet is simulating this transaction.'],
+    [CheckStatus.BENIGN, 'Safenet found no issues'],
+    [CheckStatus.MALICIOUS, 'Safenet flagged this address/transaction as malicious'],
+    [CheckStatus.TIMED_OUT, 'Safenet check is unavailable. You can still continue.'],
+  ])('renders %s with the PRD copy', (status, copy) => {
+    const snapshot = buildSnapshot({ safeTxHash: HASH as `0x${string}`, status })
+    mockUseSafenetCheck.mockReturnValue(buildCheckView({ snapshot, status, publicStatus: status }))
+
+    renderInFlow({ txId: TX_ID, txDetails })
+
+    const section = screen.getByTestId('safenet-checks-section')
+    expect(section).toHaveAttribute('data-status', status)
+    expect(section).toHaveTextContent('Safenet check')
+    expect(section).toHaveTextContent(copy)
+  })
+})

--- a/apps/web/src/features/safenet-checks/components/__tests__/SafenetQueueStatus.test.tsx
+++ b/apps/web/src/features/safenet-checks/components/__tests__/SafenetQueueStatus.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@/tests/test-utils'
+import { CheckStatus, type PublicCheckStatus } from '@safe-global/utils/features/safenet-checks'
+import { useSafenetCheck } from '@safe-global/utils/features/safenet-checks/hooks'
+import { buildCheckView, buildSnapshot } from '@safe-global/utils/features/safenet-checks/builders'
+import { SafenetQueueStatus } from '../SafenetQueueStatus'
+
+jest.mock('@safe-global/utils/features/safenet-checks/hooks', () => ({
+  ...jest.requireActual('@safe-global/utils/features/safenet-checks/hooks'),
+  useSafenetCheck: jest.fn(),
+}))
+
+const mockUseSafenetCheck = useSafenetCheck as jest.MockedFunction<typeof useSafenetCheck>
+
+const HASH = `0x${'ab'.repeat(32)}`
+const TS = 1_700_000_000_000
+
+describe('SafenetQueueStatus', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('renders nothing when no check was observed', () => {
+    mockUseSafenetCheck.mockReturnValue(buildCheckView())
+
+    const { container } = render(<SafenetQueueStatus safeTxHash={HASH} timestampMs={TS} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing for a pinned verdict without a snapshot (collapse invariant)', () => {
+    // A session-pinned floor must stay invisible until a refetch restores the
+    // snapshot — a verdict row with no data behind it would be unexplainable.
+    mockUseSafenetCheck.mockReturnValue(
+      buildCheckView({ snapshot: undefined, status: CheckStatus.MALICIOUS, publicStatus: CheckStatus.MALICIOUS }),
+    )
+
+    const { container } = render(<SafenetQueueStatus safeTxHash={HASH} timestampMs={TS} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it.each<[Exclude<PublicCheckStatus, CheckStatus.UNAVAILABLE>, string]>([
+    [CheckStatus.SUBMITTED, 'Submitted'],
+    [CheckStatus.IN_PROGRESS, 'Simulating'],
+    [CheckStatus.BENIGN, 'No issues found'],
+    [CheckStatus.MALICIOUS, 'Risk detected'],
+    [CheckStatus.TIMED_OUT, 'Safenet check failed'],
+  ])('renders %s as "%s"', (status, label) => {
+    const snapshot = buildSnapshot({ safeTxHash: HASH as `0x${string}`, status })
+    mockUseSafenetCheck.mockReturnValue(buildCheckView({ snapshot, status, publicStatus: status }))
+
+    render(<SafenetQueueStatus safeTxHash={HASH} timestampMs={TS} />)
+
+    const cell = screen.getByTestId('safenet-queue-status')
+    expect(cell).toHaveAttribute('data-status', status)
+    expect(cell).toHaveTextContent(label)
+  })
+})

--- a/apps/web/src/features/safenet-checks/feature.tsx
+++ b/apps/web/src/features/safenet-checks/feature.tsx
@@ -1,8 +1,12 @@
 import type { SafenetChecksContract } from './types'
 import SafenetAuditRow from './components/SafenetAuditRow'
+import SafenetChecksSection from './components/SafenetChecksSection'
+import SafenetQueueStatus from './components/SafenetQueueStatus'
 
 const feature: SafenetChecksContract = {
   SafenetAuditRow,
+  SafenetChecksSection,
+  SafenetQueueStatus,
 }
 
 export default feature

--- a/apps/web/src/features/safenet-checks/statusPresentation.ts
+++ b/apps/web/src/features/safenet-checks/statusPresentation.ts
@@ -1,0 +1,43 @@
+import { Severity } from '@safe-global/utils/features/safe-shield/types'
+import { CheckStatus, type PublicCheckStatus } from '@safe-global/utils/features/safenet-checks'
+
+type SafenetStatusPresentation = {
+  /** Safe Shield severity vocabulary — drives SeverityIcon and its colors. */
+  severity: Severity
+  /** Short state name (PRD states table) for compact placements. */
+  label: string
+  /** Full-sentence copy (PRD states table, verbatim) for the flow surface. */
+  copy: string
+}
+
+/** The PRD "States & Warnings" table. UNAVAILABLE renders nothing everywhere. */
+export const STATUS_PRESENTATION: Record<
+  Exclude<PublicCheckStatus, CheckStatus.UNAVAILABLE>,
+  SafenetStatusPresentation
+> = {
+  [CheckStatus.SUBMITTED]: {
+    severity: Severity.INFO,
+    label: 'Submitted',
+    copy: 'Check submitted to Safenet.',
+  },
+  [CheckStatus.IN_PROGRESS]: {
+    severity: Severity.INFO,
+    label: 'Simulating',
+    copy: 'Safenet is simulating this transaction.',
+  },
+  [CheckStatus.BENIGN]: {
+    severity: Severity.OK,
+    label: 'No issues found',
+    copy: 'Safenet found no issues',
+  },
+  [CheckStatus.MALICIOUS]: {
+    severity: Severity.CRITICAL,
+    label: 'Risk detected',
+    copy: 'Safenet flagged this address/transaction as malicious',
+  },
+  [CheckStatus.TIMED_OUT]: {
+    severity: Severity.ERROR,
+    label: 'Safenet check failed',
+    copy: 'Safenet check is unavailable. You can still continue.',
+  },
+}

--- a/apps/web/src/features/safenet-checks/types.ts
+++ b/apps/web/src/features/safenet-checks/types.ts
@@ -1,12 +1,18 @@
 import type { FeatureImplementation } from '@/features/__core__'
 import type SafenetAuditRow from './components/SafenetAuditRow'
+import type SafenetChecksSection from './components/SafenetChecksSection'
+import type SafenetQueueStatus from './components/SafenetQueueStatus'
 
 /**
  * Lazy-loaded surface of the Safenet checks feature. All are PascalCase
  * components (stubs render null until the feature is loaded and enabled):
- * `SafenetAuditRow` is the check's step in the transaction audit log (status
- * + attestation link, PRD history design).
+ * `SafenetAuditRow` is the check's step in the transaction audit log,
+ * `SafenetQueueStatus` is the compact per-row state in the queue,
+ * `SafenetChecksSection` is the check's section in the Safe Shield widget
+ * during confirm/execute flows.
  */
 export interface SafenetChecksContract extends FeatureImplementation {
   SafenetAuditRow: typeof SafenetAuditRow
+  SafenetChecksSection: typeof SafenetChecksSection
+  SafenetQueueStatus: typeof SafenetQueueStatus
 }

--- a/apps/web/src/features/safenet-checks/useSafenetDisplayStatus.ts
+++ b/apps/web/src/features/safenet-checks/useSafenetDisplayStatus.ts
@@ -3,22 +3,21 @@ import { useSafenetCheck } from '@safe-global/utils/features/safenet-checks/hook
 import type { SafenetCheckSnapshot } from '@safe-global/utils/features/safenet-checks'
 
 export type SafenetDisplayStatus = {
-  /** UNAVAILABLE means render nothing — no check observed (or snapshot not yet loaded). */
-  publicStatus: PublicCheckStatus
-  snapshot: SafenetCheckSnapshot | undefined
+  publicStatus: Exclude<PublicCheckStatus, CheckStatus.UNAVAILABLE>
+  snapshot: SafenetCheckSnapshot
 }
 
 /**
- * The check status as every Safenet surface renders it: without a snapshot the
- * status collapses to UNAVAILABLE — a session-pinned verdict alone never
- * renders, the refetch restores its snapshot within one poll.
+ * The check status as every Safenet surface renders it. `null` means render
+ * nothing: no check observed, or no snapshot yet — a session-pinned verdict
+ * alone never renders, the refetch restores its snapshot within one poll.
  */
 export const useSafenetDisplayStatus = (
   safeTxHash: string | undefined,
   timestampMs?: number | null,
-): SafenetDisplayStatus => {
+): SafenetDisplayStatus | null => {
   const { publicStatus, snapshot } = useSafenetCheck(safeTxHash, timestampMs)
 
-  if (!snapshot) return { publicStatus: CheckStatus.UNAVAILABLE, snapshot: undefined }
+  if (!snapshot || publicStatus === CheckStatus.UNAVAILABLE) return null
   return { publicStatus, snapshot }
 }

--- a/apps/web/src/features/safenet-checks/useSafenetDisplayStatus.ts
+++ b/apps/web/src/features/safenet-checks/useSafenetDisplayStatus.ts
@@ -1,0 +1,24 @@
+import { CheckStatus, type PublicCheckStatus } from '@safe-global/utils/features/safenet-checks'
+import { useSafenetCheck } from '@safe-global/utils/features/safenet-checks/hooks'
+import type { SafenetCheckSnapshot } from '@safe-global/utils/features/safenet-checks'
+
+export type SafenetDisplayStatus = {
+  /** UNAVAILABLE means render nothing — no check observed (or snapshot not yet loaded). */
+  publicStatus: PublicCheckStatus
+  snapshot: SafenetCheckSnapshot | undefined
+}
+
+/**
+ * The check status as every Safenet surface renders it: without a snapshot the
+ * status collapses to UNAVAILABLE — a session-pinned verdict alone never
+ * renders, the refetch restores its snapshot within one poll.
+ */
+export const useSafenetDisplayStatus = (
+  safeTxHash: string | undefined,
+  timestampMs?: number | null,
+): SafenetDisplayStatus => {
+  const { publicStatus, snapshot } = useSafenetCheck(safeTxHash, timestampMs)
+
+  if (!snapshot) return { publicStatus: CheckStatus.UNAVAILABLE, snapshot: undefined }
+  return { publicStatus, snapshot }
+}

--- a/packages/utils/src/features/safenet-checks/builders/checkView.ts
+++ b/packages/utils/src/features/safenet-checks/builders/checkView.ts
@@ -1,0 +1,14 @@
+import { CheckStatus } from '../types'
+import type { SafenetCheckView } from '../hooks/useSafenetCheck'
+
+/** Builder for the {@link useSafenetCheck} view — the default is the no-check-observed state. */
+export const buildCheckView = (over: Partial<SafenetCheckView> = {}): SafenetCheckView => ({
+  snapshot: undefined,
+  status: CheckStatus.UNAVAILABLE,
+  publicStatus: CheckStatus.UNAVAILABLE,
+  isLoading: false,
+  isFetching: false,
+  isStale: false,
+  refetch: () => {},
+  ...over,
+})

--- a/packages/utils/src/features/safenet-checks/builders/index.ts
+++ b/packages/utils/src/features/safenet-checks/builders/index.ts
@@ -1,3 +1,4 @@
 export * from './rawLogs'
 export * from './checkEvents'
 export * from './snapshot'
+export * from './checkView'


### PR DESCRIPTION
## What it solves

Resolves: the remaining PRD surfaces for Safenet checks — the queue list and<br>the signing flow had no check visibility; only the audit log (safe-global/safe-wallet-monorepo#8485, merged)<br>showed verdicts.

## How this PR fixes it

* **Queue rows**: `SafenetQueueStatus` (severity icon + PRD state name,<br>full-sentence copy on hover) mounts in `TxSummary` as a new `safenet` grid<br>column, mirroring the Hypernative `assessment` column exactly (zero-width<br>until the row class toggles it). Mount is gated on flag + queue context +<br>derivable safeTxHash + not-bulk-group — hidden cells must not read the<br>chain. The row's `tx.timestamp` aims the reader's block window.
* **Safe Shield widget**: `SafenetChecksSection` renders inside<br>`SafeShieldContent`'s card stack through the lazy feature registry (same<br>pattern as the Hypernative cards), satisfying the PRD display rule — reuse<br>the severity components, no new banner UI. It subscribes only for<br>confirm/execute flows of an already-proposed transaction AND only once the<br>submission time is known: the check cache keys by hash and the last fetch's<br>args aim every later poll, so a fetch without the submission time would<br>cache a mis-aimed read for every surface.
* **Shared presentation**: `STATUS_PRESENTATION` is the single<br>severity/label/copy table for all three surfaces (the audit-log row's<br>labels moved onto it); `useSafenetDisplayStatus` owns the render-nothing<br>decision — it returns `null` (not an `UNAVAILABLE` status), so each<br>surface is one `if (!display) return null` and the type it hands back<br>excludes `UNAVAILABLE` with a non-optional snapshot. Review feedback,<br>folded in `035aacf8b`.

## How to test it

Queue: open a Safe with queued transactions on a flag-enabled chain — rows<br>with observed checks show the state next to confirmations. Flow: confirm or<br>execute a queued transaction — the Safe Shield widget shows the check<br>section. A transaction without a check renders neither. Locally:<br>`yarn workspace @safe-global/web dev`, then enable `SAFENET_CHECKS` in the sidebar's "Feature flags" override panel.

## Affected flows

* Owner scans the transaction queue — checked rows show the verdict inline.
* Owner confirms/executes a queued transaction — the Safe Shield widget<br>includes the Safenet check state.

## Blast radius

* `TxSummary` row grid: new `safenet` column (zero-width unless toggled);<br>conflict/bulk/history/compact variants keep their templates.
* `SafeShieldContent`: one lazy section added to the card stack, behind the<br>same reveal gate as the sibling cards.
* Feature contract grows to `{SafenetAuditRow, SafenetChecksSection, SafenetQueueStatus}`.
* `buildCheckView` added to `@safe-global/utils` test builders.
* Per-row subscriptions: each visible queue row with a hash does one aimed<br>chain read (settled/UNAVAILABLE checks stop polling after it).
* Mobile: none (web-only mounts).

## Risks / not checked

* The flow section was not exercised in a real signing session (flow buttons<br>are wallet-gated); its mount is pinned by an integration test through the<br>real lazy chunk.
* When the flag is on but a Safe has no checks, queue rows keep a uniform<br>empty column (per-row toggling would misalign the grid across rows — same<br>tradeoff as the Hypernative column).
* All five rendered states plus the render-nothing case were observed<br>live on real queued transactions (see the state matrix below); component<br>tests still pin them.
* Not tested on mobile (no mobile surface).
* Reviewed pre-open (fresh-context defensive pass): ship verdict; folded<br>`timestampMs` required on the queue cell (mis-aim hardening) and a test<br>pinning the pinned-verdict-without-snapshot collapse.
* Not verified: container widths \~680–715px with BOTH the Hypernative<br>assessment column (auth-gated) and the Safenet column active may overflow<br>the one-line queue grid before the 680px two-row fallback engages;<br>Safenet alone stays within budget.

## Visual summary

Queue rows rendering **real checks** against the redeployed Sepolia<br>contracts (2026-08-20). Each frame is one queue list, so several states<br>appear side by side; rows without a check keep an empty cell, which is<br>the `UNAVAILABLE` render-nothing case.

<!-- linear:table-colwidths:400,400 -->
| rows shown | Light | Dark |
| -- | -- | -- |
| "No issues found" + "Risk detected" + "Safenet check failed" + empty | ![](https://gist.githubusercontent.com/Fbartoli/42d353ade65f55cd206edf9b79e1572d/raw/queue-states-light.webp) | ![](https://gist.githubusercontent.com/Fbartoli/42d353ade65f55cd206edf9b79e1572d/raw/queue-states-dark.webp) |
| "Simulating" in flight, next to settled rows | ![](https://gist.githubusercontent.com/Fbartoli/42d353ade65f55cd206edf9b79e1572d/raw/queue-simulating-light.webp) | ![](https://gist.githubusercontent.com/Fbartoli/42d353ade65f55cd206edf9b79e1572d/raw/queue-simulating-dark.webp) |
| "Submitted" (check whose oracle is not allowlisted) | ![](https://gist.githubusercontent.com/Fbartoli/42d353ade65f55cd206edf9b79e1572d/raw/queue-submitted-light.webp) | ![](https://gist.githubusercontent.com/Fbartoli/42d353ade65f55cd206edf9b79e1572d/raw/queue-submitted-dark.webp) |

How these were produced: a Safe was deployed for the purpose<br>(`0xb17d308D77F15fa7Fc450e0dE2b1EB47800Ee49C`, 1/1), nine real<br>transactions were proposed to the Sepolia transaction service with<br>payloads shaped to steer the sentinel verdict (plain transfer → approve;<br>`approve(spender, uint256 max)` → unanimous deny; a check submitted just<br>before an epoch rollover → missed attestation), and eight checks were<br>submitted on-chain and watched to settlement. `Submitted` is the one<br>state the oracle path cannot reach on its own — the oracle request is<br>created in the same transaction as the proposal — so it was produced the<br>way a user meets it, with the check's oracle outside the wallet's<br>allowlist.

Because the redeployed contracts need the new event fragments from<br>safe-global/safe-wallet-monorepo#8547, these frames were captured with this branch merged locally onto<br>that one (merge kept local, nothing pushed); the queue-cell code in the<br>frames is exactly this PR's. The grid, gating and copy are unchanged by<br>the merge.

The Safe Shield flow section is wallet-gated and not capturable headless;<br>its mount is pinned by an integration test through the real lazy chunk.


```mermaid
flowchart LR
  A[queue row TxSummary] --> C[SafenetQueueStatus]
  B[Safe Shield widget] --> D[SafenetChecksSection]
  C --> E[useSafenetDisplayStatus]
  D --> E
  E --> F[useSafenetCheck / shared cache]
  F --> G[STATUS_PRESENTATION: severity + label + copy]
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (no mobile surface in this PR)
- [X] I've documented how it affects the analytics (if at all) 📊 — no<br>    analytics events added or changed
- [X] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [X] I've listed affected flows and blast radius, and named what I did not<br>    verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](<https://safe.global/cla>).

