### PR TITLE
fix(UI): multiple UI fixes after Shadcn migration: Notifications, Members, Tx-flow, Owners, WC, color coding, etc.

### DIFF
--- a/apps/web/src/components/common/Header/Topbar/NotificationsPopover.tsx
+++ b/apps/web/src/components/common/Header/Topbar/NotificationsPopover.tsx
@@ -64,7 +64,7 @@ const NotificationsPopover = forwardRef<NotificationsPopoverRef>((_props, ref): 
         className={cn('w-auto gap-0 p-0', notificationCss.popoverContainer)}
       >
         <div className={notificationCss.popoverHeader}>
-          <div>
+          <div className="flex items-center">
             <Typography data-testid="notifications-title" variant="h4" className="font-bold">
               Notifications
             </Typography>
@@ -75,7 +75,11 @@ const NotificationsPopover = forwardRef<NotificationsPopoverRef>((_props, ref): 
             )}
           </div>
           {notifications.length > 0 && (
-            <ShadcnLink render={<button type="button" />} onClick={handleClear} className="no-underline">
+            <ShadcnLink
+              render={<button type="button" />}
+              onClick={handleClear}
+              className={cn(notificationCss.actionLink, 'no-underline')}
+            >
               Clear all
             </ShadcnLink>
           )}

--- a/apps/web/src/components/notification-center/NotificationCenter/styles.module.css
+++ b/apps/web/src/components/notification-center/NotificationCenter/styles.module.css
@@ -62,7 +62,13 @@
   height: 18px;
 }
 
