### PR TITLE
fix: send funds form alerts and input error styling

### DIFF
--- a/apps/web/src/components/common/DatePickerInput/__snapshots__/DatePickerInput.stories.test.tsx.snap
+++ b/apps/web/src/components/common/DatePickerInput/__snapshots__/DatePickerInput.stories.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`./DatePickerInput.stories AllowFutureDates 1`] = `
 <div
@@ -37,7 +37,7 @@ exports[`./DatePickerInput.stories AllowFutureDates 1`] = `
           >
             <input
               autocomplete="off"
-              class="border-border focus-visible:border-border aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 py-1.5 text-base transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 h-9 px-3 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent flex-1"
+              class="border-border focus-visible:border-border aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 py-1.5 text-base text-foreground transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 h-9 px-3 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent flex-1"
               data-slot="input-group-control"
               id="expiryDate-date"
               name="expiryDate"
@@ -139,7 +139,7 @@ exports[`./DatePickerInput.stories Default 1`] = `
           >
             <input
               autocomplete="off"
-              class="border-border focus-visible:border-border aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 py-1.5 text-base transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 h-9 px-3 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent flex-1"
+              class="border-border focus-visible:border-border aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 py-1.5 text-base text-foreground transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 h-9 px-3 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent flex-1"
               data-slot="input-group-control"
               id="birthDate-date"
               name="birthDate"
@@ -241,7 +241,7 @@ exports[`./DatePickerInput.stories DisableFutureDates 1`] = `
           >
             <input
               autocomplete="off"
-              class="border-border focus-visible:border-border aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 py-1.5 text-base transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 h-9 px-3 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent flex-1"
+              class="border-border focus-visible:border-border aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 py-1.5 text-base text-foreground transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 h-9 px-3 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent flex-1"
               data-slot="input-group-control"
               id="createdDate-date"
               name="createdDate"

--- a/apps/web/src/components/common/NameInput/__snapshots__/NameInput.stories.test.tsx.snap
+++ b/apps/web/src/components/common/NameInput/__snapshots__/NameInput.stories.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`./NameInput.stories Default 1`] = `
 <div
@@ -27,7 +27,7 @@ exports[`./NameInput.stories Default 1`] = `
           class="w-full"
         >
           <input
-            class="border-border border shadow-none focus-visible:ring-0 focus-visible:border-border aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md py-1.5 text-base transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 h-9 px-3 bg-input"
+            class="border-border border shadow-none focus-visible:ring-0 focus-visible:border-border aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md py-1.5 text-base text-foreground transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 h-9 px-3 bg-input"
             data-slot="input"
             id="_r_0_"
             name="ownerName"
@@ -67,7 +67,7 @@ exports[`./NameInput.stories Disabled 1`] = `
           class="w-full"
         >
           <input
-            class="border-border border shadow-none focus-visible:ring-0 focus-visible:border-border aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md py-1.5 text-base transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 h-9 px-3 bg-input"
+            class="border-border border shadow-none focus-visible:ring-0 focus-visible:border-border aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md py-1.5 text-base text-foreground transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 h-9 px-3 bg-input"
             data-disabled=""
             data-slot="input"
             disabled=""
@@ -109,7 +109,7 @@ exports[`./NameInput.stories Required 1`] = `
           class="w-full"
         >
           <input
-            class="border-border border shadow-none focus-visible:ring-0 focus-visible:border-border aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md py-1.5 text-base transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 h-9 px-3 bg-input"
+            class="border-border border shadow-none focus-visible:ring-0 focus-visible:border-border aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md py-1.5 text-base text-foreground transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 h-9 px-3 bg-input"
             data-slot="input"
             id="_r_4_"
             name="ownerName"
