### PR TITLE
fix: propagate nonce to SafeTxContext on reset and blur recovery

### DIFF
--- a/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.contextSync.test.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.contextSync.test.tsx
@@ -13,13 +13,7 @@ jest.mock('@/hooks/useAddressBook', () => ({
   default: () => ({}),
 }))
 
-/**
- * Regression for WA-3193: both nonce-reset paths update the rendered input via RHF's
- * `setValue`, which does not re-run the `validate` rule that calls `setNonce`. The input
- * can therefore show the recommended nonce while `SafeTxContext.nonce` — and the SafeTx
- * actually signed — still holds the stale value. These tests assert on the propagated
- * `setNonce` call, not just the rendered text.
- */
+// Regression for WA-3193: both reset paths must propagate to SafeTxContext, not only the rendered text.
 
 const mockUseSafeInfo = jest.requireMock('@/hooks/useSafeInfo').default as jest.Mock
 const mockUsePreviousNonces = jest.requireMock('@/hooks/usePreviousNonces').default as jest.Mock

--- a/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.contextSync.test.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.contextSync.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, waitFor } from '@/tests/test-utils'
+import { userEvent } from '@testing-library/user-event'
+import TxNonce from '../index'
+import { SafeTxContext, type SafeTxContextParams } from '@/components/tx-flow/SafeTxProvider'
+import { TxFlowContext, initialContext as initialTxFlowContext } from '@/components/tx-flow/TxFlowProvider'
+import { extendedSafeInfoBuilder } from '@/tests/builders/safe'
+
+jest.mock('@/hooks/useSafeInfo')
+jest.mock('@/hooks/usePreviousNonces')
+jest.mock('@/hooks/useTxQueue')
+jest.mock('@/hooks/useAddressBook', () => ({
+  __esModule: true,
+  default: () => ({}),
+}))
+
+/**
+ * Regression for WA-3193: both nonce-reset paths update the rendered input via RHF's
+ * `setValue`, which does not re-run the `validate` rule that calls `setNonce`. The input
+ * can therefore show the recommended nonce while `SafeTxContext.nonce` — and the SafeTx
+ * actually signed — still holds the stale value. These tests assert on the propagated
+ * `setNonce` call, not just the rendered text.
+ */
+
+const mockUseSafeInfo = jest.requireMock('@/hooks/useSafeInfo').default as jest.Mock
+const mockUsePreviousNonces = jest.requireMock('@/hooks/usePreviousNonces').default as jest.Mock
+const mockUseQueuedTxByNonce = jest.requireMock('@/hooks/useTxQueue').useQueuedTxByNonce as jest.Mock
+
+const SAFE_NONCE = 5
+
+const defaultSafeTxContext: SafeTxContextParams = {
+  safeTx: undefined,
+  setSafeTx: jest.fn(),
+  safeMessage: undefined,
+  setSafeMessage: jest.fn(),
+  safeMessageHash: undefined,
+  setSafeMessageHash: jest.fn(),
+  safeTxError: undefined,
+  setSafeTxError: jest.fn(),
+  nonce: SAFE_NONCE,
+  setNonce: jest.fn(),
+  nonceNeeded: true,
+  setNonceNeeded: jest.fn(),
+  safeTxGas: undefined,
+  setSafeTxGas: jest.fn(),
+  recommendedNonce: SAFE_NONCE,
+  txOrigin: undefined,
+  setTxOrigin: jest.fn(),
+  isReadOnly: false,
+  gtfPaymentMode: 'safe',
+  setGtfPaymentMode: jest.fn(),
+  gtfSelectedGasToken: undefined,
+  setGtfSelectedGasToken: jest.fn(),
+}
+
+const renderTxNonce = (contextOverrides: Partial<SafeTxContextParams> = {}) => {
+  const contextValue = { ...defaultSafeTxContext, ...contextOverrides }
+  render(
+    <TxFlowContext.Provider value={initialTxFlowContext}>
+      <SafeTxContext.Provider value={contextValue}>
+        <TxNonce />
+      </SafeTxContext.Provider>
+    </TxFlowContext.Provider>,
+  )
+  return contextValue
+}
+
+const getNonceInput = () => screen.getByRole('combobox') as HTMLInputElement
+
+describe('TxNonce context sync (WA-3193)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    const safe = extendedSafeInfoBuilder().with({ nonce: SAFE_NONCE }).build()
+    mockUseSafeInfo.mockReturnValue({
+      safe,
+      safeAddress: safe.address.value,
+      safeLoaded: true,
+      safeLoading: false,
+    })
+    mockUsePreviousNonces.mockReturnValue([])
+    mockUseQueuedTxByNonce.mockReturnValue([])
+  })
+
+  it('propagates the recommended nonce to SafeTxContext when the reset button is clicked', async () => {
+    const user = userEvent.setup()
+    const contextValue = renderTxNonce({ nonce: 10, recommendedNonce: 5 })
+
+    const resetButton = screen.getByRole('button', { name: /reset to recommended nonce/i })
+    await user.click(resetButton)
+
+    await waitFor(() => {
+      expect(contextValue.setNonce).toHaveBeenCalledWith(5)
+    })
+
+    expect(getNonceInput()).toHaveValue('5')
+  })
+
+  it('propagates the recommended nonce to SafeTxContext when an invalid value is recovered onBlur', async () => {
+    const user = userEvent.setup()
+    const contextValue = renderTxNonce({ nonce: 10, recommendedNonce: 12 })
+
+    const input = getNonceInput()
+    await user.clear(input)
+    await user.type(input, '1')
+    await waitFor(() => expect(input).toHaveAttribute('aria-label', "Nonce can't be lower than 5"))
+
+    await user.click(document.body)
+
+    await waitFor(() => {
+      expect(contextValue.setNonce).toHaveBeenCalledWith(12)
+    })
+
+    expect(getNonceInput()).toHaveValue('12')
+  })
+})

