### PR TITLE
fix(web): count only known feature flags in the override badge

### DIFF
--- a/apps/web/src/features/feature-flag-overrides/hooks/useChainOverrides.test.ts
+++ b/apps/web/src/features/feature-flag-overrides/hooks/useChainOverrides.test.ts
@@ -82,11 +82,23 @@ describe('applyFeatureOverrides', () => {
     expect(result.features).toContain(forcedOn)
   })
 
-  it('handles an override key that is not a known feature (string cast)', () => {
+  // Overrides are persisted, so one set on a branch that declares the flag outlives the switch to a
+  // branch that does not. It must not reach `chain.features` here any more than it is counted or
+  // listed elsewhere.
+  it('ignores an override of a flag this build does not declare', () => {
     const chain = makeChain([])
     const overrides = { CUSTOM_UNKNOWN_FLAG: true } as unknown as FeatureFlagOverridesState
-    const result = applyFeatureOverrides(chain, overrides)
-    expect(result.features).toContain('CUSTOM_UNKNOWN_FLAG')
+
+    expect(applyFeatureOverrides(chain, overrides)).toBe(chain)
+  })
+
+  it('applies the known overrides alongside one from another branch', () => {
+    const [overridden] = pickFeatures()
+    const overrides = { [overridden]: true, CUSTOM_UNKNOWN_FLAG: true } as unknown as FeatureFlagOverridesState
+    const result = applyFeatureOverrides(makeChain([]), overrides)
+
+    expect(result.features).toContain(overridden)
+    expect(result.features).not.toContain('CUSTOM_UNKNOWN_FLAG')
   })
 
   // The production policy lives in the hooks, not here. Pinning the purity keeps the guard from

--- a/apps/web/src/features/feature-flag-overrides/hooks/useChainOverrides.ts
+++ b/apps/web/src/features/feature-flag-overrides/hooks/useChainOverrides.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { useAppSelector } from '@/store'
 import { selectFeatureFlagOverrides, type FeatureFlagOverridesState } from '@/features/feature-flag-overrides/store'
+import { isKnownFeature } from '@/features/feature-flag-overrides/knownFeatures'
 
 /**
  * The single production check governing override behaviour — overrides are dev-only.
@@ -17,9 +18,12 @@ const IS_PRODUCTION_BUILD = process.env.NEXT_PUBLIC_IS_PRODUCTION === 'true'
 /**
  * Applies local overrides to a chain's `features` array. Pure: whether overrides apply at all is
  * decided by the hooks below, not here.
+ *
+ * Overrides of flags this build does not declare are skipped, so a leftover from another branch
+ * cannot reach `chain.features` — every reader of the overrides honours the same rule.
  */
 export const applyFeatureOverrides = (chain: Chain, overrides: FeatureFlagOverridesState): Chain => {
-  const entries = Object.entries(overrides)
+  const entries = Object.entries(overrides).filter(([feature]) => isKnownFeature(feature))
   if (entries.length === 0) return chain
 
   const features = new Set(chain.features)

--- a/apps/web/src/features/feature-flag-overrides/hooks/useFeatureFlagEditorData.test.tsx
+++ b/apps/web/src/features/feature-flag-overrides/hooks/useFeatureFlagEditorData.test.tsx
@@ -3,7 +3,9 @@ import { FEATURES } from '@safe-global/utils/utils/chains'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import * as gateway from '@safe-global/store/gateway'
 import * as store from '@/store'
+import type { RootState } from '@/store'
 import * as useChainIdModule from '@/hooks/useChainId'
+import { selectOverrideCount } from '@/features/feature-flag-overrides/store'
 import { useFeatureFlagEditorData } from './useFeatureFlagEditorData'
 
 const chain = (chainId: string, features: FEATURES[]): Chain => ({ chainId, features }) as unknown as Chain
@@ -76,5 +78,30 @@ describe('useFeatureFlagEditorData', () => {
     expect(row?.override).toBe(true)
     expect(row?.effective).toBe(true)
     expect(row?.matchesCurrentChain).toBe(false)
+  })
+
+  // The badge and this list are what a user compares, so pin them to the same literal against the
+  // real hook and the real selector — one persisted override this build declares, one it does not.
+  describe('with an override left behind by another branch', () => {
+    const overrides = { [FEATURES.EARN]: true, FLAG_FROM_ANOTHER_BRANCH: true }
+
+    beforeEach(() => {
+      mockChains([chain('1', [])])
+      jest.spyOn(store, 'useAppSelector').mockReturnValue(overrides)
+    })
+
+    it('lists it in neither section', () => {
+      const { result } = renderHook(() => useFeatureFlagEditorData())
+      const all = [...result.current.overridden, ...result.current.rest]
+
+      expect(all.some((row) => String(row.feature) === 'FLAG_FROM_ANOTHER_BRANCH')).toBe(false)
+    })
+
+    it('lists one overridden row, which is what the badge counts', () => {
+      const { result } = renderHook(() => useFeatureFlagEditorData())
+
+      expect(result.current.overridden.map((row) => row.feature)).toEqual([FEATURES.EARN])
+      expect(selectOverrideCount({ featureFlagOverrides: overrides } as unknown as RootState)).toBe(1)
+    })
   })
 })

--- a/apps/web/src/features/feature-flag-overrides/hooks/useFeatureFlagEditorData.ts
+++ b/apps/web/src/features/feature-flag-overrides/hooks/useFeatureFlagEditorData.ts
@@ -2,10 +2,11 @@ import { useMemo } from 'react'
 import partition from 'lodash/partition'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { useGetChainsConfigV2Query } from '@safe-global/store/gateway'
-import { FEATURES, hasFeature } from '@safe-global/utils/utils/chains'
+import { type FEATURES, hasFeature } from '@safe-global/utils/utils/chains'
 import { CONFIG_SERVICE_KEY } from '@/config/constants'
 import { useAppSelector } from '@/store'
 import { selectFeatureFlagOverrides } from '@/features/feature-flag-overrides/store'
+import { SORTED_FEATURES } from '@/features/feature-flag-overrides/knownFeatures'
 import useChainId from '@/hooks/useChainId'
 
 export type FeatureFlagRowData = {
@@ -28,9 +29,6 @@ const getChainScope = (chains: Chain[], feature: FEATURES): FeatureFlagRowData['
   if (withFeature.length === chains.length) return 'global'
   return withFeature
 }
-
-// The flag list is a fixed enum, so sort it once at module scope rather than on every render.
-const SORTED_FEATURES: FEATURES[] = [...Object.values(FEATURES)].sort((a, b) => a.localeCompare(b))
 
 /**
  * Derives the editor's per-flag display data.

--- a/apps/web/src/features/feature-flag-overrides/knownFeatures.test.ts
+++ b/apps/web/src/features/feature-flag-overrides/knownFeatures.test.ts
@@ -1,0 +1,29 @@
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import { isKnownFeature, SORTED_FEATURES } from './knownFeatures'
+
+describe('knownFeatures', () => {
+  it('knows every flag this build declares', () => {
+    const unknown = Object.values(FEATURES).filter((feature) => !isKnownFeature(feature))
+
+    expect(unknown).toEqual([])
+  })
+
+  it('does not know a flag from another branch', () => {
+    expect(isKnownFeature('FLAG_FROM_ANOTHER_BRANCH')).toBe(false)
+  })
+
+  it('does not know an empty key', () => {
+    expect(isKnownFeature('')).toBe(false)
+  })
+
+  it('does not mistake an inherited object property for a flag', () => {
+    expect(isKnownFeature('toString')).toBe(false)
+    expect(isKnownFeature('constructor')).toBe(false)
+  })
+
+  it('lists every flag exactly once, alphabetically', () => {
+    expect(SORTED_FEATURES).toHaveLength(Object.values(FEATURES).length)
+    expect(new Set(SORTED_FEATURES).size).toBe(SORTED_FEATURES.length)
+    expect(SORTED_FEATURES).toEqual([...SORTED_FEATURES].sort((a, b) => a.localeCompare(b)))
+  })
+})

--- a/apps/web/src/features/feature-flag-overrides/knownFeatures.ts
+++ b/apps/web/src/features/feature-flag-overrides/knownFeatures.ts
@@ -1,0 +1,16 @@
+import { FEATURES } from '@safe-global/utils/utils/chains'
+
+/**
+ * The flags this build declares — the single source of truth for "known" across the feature.
+ *
+ * Overrides are persisted, so they outlive the enum: a flag overridden on a branch that declares it
+ * stays in localStorage after switching to a branch that never did. Every reader of the overrides
+ * filters through here, so such a leftover is neither counted, applied to a chain, listed in the
+ * editor, nor cleared by the branch that cannot see it.
+ */
+const KNOWN_FEATURES = new Set<string>(Object.values(FEATURES))
+
+export const isKnownFeature = (feature: string): feature is FEATURES => KNOWN_FEATURES.has(feature)
+
+// The flag list is a fixed enum, so sort it once at module scope rather than on every render.
+export const SORTED_FEATURES: FEATURES[] = [...Object.values(FEATURES)].sort((a, b) => a.localeCompare(b))

--- a/apps/web/src/features/feature-flag-overrides/store/featureFlagOverridesSlice.test.ts
+++ b/apps/web/src/features/feature-flag-overrides/store/featureFlagOverridesSlice.test.ts
@@ -6,6 +6,7 @@ import {
   clearAllOverrides,
   selectFeatureFlagOverrides,
   selectOverrideCount,
+  type FeatureFlagOverridesState,
 } from './featureFlagOverridesSlice'
 import type { RootState } from '@/store'
 
@@ -48,5 +49,38 @@ describe('featureFlagOverridesSlice', () => {
       [featureFlagOverridesSlice.name]: { [FEATURES.EARN]: true, [FEATURES.BRIDGE]: false },
     } as unknown as RootState
     expect(selectOverrideCount(state)).toBe(2)
+  })
+
+  it('counts nothing when there are no overrides', () => {
+    expect(selectOverrideCount({} as RootState)).toBe(0)
+  })
+
+  // Overrides are persisted, so a flag overridden on a branch that declares it survives the switch
+  // to a branch that does not. The editor never lists such a flag, so the badge must not count it.
+  it('ignores persisted overrides of flags this build does not declare', () => {
+    const state = {
+      [featureFlagOverridesSlice.name]: { FLAG_FROM_ANOTHER_BRANCH: true, ANOTHER_UNKNOWN_FLAG: false },
+    } as unknown as RootState
+    expect(selectOverrideCount(state)).toBe(0)
+  })
+
+  it('counts only the known flags in a mixed state', () => {
+    const state = {
+      [featureFlagOverridesSlice.name]: {
+        [FEATURES.EARN]: true,
+        FLAG_FROM_ANOTHER_BRANCH: true,
+        [FEATURES.BRIDGE]: false,
+      },
+    } as unknown as RootState
+    expect(selectOverrideCount(state)).toBe(2)
+  })
+
+  it('matches the number of flags the editor lists as overridden', () => {
+    const overrides = { [FEATURES.EARN]: true, FLAG_FROM_ANOTHER_BRANCH: true } as FeatureFlagOverridesState
+    const state = { [featureFlagOverridesSlice.name]: overrides } as unknown as RootState
+
+    const editorRows = Object.values(FEATURES).filter((feature) => overrides[feature] !== undefined)
+
+    expect(selectOverrideCount(state)).toBe(editorRows.length)
   })
 })