@@ -150,7 +150,7 @@ exports[`./NameInput.stories WithPlaceholder 1`] = `
           class="w-full"
         >
           <input
-            class="border-border border shadow-none focus-visible:ring-0 focus-visible:border-border aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md py-1.5 text-base transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 h-9 px-3 bg-input"
+            class="border-border border shadow-none focus-visible:ring-0 focus-visible:border-border aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md py-1.5 text-base text-foreground transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 h-9 px-3 bg-input"
             data-slot="input"
             id="_r_6_"
             name="ownerName"

--- a/apps/web/src/components/common/TokenAmountInput/TokenAmountInput.test.tsx
+++ b/apps/web/src/components/common/TokenAmountInput/TokenAmountInput.test.tsx
@@ -418,4 +418,40 @@ describe('TokenAmountInput', () => {
       expect(screen.queryByTestId('fiat-display')).not.toBeInTheDocument()
     })
   })
+
+  describe('Error state styling', () => {
+    // WA-3185: the amount FIELD (label + border) must turn destructive on error, but the typed
+    // VALUE text must stay neutral — the invalid `Field` ancestor would otherwise cascade its red
+    // colour onto the value via CSS inheritance (see ui/input.tsx's `text-foreground`).
+    const ErroredWrapper = ({ defaultAmount }: { defaultAmount: string }) => {
+      const methods = useForm({
+        defaultValues: { [TokenAmountFields.tokenAddress]: USDC_ADDRESS, [TokenAmountFields.amount]: defaultAmount },
+      })
+
+      React.useEffect(() => {
+        methods.setError(TokenAmountFields.amount, { type: 'validate', message: 'Insufficient funds' })
+      }, [methods])
+
+      const selectedToken = mockBalances.find((b) => b.tokenInfo.address === USDC_ADDRESS)
+
+      return (
+        <FormProvider {...methods}>
+          <TokenAmountInput balances={mockBalances} selectedToken={selectedToken} maxAmount={0n} />
+        </FormProvider>
+      )
+    }
+
+    it('keeps the typed value neutral while the label goes destructive on an insufficient-funds error', () => {
+      render(<ErroredWrapper defaultAmount="0.0159" />)
+
+      const amountField = screen.getByTestId('token-amount-field')
+
+      // The label swaps in the error message and turns destructive...
+      expect(screen.getByText('Insufficient funds')).toHaveClass('text-destructive')
+      // ...but the typed value stays the normal foreground colour, not red.
+      expect(amountField).toHaveDisplayValue('0.0159')
+      expect(amountField).toHaveClass('text-foreground')
+      expect(amountField.className).not.toContain('text-destructive')
+    })
+  })
 })

--- a/apps/web/src/components/common/TokenAmountInput/TokenAmountInput.test.tsx
+++ b/apps/web/src/components/common/TokenAmountInput/TokenAmountInput.test.tsx
@@ -420,7 +420,7 @@ describe('TokenAmountInput', () => {
   })
 
   describe('Error state styling', () => {
-    // WA-3185: the amount FIELD (label + border) must turn destructive on error, but the typed
+    // The amount FIELD (label + border) must turn destructive on error, but the typed
     // VALUE text must stay neutral — the invalid `Field` ancestor would otherwise cascade its red
     // colour onto the value via CSS inheritance (see ui/input.tsx's `text-foreground`).
     const ErroredWrapper = ({ defaultAmount }: { defaultAmount: string }) => {

--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
@@ -3,7 +3,7 @@ import { type ReactElement, useContext, useEffect, useMemo, useState } from 'rea
 import { type Balance } from '@safe-global/store/gateway/AUTO_GENERATED/balances'
 import { FormProvider, useFieldArray, useForm, useWatch } from 'react-hook-form'
 
-import { Alert, AlertTitle, AlertDescription, AlertAction } from '@/components/ui/alert'
+import { Alert, AlertTitle, AlertDescription, AlertAction, AlertSeverityIcon } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { Link } from '@/components/ui/link'
@@ -206,7 +206,8 @@ const CreateTokenTransfer = ({ txNonce }: CreateTokenTransferProps): ReactElemen
                 {isEligible && isNoFeeCampaignEnabled && <NoFeeCampaignTransactionCard />}
 
                 {hasInsufficientFunds && (
-                  <Alert data-testid="insufficient-balance-error" variant="destructive">
+                  <Alert data-testid="insufficient-balance-error" variant="destructive" outlined={false}>
+                    <AlertSeverityIcon variant="destructive" />
                     <AlertTitle>Insufficient balance</AlertTitle>
                     <AlertDescription>
                       The total amount assigned to all recipients exceeds your available balance. Please adjust the
@@ -216,7 +217,8 @@ const CreateTokenTransfer = ({ txNonce }: CreateTokenTransferProps): ReactElemen
                 )}
 
                 {canAddMoreRecipients && maxRecipientsInfo && !!csvAirdropAppUrl && (
-                  <Alert variant="default">
+                  <Alert data-testid="csv-airdrop-hint" variant="info">
+                    <AlertSeverityIcon variant="info" />
                     <AlertDescription>
                       If you want to add more than {MAX_RECIPIENTS} recipients, use <CsvAirdropLink />
                     </AlertDescription>
@@ -234,7 +236,8 @@ const CreateTokenTransfer = ({ txNonce }: CreateTokenTransferProps): ReactElemen
                 )}
 
                 {!canAddMoreRecipients && (
-                  <Alert data-testid="max-recipients-reached" variant="warning">
+                  <Alert data-testid="max-recipients-reached" variant="warning" outlined={false}>
+                    <AlertSeverityIcon variant="warning" />
                     <AlertDescription>
                       No more recipients can be added.
                       {!!csvAirdropAppUrl && (

--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/RecipientRow/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/RecipientRow/index.tsx
@@ -18,7 +18,7 @@ import { sameAddress } from '@safe-global/utils/utils/addresses'
 import Track from '@/components/common/Track'
 import { MODALS_EVENTS } from '@/services/analytics'
 import SpendingLimitRow from '../SpendingLimitRow'
-import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Alert, AlertDescription, AlertSeverityIcon } from '@/components/ui/alert'
 import { X } from 'lucide-react'
 import { useHasFeature } from '@/hooks/useChains'
 import { FEATURES } from '@safe-global/utils/utils/chains'
@@ -127,7 +127,8 @@ const RecipientRow = ({ fieldArray, removable = true, remove, disableSpendingLim
         </div>
 
         {showFeeBanner && (
-          <Alert data-testid="gtf-fee-banner" className="items-center">
+          <Alert data-testid="gtf-fee-banner" variant="info" className="items-center">
+            <AlertSeverityIcon variant="info" />
             <AlertDescription className="flex w-full items-center justify-between gap-2">
               <span>
                 Your max send amount accounts for fees paid in {selectedToken?.tokenInfo.symbol}. This updates if fees

--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/__tests__/CreateTokenTransfer.test.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/__tests__/CreateTokenTransfer.test.tsx
@@ -454,7 +454,7 @@ describe('CreateTokenTransfer', () => {
       expect(queryByTestId('gtf-fee-banner')).not.toBeInTheDocument()
     })
 
-    // WA-3185: the fee banner renders as an info alert, not the plain default
+    // The fee banner renders as an info alert, not the plain default
     it('renders the fee banner with the info alert styling, not the plain default alert', async () => {
       useHasFeatureSpy.mockImplementation(() => true)
       mockBalancesForGtf()
@@ -488,7 +488,7 @@ describe('CreateTokenTransfer', () => {
     })
   })
 
-  // WA-3185: the CSV airdrop hint renders as an info alert, not the plain default
+  // The CSV airdrop hint renders as an info alert, not the plain default
   describe('CSV airdrop hint', () => {
     const useHasFeatureSpy = jest.spyOn(chainHooks, 'useHasFeature')
     const useRemoteSafeAppsSpy = jest.spyOn(remoteSafeAppsHooks, 'useRemoteSafeApps')

--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/__tests__/CreateTokenTransfer.test.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/__tests__/CreateTokenTransfer.test.tsx
@@ -16,6 +16,9 @@ import * as useBalances from '@/hooks/useBalances'
 import * as useTrustedTokenBalances from '@/hooks/loadables/useTrustedTokenBalances'
 import * as chainHooks from '@/hooks/useChains'
 import * as gtfHooks from '@/features/gtf'
+import * as remoteSafeAppsHooks from '@/hooks/safe-apps/useRemoteSafeApps'
+import type { SafeApp } from '@safe-global/store/gateway/AUTO_GENERATED/safe-apps'
+import { FEATURES } from '@safe-global/utils/utils/chains'
 import { fireEvent, waitFor } from '@testing-library/react'
 
 // Mock the SpendingLimitRowWrapper component with the same "Send as" label as the real component
@@ -449,6 +452,217 @@ describe('CreateTokenTransfer', () => {
       fireEvent.click(getByLabelText('Dismiss fee banner'))
 
       expect(queryByTestId('gtf-fee-banner')).not.toBeInTheDocument()
+    })
+
+    // WA-3185: the fee banner renders as an info alert, not the plain default
+    it('renders the fee banner with the info alert styling, not the plain default alert', async () => {
+      useHasFeatureSpy.mockImplementation(() => true)
+      mockBalancesForGtf()
+      mockResolvedToSentToken()
+
+      const { getByTestId } = renderCreateTokenTransfer()
+
+      fireEvent.click(getByTestId('max-btn'))
+
+      await waitFor(() => {
+        expect(getByTestId('gtf-fee-banner')).toBeInTheDocument()
+      })
+
+      expect(getByTestId('gtf-fee-banner')).toHaveClass('bg-muted', 'text-foreground', 'border-transparent')
+    })
+
+    it('renders the standard info icon inside the fee banner', async () => {
+      useHasFeatureSpy.mockImplementation(() => true)
+      mockBalancesForGtf()
+      mockResolvedToSentToken()
+
+      const { getByTestId } = renderCreateTokenTransfer()
+
+      fireEvent.click(getByTestId('max-btn'))
+
+      await waitFor(() => {
+        expect(getByTestId('gtf-fee-banner')).toBeInTheDocument()
+      })
+
+      expect(getByTestId('gtf-fee-banner').querySelector('svg.lucide-info')).toBeInTheDocument()
+    })
+  })
+
+  // WA-3185: the CSV airdrop hint renders as an info alert, not the plain default
+  describe('CSV airdrop hint', () => {
+    const useHasFeatureSpy = jest.spyOn(chainHooks, 'useHasFeature')
+    const useRemoteSafeAppsSpy = jest.spyOn(remoteSafeAppsHooks, 'useRemoteSafeApps')
+
+    const csvApp: SafeApp = {
+      id: 1,
+      name: 'CSV Airdrop',
+      url: 'https://example.com/csv-airdrop',
+      description: '',
+      chainIds: [],
+      accessControl: { type: 'NO_RESTRICTIONS' },
+      tags: [],
+      features: [],
+      socialProfiles: [],
+      featured: false,
+    }
+
+    beforeEach(() => {
+      useHasFeatureSpy.mockImplementation((feature) => feature === FEATURES.MASS_PAYOUTS)
+      useRemoteSafeAppsSpy.mockReturnValue([[csvApp], undefined, false])
+    })
+
+    it('shows the CSV hint as an info alert after adding a second recipient', () => {
+      const { getByTestId } = renderCreateTokenTransfer()
+
+      fireEvent.click(getByTestId('add-recipient-btn'))
+
+      const csvHint = getByTestId('csv-airdrop-hint')
+      expect(csvHint).toBeInTheDocument()
+      expect(csvHint).toHaveClass('bg-muted', 'text-foreground', 'border-transparent')
+    })
+
+    it('renders the standard info icon inside the CSV hint', () => {
+      const { getByTestId } = renderCreateTokenTransfer()
+
+      fireEvent.click(getByTestId('add-recipient-btn'))
+
+      expect(getByTestId('csv-airdrop-hint').querySelector('svg.lucide-info')).toBeInTheDocument()
+    })
+
+    it('dismisses the CSV hint on close button click', () => {
+      const { getByTestId, queryByTestId, getByLabelText } = renderCreateTokenTransfer()
+
+      fireEvent.click(getByTestId('add-recipient-btn'))
+      expect(getByTestId('csv-airdrop-hint')).toBeInTheDocument()
+
+      fireEvent.click(getByLabelText('close'))
+
+      expect(queryByTestId('csv-airdrop-hint')).not.toBeInTheDocument()
+    })
+
+    it('renders the standard warning icon on the max-recipients-reached alert', () => {
+      const { getByTestId } = renderCreateTokenTransfer()
+
+      // MAX_RECIPIENTS is 5 — starting from 1 recipient, 4 more clicks fills the cap.
+      for (let i = 0; i < 4; i++) {
+        fireEvent.click(getByTestId('add-recipient-btn'))
+      }
+
+      const maxReached = getByTestId('max-recipients-reached')
+      expect(maxReached).toBeInTheDocument()
+      expect(maxReached.querySelector('svg.lucide-triangle-alert')).toBeInTheDocument()
+    })
+
+    it('renders the max-recipients-reached alert filled (tinted background, no border)', () => {
+      const { getByTestId } = renderCreateTokenTransfer()
+
+      for (let i = 0; i < 4; i++) {
+        fireEvent.click(getByTestId('add-recipient-btn'))
+      }
+
+      const maxReached = getByTestId('max-recipients-reached')
+      expect(maxReached).toHaveClass('bg-warning-subtle', 'border-transparent', 'text-warning-strong')
+      expect(maxReached).not.toHaveClass('bg-card')
+    })
+  })
+
+  describe('Insufficient balance alert', () => {
+    const useHasFeatureSpy = jest.spyOn(chainHooks, 'useHasFeature')
+
+    beforeEach(() => {
+      useHasFeatureSpy.mockImplementation((feature) => feature === FEATURES.MASS_PAYOUTS)
+
+      const balances = {
+        fiatTotal: '0',
+        items: [
+          {
+            balance: '1000000', // 1 USDC
+            tokenInfo: {
+              address: USDC_ADDRESS,
+              decimals: 6,
+              logoUri: '',
+              name: 'USD Coin',
+              symbol: 'USDC',
+              type: TokenType.ERC20,
+            },
+            fiatBalance: '1',
+            fiatConversion: '1',
+          },
+        ],
+      }
+
+      jest.spyOn(useTrustedTokenBalances, 'useTrustedTokenBalances').mockReturnValue([balances, undefined, false])
+      jest.spyOn(useBalances, 'default').mockReturnValue({
+        balances,
+        loaded: true,
+        loading: false,
+        error: undefined,
+      })
+      // `should display a type selection...` mocks useTokenAmount without restoring it — re-mock
+      // here so this describe is immune to run order.
+      jest.spyOn(tokenUtils, 'useTokenAmount').mockImplementation((selectedToken) => ({
+        totalAmount: BigInt(selectedToken?.balance || 0),
+        spendingLimitAmount: 0n,
+      }))
+    })
+
+    it('renders the standard destructive icon once the assigned total exceeds the balance', async () => {
+      const twoRecipientParams = {
+        recipients: [
+          { recipient: '', tokenAddress: USDC_ADDRESS, amount: '' },
+          { recipient: '', tokenAddress: USDC_ADDRESS, amount: '' },
+        ],
+        type: TokenTransferType.multiSig,
+      }
+
+      const { getByTestId, getAllByTestId } = render(
+        <SafeShieldProvider>
+          <TxFlowProvider step={0} data={twoRecipientParams} prevStep={() => {}} nextStep={jest.fn()}>
+            <CreateTokenTransfer />
+          </TxFlowProvider>
+        </SafeShieldProvider>,
+      )
+
+      const amountFields = getAllByTestId('token-amount-field')
+      // 0.6 + 0.6 USDC assigned against a 1 USDC balance — sum exceeds what's available.
+      fireEvent.change(amountFields[0], { target: { value: '0.6' } })
+      fireEvent.change(amountFields[1], { target: { value: '0.6' } })
+
+      await waitFor(() => {
+        expect(getByTestId('insufficient-balance-error')).toBeInTheDocument()
+      })
+
+      expect(getByTestId('insufficient-balance-error').querySelector('svg.lucide-circle-alert')).toBeInTheDocument()
+    })
+
+    it('renders the insufficient-balance alert filled (tinted background, no border)', async () => {
+      const twoRecipientParams = {
+        recipients: [
+          { recipient: '', tokenAddress: USDC_ADDRESS, amount: '' },
+          { recipient: '', tokenAddress: USDC_ADDRESS, amount: '' },
+        ],
+        type: TokenTransferType.multiSig,
+      }
+
+      const { getByTestId, getAllByTestId } = render(
+        <SafeShieldProvider>
+          <TxFlowProvider step={0} data={twoRecipientParams} prevStep={() => {}} nextStep={jest.fn()}>
+            <CreateTokenTransfer />
+          </TxFlowProvider>
+        </SafeShieldProvider>,
+      )
+
+      const amountFields = getAllByTestId('token-amount-field')
+      fireEvent.change(amountFields[0], { target: { value: '0.6' } })
+      fireEvent.change(amountFields[1], { target: { value: '0.6' } })
+
+      await waitFor(() => {
+        expect(getByTestId('insufficient-balance-error')).toBeInTheDocument()
+      })
+
+      const alert = getByTestId('insufficient-balance-error')
+      expect(alert).toHaveClass('bg-error-subtle', 'border-transparent', 'text-error-strong')
+      expect(alert).not.toHaveClass('bg-card')
     })
   })
 })

--- a/apps/web/src/components/ui/alert.test.tsx
+++ b/apps/web/src/components/ui/alert.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { Alert, AlertTitle, AlertDescription, AlertAction } from './alert'
+import { Alert, AlertTitle, AlertDescription, AlertAction, AlertSeverityIcon } from './alert'
 
 describe('Alert', () => {
   it('renders as an alert with title and description', () => {
@@ -137,5 +137,36 @@ describe('Alert', () => {
     )
 
     expect(screen.getByRole('button', { name: 'Retry' }).parentElement).toHaveClass('text-foreground')
+  })
+})
+
+describe('AlertSeverityIcon', () => {
+  it.each([
+    ['destructive', 'lucide-circle-alert'],
+    ['warning', 'lucide-triangle-alert'],
+    ['success', 'lucide-circle-check'],
+    ['info', 'lucide-info'],
+  ] as const)('renders the standard icon for the %s variant', (variant, iconClass) => {
+    const { container } = render(<AlertSeverityIcon variant={variant} />)
+
+    expect(container.querySelector(`svg.${iconClass}`)).toBeInTheDocument()
+  })
+
+  it('renders nothing for the default variant, which has no standard icon', () => {
+    const { container } = render(<AlertSeverityIcon variant="default" />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when no variant is given', () => {
+    const { container } = render(<AlertSeverityIcon />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('forwards props (e.g. className) to the rendered icon', () => {
+    render(<AlertSeverityIcon variant="warning" className="size-6" data-testid="severity-icon" />)
+
+    expect(screen.getByTestId('severity-icon')).toHaveClass('size-6', 'lucide-triangle-alert')
   })
 })

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { cva, type VariantProps } from 'class-variance-authority'
+import { CircleAlertIcon, CircleCheckIcon, InfoIcon, TriangleAlertIcon, type LucideIcon } from 'lucide-react'
 
 import { cn } from '@/utils/cn'
 
@@ -12,8 +13,8 @@ import { cn } from '@/utils/cn'
  *
  * @example
  * ```tsx