--- a/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.contextSync.test.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.contextSync.test.tsx
@@ -13,7 +13,7 @@ jest.mock('@/hooks/useAddressBook', () => ({
   default: () => ({}),
 }))
 
-// Regression for WA-3193: both reset paths must propagate to SafeTxContext, not only the rendered text.
+// Regression: both reset paths must propagate to SafeTxContext, not only the rendered text.
 
 const mockUseSafeInfo = jest.requireMock('@/hooks/useSafeInfo').default as jest.Mock
 const mockUsePreviousNonces = jest.requireMock('@/hooks/usePreviousNonces').default as jest.Mock
@@ -60,7 +60,7 @@ const renderTxNonce = (contextOverrides: Partial<SafeTxContextParams> = {}) => {
 
 const getNonceInput = () => screen.getByRole('combobox') as HTMLInputElement
 
-describe('TxNonce context sync (WA-3193)', () => {
+describe('TxNonce context sync', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     const safe = extendedSafeInfoBuilder().with({ nonce: SAFE_NONCE }).build()

--- a/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.test.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.test.tsx
@@ -139,11 +139,12 @@ describe('TxNonce', () => {
       expect(input.value).toBe('42')
     })
 
-    // The clamp() width style isn't assertable — jsdom drops clamp() on `width` — so assert the classes.
-    it('forces the inner input to fill its clamped box', () => {
+    // jsdom drops both clamp() values and custom properties, so assert the class wiring only.
+    it('sizes the inner input to the value-width variable, leaving room for the addons', () => {
       renderTxNonce({ nonce: 42, recommendedNonce: 42 })
       const input = screen.getByRole('combobox') as HTMLInputElement
-      expect(input.closest('[data-slot="input-group"]')).toHaveClass('[&_input]:w-full', '[&_input]:min-w-0')
+      const group = input.closest('[data-slot="input-group"]') as HTMLElement
+      expect(group).toHaveClass('[&_input]:w-(--nonce-width)', '[&_input]:min-w-0')
     })
 
     it('shows reset button when nonce differs from recommended', () => {

--- a/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.test.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.test.tsx
@@ -139,6 +139,13 @@ describe('TxNonce', () => {
       expect(input.value).toBe('42')
     })
 
+    // The clamp() width style isn't assertable — jsdom drops clamp() on `width` — so assert the classes.
+    it('forces the inner input to fill its clamped box', () => {
+      renderTxNonce({ nonce: 42, recommendedNonce: 42 })
+      const input = screen.getByRole('combobox') as HTMLInputElement
+      expect(input.closest('[data-slot="input-group"]')).toHaveClass('[&_input]:w-full', '[&_input]:min-w-0')
+    })
+
     it('shows reset button when nonce differs from recommended', () => {
       renderTxNonce({ nonce: 10, recommendedNonce: 5 })
       // Reset to recommended nonce button appears as an IconButton
@@ -226,6 +233,20 @@ describe('TxNonce', () => {
       await waitFor(() => {
         expect(screen.getByRole('listbox')).toBeInTheDocument()
       })
+    })
+
+    it('sizes the popup to fit its content instead of the tiny input', async () => {
+      const user = userEvent.setup()
+      renderTxNonce({ nonce: 5, recommendedNonce: 5 })
+
+      await user.click(screen.getByRole('combobox'))
+
+      const content = await waitFor(() => {
+        const el = document.querySelector('[data-slot="combobox-content"]')
+        expect(el).toBeInTheDocument()
+        return el as HTMLElement
+      })
+      expect(content).toHaveClass('w-max', 'min-w-40', 'max-w-[300px]')
     })
   })
 

--- a/apps/web/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/index.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactElement, useContext, useMemo, useState, useEffect } from 'react'
+import { memo, type CSSProperties, type ReactElement, useContext, useMemo, useState, useEffect } from 'react'
 import { RotateCcw } from 'lucide-react'
 import { Controller, useForm } from 'react-hook-form'
 
@@ -180,9 +180,9 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
                   name={field.name}
                   aria-label={message || undefined}
                   showTrigger
-                  // w-full/min-w-0 keep the inner <input> inside the clamped box instead of its intrinsic ~20ch width
-                  className="[&_input]:font-bold [&_input]:w-full [&_input]:min-w-0"
-                  style={{ width: getFieldMinWidth(field.value) }}
+                  // The clamp sizes the text input itself; the group grows to fit the trigger/reset addons
+                  className="[&_input]:font-bold [&_input]:w-(--nonce-width) [&_input]:min-w-0"
+                  style={{ '--nonce-width': getFieldMinWidth(field.value) } as CSSProperties}
                   onBlur={() => {
                     field.onBlur()
 

--- a/apps/web/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/index.tsx
@@ -97,8 +97,7 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
   })
 
   const resetNonce = () => {
-    // shouldValidate re-runs the `validate` rule below, which is what propagates the new
-    // value to SafeTxContext via `setNonce` — a plain `setValue` only updates the input.
+    // shouldValidate re-runs the `validate` rule, which propagates the value to SafeTxContext
     formMethods.setValue(TxNonceFormFieldNames.NONCE, recommendedNonce, { shouldValidate: true })
   }
 
@@ -181,8 +180,9 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
                   name={field.name}
                   aria-label={message || undefined}
                   showTrigger
-                  className="[&_input]:font-bold"
-                  style={{ minWidth: getFieldMinWidth(field.value) }}
+                  // w-full/min-w-0 keep the inner <input> inside the clamped box instead of its intrinsic ~20ch width
+                  className="[&_input]:font-bold [&_input]:w-full [&_input]:min-w-0"
+                  style={{ width: getFieldMinWidth(field.value) }}
                   onBlur={() => {
                     field.onBlur()
 
@@ -211,7 +211,11 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
               {message && <TooltipContent side="top">{message}</TooltipContent>}
             </Tooltip>
 
-            <ComboboxContent>
+            {/* The input itself is tiny (clamped to a few characters), but the shared default ties
+                the popup width to it via --anchor-width. Options show full labels like "12 - New
+                transaction", so size the popup to that content instead — matching the pre-migration
+                MUI Popper, which explicitly opted out of the anchor-width tie for this field. */}
+            <ComboboxContent className="w-max min-w-40 max-w-[300px]">
               <ComboboxList>
                 {/* Each label must live inside its own ComboboxGroup — Base UI's GroupLabel throws
                     without a Group ancestor, which previously crashed the popup on open. */}

--- a/apps/web/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/index.tsx
@@ -97,7 +97,9 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
   })
 
   const resetNonce = () => {
-    formMethods.setValue(TxNonceFormFieldNames.NONCE, recommendedNonce)
+    // shouldValidate re-runs the `validate` rule below, which is what propagates the new
+    // value to SafeTxContext via `setNonce` — a plain `setValue` only updates the input.
+    formMethods.setValue(TxNonceFormFieldNames.NONCE, recommendedNonce, { shouldValidate: true })
   }
 
   useEffect(() => {
@@ -185,7 +187,7 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
                     field.onBlur()
 
                     if (fieldState.error) {
-                      formMethods.setValue(field.name, recommendedNonce.toString())
+                      formMethods.setValue(field.name, recommendedNonce.toString(), { shouldValidate: true })
                     }
                   }}
                 >


### PR DESCRIPTION
## What it solves

Resolves [WA-3193](https://linear.app/safe-global/issue/WA-3193). Split out of #8517 per review, this PR carries only the S1 nonce fix.

The nonce shown to the signer could differ from the nonce actually signed. Both nonce-reset paths (the reset arrow and the onBlur recovery of an invalid value) updated the input via RHF `setValue`, which never re-runs the validate rule that calls `setNonce` — so `SafeTxContext` kept the stale nonce while the input displayed the recommended one, and the SafeTx was built with the stale value. Pre-migration, MUI Autocomplete re-fired `onInputChange` on programmatic value changes; Base UI's controlled `inputValue` doesn't.

## How this PR fixes it

- Both `setValue` calls pass `shouldValidate: true`, so the validate rule re-runs and propagates to `SafeTxContext`
- New regression tests assert on the propagated `setNonce` call, not just the rendered input text — the exact invariant that broke
- Second commit: the nonce field tracked the input's intrinsic ~20ch width and the dropdown was pinned to it; the field now hugs the value (existing clamp helper) and the dropdown fits its content with a 300px cap

```
before:  reset → setValue only → input shows new nonce,
         context keeps the stale one → SafeTx signs the OLD nonce
after:   reset → setValue + shouldValidate → validate runs
         → setNonce updates SafeTxContext → SafeTx uses the nonce shown
```

## How to test it

1. Start a tx, set the nonce to an older queued one, click the reset arrow. The arrow should disappear and the signed tx should carry the recommended nonce.
2. Type an invalid nonce and click away. The recovered value should propagate too.
3. Check the field is compact and the dropdown fits its option labels.

## Affected flows

- Tx review/sign step (nonce field, all flows)

## Blast radius

- Everything is inside `tx-flow/common/TxNonce/`. `ComboboxContent` default sizing untouched; the width override is local to this component.
- Swept the app for the same `setValue`-without-validation pattern against Base UI controlled inputs: the only other form-bound combobox (`ApprovalValueField`) has no `setValue` calls; all other `setValue` sites read state directly rather than through a validate rule.

## Risks / not checked

- Unit/component level only, no signing against a live chain
- TxNonce never sets `aria-invalid`, so errors show as tooltip only, no red border — pre-existing, out of scope

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics impact)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qf2SonFgLpjter6H1fd61V

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qf2SonFgLpjter6H1fd61V)_