--- a/apps/web/src/features/feature-flag-overrides/store/featureFlagOverridesSlice.test.ts
+++ b/apps/web/src/features/feature-flag-overrides/store/featureFlagOverridesSlice.test.ts
@@ -40,6 +40,20 @@ describe('featureFlagOverridesSlice', () => {
     expect(state).toEqual({})
   })
 
+  // The editor lists — and the reset button reports on — known flags only. Wiping a flag this build
+  // cannot see would destroy an override only the branch that declares it can manage.
+  it('leaves overrides of flags this build does not declare untouched when clearing all', () => {
+    const start = { [FEATURES.EARN]: true, FLAG_FROM_ANOTHER_BRANCH: false } as FeatureFlagOverridesState
+
+    expect(reducer(start, clearAllOverrides())).toEqual({ FLAG_FROM_ANOTHER_BRANCH: false })
+  })
+
+  it('clears nothing when every override belongs to another branch', () => {
+    const start = { FLAG_FROM_ANOTHER_BRANCH: true } as FeatureFlagOverridesState
+
+    expect(reducer(start, clearAllOverrides())).toEqual(start)
+  })
+
   it('selector falls back to empty object when the slice is absent', () => {
     expect(selectFeatureFlagOverrides({} as RootState)).toEqual({})
   })
