### PR TITLE
fix: File Import Card CSS

### DIFF
--- a/apps/web/src/components/settings/DataManagement/FileListCard.tsx
+++ b/apps/web/src/components/settings/DataManagement/FileListCard.tsx
@@ -210,9 +210,9 @@ export const FileListCard = ({
       <div className={css.content}>
         <ul className="m-0 flex list-none flex-col p-0">
           {items.map((item, i) => (
-            <li key={i} className="flex items-start p-0">
-              <span className={css.listIcon}>
-                <FileIcon className="size-4 fill-none" />
+            <li key={i} className="flex items-start p-1">
+              <span className="mt-0.5 mr-6 shrink-0">
+                <FileIcon className="block size-4 fill-none" />
               </span>
               <div className="flex min-w-0 flex-col">
                 <span className="text-sm text-foreground">{item.primary}</span>

--- a/apps/web/src/components/settings/DataManagement/ImportDialog.tsx
+++ b/apps/web/src/components/settings/DataManagement/ImportDialog.tsx
@@ -18,6 +18,7 @@ import { showNotification } from '@/store/notificationsSlice'
 import { visitedSafesSlice } from '@/store/visitedSafesSlice'
 
 import css from './styles.module.css'
+import { TriangleAlert } from 'lucide-react'
 
 export const ImportDialog = ({
   onClose,
@@ -119,8 +120,9 @@ export const ImportDialog = ({
               showPreview
             />
             {!isDisabled && (
-              <Alert variant="warning">
-                <AlertTitle>Overwrite your current data?</AlertTitle>
+              <Alert variant="warning" outlined={false}>
+                <TriangleAlert />
+                <AlertTitle className="font-bold">Overwrite your current data?</AlertTitle>
                 <AlertDescription>
                   This action will overwrite your currently added Safe accounts, address book and settings with those
                   from the imported file.
@@ -130,7 +132,7 @@ export const ImportDialog = ({
           </>
         )}
       </div>
-      <div className="flex justify-end gap-2 p-6 pt-0">
+      <div className="flex justify-between gap-2 p-6 pt-0">
         <Button data-testid="dialog-cancel-btn" variant="outline" onClick={handleClose}>
           Cancel
         </Button>

--- a/apps/web/src/components/settings/DataManagement/styles.module.css
+++ b/apps/web/src/components/settings/DataManagement/styles.module.css
@@ -29,13 +29,6 @@
   padding: var(--space-3);
 }
 
-.listIcon {
-  min-width: unset;
-  margin-right: var(--space-3);
-  padding-top: var(--space-1);
-  align-self: flex-start;
-}
-
 .networkIcon {
   width: 10px;
   height: 10px;


### PR DESCRIPTION
## What it solves

Resolves: [WA-3203](https://linear.app/safe-global/issue/WA-3203/data-import-summary-file-icons-are-not-vertically-aligned-with-their)

In the data import summary card, the file icons sat well below the text they belong to, so each row read as misaligned. The import dialog's footer buttons were also both bunched in the right corner.

## How this PR fixes it

**Icon alignment (`FileListCard`)** — the list icon carried two independent sources of vertical offset:

- `.listIcon` applied `padding-top: var(--space-1)` = **8px**
- the `FileIcon` SVG rendered `inline`, so it also picked up baseline descender space from the `<li>`'s inherited 16px line-height

Together those pushed the 16px icon ~8–9px below the centre of its 20px `text-sm` first line. Replaced the CSS-module class with Tailwind on the element:

```tsx
<span className="mt-0.5 mr-6 shrink-0">
  <FileIcon className="block size-4 fill-none" />
</span>
```

- `block` removes the inline baseline gap, so the span is exactly 16px tall
- `mt-0.5` (2px) centres the icon on the first text line — `(20 − 16) / 2`
- `mr-6` (24px) preserves the previous `--space-3` gap; `shrink-0` stops the icon squashing when text wraps

Deleted the now-unused `.listIcon` rule from `styles.module.css` — a leftover from the MUI `ListItemIcon` era, whose `min-width: unset` and `align-self: flex-start` were already redundant with the `flex items-start` on the `<li>`.

**Dialog footer** — `justify-end` → `justify-between`, so Cancel anchors bottom-left and Import bottom-right.

**Overwrite warning** — the alert now renders a `TriangleAlert` icon, drops the outline (`outlined={false}`), and bolds its title, matching the alert treatment used elsewhere post-shadcn.

## How to test it

1. Go to **Settings → Data**
2. In the **Data export** card, download your local data as JSON
3. Open the import dialog and drop that JSON back in
4. In the summary card, check each file icon is vertically centred on the first line of its row — including the multi-line rows ("Added Safe accounts…" with per-chain sub-lines, and "Settings (appearance, currency…)" which wraps)
5. Check **Cancel** sits in the bottom-left corner and **Import** in the bottom-right
6. Check the "Overwrite your current data?" warning shows its triangle icon with a bold title
7. Confirm the export card's own summary list (same `FileListCard`, single-line rows only) is still aligned

## Affected flows

- Settings → Data → **import** a JSON backup — summary list rendering and dialog footer layout
- Settings → Data → **export** card — renders the same `FileListCard`, without `showPreview`

## Blast radius

- **`FileListCard`** — shared by exactly two consumers, both in `settings/DataManagement/`: `ImportDialog.tsx` and `index.tsx`. Presentational only; no props, state, or logic changed.
- **`styles.module.css`** — `.listIcon` removed; `FileListCard` was its only consumer (verified by grep across `src/`, `cypress/`, `e2e/`).
- **Cypress** — `import_export.pages.js` targets `dialog-import-btn` / `dialog-cancel-btn` / `export-file-section` by `data-testid` and asserts visibility, count, and enabled state only. No selector or assertion depends on the layout properties changed here.
- No Redux slices, RTK Query endpoints, feature flags, routes, persisted state, or shared `packages/**` code touched. **No mobile impact.**

## Risks / not checked

- **No visual coverage exists for this component.** There is no `.stories.tsx` under `DataManagement/`, and `apps/web/__visual_snapshots__/` does not exist yet, so neither `test:visual` nor `test:storybook` guards these rows. Adding a `FileListCard` story was considered and deliberately deferred.
- `index.test.tsx` mocks `FileListCard` wholesale, so the unit suite cannot catch a regression here either.
- Did not run the Cypress `import_export_data` specs locally — reasoned about selector impact rather than executing them.
- Did not verify on a mobile viewport, or check whether 24px is still the intended icon-to-text gap at narrow widths.
- Did not check the alert restyle against other `variant="warning"` alerts for consistency.
- Two adjacent inconsistencies left alone as out of scope: the import dialog's header avatar uses a bare `rounded` div while the export card uses `css.fileIcon` (which adds a border), so the two header icons differ; and the per-chain network swatches lack `shrink-0`, so they can compress on long chain names.

## Visual summary

**Before / after**
<img width="620" height="613" alt="Screenshot 2026-08-18 at 4 20 52 PM" src="https://github.com/user-attachments/assets/41c5c671-5144-4520-ad8f-6cede169fcf0" />

<!-- Drop before/after screenshots of Settings → Data → import dialog here -->

```mermaid
flowchart LR
  subgraph Before["Before — icon 8-9px too low"]
    B1["padding-top: 8px<br/>(--space-1)"] --> B3["icon centre ≈ 19px"]
    B2["inline SVG<br/>+ baseline descender gap"] --> B3
    B3 --> B4["text line centre = 10px<br/>❌ mismatch"]
  end
  subgraph After["After — aligned"]
    A1["mt-0.5 = 2px"] --> A3["icon centre = 10px"]
    A2["block SVG<br/>no baseline gap"] --> A3
    A3 --> A4["text line centre = 10px<br/>✅ match"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact, styling only
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — no logic changed; see Risks for the coverage gap
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
