### PR TITLE
[WA-2305] Spending limits UI stuck at transaction creation

### DIFF
--- a/apps/web/src/features/spending-limits/__tests__/spendingLimitDeployments.test.ts
+++ b/apps/web/src/features/spending-limits/__tests__/spendingLimitDeployments.test.ts
@@ -58,6 +58,22 @@ describe('getLatestSpendingLimitAddress', () => {
     expect(result).toBeUndefined()
   })
 
+  // WA-2305 (Pharos) and CUS-132 (Optimism, Arbitrum) were all reported as "spending limit setup
+  // hangs on an infinite spinner". The shared cause was that the AllowanceModule was not registered
+  // for those chains in the pinned @safe-global/safe-modules-deployments, so this resolver returned
+  // undefined and the tx builder bailed out silently. Optimism and Arbitrum were only registered in
+  // v3.0.9. Pin it: if a deployments bump ever drops them again, that regresses both tickets.
+  it.each([
+    ['Pharos', '1672'],
+    ['Optimism', '10'],
+    ['Arbitrum One', '42161'],
+  ])('should resolve a module address on %s (chainId %s)', (_name, chainId) => {
+    expect(getLatestSpendingLimitAddress(chainId)).toBe(
+      getAllowanceModuleDeployment({ version: '0.1.1' })?.networkAddresses[chainId],
+    )
+    expect(getLatestSpendingLimitAddress(chainId)).toBeDefined()
+  })
+
   it('should return v0.1.0 address for Sepolia (chainId 11155111)', () => {
     const v010 = getAllowanceModuleDeployment({ version: '0.1.0' })
     const expectedAddress = v010?.networkAddresses['11155111']

--- a/apps/web/src/features/spending-limits/__tests__/spendingLimitDeployments.test.ts
+++ b/apps/web/src/features/spending-limits/__tests__/spendingLimitDeployments.test.ts
@@ -59,10 +59,12 @@ describe('getLatestSpendingLimitAddress', () => {
   })
 
   // WA-2305 (Pharos) and CUS-132 (Optimism, Arbitrum) were all reported as "spending limit setup
-  // hangs on an infinite spinner". The shared cause was that the AllowanceModule was not registered
-  // for those chains in the pinned @safe-global/safe-modules-deployments, so this resolver returned
-  // undefined and the tx builder bailed out silently. Optimism and Arbitrum were only registered in
-  // v3.0.9. Pin it: if a deployments bump ever drops them again, that regresses both tickets.
+  // hangs on an infinite spinner": the shared cause was that all three chains resolved no
+  // AllowanceModule address in the pinned @safe-global/safe-modules-deployments, so this resolver
+  // returned undefined and the tx builder bailed out silently. Optimism and Arbitrum were only added
+  // to the package in v3.0.9; Pharos was added in v3.0.4, but the app was still pinned at v3.0.2 when
+  // WA-2305 was filed, so it was equally unresolvable in practice. Pin it: if a deployments bump ever
+  // drops any of them again, that regresses both tickets.
   it.each([
     ['Pharos', '1672'],
     ['Optimism', '10'],

--- a/apps/web/src/features/spending-limits/services/spendingLimitExecution.test.ts
+++ b/apps/web/src/features/spending-limits/services/spendingLimitExecution.test.ts
@@ -1,0 +1,70 @@
+import type Safe from '@safe-global/protocol-kit'
+import type { SafeTransaction } from '@safe-global/types-kit'
+import * as safeCoreSDK from '@/hooks/coreSDK/safeCoreSDK'
+import * as txSender from '@/services/tx/tx-sender/create'
+import { chainBuilder } from '@/tests/builders/chains'
+import { ZERO_ADDRESS } from '@safe-global/utils/utils/constants'
+import type { NewSpendingLimitData } from '../types'
+import { createNewSpendingLimitTx, NO_ALLOWANCE_MODULE_ERROR } from './spendingLimitExecution'
+
+const mockData: NewSpendingLimitData = {
+  beneficiary: ZERO_ADDRESS,
+  tokenAddress: ZERO_ADDRESS,
+  amount: '1',
+  resetTime: '0',
+}
+
+const mockChain = chainBuilder().build()
+
+// Sepolia — the AllowanceModule is registered for it in @safe-global/safe-modules-deployments
+const REGISTERED_CHAIN_ID = '11155111'
+
+// Not a real chain: deployment bumps keep registering new networks, so any real id picked as
+// "unregistered" eventually becomes registered (Optimism and Arbitrum did, in v3.0.9).
+const UNREGISTERED_CHAIN_ID = '999999999999'
+
+/**
+ * WA-2305 / CUS-132 — "spending limits UI stuck at transaction creation".
+ *
+ * The review step does `createNewSpendingLimitTx(...).then(setSafeTx).catch(setSafeTxError)`, and
+ * `ReviewTransaction` renders its skeleton while `!safeTx && !safeTxError`. A builder that resolves
+ * `undefined` therefore parks the flow on an indefinite spinner: no error, no chain interaction, no
+ * way out. Every unmet precondition must reject instead.
+ */
+describe('createNewSpendingLimitTx preconditions', () => {
+  let mockSDK: Safe
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    mockSDK = {
+      createEnableModuleTx: jest.fn(() => ({ data: { data: '0x', to: ZERO_ADDRESS } })),
+    } as unknown as Safe
+
+    jest.spyOn(safeCoreSDK, 'getSafeSDK').mockReturnValue(mockSDK)
+    jest
+      .spyOn(txSender, 'createMultiSendCallOnlyTx')
+      .mockResolvedValue({ data: { to: ZERO_ADDRESS } } as unknown as SafeTransaction)
+  })
+
+  it('rejects instead of resolving undefined when the Safe SDK is unavailable', async () => {
+    jest.spyOn(safeCoreSDK, 'getSafeSDK').mockReturnValue(undefined)
+
+    await expect(createNewSpendingLimitTx(mockData, [], REGISTERED_CHAIN_ID, mockChain, [], true, 18)).rejects.toThrow(
+      /Safe SDK could not be initialized/,
+    )
+  })
+
+  it('rejects instead of resolving undefined when no module address resolves for the chain', async () => {
+    await expect(
+      createNewSpendingLimitTx(mockData, [], UNREGISTERED_CHAIN_ID, mockChain, [], true, 18),
+    ).rejects.toThrow(NO_ALLOWANCE_MODULE_ERROR)
+  })
+
+  it('still resolves a transaction when the module resolves for the chain', async () => {
+    const result = await createNewSpendingLimitTx(mockData, [], REGISTERED_CHAIN_ID, mockChain, [], true, 18)
+
+    expect(result).toBeDefined()
+    expect(txSender.createMultiSendCallOnlyTx).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/features/spending-limits/services/spendingLimitExecution.ts
+++ b/apps/web/src/features/spending-limits/services/spendingLimitExecution.ts
@@ -1,5 +1,4 @@
 import type { SpendingLimitState, NewSpendingLimitData, SpendingLimitTxParams } from '../types'
-import { getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import {
   getLatestSpendingLimitAddress,
   getDeployedSpendingLimitModuleAddress,
@@ -20,9 +19,20 @@ import { currentMinutes } from '@safe-global/utils/utils/date'
 import { createMultiSendCallOnlyTx } from '@/services/tx/tx-sender/create'
 import { txDispatch, TxEvent } from '@/services/tx/txEvents'
 import { didRevert } from '@/utils/ethers-utils'
-import { getUncheckedSigner } from '@/services/tx/tx-sender/sdk'
+import { getAndValidateSafeSDK, getUncheckedSigner } from '@/services/tx/tx-sender/sdk'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
 
+export const NO_ALLOWANCE_MODULE_ERROR =
+  'The spending limit module is not available on this network, so the transaction could not be created.'
+
+/**
+ * Builds the multiSend that enables the AllowanceModule (when needed) and sets the allowance.
+ *
+ * Never resolves `undefined`: the review step feeds the result straight into `setSafeTx`, so a
+ * silent `undefined` leaves `ReviewTransaction` on its skeleton forever with no error and no chain
+ * interaction (WA-2305 / CUS-132). Every unmet precondition therefore throws, matching the other
+ * tx builders in `services/tx/tx-sender/create` and letting `setSafeTxError` surface it.
+ */
 export const createNewSpendingLimitTx = async (
   data: NewSpendingLimitData,
   spendingLimits: SpendingLimitState[],
@@ -33,15 +43,16 @@ export const createNewSpendingLimitTx = async (
   tokenDecimals?: number | null,
   existingSpendingLimit?: SpendingLimitState,
 ) => {
-  const sdk = getSafeSDK()
-  if (!sdk) return
+  const sdk = getAndValidateSafeSDK()
 
   let spendingLimitAddress = deployed && getDeployedSpendingLimitModuleAddress(chainId, safeModules)
   const isModuleEnabled = !!spendingLimitAddress
   if (!isModuleEnabled) {
     spendingLimitAddress = getLatestSpendingLimitAddress(chainId)
   }
-  if (!spendingLimitAddress) return
+  if (!spendingLimitAddress) {
+    throw new Error(NO_ALLOWANCE_MODULE_ERROR)
+  }
 
   const txs: MetaTransactionData[] = []
 

--- a/apps/web/src/services/tx/__tests__/spendingLimitParams.test.ts
+++ b/apps/web/src/services/tx/__tests__/spendingLimitParams.test.ts
@@ -45,19 +45,8 @@ describe('createNewSpendingLimitTx', () => {
     jest.spyOn(safeCoreSDK, 'getSafeSDK').mockReturnValue(mockSDK)
   })
 
-  it('returns undefined if there is no sdk instance', async () => {
-    jest.spyOn(safeCoreSDK, 'getSafeSDK').mockReturnValue(undefined)
-    const result = await createNewSpendingLimitTx(mockData, [], '4', mockChain, mockModules, true, 18)
-
-    expect(result).toBeUndefined()
-  })
-
-  it('returns undefined if there is no contract address', async () => {
-    jest.spyOn(safeCoreSDK, 'getSafeSDK').mockReturnValue(mockSDK)
-    const result = await createNewSpendingLimitTx(mockData, [], '4', mockChain, mockModules, true, 18)
-
-    expect(result).toBeUndefined()
-  })
+  // The unmet-precondition cases (no SDK, no module address for the chain) live in the colocated
+  // spendingLimitExecution.test.ts — they assert a rejection now, not a resolved `undefined`.
 
   it('creates a tx to enable the spending limit module if its not registered yet', async () => {
     await createNewSpendingLimitTx(mockData, [], '4', mockChain, [], true, 18)


### PR DESCRIPTION
## What it solves

Resolves: https://linear.app/safe-global/issue/WA-2305/spending-limits-ui-stuck-at-transaction-creation
Related (same root cause, Optimism + Arbitrum): https://linear.app/safe-global/issue/CUS-132/spending-limit-change-causes-loading-screen-hang

**Investigation first — the ticket's stated theory is wrong.** WA-2305 suspected the CREATE2 fallback in `spendingLimitDeployments.ts` ("Fall back to first known address for unregistered chains"). It is not that:

* Pharos is chain **1672** (EIP-3770 `pharos`), and 1672 **is** registered for AllowanceModule v0.1.1 in the pinned `@safe-global/safe-modules-deployments@3.0.9` — no fallback is ever taken there.
* The fallback lives in `getModuleAddress`, used only by `getDeployment` / `getDeployedSpendingLimitModuleAddress` (the *already-enabled-module* path). New enablements go through `getLatestSpendingLimitAddress`, which deliberately does **not** fall back.
* Where the fallback *is* taken it does not misroute: within v0.1.1 all 52 registered chains share one CREATE2 address (`0xAA46…`); v0.1.0 resolves to the canonical `0xCFbF…`.

**The actual root cause, which explains Pharos, Optimism and Arbitrum with one mechanism:** the config-service `SPENDING_LIMIT` flag was enabled on chains for which no AllowanceModule address was registered in the pinned deployments package. `getLatestSpendingLimitAddress()` returned `undefined`, `createNewSpendingLimitTx` hit `if (!spendingLimitAddress) return`, and the review step ran `setSafeTx(undefined)` without ever calling `setSafeTxError` — so `ReviewTransaction` stayed on `ReviewTransactionSkeleton` forever (`!safeTx && !safeTxError`). Infinite spinner, no error, no blockchain action. That is exactly the CUS-132 screenshot.

Optimism really was such a chain: `10` and `42161` were **absent from every AllowanceModule version** until `safe-modules-deployments@3.0.9` (published 2026-08-03). The in-repo proof is PR #8433, which bumped 3.0.8 → 3.0.9 and in the same diff had to change the test constant `UNSUPPORTED_CHAIN_ID` from `'42161' // Arbitrum One` to a fake id, because the bump made Arbitrum supported.

**The reported trigger is therefore already fixed on `dev`**, twice over: #8401 added the `useIsSpendingLimitSupported` gate (unregistered chain → explanatory message instead of a hang), and #8433's bump registers Optimism, Arbitrum and Pharos so those chains are genuinely supported again. This PR does not re-fix that.

What it fixes is the **dead-end that made the failure invisible**, which #8401 explicitly left in place ("Rather than surface an error on the Review step…"). It is still reachable: the `!sdk` branch is not covered by the gate at all, and `initSafeSDK` can resolve `undefined` *silently* (provider/chain mismatch, unrecognised master copy) with no notification. Any such case reproduces the same infinite spinner today.

## How this PR fixes it

`createNewSpendingLimitTx` no longer resolves `undefined`. Both preconditions throw, so `.catch(setSafeTxError)` surfaces them and the review step renders an error instead of a skeleton:

* `getSafeSDK()` + `if (!sdk) return` → `getAndValidateSafeSDK()`, the same helper every other builder in `services/tx/tx-sender/create` uses. This cannot introduce a new failure: the last line of this same function calls `createMultiSendCallOnlyTx`, which already threw via `getAndValidateSafeSDK` for exactly that condition. The early return was internally inconsistent.
* `if (!spendingLimitAddress) return` → `throw new Error(NO_ALLOWANCE_MODULE_ERROR)`. The UI still gates this earlier via `useIsSpendingLimitSupported`, so this is a backstop for the two ever diverging again.

Return type narrows from `Promise<SafeTransaction | undefined>` to `Promise<SafeTransaction>`.

## How to test it

1. On a supported chain (Sepolia/mainnet), create a spending limit — unchanged, the multiSend is built and the review renders as before.
2. On a chain without a registered AllowanceModule, Settings → Spending limits still shows the explanatory message from #8401 (the throw is never reached).
3. To exercise the new path: force `getSafeSDK()` to return `undefined` (or point at a Safe whose SDK init bails). Before: infinite spinner. After: the review shows an error and the flow is escapable.
4. `yarn workspace @safe-global/web test --testPathPattern="spendingLimit|spending-limits"` — 54 tests, 7 suites.

## Affected flows

- Settings → Spending limits → "New spending limit" → Review (the only caller of `createNewSpendingLimitTx`)
- Replacing/modifying an existing spending limit — same flow with `existingSpendingLimit` set
- First spending limit on a Safe without the module enabled (enable-module tx prepended), both for deployed and counterfactual Safes

## Blast radius

- **`createNewSpendingLimitTx`** (`features/spending-limits/services/spendingLimitExecution.ts`) — single runtime consumer, `ReviewSpendingLimit`, which already wires `.catch(setSafeTxError)`. Verified by grep across `apps/` and `packages/`: no other caller.
- **Type surface only**: `features/spending-limits/feature.ts` and `contract.ts` re-export it through the lazy feature contract; the narrowed return type flows through automatically.
- **Downstream, read-only**: `SafeTxProvider.safeTxError` → `ReviewTransactionV2`'s skeleton/error branch → `TxCheckError`. This error path already exists for every other flow whose builder throws; nothing new was added to it.
- **Not touched**: `spendingLimitDeployments.ts` resolution logic, `useIsSpendingLimitSupported`, `components/tx-flow/**`, nested-safe/multichain code.
- **Feature flags / chain configs**: none changed. The underlying mismatch — the config service and the deployments package being independent sources of truth — is unchanged and still belongs upstream.
- **Mobile / shared packages**: none. Spending limits are web-only; no `packages/**` file is touched and no mobile consumer exists.
- **Persistence / cache / migrations / routes**: none.

## Risks / not checked

- **No manual UI verification and no live-chain execution were possible in this environment.** The hang was not reproduced by hand; the diagnosis rests on reading the render conditions, on the CUS-132 console screenshot, and on the deployments-package archaeology above.
- The `if (!chain || !data) return` early return in `ReviewSpendingLimit`'s effect can still leave the skeleton up. Left deliberately: `useCurrentChain()` is legitimately `undefined` while the chains query loads and self-heals, so raising an error there would be a false positive.
- `TxCheckError`'s headline copy ("Could not check this transaction. … is not responding.") is an imperfect fit for a build-precondition failure; the real message shows in the error details. Improving that copy is out of scope here.
- Not verified with the `SPENDING_LIMIT` flag off, on mobile, or against a counterfactual Safe end-to-end.
- **Found but deliberately not fixed (out of scope, filed as a follow-up suggestion):** `getSpendingLimitContract` reads `networkAddresses[chainId]` *without* the fallback that `getDeployedSpendingLimitModuleAddress` applies. For a Safe whose enabled module only resolves via that fallback — e.g. an Optimism or Arbitrum Safe holding the legacy v0.1.0 module at `0xCFbF…`, since v0.1.0 still lists only 15 chains and never 10/42161 — it yields `undefined`, `AllowanceModule__factory.connect(undefined, …)` throws, and `loadSpendingLimits` swallows it, so existing limits silently never load. Real and live today, but a different symptom from this ticket.

## Visual summary

```mermaid
flowchart TB
  subgraph Before["Before — silent dead-end"]
    A1[ReviewSpendingLimit effect] --> B1[createNewSpendingLimitTx]
    B1 -->|no SDK| C1["return undefined"]
    B1 -->|no module address| C1
    C1 --> D1["setSafeTx(undefined)"]
    D1 --> E1{"!safeTx && !safeTxError"}
    E1 -->|true, forever| F1[["ReviewTransactionSkeleton<br/>infinite spinner, no error,<br/>no chain interaction"]]
  end

  subgraph After["After — every failure is surfaced"]
    A2[ReviewSpendingLimit effect] --> B2[createNewSpendingLimitTx]
    B2 -->|no SDK| C2["throw via getAndValidateSafeSDK"]
    B2 -->|no module address| C3["throw NO_ALLOWANCE_MODULE_ERROR"]
    C2 --> D2["catch -> setSafeTxError"]
    C3 --> D2
    D2 --> E2{"!safeTx && !safeTxError"}
    E2 -->|false| F2[["ReviewTransactionContent<br/>+ TxCheckError — user sees<br/>why and can go back"]]
    B2 -->|preconditions met| G2["createMultiSendCallOnlyTx -> setSafeTx"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — n/a, spending limits are web-only and no shared package is touched
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics change; `SETTINGS_EVENTS.SPENDING_LIMIT.RESET_PERIOD` still fires on submit only
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

### Tests

New colocated `features/spending-limits/services/spendingLimitExecution.test.ts`:
- rejects instead of resolving `undefined` when the Safe SDK is unavailable
- rejects instead of resolving `undefined` when no module address resolves for the chain
- positive control: still resolves a transaction when the module does resolve (so the change is not indiscriminate)

`__tests__/spendingLimitDeployments.test.ts` gains a regression pin that Pharos (1672), Optimism (10) and Arbitrum One (42161) all resolve a module address — if a future deployments bump drops them, both tickets regress and this fails.

The two obsolete `expect(result).toBeUndefined()` cases in the legacy `services/tx/__tests__/spendingLimitParams.test.ts` are replaced by the colocated ones (one of them was vacuous anyway: it passed only because `createMultiSendCallOnlyTx` was mocked to return `undefined`, on a chain where the address *did* resolve). All seven happy-path assertions there are untouched and still pass.

**Revert check:** with `spendingLimitExecution.ts` reverted, exactly the two precondition tests fail and the positive control plus all pre-existing tests pass.

### Gates run

`yarn install`, `yarn prettier:fix`, `yarn workspace @safe-global/web type-check` (0), `lint` (0 errors, 19 pre-existing warnings), `prettier` check (clean), `yarn workspace @safe-global/web build` (0), spending-limits suites 54/54.

`yarn verify:changed:web` reported one failing suite on each of two runs — a *different* suite each time (`tests/pages/apps.test.tsx`, then `features/multichain/…/SafeCreationNetworkInput`), both 5000 ms timeouts under parallel load, both in the dependency graph of the `Popup`/`popover` files from base commit c47ad80 rather than of anything in this diff. Both pass in isolation (25/25 and 8/8) with this branch checked out.

> Note: the `safe-engineering-plugin` review pipeline (and the `superpowers` / `safe-product:linear-context` skills) are not installed in this environment. A manual structured review against `AGENTS.md` / `apps/web/AGENTS.md` was performed instead, with the repo `verify` scripts as the gate.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TmBQnjzk5PSSuwScGCkvEH)_