@@ -73,14 +87,5 @@ describe('featureFlagOverridesSlice', () => {
       },
     } as unknown as RootState
     expect(selectOverrideCount(state)).toBe(2)
-  })
-
-  it('matches the number of flags the editor lists as overridden', () => {
-    const overrides = { [FEATURES.EARN]: true, FLAG_FROM_ANOTHER_BRANCH: true } as FeatureFlagOverridesState
-    const state = { [featureFlagOverridesSlice.name]: overrides } as unknown as RootState
-
-    const editorRows = Object.values(FEATURES).filter((feature) => overrides[feature] !== undefined)
-
-    expect(selectOverrideCount(state)).toBe(editorRows.length)
   })
 })

--- a/apps/web/src/features/feature-flag-overrides/store/featureFlagOverridesSlice.ts
+++ b/apps/web/src/features/feature-flag-overrides/store/featureFlagOverridesSlice.ts
@@ -1,6 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSelector, createSlice } from '@reduxjs/toolkit'
-import { FEATURES } from '@safe-global/utils/utils/chains'
+import type { FEATURES } from '@safe-global/utils/utils/chains'
+import { isKnownFeature } from '@/features/feature-flag-overrides/knownFeatures'
 import type { RootState } from '@/store'
 
 export type FeatureFlagOverridesState = Partial<Record<FEATURES, boolean>>