- * <Alert variant="default">
- *   <InfoIcon />
+ * <Alert variant="warning">
+ *   <AlertSeverityIcon variant="warning" />
  *   <AlertTitle>Heads up!</AlertTitle>
  *   <AlertDescription>You can add components using the cli.</AlertDescription>
  *   <AlertAction>
@@ -28,6 +29,8 @@ import { cn } from '@/utils/cn'
  * - Alert: `outlined` (destructive & warning only; default true = card surface with border,
  *   false = borderless severity tint)
  * - AlertAction: for action buttons (positioned top-right)
+ * - AlertSeverityIcon: renders the standard lucide icon for a given `variant` (opt-in child —
+ *   pass it your own icon, or none, if a consumer needs something different)
  */
 
 const alertVariants = cva(
@@ -109,4 +112,18 @@ function AlertAction({ className, ...props }: React.ComponentProps<'div'>) {
   )
 }
 
-export { Alert, AlertTitle, AlertDescription, AlertAction }
+// Standard icon per severity, mirroring the Sonner toast icon map. `default` has none.
+const alertSeverityIcons: Partial<Record<NonNullable<VariantProps<typeof alertVariants>['variant']>, LucideIcon>> = {
+  destructive: CircleAlertIcon,
+  warning: TriangleAlertIcon,
+  success: CircleCheckIcon,
+  info: InfoIcon,
+}
+
+/** Standard lucide icon for an Alert's severity `variant` — an opt-in child of `<Alert>`. */
+function AlertSeverityIcon({ variant, ...props }: React.ComponentProps<'svg'> & VariantProps<typeof alertVariants>) {
+  const Icon = variant ? alertSeverityIcons[variant] : undefined
+  return Icon ? <Icon {...props} /> : null
+}
+
+export { Alert, AlertTitle, AlertDescription, AlertAction, AlertSeverityIcon }