+.actionLink {
+  color: var(--color-text-primary);
+  font-weight: 700;
+}
+
 .settingsLink {
+  composes: actionLink;
   margin-left: auto;
   display: flex;
   align-items: center;

--- a/apps/web/src/components/notification-center/NotificationCenterItem/index.tsx
+++ b/apps/web/src/components/notification-center/NotificationCenterItem/index.tsx
@@ -72,7 +72,7 @@ const NotificationCenterItem = ({
           {getNotificationIcon(variant)}
         </UnreadBadge>
       </div>
-      <div className="flex min-w-0 flex-col">
+      <div className="flex min-w-0 flex-1 flex-col">
         {primaryText}
         {secondaryText}
       </div>

--- a/apps/web/src/components/notification-center/NotificationCenterItem/styles.module.css
+++ b/apps/web/src/components/notification-center/NotificationCenterItem/styles.module.css
@@ -27,3 +27,7 @@
   align-items: center;
   color: var(--color-border-main);
 }
+
+.secondaryText a {
+  color: var(--color-text-primary);
+}

--- a/apps/web/src/components/tx-flow/common/TxLayoutBase/index.tsx
+++ b/apps/web/src/components/tx-flow/common/TxLayoutBase/index.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Typography } from '@/components/ui/typography'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { useIsBelowMd, useMediaQuery } from '@/hooks/useMediaQuery'
+import { useDarkMode } from '@/hooks/useDarkMode'
 import { ProgressBar } from '@/components/common/ProgressBar'
 import { SafeTxContext } from '../../SafeTxProvider'
 import TxNonce from '../TxNonce'
@@ -103,6 +104,7 @@ const TxLayoutBase = ({
 }: TxLayoutBaseProps): ReactElement => {
   const isSmallScreen = useIsBelowMd()
   const isDesktop = useMediaQuery('(min-width:1200px)')
+  const isDarkMode = useDarkMode()
 
   return (
     <div className={classnames('flex flex-wrap', css.container)}>
@@ -150,7 +152,7 @@ const TxLayoutBase = ({
               >
                 {!hideProgress && (
                   <div className={css.progressBar}>
-                    <ProgressBar value={progress} />
+                    <ProgressBar value={progress} color={isDarkMode ? 'primary' : 'secondary'} />
                   </div>
                 )}
 

--- a/apps/web/src/components/tx-flow/flows/ManagerSigners/SignersStructureView.tsx
+++ b/apps/web/src/components/tx-flow/flows/ManagerSigners/SignersStructureView.tsx
@@ -49,7 +49,7 @@ export function SignersStructureView(props: Props): ReactElement {
 
           <Separator className={commonCss.nestedDivider} />
 
-          <div className="flex items-center p-2">
+          <div className="flex items-center justify-end pt-4">
             <Button
               data-testId="submit-next"
               type="submit"

--- a/apps/web/src/components/tx-flow/flows/NewTx/__snapshots__/index.stories.test.tsx.snap
+++ b/apps/web/src/components/tx-flow/flows/NewTx/__snapshots__/index.stories.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`./index.stories Default 1`] = `
                         data-slot="progress-track"
                       >
                         <div
-                          class="bg-primary h-full transition-all"
+                          class="h-full transition-all bg-[var(--color-secondary-main)]"
                           data-progressing=""
                           data-slot="progress-indicator"
                           style="inset-inline-start: 0; height: inherit; width: 10%;"
@@ -215,7 +215,7 @@ exports[`./index.stories SendTokensJourney 1`] = `
                         data-slot="progress-track"
                       >
                         <div
-                          class="bg-primary h-full transition-all"
+                          class="h-full transition-all bg-[var(--color-secondary-main)]"
                           data-progressing=""
                           data-slot="progress-indicator"
                           style="inset-inline-start: 0; height: inherit; width: 10%;"

--- a/apps/web/src/components/tx-flow/flows/NewTx/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/NewTx/index.tsx
@@ -5,6 +5,7 @@ import { TxModalContext } from '../../'
 import TokenTransferFlow from '../TokenTransfer'
 import { ProgressBar } from '@/components/common/ProgressBar'
 import ChainIndicator from '@/components/common/ChainIndicator'
+import { useDarkMode } from '@/hooks/useDarkMode'
 import NewTxIcon from '@/public/images/transactions/new-tx.svg'
 import { HypernativeFeature } from '@/features/hypernative'
 import { useLoadFeature } from '@/features/__core__'
@@ -14,6 +15,7 @@ import css from './styles.module.css'
 const NewTxFlow = () => {
   const { setTxFlow } = useContext(TxModalContext)
   const hn = useLoadFeature(HypernativeFeature)
+  const isDarkMode = useDarkMode()
 
   const onTokensClick = useCallback(() => {
     setTxFlow(<TokenTransferFlow />)
@@ -34,7 +36,7 @@ const NewTxFlow = () => {
             className={`relative grid grid-cols-1 overflow-hidden rounded-xl bg-card shadow-sm md:grid-cols-12 ${css.surface}`}
           >
             <div className={`md:col-span-12 ${css.progressBar}`}>
-              <ProgressBar value={progress} />
+              <ProgressBar value={progress} color={isDarkMode ? 'primary' : 'secondary'} />
             </div>
             <div className={`md:col-span-6 ${css.pane}`}>
               <div className={css.globs}>

--- a/apps/web/src/components/tx/ColorCodedTxAccordion/index.tsx
+++ b/apps/web/src/components/tx/ColorCodedTxAccordion/index.tsx
@@ -24,15 +24,15 @@ const TX_INFO_LEVEL = {
   [ColorLevel.success]: ['Transfer', 'SwapTransfer', 'TwapOrder', 'NativeStakingDeposit'],
 }
 
-/** `main` inks the method chip; `border` outlines the panel and uses the palette's `*-light` tier,
- * which is our border weight everywhere else (shadcn.css maps `--color-*-muted` to it). */
-const TxInfoColors: Record<ColorLevel, { main: string; mainDark?: string; border: string }> = {
-  [ColorLevel.info]: { main: 'info.dark', border: 'info.light' },
-  [ColorLevel.warning]: { main: 'warning.main', border: 'warning.light' },
+/** `main` inks the chip text, `background` tints its fill, `border` outlines the panel. */
+const TxInfoColors: Record<ColorLevel, { main: string; mainDark?: string; border: string; background: string }> = {
+  [ColorLevel.info]: { main: 'info.dark', border: 'info.light', background: 'info.background' },
+  [ColorLevel.warning]: { main: 'warning.main', border: 'warning.light', background: 'warning.background' },
   [ColorLevel.success]: {
     main: 'success.main',
     mainDark: 'primary.main',
     border: 'success.light',
+    background: 'background.light',
   },
 }
 
@@ -93,6 +93,7 @@ const ColorCodedTxAccordion = ({ txInfo, txData, children, defaultExpanded }: De
                   className={css.methodChip}
                   style={{
                     color: isDarkMode ? toCssVar(colors.mainDark ?? colors.main) : toCssVar(colors.main),
+                    backgroundColor: toCssVar(colors.background),
                   }}
                 >
                   {methodLabel}

--- a/apps/web/src/components/tx/ColorCodedTxAccordion/styles.module.css
+++ b/apps/web/src/components/tx/ColorCodedTxAccordion/styles.module.css
@@ -30,9 +30,10 @@
   background-color: transparent;
 }
 
+/* Fill is a per-tx-level tint set inline (see TxInfoColors.background); no border, matching the
+   pre-shadcn chip which was a plain tinted label. */
 .methodChip {
-  border-color: color-mix(in srgb, var(--foreground) 12%, transparent);
-  background-color: color-mix(in srgb, var(--background) 72%, transparent);
+  border-color: transparent;
 }
 
 .divider {

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -70,7 +70,7 @@ function DropdownMenuContent({
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
           className={cn(
-            'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-md p-1 shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-[var(--z-overlay)] max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden',
+            'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-[max(8rem,var(--anchor-width))] rounded-md p-1 shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-[var(--z-overlay)] max-h-(--available-height) w-auto origin-(--transform-origin) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden',
             className,
           )}
           {...props}

--- a/apps/web/src/components/ui/stories/dropdown-menu.stories.tsx
+++ b/apps/web/src/components/ui/stories/dropdown-menu.stories.tsx
@@ -16,7 +16,7 @@ import {
   DropdownMenuTrigger,
 } from '../dropdown-menu'
 import { Button } from '../button'
-import { Settings, User, LogOut, CreditCard } from 'lucide-react'
+import { Settings, User, LogOut, CreditCard, EllipsisVertical, Plus, Trash2 } from 'lucide-react'
 
 /**
  * DropdownMenu Component Stories
@@ -63,6 +63,32 @@ export const Open: Story = {
               Logout
             </DropdownMenuItem>
           </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  ),
+}
+
+/**
+ * A narrow icon-only trigger must not force menu items to wrap. The menu sizes to
+ * its longest item while staying at least as wide as the trigger.
+ */
+export const NarrowTrigger: Story = {
+  render: () => (
+    <div className="flex min-h-64 items-start justify-end pt-2">
+      <DropdownMenu defaultOpen>
+        <DropdownMenuTrigger render={<Button variant="ghost" size="icon-sm" />}>
+          <EllipsisVertical />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem>
+            <Plus />
+            Add another network
+          </DropdownMenuItem>
+          <DropdownMenuItem variant="destructive">
+            <Trash2 />
+            Remove from workspace
+          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/apps/web/src/features/spaces/components/AddMemberModal/AddMemberInput.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/AddMemberInput.tsx
@@ -86,9 +86,9 @@ const AddMemberInput = ({ error, inputProps, onSelectAddress, value }: AddMember
 
   return (
     <div className="flex flex-col gap-1.5">
-      <Label htmlFor="member-invitee-identifier-input" className={cn(error && 'text-destructive')}>
+      <Label htmlFor="member-invitee-identifier-input" className={cn('gap-1', error && 'text-destructive')}>
         {error || 'Address, email or ENS'}
-        {!error && <span className="text-destructive"> *</span>}
+        {!error && <span className="text-destructive">*</span>}
       </Label>
 
       <Autocomplete
@@ -110,6 +110,7 @@ const AddMemberInput = ({ error, inputProps, onSelectAddress, value }: AddMember
       >
         <ComboboxInput
           id="member-invitee-identifier-input"
+          className="min-h-[66px]"
           name={inputProps.name}
           aria-invalid={!!error}
           autoComplete="off"

--- a/apps/web/src/features/spaces/components/AddMemberModal/MemberInfoForm.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/MemberInfoForm.tsx
@@ -2,6 +2,7 @@ import NameInput from '@/components/common/NameInput'
 import { MEMBER_NAME_MAX_LENGTH, NAME_MIN_LENGTH } from '@safe-global/utils/validation/names'
 import { Controller, useFormContext } from 'react-hook-form'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { FieldLabel } from '@/components/ui/field'
 import { RoleMenuItem } from './index'
 import { MemberRole } from '@/features/spaces'
 
@@ -19,7 +20,8 @@ const MemberInfoForm = ({
   const { control } = useFormContext()
 
   return (
-    <div className="flex flex-row items-end gap-4">
+    // Top-aligned so the Name error can't drag the Role select down; spacer label keeps them level.
+    <div className="flex flex-row items-start gap-4">
       <NameInput
         data-testid="member-name-input"
         name="name"
@@ -29,28 +31,37 @@ const MemberInfoForm = ({
         validateCharset
         minLength={NAME_MIN_LENGTH}
         maxLength={nameMaxLength}
+        InputProps={{ className: 'min-h-[66px]' }}
+        // Float the error so it doesn't grow the field's height and shift the form.
+        className="gap-1.5 relative [&_[data-slot=field-error]]:absolute [&_[data-slot=field-error]]:top-full"
       />
 
-      <Controller
-        control={control}
-        name="role"
-        defaultValue={MemberRole.MEMBER}
-        render={({ field: { value, onChange } }) => (
-          <Select value={value} onValueChange={onChange} required disabled={disableRole}>
-            <SelectTrigger aria-label="Role" className="min-w-[150px]">
-              <SelectValue>{(role) => <RoleMenuItem role={role as MemberRole} />}</SelectValue>
-            </SelectTrigger>
-            <SelectContent align="end" alignItemWithTrigger={false} showBackdrop className="w-[340px]">
-              <SelectItem value={MemberRole.ADMIN}>
-                <RoleMenuItem role={MemberRole.ADMIN} hasDescription />
-              </SelectItem>
-              <SelectItem value={MemberRole.MEMBER}>
-                <RoleMenuItem role={MemberRole.MEMBER} hasDescription />
-              </SelectItem>
-            </SelectContent>
-          </Select>
-        )}
-      />
+      <div className="flex flex-col gap-1.5">
+        <FieldLabel aria-hidden className="invisible">
+          Role
+        </FieldLabel>
+
+        <Controller
+          control={control}
+          name="role"
+          defaultValue={MemberRole.MEMBER}
+          render={({ field: { value, onChange } }) => (
+            <Select value={value} onValueChange={onChange} required disabled={disableRole}>
+              <SelectTrigger aria-label="Role" className="min-h-[66px]! min-w-[150px]">
+                <SelectValue>{(role) => <RoleMenuItem role={role as MemberRole} />}</SelectValue>
+              </SelectTrigger>
+              <SelectContent align="end" alignItemWithTrigger={false} showBackdrop className=" min-h-[66px] w-[340px]">
+                <SelectItem value={MemberRole.ADMIN}>
+                  <RoleMenuItem role={MemberRole.ADMIN} hasDescription />
+                </SelectItem>
+                <SelectItem value={MemberRole.MEMBER}>
+                  <RoleMenuItem role={MemberRole.MEMBER} hasDescription />
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          )}
+        />
+      </div>
     </div>
   )
 }

--- a/apps/web/src/features/spaces/components/AddMemberModal/index.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/index.tsx
@@ -183,7 +183,7 @@ const AddMemberModal = ({ onClose }: { onClose: () => void }): ReactElement => {
                 Invite a member by email or wallet address.
               </Typography>
 
-              <div className="flex flex-col gap-6">
+              <div className="flex flex-col gap-8">
                 <MemberInfoForm />
 
                 <AddMemberInput

--- a/apps/web/src/features/walletconnect/components/WcHints/index.tsx
+++ b/apps/web/src/features/walletconnect/components/WcHints/index.tsx
@@ -20,15 +20,18 @@ const HintAccordion = ({
 }): ReactElement => {
   return (
     <Accordion value={expanded ? ['item'] : []} onValueChange={onExpand}>
-      <AccordionItem value="item">
-        <AccordionTrigger>
+      <AccordionItem
+        value="item"
+        className="overflow-hidden rounded-lg border border-transparent transition-colors hover:border-[var(--color-success-light)] data-open:border-[var(--color-success-light)]"
+      >
+        <AccordionTrigger className="px-4 transition-colors hover:bg-[var(--color-success-background)] aria-expanded:bg-[var(--color-success-background)]">
           <Typography className={css.title}>
             <Question className={`size-4 ${css.questionIcon}`} />
             {title}
           </Typography>
         </AccordionTrigger>
 
-        <AccordionContent className="p-0">
+        <AccordionContent className="px-4 pb-4 pt-0">
           <div className={css.list}>
             {items.map((item, i) => (
               <div key={i} className="flex items-center">


### PR DESCRIPTION
## What it solves

Post-shadcn UI regressions across notifications, tx-flow, Add Member, color-coded tx accordion, and WC hints.
Resolves: [WA-3186](https://linear.app/safe-global/issue/WA-3186/workspace-inviting-a-member-modal-breaks)
Resolves: [WA-3183](https://linear.app/safe-global/issue/WA-3183/slider-color-tx-flow)
Resolves: [WA-3206](https://linear.app/safe-global/issue/WA-3206/next-button-in-the-add-owner-flow-is-missplaced)
Resolves: [WA-3195](https://linear.app/safe-global/issue/WA-3195/notifications-popover-unread-count-badge-wraps-below-the-title-action)
Resolves: [WA-3199](https://linear.app/safe-global/issue/WA-3199/walletconnect-popover-help-accordions-lost-their-green-background-and)
Resolves: [WA-3196](https://linear.app/safe-global/issue/WA-3196/accounts-list-3-dots-menu-add-another-network-wraps-onto-three-lines)

## How this PR fixes it

- **Notifications popup**: bold "Clear all" / links use `--color-text-primary`; notification item text takes remaining width.
- **Tx-flow progress bar**: `secondary` color in light mode, `primary` in dark (was always primary).
- **Owners flow**: right-aligned the "Next" button so it no longer sits displaced.
- **Add Member modal**: top-aligned Name/Role so a Name error no longer shifts the Role select; floated the error, added a spacer label, equalized field heights and spacing.
- **Color-coded tx accordion**: restored the tinted, borderless method chip (per-level `background` fill + `main` text color).
- **WC hints accordion**: colored border + background tint on hover/expanded using the success palette.
- Updated affected story snapshots.

## How to test it

See screenshots for a better understanding.
- Open each ticket - almost in each of them there are screenshots of the issue reported;
- Open the app and check the UI fix of the reported element.

Open each surface in light and dark mode: notifications popover, a tx flow (progress bar), Owners flow, Add Member modal (trigger a name error), a color-coded tx label, the WalletConnect hints accordion, the notifications popup, the Safe menu with the "Add another network" item. 

## Affected flows

- Owner adds a member from Spaces > Add member
- User starts / progresses a transaction flow
- User reviews a color-coded transaction
- User opens WalletConnect hints

## Blast radius

- Shared components: `ProgressBar` (now takes `color`), `ColorCodedTxAccordion`, notification-center items. CSS-module and Tailwind-only changes otherwise.
- No API, feature-flag, persistence, or routing changes.

## Risks / not checked

- Not tested on mobile.
- Did not exercise analytics.
- Visual-only; relied on story snapshots for regression coverage.

## Visual summary

<img width="952" height="564" alt="image" src="https://github.com/user-attachments/assets/b5c90884-259b-4c08-baee-8f51418b2f9b" />
<br>

<img width="988" height="1490" alt="image" src="https://github.com/user-attachments/assets/53537890-fae9-464b-83e6-be8dbcd9d47f" />
<br>

<img width="1462" height="942" alt="image" src="https://github.com/user-attachments/assets/72f1a3a7-fcbf-4d85-8d5d-cea0144a3247" />
<br>

<img width="1306" height="982" alt="image" src="https://github.com/user-attachments/assets/968cc4c4-f8cc-47e5-afcf-8bb57eec0275" />
<br>

<img width="1444" height="508" alt="image" src="https://github.com/user-attachments/assets/12ff01cf-7413-4b4c-8cee-b07c00e921ae" />
<br>

<img width="462" height="254" alt="image" src="https://github.com/user-attachments/assets/57360ad0-3025-41c3-b523-a8326b8a62f5" />



## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