@@ -17,7 +18,13 @@ export const featureFlagOverridesSlice = createSlice({
     clearOverride: (state, { payload }: PayloadAction<FEATURES>) => {
       delete state[payload]
     },
-    clearAllOverrides: () => ({}),
+    /**
+     * Resets the flags this build declares, and only those. Overrides of flags it does not know
+     * belong to the branch that declared them — that branch's editor is the only place they can be
+     * seen, so this one must not silently wipe them.
+     */
+    clearAllOverrides: (state): FeatureFlagOverridesState =>
+      Object.fromEntries(Object.entries(state).filter(([feature]) => !isKnownFeature(feature))),
   },
 })
 
@@ -26,17 +33,9 @@ export const { setOverride, clearOverride, clearAllOverrides } = featureFlagOver
 export const selectFeatureFlagOverrides = (state: RootState): FeatureFlagOverridesState =>
   state[featureFlagOverridesSlice.name] || initialState
 
-const KNOWN_FEATURES = new Set<string>(Object.values(FEATURES))
-
-export const isKnownFeature = (feature: string): feature is FEATURES => KNOWN_FEATURES.has(feature)
-
 /**
- * Counts only overrides of flags this build declares.
- *
- * Overrides are persisted, so they outlive the enum: a flag overridden on a branch that adds it
- * stays in localStorage after switching to a branch that never declared it. The editor lists
- * `FEATURES` and nothing else, so counting those leftovers badges overrides the user can neither
- * see nor clear individually.
+ * Counts only overrides of flags this build declares — the editor lists `FEATURES` and nothing
+ * else, so counting a leftover would badge an override the user can neither see nor clear.
  */
 export const selectOverrideCount = createSelector(
   selectFeatureFlagOverrides,

--- a/apps/web/src/features/feature-flag-overrides/store/featureFlagOverridesSlice.ts
+++ b/apps/web/src/features/feature-flag-overrides/store/featureFlagOverridesSlice.ts
@@ -1,6 +1,6 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSelector, createSlice } from '@reduxjs/toolkit'
-import type { FEATURES } from '@safe-global/utils/utils/chains'
+import { FEATURES } from '@safe-global/utils/utils/chains'
 import type { RootState } from '@/store'
 
 export type FeatureFlagOverridesState = Partial<Record<FEATURES, boolean>>
@@ -26,7 +26,19 @@ export const { setOverride, clearOverride, clearAllOverrides } = featureFlagOver
 export const selectFeatureFlagOverrides = (state: RootState): FeatureFlagOverridesState =>
   state[featureFlagOverridesSlice.name] || initialState
 