--- a/apps/web/src/components/ui/input.render.test.tsx
+++ b/apps/web/src/components/ui/input.render.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 
 import { Input } from './input'
+import { Field, FieldLabel } from './field'
 
 describe('Input invalid state', () => {
   it('marks the field invalid from the error prop', () => {
@@ -15,9 +16,6 @@ describe('Input invalid state', () => {
     expect(screen.getByPlaceholderText('Explicitly invalid')).toHaveAttribute('aria-invalid', 'true')
   })
 
-  // The computed attribute used to be overwritten by the `{...props}` spread that followed it, so a
-  // caller passing an undefined/false `aria-invalid` alongside `error` silently erased the invalid
-  // state. AdvancedOptionsStep passes both and was only safe because they shared one boolean.
   it('keeps the error-driven invalid state when aria-invalid is passed as undefined', () => {
     render(<Input error="Boom" aria-invalid={undefined} placeholder="Undefined aria" />)
 
@@ -34,5 +32,26 @@ describe('Input invalid state', () => {
     render(<Input placeholder="Valid" />)
 
     expect(screen.getByPlaceholderText('Valid')).not.toHaveAttribute('aria-invalid')
+  })
+
+  it('sets its own text-foreground colour so the typed value never inherits red text', () => {
+    render(<Input error="Boom" placeholder="With error" />)
+
+    const input = screen.getByPlaceholderText('With error')
+    expect(input).toHaveClass('text-foreground')
+    expect(input.className).not.toContain('text-destructive')
+  })
+
+  // A Field ancestor turns red when invalid; the input's own text-foreground must win over inheritance.
+  it('keeps the value text neutral even nested inside an invalid Field, while the label stays destructive', () => {
+    render(
+      <Field data-invalid>
+        <FieldLabel className="text-destructive">Amount</FieldLabel>
+        <Input aria-invalid placeholder="Nested in invalid field" />
+      </Field>,
+    )
+
+    expect(screen.getByText('Amount')).toHaveClass('text-destructive')
+    expect(screen.getByPlaceholderText('Nested in invalid field')).toHaveClass('text-foreground')
   })
 })

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -16,9 +16,12 @@ import { cn } from '@/utils/cn'
  * Skins: `default` (`bg-input`) is the filled field — white in light mode, a translucent lift in dark
  * that works over any parent surface. `surface` (`bg-card`) is the opaque card-coloured fill; reach
  * for it only when translucency would show through (over images, gradients or coloured strips).
+ *
+ * `text-foreground` is explicit because an invalid `Field` ancestor sets `text-destructive`,
+ * which the typed value would otherwise inherit — only border/ring and label carry the error colour.
  */
 const inputVariants = cva(
-  'border-border border shadow-none focus-visible:ring-0 focus-visible:border-border aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md py-1.5 text-base transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+  'border-border border shadow-none focus-visible:ring-0 focus-visible:border-border aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md py-1.5 text-base text-foreground transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
   {
     variants: {
       // Named `inputSize` (not `size`) so it doesn't collide with the native numeric `size` attr

--- a/apps/web/src/components/ui/stories/alert.stories.tsx
+++ b/apps/web/src/components/ui/stories/alert.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { Alert, AlertTitle, AlertDescription, AlertAction } from '../alert'
+import { Alert, AlertTitle, AlertDescription, AlertAction, AlertSeverityIcon } from '../alert'
 import { AlertCircle, Check, TriangleAlert, Wallet, X } from 'lucide-react'
 import { Button } from '../button'
 
@@ -171,6 +171,51 @@ export const AllVariants: Story = {
               <AlertCircle />
               <AlertTitle>Destructive with Icon</AlertTitle>
               <AlertDescription>This destructive alert includes an icon.</AlertDescription>
+            </Alert>
+          </div>
+        </div>
+      </div>
+
+      <div style={{ marginBottom: '2rem' }}>
+        <h3 className="mb-4 text-lg font-semibold">Severity Icons</h3>
+        <p className="mb-4 text-sm text-muted-foreground">
+          <code>AlertSeverityIcon</code> renders the standard icon for a given `variant` — opt in per alert, existing
+          consumers with their own icon (or none) are unaffected.
+        </p>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(400px, max-content))',
+            gap: '1.5rem',
+            justifyItems: 'start',
+          }}
+        >
+          <div style={{ width: '400px' }}>
+            <Alert variant="destructive">
+              <AlertSeverityIcon variant="destructive" />
+              <AlertTitle>Destructive Alert</AlertTitle>
+              <AlertDescription>Uses the standard destructive icon.</AlertDescription>
+            </Alert>
+          </div>
+          <div style={{ width: '400px' }}>
+            <Alert variant="warning">
+              <AlertSeverityIcon variant="warning" />
+              <AlertTitle>Warning Alert</AlertTitle>
+              <AlertDescription>Uses the standard warning icon.</AlertDescription>
+            </Alert>
+          </div>
+          <div style={{ width: '400px' }}>
+            <Alert variant="success">
+              <AlertSeverityIcon variant="success" />
+              <AlertTitle>Success Alert</AlertTitle>
+              <AlertDescription>Uses the standard success icon.</AlertDescription>
+            </Alert>
+          </div>
+          <div style={{ width: '400px' }}>
+            <Alert variant="info">
+              <AlertSeverityIcon variant="info" />
+              <AlertTitle>Info Alert</AlertTitle>
+              <AlertDescription>Uses the standard info icon.</AlertDescription>
             </Alert>
           </div>
         </div>


### PR DESCRIPTION
## What it solves

Resolves [WA-3185](https://linear.app/safe-global/issue/WA-3185). Split out of #8517 per review.

QA reported four issues in the multi-recipient send funds form after the shadcn migration. Two were real at HEAD (banner styling, input error color); two (error placement, red recipient label) are already correct, likely fixed by #8505/#8514 — QA to re-verify on this build.

## How this PR fixes it

| Problem | Fix |
|---|---|
| Max-send-amount banner and CSV hint rendered as plain cards | Both use the `info` variant, same as the MUI severity they replaced |
| Insufficient-balance and max-recipients alerts: bordered cards, all-red text | Switched to the Obra Figma DS filled style: tinted background, no border (`outlined={false}`, already in the component) |
| Alerts pick their own icon, or none | New `AlertSeverityIcon` in `ui/alert.tsx`, a variant-to-icon map mirroring the sonner toast pairing. Opt-in child, existing consumers untouched. Wired into all four alerts of this form. App-wide sweep: [WA-3194](https://linear.app/safe-global/issue/WA-3194) |
| Error state turned the typed value red inside inputs | `field.tsx` sets `text-destructive` on the whole field when invalid and the input inherited it. Inputs now carry explicit `text-foreground`: label and border stay red, the value stays neutral, matching pre-migration MUI |

## How to test it

Send funds with multiple recipients:
1. Click Max → gray info banner with ⓘ
2. Add recipients past the limit → tinted warning banner with ⚠
3. Enter more than your balance → tinted red alert with the circle icon, and the typed amount stays the normal text color while the field label and border turn red
4. The CSV airdrop hint shows as a gray info banner with ⓘ

## Affected flows

- Multi-recipient send funds form
- Any form input in error state (value text color only)

## Blast radius

- `ui/alert.tsx`: additive `AlertSeverityIcon` export only, no changes to `Alert` behavior or classes
- `ui/input.tsx`: explicit `text-foreground` on the control — checked all ~15 input consumers, none pass a conflicting text color, twMerge still allows overrides. Storybook snapshots updated for the class change (NameInput, DatePickerInput)
- The 5 existing `outlined={false}` consumers are untouched and already match the DS

## Risks / not checked

- Component-level verification (jest + Storybook renders in light and dark), no full flow with a real wallet
- The CSV tip links only render when the gateway lists the CSV Airdrop app for the chain — testnets may not show them, that's data, not code

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics impact)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qf2SonFgLpjter6H1fd61V

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qf2SonFgLpjter6H1fd61V)_