+const KNOWN_FEATURES = new Set<string>(Object.values(FEATURES))
+
+export const isKnownFeature = (feature: string): feature is FEATURES => KNOWN_FEATURES.has(feature)
+
+/**
+ * Counts only overrides of flags this build declares.
+ *
+ * Overrides are persisted, so they outlive the enum: a flag overridden on a branch that adds it
+ * stays in localStorage after switching to a branch that never declared it. The editor lists
+ * `FEATURES` and nothing else, so counting those leftovers badges overrides the user can neither
+ * see nor clear individually.
+ */
 export const selectOverrideCount = createSelector(
   selectFeatureFlagOverrides,
-  (overrides) => Object.keys(overrides).length,
+  (overrides) => Object.keys(overrides).filter(isKnownFeature).length,
 )

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarContent/__tests__/SafeSidebarContent.developerAction.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarContent/__tests__/SafeSidebarContent.developerAction.test.tsx
@@ -25,7 +25,10 @@ jest.mock('@/utils/chains', () => ({
   isRouteEnabled: () => true,
 }))
 
+// Keeps the real module — the developer group's override count reads the real `FEATURES` enum — and
+// stubs only the version check this tree would otherwise run.
 jest.mock('@safe-global/utils/utils/chains', () => ({
+  ...jest.requireActual('@safe-global/utils/utils/chains'),
   isNonCriticalUpdate: () => false,
 }))
 


### PR DESCRIPTION
## What it solves

Overrides are persisted, so they outlive the `FEATURES` enum: one set on a branch that adds a flag stays in `localStorage` after switching away. Readers disagreed about those leftovers — the badge counted them, `applyFeatureOverrides` injected them into `chain.features`, the editor never listed them, and "Reset all overrides" wiped them on behalf of a branch that couldn't see them.

## How this PR fixes it

One rule, one source of truth: new `knownFeatures.ts` owns `isKnownFeature` and the sorted flag list, and every reader of the overrides goes through it.

- **Badge** — `selectOverrideCount` counts only flags this build declares, so it always matches the editor's "Local overrides" list
- **Chain features** — `applyFeatureOverrides` skips unknown keys
- **Reset all** — clears known flags only; overrides belonging to another branch survive, since only that branch's editor can manage them

Also fixes an incomplete mock in `SafeSidebarContent.developerAction.test.tsx` that dropped `FEATURES`.

## How to test it

Dev/staging build only. Toggle a few flags — the badge matches the "Local overrides" row count. Then add an unknown key to the persisted overrides in DevTools and reload: it isn't counted, isn't listed, and survives "Reset all overrides".

## Affected flows

- Reading the feature-flag override badge in the sidebar
- Toggling / clearing / resetting overrides in the editor
- Feature flags applied to chains in dev builds

## Blast radius

- `selectOverrideCount` — sole consumer is `useFeatureFlagsItem` (the badge)
- `applyFeatureOverrides` → `useChainsWithOverrides`, which `useChains`/`useChain` feed app-wide. Behaviour changes only for keys not in `FEATURES`, which nothing reads anyway
- `clearAllOverrides` — sole dispatcher is the editor's reset button, already disabled unless a known flag is overridden
- The slice now imports the enum via `knownFeatures.ts`; that module is already app-wide via `useChains`, so no bundle change
- Persistence: no migration, read-side only. Production and mobile unaffected

## Risks / not checked

- No manual browser check — unit tests only
- Reset-all silently retains foreign keys; no UI copy for it
- "Known" means in the `FEATURES` enum, not in the config service response — consistent with the editor

## Visual summary

```mermaid
flowchart LR
  LS["persisted overrides<br/>EARN + FLAG_FROM_OTHER_BRANCH"] --> K{"isKnownFeature<br/>(knownFeatures.ts)"}
  K -->|known| A["badge counts it<br/>editor lists it<br/>applied to chain<br/>reset clears it"]
  K -->|unknown| B["ignored everywhere<br/>kept for its own branch"]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — none
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

New `knownFeatures.test.ts` plus selector, reducer, chain-override and editor-hook cases. `yarn verify:changed:web` clean — 623 suites / 5259 tests, plus type-check, lint, prettier.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
