### PR TITLE
fix: give every popup the same blurred background

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -10,6 +10,7 @@ Web-specific guidance for the Next.js app under `apps/web/`. For monorepo-wide r
 - When making a new component, create a Storybook story file for it
 - Use theme variables from vars.css instead of hard-coded CSS values
 - Build UI from the shadcn/ui primitives in `@/components/ui/*` (Tailwind); MUI/Emotion are removed
+- **Never hand-roll a modal scrim.** Anything that dims the page behind it — a dialog, alert dialog, sheet, drawer, backdrop-ed select — renders `overlayVariants()` from [`@/components/ui/overlay`](src/components/ui/overlay.ts). Tint lives in the `--backdrop` token, the blur and the stacking layer live in that one cva. `overlay.test.tsx` fails if a surface drifts. Anchored surfaces (popovers, dropdowns, menus, tooltips) have no scrim by design.
 - **Prefer a component's variant/size prop over one-off `className` overrides.** If you find yourself hand-rolling padding, height, border color, or hover on a `Button`/`Input`/etc., there is probably a variant for it — and if a pattern recurs, add a variant rather than repeating the classes. Watch the tokens: `--input` is white in light mode, so a visible field border needs `border-border`, not `border-input`. The `Button` and `Input` stories are the canonical variant reference; see [.storybook/AGENTS.md](.storybook/AGENTS.md#component-variants-over-custom-styling).
 
 ## Feature Architecture Import Rules

--- a/apps/web/src/components/common/ConnectWallet/AccountCenter.tsx
+++ b/apps/web/src/components/common/ConnectWallet/AccountCenter.tsx
@@ -30,6 +30,7 @@ const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
       </PopoverTrigger>
 
       <PopoverContent
+        showBackdrop
         align="center"
         side="bottom"
         sideOffset={0}

--- a/apps/web/src/components/common/Header/Topbar/NotificationsPopover.tsx
+++ b/apps/web/src/components/common/Header/Topbar/NotificationsPopover.tsx
@@ -57,6 +57,7 @@ const NotificationsPopover = forwardRef<NotificationsPopoverRef>((_props, ref): 
       }}
     >
       <PopoverContent
+        showBackdrop
         anchor={anchorEl}
         side="bottom"
         align="start"

--- a/apps/web/src/components/common/Popup/index.tsx
+++ b/apps/web/src/components/common/Popup/index.tsx
@@ -29,6 +29,7 @@ const Popup = ({ children, open, onClose, anchorEl, modal = true }: PopupProps):
       }}
     >
       <PopoverContent
+        showBackdrop
         anchor={anchorEl ?? undefined}
         align="center"
         side="bottom"

--- a/apps/web/src/components/nested-safes/NestedSafesPopover/index.tsx
+++ b/apps/web/src/components/nested-safes/NestedSafesPopover/index.tsx
@@ -311,6 +311,7 @@ export function NestedSafesPopover({
       }}
     >
       <PopoverContent
+        showBackdrop
         anchor={centered ? centeredAnchor : anchorEl}
         side="bottom"
         align="start"

--- a/apps/web/src/components/notification-center/NotificationCenter/index.tsx
+++ b/apps/web/src/components/notification-center/NotificationCenter/index.tsx
@@ -121,7 +121,13 @@ const NotificationCenter = (): ReactElement => {
           }
         }}
       >
-        <PopoverContent anchor={anchorEl} side="bottom" align="start" className={`${css.popoverContainer} gap-0 p-0`}>
+        <PopoverContent
+          showBackdrop
+          anchor={anchorEl}
+          side="bottom"
+          align="start"
+          className={`${css.popoverContainer} gap-0 p-0`}
+        >
           <div className={css.popoverHeader}>
             {/* flex, so the count centres on the heading's box. As inline boxes the two sat on a
                 shared text baseline, which put the small badge low against a 20px/24px heading. */}

--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -5,6 +5,7 @@ import { AlertDialog as AlertDialogPrimitive } from '@base-ui/react/alert-dialog
 
 import { cn } from '@/utils/cn'
 import { usePortalContainer } from '@/components/ui/ShadcnProvider'
+import { overlayVariants } from '@/components/ui/overlay'
 import { Button } from '@/components/ui/button'
 
 /**
@@ -54,10 +55,7 @@ function AlertDialogOverlay({ className, ...props }: AlertDialogPrimitive.Backdr
   return (
     <AlertDialogPrimitive.Backdrop
       data-slot="alert-dialog-overlay"
-      className={cn(
-        'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-50',
-        className,
-      )}
+      className={cn(overlayVariants(), className)}
       {...props}
     />
   )
@@ -77,7 +75,7 @@ function AlertDialogContent({
         data-slot="alert-dialog-content"
         data-size={size}
         className={cn(
-          'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-dialog ring-foreground/10 gap-6 rounded-xl p-6 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none',
+          'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-dialog ring-foreground/10 gap-6 rounded-xl p-6 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg group/alert-dialog-content fixed top-1/2 left-1/2 z-[var(--z-overlay)] grid w-full -translate-x-1/2 -translate-y-1/2 outline-none',
           className,
         )}
         {...props}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -4,6 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/utils/cn'
 import { usePortalContainer } from '@/components/ui/ShadcnProvider'
+import { overlayVariants } from '@/components/ui/overlay'
 import { Button } from '@/components/ui/button'
 import { XIcon } from 'lucide-react'
 
@@ -106,16 +107,7 @@ function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
 }
 
 function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) {
-  return (
-    <DialogPrimitive.Backdrop
-      data-slot="dialog-overlay"
-      className={cn(
-        'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-starting-style:opacity-0 data-ending-style:opacity-0 bg-backdrop fixed inset-0 z-[var(--z-overlay)]',
-        className,
-      )}
-      {...props}
-    />
-  )
+  return <DialogPrimitive.Backdrop data-slot="dialog-overlay" className={cn(overlayVariants(), className)} {...props} />
 }
 
 function DialogContent({

--- a/apps/web/src/components/ui/drawer.tsx
+++ b/apps/web/src/components/ui/drawer.tsx
@@ -3,6 +3,7 @@ import { Drawer as DrawerPrimitive } from 'vaul'
 
 import { cn } from '@/utils/cn'
 import { usePortalContainerElement } from '@/components/ui/ShadcnProvider'
+import { overlayVariants } from '@/components/ui/overlay'
 
 /**
  * Drawer Component
@@ -56,16 +57,7 @@ function DrawerClose({ ...props }: React.ComponentProps<typeof DrawerPrimitive.C
 }
 
 function DrawerOverlay({ className, ...props }: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
-  return (
-    <DrawerPrimitive.Overlay
-      data-slot="drawer-overlay"
-      className={cn(
-        'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-50',
-        className,
-      )}
-      {...props}
-    />
-  )
+  return <DrawerPrimitive.Overlay data-slot="drawer-overlay" className={cn(overlayVariants(), className)} {...props} />
 }
 
 function DrawerContent({ className, children, ...props }: React.ComponentProps<typeof DrawerPrimitive.Content>) {
@@ -75,7 +67,7 @@ function DrawerContent({ className, children, ...props }: React.ComponentProps<t
       <DrawerPrimitive.Content
         data-slot="drawer-content"
         className={cn(
-          'bg-background flex h-auto flex-col text-sm data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-xl data-[vaul-drawer-direction=bottom]:border-t data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:rounded-r-xl data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:rounded-l-xl data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-xl data-[vaul-drawer-direction=top]:border-b data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm group/drawer-content fixed z-50',
+          'bg-background flex h-auto flex-col text-sm data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-xl data-[vaul-drawer-direction=bottom]:border-t data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:rounded-r-xl data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:rounded-l-xl data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-xl data-[vaul-drawer-direction=top]:border-b data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm group/drawer-content fixed z-[var(--z-overlay)]',
           className,
         )}
         {...props}

--- a/apps/web/src/components/ui/overlay.test.tsx
+++ b/apps/web/src/components/ui/overlay.test.tsx
@@ -1,0 +1,101 @@
+import { render } from '@testing-library/react'
+import { overlayVariants } from './overlay'
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from './dialog'
+import { AlertDialog, AlertDialogContent } from './alert-dialog'
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from './sheet'
+import { Select, SelectContent, SelectItem } from './select'
+import { Drawer, DrawerContent, DrawerDescription, DrawerTitle } from './drawer'
+
+/** The tint + blur pair that makes a scrim a Safe scrim. Every modal surface must carry both. */
+const SCRIM = ['bg-backdrop', 'supports-backdrop-filter:backdrop-blur-xs']
+
+const SURFACES: [name: string, ui: React.ReactElement, slot: string][] = [
+  [
+    'dialog',
+    <Dialog open key="dialog">
+      <DialogContent showCloseButton={false}>
+        <DialogTitle>Title</DialogTitle>
+        <DialogDescription>Body</DialogDescription>
+      </DialogContent>
+    </Dialog>,
+    'dialog-overlay',
+  ],
+  [
+    'alert dialog',
+    <AlertDialog open key="alert-dialog">
+      <AlertDialogContent>Body</AlertDialogContent>
+    </AlertDialog>,
+    'alert-dialog-overlay',
+  ],
+  [
+    'sheet',
+    <Sheet open key="sheet">
+      <SheetContent showCloseButton={false}>
+        <SheetTitle>Title</SheetTitle>
+        <SheetDescription>Body</SheetDescription>
+      </SheetContent>
+    </Sheet>,
+    'sheet-overlay',
+  ],
+  [
+    'drawer',
+    <Drawer open key="drawer">
+      <DrawerContent>
+        <DrawerTitle>Title</DrawerTitle>
+        <DrawerDescription>Body</DrawerDescription>
+      </DrawerContent>
+    </Drawer>,
+    'drawer-overlay',
+  ],
+  [
+    'select',
+    <Select open key="select">
+      <SelectContent showBackdrop>
+        <SelectItem value="a">A</SelectItem>
+      </SelectContent>
+    </Select>,
+    'select-backdrop',
+  ],
+]
+
+describe('overlayVariants', () => {
+  it('tints and blurs, with the blur behind a support guard', () => {
+    expect(overlayVariants()).toContain('bg-backdrop')
+    expect(overlayVariants()).toContain('supports-backdrop-filter:backdrop-blur-xs')
+  })
+
+  it('stacks on the overlay layer', () => {
+    expect(overlayVariants()).toContain('z-[var(--z-overlay)]')
+  })
+
+  it('never lets a closed backdrop capture pointer events', () => {
+    expect(overlayVariants()).toContain('data-closed:pointer-events-none')
+  })
+
+  it('fades on mount when there are no open/closed data attributes to read', () => {
+    const mount = overlayVariants({ transition: 'mount' })
+    expect(mount).toContain('animate-in')
+    expect(mount).not.toContain('data-open:')
+  })
+})
+
+describe('modal surfaces', () => {
+  it.each(SURFACES)('%s renders the shared scrim', (_name, ui, slot) => {
+    const { baseElement } = render(ui)
+    const backdrop = baseElement.querySelector(`[data-slot="${slot}"]`)
+
+    expect(backdrop).not.toBeNull()
+    SCRIM.forEach((className) => expect(backdrop).toHaveClass(className))
+  })
+
+  it('gives every surface the same scrim, so none of them drifts', () => {
+    const scrims = SURFACES.map(([, ui, slot]) => {
+      const { baseElement, unmount } = render(ui)
+      const className = baseElement.querySelector(`[data-slot="${slot}"]`)?.className ?? ''
+      unmount()
+      return className
+    })
+
+    expect(new Set(scrims).size).toBe(1)
+  })
+})

--- a/apps/web/src/components/ui/overlay.test.tsx
+++ b/apps/web/src/components/ui/overlay.test.tsx
@@ -5,6 +5,7 @@ import { AlertDialog, AlertDialogContent } from './alert-dialog'
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from './sheet'
 import { Select, SelectContent, SelectItem } from './select'
 import { Drawer, DrawerContent, DrawerDescription, DrawerTitle } from './drawer'
+import { Popover, PopoverContent } from './popover'
 
 /** The tint + blur pair that makes a scrim a Safe scrim. Every modal surface must carry both. */
 const SCRIM = ['bg-backdrop', 'supports-backdrop-filter:backdrop-blur-xs']
@@ -46,6 +47,13 @@ const SURFACES: [name: string, ui: React.ReactElement, slot: string][] = [
       </DrawerContent>
     </Drawer>,
     'drawer-overlay',
+  ],
+  [
+    'popover panel',
+    <Popover open key="popover">
+      <PopoverContent showBackdrop>Body</PopoverContent>
+    </Popover>,
+    'popover-backdrop',
   ],
   [
     'select',
@@ -97,5 +105,17 @@ describe('modal surfaces', () => {
     })
 
     expect(new Set(scrims).size).toBe(1)
+  })
+})
+
+describe('anchored surfaces', () => {
+  it('a popover has no scrim unless it opts in', () => {
+    const { baseElement } = render(
+      <Popover open>
+        <PopoverContent>Body</PopoverContent>
+      </Popover>,
+    )
+
+    expect(baseElement.querySelector('[data-slot="popover-backdrop"]')).toBeNull()
   })
 })

--- a/apps/web/src/components/ui/overlay.ts
+++ b/apps/web/src/components/ui/overlay.ts
@@ -1,0 +1,43 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+
+/**
+ * Overlay — the one backdrop every modal surface shares.
+ *
+ * Dialogs, alert dialogs, sheets, drawers, backdrop-ed selects and the support-chat panel all
+ * render this class, so the scrim is tinted, blurred and stacked in a single place. Before this
+ * existed the app shipped four hand-copied scrims that drifted apart in the MUI -> shadcn
+ * migration: two of them had no blur at all and two sat two orders of magnitude below
+ * `--z-overlay`. Change the look here, never at the call site.
+ *
+ * The tint is the `--backdrop` token (styles/shadcn.css). The blur sits behind
+ * `supports-backdrop-filter:` so a browser without `backdrop-filter` still gets the tint.
+ *
+ * `data-closed:pointer-events-none` is load-bearing, not a nicety: a surface that mounts already
+ * open and closes in the same commit never runs its enter animation, so Base UI waits forever for
+ * an `animationend` and leaves the backdrop mounted at `opacity: 0` with `pointer-events: auto` —
+ * an invisible full-viewport shield that swallows every click on the page (this is what broke the
+ * topbar's "Open sidebar menu" button below `md`). A closed backdrop must never capture pointer
+ * events, however it got there.
+ */
+export const overlayVariants = cva(
+  'bg-backdrop supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-[var(--z-overlay)] duration-100',
+  {
+    variants: {
+      /**
+       * How the scrim fades. `state` reads the `data-open` / `data-closed` (and Base UI
+       * starting/ending style) attributes the overlay primitives put on the backdrop element;
+       * `mount` is for a plain element that has none of those and is unmounted when closed.
+       */
+      transition: {
+        state:
+          'data-open:animate-in data-closed:animate-out data-open:fade-in-0 data-closed:fade-out-0 data-starting-style:opacity-0 data-ending-style:opacity-0 data-closed:pointer-events-none',
+        mount: 'animate-in fade-in-0',
+      },
+    },
+    defaultVariants: {
+      transition: 'state',
+    },
+  },
+)
+
+export type OverlayVariants = VariantProps<typeof overlayVariants>

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -5,6 +5,7 @@ import { Popover as PopoverPrimitive } from '@base-ui/react/popover'
 
 import { cn } from '@/utils/cn'
 import { usePortalContainer } from '@/components/ui/ShadcnProvider'
+import { overlayVariants } from '@/components/ui/overlay'
 
 /**
  * Popover Component
@@ -23,7 +24,7 @@ import { usePortalContainer } from '@/components/ui/ShadcnProvider'
  *
  * @remarks
  * Key Props:
- * - PopoverContent: `align`, `alignOffset`, `side`, `sideOffset`
+ * - PopoverContent: `align`, `alignOffset`, `side`, `sideOffset`, `showBackdrop`
  * - Root / Trigger: see Base UI popover
  */
 
@@ -43,15 +44,32 @@ function PopoverContent({
   sideOffset = 4,
   anchor,
   collisionAvoidance,
+  showBackdrop = false,
   ...props
 }: PopoverPrimitive.Popup.Props &
   Pick<
     PopoverPrimitive.Positioner.Props,
     'align' | 'alignOffset' | 'side' | 'sideOffset' | 'anchor' | 'collisionAvoidance'
-  >) {
+  > & {
+    /**
+     * Dims and blurs the page behind the popover with the shared overlay scrim.
+     *
+     * Set this on a popover that reads as a panel — a titled card with its own close button, like
+     * the header's Nested Safes, notifications, wallet and WalletConnect popups. Those are modals
+     * that happen to be anchored, and without a scrim they float on a page that still looks live.
+     *
+     * Leave it off for a true dropdown: a menu, a select, a date picker, a filter, a tooltip. Those
+     * belong to the control that opened them, and dimming the page around a menu item is wrong.
+     *
+     * Do NOT set it on a popover opened from inside a dialog or sheet — the scrim paints above that
+     * surface and would blur the content the popover belongs to.
+     */
+    showBackdrop?: boolean
+  }) {
   const portalContainer = usePortalContainer()
   return (
     <PopoverPrimitive.Portal container={portalContainer}>
+      {showBackdrop && <PopoverPrimitive.Backdrop data-slot="popover-backdrop" className={overlayVariants()} />}
       <PopoverPrimitive.Positioner
         align={align}
         alignOffset={alignOffset}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -4,6 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/utils/cn'
 import { usePortalContainer } from '@/components/ui/ShadcnProvider'
+import { overlayVariants } from '@/components/ui/overlay'
 import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from 'lucide-react'
 
 /**
@@ -151,12 +152,7 @@ function SelectContent({
   const portalContainer = usePortalContainer()
   return (
     <SelectPrimitive.Portal container={portalContainer}>
-      {showBackdrop && (
-        <SelectPrimitive.Backdrop
-          data-slot="select-backdrop"
-          className="data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-starting-style:opacity-0 data-ending-style:opacity-0 bg-backdrop fixed inset-0 z-[var(--z-overlay)]"
-        />
-      )}
+      {showBackdrop && <SelectPrimitive.Backdrop data-slot="select-backdrop" className={overlayVariants()} />}
       <SelectPrimitive.Positioner
         side={side}
         sideOffset={sideOffset}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -146,7 +146,13 @@ function SelectContent({
     | 'collisionBoundary'
     | 'collisionAvoidance'
   > & {
-    /** Dims the rest of the page while the select is open (same look as the dialog overlay). */
+    /**
+     * Dims the rest of the page while the select is open (the shared overlay scrim).
+     *
+     * Do NOT set this on a select rendered inside a dialog or sheet. The scrim paints above that
+     * surface, so it blurs the very form the dropdown belongs to — and the dialog's own backdrop
+     * already handles the dimming, the scroll lock and the outside click.
+     */
     showBackdrop?: boolean
   }) {
   const portalContainer = usePortalContainer()

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -4,6 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/utils/cn'
 import { usePortalContainer } from '@/components/ui/ShadcnProvider'
+import { overlayVariants } from '@/components/ui/overlay'
 import { Button } from '@/components/ui/button'
 import { XIcon } from 'lucide-react'
 
@@ -116,22 +117,7 @@ function SheetPortal({ ...props }: SheetPrimitive.Portal.Props) {
 }
 
 function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
-  return (
-    <SheetPrimitive.Backdrop
-      data-slot="sheet-overlay"
-      // `data-closed:pointer-events-none` is load-bearing, not a nicety: a Sheet that mounts already
-      // open and closes in the same commit never runs its enter animation, so Base UI waits forever
-      // for an `animationend` and leaves the backdrop mounted at `opacity: 0` with
-      // `pointer-events: auto` — an invisible full-viewport shield that swallows every click on the
-      // page (this is what broke the topbar's "Open sidebar menu" button below `md`). A closed
-      // backdrop must never capture pointer events, however it got there.
-      className={cn(
-        'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:pointer-events-none bg-black/10 duration-100 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-[var(--z-overlay)]',
-        className,
-      )}
-      {...props}
-    />
-  )
+  return <SheetPrimitive.Backdrop data-slot="sheet-overlay" className={cn(overlayVariants(), className)} {...props} />
 }
 
 function SheetContent({

--- a/apps/web/src/components/ui/stories/overlay.stories.tsx
+++ b/apps/web/src/components/ui/stories/overlay.stories.tsx
@@ -8,6 +8,7 @@ import {
 } from '../alert-dialog'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../dialog'
 import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } from '../drawer'
+import { Popover, PopoverContent, PopoverDescription, PopoverTitle } from '../popover'
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '../sheet'
 
 /**
@@ -129,6 +130,26 @@ export const DrawerBackdrop: Story = {
           </DrawerHeader>
         </DrawerContent>
       </Drawer>
+    </>
+  ),
+}
+
+/**
+ * A popover panel — a titled card with its own close button, like the header's Nested Safes,
+ * notifications, wallet and WalletConnect popups. Those are modals that happen to be anchored, so
+ * they opt into the same scrim via `showBackdrop`. A true dropdown (menu, select, date picker,
+ * filter) never does; see the Popover story for that shape.
+ */
+export const PopoverPanelBackdrop: Story = {
+  render: () => (
+    <>
+      <PageBehind />
+      <Popover open>
+        <PopoverContent showBackdrop anchor={{ getBoundingClientRect: () => new DOMRect(640, 320, 0, 0) }}>
+          <PopoverTitle>Popover panel</PopoverTitle>
+          <PopoverDescription>Opted into the one scrim via showBackdrop.</PopoverDescription>
+        </PopoverContent>
+      </Popover>
     </>
   ),
 }

--- a/apps/web/src/components/ui/stories/overlay.stories.tsx
+++ b/apps/web/src/components/ui/stories/overlay.stories.tsx
@@ -1,0 +1,134 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../alert-dialog'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../dialog'
+import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } from '../drawer'
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '../sheet'
+
+/**
+ * Overlay (backdrop) Stories
+ *
+ * Every modal surface shares one scrim — `overlayVariants()` in `components/ui/overlay.ts`. These
+ * stories exist for the backdrop, not the popups: each one puts a surface over dense page content
+ * so Argos can see the tint and the blur. A blank canvas cannot show either, which is how four
+ * different scrims drifted apart unnoticed in the first place.
+ *
+ * @see components/ui/overlay.ts
+ */
+const meta = {
+  title: 'UI/Overlay',
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj
+
+/** Fine text, hard table rules and saturated blocks — the detail a 4px blur is measured against. */
+const PageBehind = () => (
+  <div className="min-h-screen bg-[var(--color-background-main)] p-6">
+    <h1 className="text-foreground mb-1 text-2xl font-bold">Assets</h1>
+    <p className="text-muted-foreground mb-6 text-sm">Content behind the scrim, so the blur has something to blur.</p>
+
+    <div className="mb-6 flex gap-3">
+      {['#12ff80', '#5fddff', '#ff5f72', '#fbbf24', '#a78bfa'].map((color) => (
+        <div
+          key={color}
+          className="h-16 w-28 rounded-lg"
+          style={{ background: `linear-gradient(135deg, ${color}, #111)` }}
+        />
+      ))}
+    </div>
+
+    <table className="text-foreground w-full border-collapse text-xs">
+      <thead>
+        <tr className="border-border border-b">
+          {['Asset', 'Balance', 'Value', 'Chain', 'Updated'].map((heading) => (
+            <th key={heading} className="px-2 py-2 text-left font-medium">
+              {heading}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {Array.from({ length: 14 }, (_, row) => (
+          <tr key={row} className="border-border/60 border-b">
+            <td className="px-2 py-1.5">0x{(row * 748213).toString(16).padStart(8, '0')}…c4f1</td>
+            <td className="px-2 py-1.5">{(row * 13.37).toFixed(4)} ETH</td>
+            <td className="px-2 py-1.5">${(row * 4211.9).toFixed(2)}</td>
+            <td className="px-2 py-1.5">Ethereum</td>
+            <td className="px-2 py-1.5">2 min ago</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+)
+
+export const DialogBackdrop: Story = {
+  render: () => (
+    <>
+      <PageBehind />
+      <Dialog open>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>Dialog</DialogTitle>
+            <DialogDescription>Shares the one scrim.</DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+    </>
+  ),
+}
+
+export const AlertDialogBackdrop: Story = {
+  render: () => (
+    <>
+      <PageBehind />
+      <AlertDialog open>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Alert dialog</AlertDialogTitle>
+            <AlertDialogDescription>Shares the one scrim.</AlertDialogDescription>
+          </AlertDialogHeader>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  ),
+}
+
+export const SheetBackdrop: Story = {
+  render: () => (
+    <>
+      <PageBehind />
+      <Sheet open>
+        <SheetContent showCloseButton={false}>
+          <SheetHeader>
+            <SheetTitle>Sheet</SheetTitle>
+            <SheetDescription>Shares the one scrim.</SheetDescription>
+          </SheetHeader>
+        </SheetContent>
+      </Sheet>
+    </>
+  ),
+}
+
+export const DrawerBackdrop: Story = {
+  render: () => (
+    <>
+      <PageBehind />
+      <Drawer open direction="right">
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>Drawer</DrawerTitle>
+            <DrawerDescription>Shares the one scrim.</DrawerDescription>
+          </DrawerHeader>
+        </DrawerContent>
+      </Drawer>
+    </>
+  ),
+}

--- a/apps/web/src/features/hypernative/components/HnSignupFlow/__snapshots__/HnModal.stories.test.tsx.snap
+++ b/apps/web/src/features/hypernative/components/HnSignupFlow/__snapshots__/HnModal.stories.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`./HnModal.stories Default 1`] = `
 <div
@@ -20,7 +20,7 @@ exports[`./HnModal.stories Default 1`] = `
       />
       <div
         aria-hidden="true"
-        class="data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-starting-style:opacity-0 data-ending-style:opacity-0 bg-backdrop fixed inset-0 z-[var(--z-overlay)]"
+        class="bg-backdrop supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-[var(--z-overlay)] duration-100 data-open:animate-in data-closed:animate-out data-open:fade-in-0 data-closed:fade-out-0 data-starting-style:opacity-0 data-ending-style:opacity-0 data-closed:pointer-events-none"
         data-base-ui-inert=""
         data-open=""
         data-slot="dialog-overlay"

--- a/apps/web/src/features/hypernative/components/HnSignupFlow/__snapshots__/HnSignupFlow.stories.test.tsx.snap
+++ b/apps/web/src/features/hypernative/components/HnSignupFlow/__snapshots__/HnSignupFlow.stories.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`./HnSignupFlow.stories Default 1`] = `
 <div
@@ -20,7 +20,7 @@ exports[`./HnSignupFlow.stories Default 1`] = `
       />
       <div
         aria-hidden="true"
-        class="data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-starting-style:opacity-0 data-ending-style:opacity-0 bg-backdrop fixed inset-0 z-[var(--z-overlay)]"
+        class="bg-backdrop supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-[var(--z-overlay)] duration-100 data-open:animate-in data-closed:animate-out data-open:fade-in-0 data-closed:fade-out-0 data-starting-style:opacity-0 data-ending-style:opacity-0 data-closed:pointer-events-none"
         data-base-ui-inert=""
         data-open=""
         data-slot="dialog-overlay"

--- a/apps/web/src/features/spaces/components/AddMemberModal/MemberInfoForm.test.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/MemberInfoForm.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import { FormProvider, useForm } from 'react-hook-form'
+import MemberInfoForm from './MemberInfoForm'
+import { MemberRole } from '@/features/spaces'
+
+const Wrapper = () => {
+  const methods = useForm({ defaultValues: { name: '', role: MemberRole.MEMBER } })
+  return (
+    <FormProvider {...methods}>
+      <MemberInfoForm />
+    </FormProvider>
+  )
+}
+
+describe('MemberInfoForm', () => {
+  it('renders the name field and the role select', () => {
+    render(<Wrapper />)
+
+    expect(screen.getByTestId('member-name-input')).toBeInTheDocument()
+    expect(screen.getByLabelText('Role')).toBeInTheDocument()
+  })
+
+  // Both consumers (Add member, Edit member) are ModalDialogs. A select backdrop paints above the
+  // dialog, so it would blur the form the dropdown belongs to — the dialog's own backdrop already
+  // dims the page, locks scroll and handles the outside click.
+  it('does not add a second scrim on top of the dialog it lives in', () => {
+    render(<Wrapper />)
+
+    expect(document.querySelector('[data-slot="select-backdrop"]')).toBeNull()
+  })
+})

--- a/apps/web/src/features/spaces/components/AddMemberModal/MemberInfoForm.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/MemberInfoForm.tsx
@@ -50,7 +50,10 @@ const MemberInfoForm = ({
               <SelectTrigger aria-label="Role" className="min-h-[66px]! min-w-[150px]">
                 <SelectValue>{(role) => <RoleMenuItem role={role as MemberRole} />}</SelectValue>
               </SelectTrigger>
-              <SelectContent align="end" alignItemWithTrigger={false} showBackdrop className=" min-h-[66px] w-[340px]">
+              {/* No `showBackdrop`: both consumers (Add member, Edit member) are ModalDialogs, so the
+                  dialog already owns the scrim. A second one paints over the dialog and blurs the
+                  very form the dropdown belongs to. */}
+              <SelectContent align="end" alignItemWithTrigger={false} className=" min-h-[66px] w-[340px]">
                 <SelectItem value={MemberRole.ADMIN}>
                   <RoleMenuItem role={MemberRole.ADMIN} hasDescription />
                 </SelectItem>

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/__snapshots__/SecurityReportDrawer.stories.test.tsx.snap
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/__snapshots__/SecurityReportDrawer.stories.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`./SecurityReportDrawer.stories OpenWithContext 1`] = `
       />
       <div
         aria-hidden="true"
-        class="data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:pointer-events-none bg-black/10 duration-100 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-[var(--z-overlay)]"
+        class="bg-backdrop supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-[var(--z-overlay)] duration-100 data-open:animate-in data-closed:animate-out data-open:fade-in-0 data-closed:fade-out-0 data-starting-style:opacity-0 data-ending-style:opacity-0 data-closed:pointer-events-none"
         data-base-ui-inert=""
         data-open=""
         data-slot="sheet-overlay"

--- a/apps/web/src/features/support-chat/components/SupportChatDrawer.tsx
+++ b/apps/web/src/features/support-chat/components/SupportChatDrawer.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Typography } from '@/components/ui/typography'
 import { Spinner } from '@/components/ui/spinner'
+import { overlayVariants } from '@/components/ui/overlay'
 import { cn } from '@/utils/cn'
 
 // Types
@@ -232,7 +233,9 @@ function SupportChatDrawer({ open, onClose, config, user }: SupportChatDrawerPro
 
   return (
     <>
-      <div aria-hidden onClick={onClose} className="fixed inset-0 z-[1300] bg-black/20 dark:bg-black/40" />
+      {/* Same scrim as every dialog/sheet/drawer; only the layer differs (the chat panel above
+          sits at 1301, below the overlay layer the modal surfaces share). */}
+      <div aria-hidden onClick={onClose} className={cn(overlayVariants({ transition: 'mount' }), 'z-[1300]')} />
       <div
         className="fixed bottom-0 left-0 z-[1301] h-screen max-h-screen w-screen max-w-[100vw] origin-bottom-left animate-in fade-in zoom-in-95 slide-in-from-bottom-2 duration-150 sm:bottom-[72px] sm:left-6 sm:h-auto sm:max-h-[calc(100vh-88px)] sm:w-[var(--chat-w)] sm:max-w-[var(--chat-w)]"
         style={{ ['--chat-w' as string]: `${chatWidth}px` }}

--- a/apps/web/src/features/wallet/components/WalletPopover/index.tsx
+++ b/apps/web/src/features/wallet/components/WalletPopover/index.tsx
@@ -28,7 +28,14 @@ const WalletPopover = ({
         if (!isOpen) onClose()
       }}
     >
-      <PopoverContent anchor={anchorEl} side="bottom" align="center" sideOffset={12} className="w-[300px] rounded-3xl">
+      <PopoverContent
+        showBackdrop
+        anchor={anchorEl}
+        side="bottom"
+        align="center"
+        sideOffset={12}
+        className="w-[300px] rounded-3xl"
+      >
         <WalletInfo
           wallet={wallet}
           balance={wallet.balance}

--- a/apps/web/src/styles/shadcn.css
+++ b/apps/web/src/styles/shadcn.css
@@ -23,7 +23,9 @@
   --popover: #ffffff;
   --popover-foreground: #0a0a0a;
   --dialog: #ffffff;
-  --backdrop: rgba(99, 102, 105, 0.75);
+  /* The one modal scrim (see components/ui/overlay.ts). A light tint carries the blur;
+     the old MUI-era rgba(99, 102, 105, 0.75) was opaque enough to hide it entirely. */
+  --backdrop: rgba(0, 0, 0, 0.1);
   --primary: #171717;
   --primary-foreground: #fafafa;
   --secondary: #f5f5f5;
@@ -91,7 +93,8 @@
   --popover: #171717;
   --popover-foreground: #f5f5f5;
   --dialog: #1c1c1c;
-  --backdrop: rgba(99, 102, 105, 0.75);
+  /* Same scrim in dark mode: the blur, not the tint, is what separates the surface. */
+  --backdrop: rgba(0, 0, 0, 0.1);
   --primary: #12ff80;
   --primary-foreground: #0a0a0a;
   --secondary: #262626;


### PR DESCRIPTION
## What it solves

Resolves: [WA-3236](https://linear.app/safe-global/issue/WA-3236/popup-backdrops-drifted-into-four-different-scrims-after-shadcn) (child of [WA-3111](https://linear.app/safe-global/issue/WA-3111/ui-shadcn-post-migration-findings-part-2))

Popups don't agree on what the page behind them should look like. Dialogs get a flat grey wash. Sheets and drawers get a light tint with a blur. The header panels (Nested Safes, notifications, wallet, WalletConnect) get nothing at all and float on a page that still looks live. The support chat has its own third thing.

Five copies of the same scrim with nobody owning it, plus a set of panels that never had one. They drifted apart in the MUI to shadcn migration (#8040): `dialog` and `select` were hand-ported to MUI's old grey, the rest kept the shadcn default.

| Surface | Before | Blur |
| --- | --- | --- |
| Dialog (24 direct + 39 via `ModalDialog`) | grey 75% | no |
| Select (`showBackdrop`) | grey 75% | no |
| Alert dialog | black 10% | yes, `z-50` |
| Sheet | black 10% | yes |
| Drawer | black 10% | yes, `z-50` |
| Support chat | black 20% / dark 40%, hand-rolled | no |
| Popover panels (Nested Safes, notifications, wallet, WalletConnect) | none | no |

## How this PR fixes it

One definition: `overlayVariants()` in `components/ui/overlay.ts`. Dialog, alert dialog, sheet, drawer, select, popover panels and the support chat panel all render it. Tint stays in the `--backdrop` token, blur and stacking layer live in the cva.

The tint had to get lighter. At 75% grey a 4px blur is invisible, so keeping the old dialog value would have made the blur pointless. The blurred look already shipped on sheets and alert dialogs, so that one wins and the rest match it.

**Which surfaces get a scrim.** A titled card with its own close button is a modal, even when it is anchored to a trigger, so the five header panels opt in via `showBackdrop` on `PopoverContent`, mirroring the prop `select.tsx` already had. A true dropdown does not: menus, selects, the date picker, the tx history filter, tooltips, the help menu, the spaces profile menu. Dimming the page around a menu item is a different design decision, not a normalisation. The tx-flow modal also keeps none, it's an opaque full-page panel rather than a popup.

**Two stacking bugs fell out.** The alert dialog scrim sat at `z-50`, 1350 below `--z-overlay`, so it was stranded behind the tx modal it was meant to dim. The Safe App preview drawer had the same problem and slid under the topbar. Both popups move up with their backdrops.

**One nested-scrim bug fixed.** The Add member / Edit member role select passed `showBackdrop` while living inside a `ModalDialog`. Its scrim painted over the dialog, and once the scrim gained a blur the form you were filling in became unreadable. Dropped it: the dialog's own backdrop already dims the page, locks scroll and handles the outside click.

## How to test it

`yarn workspace @safe-global/web storybook` then open **UI / Overlay** for all five surfaces over dense content. Toggle the theme in the toolbar.

Automated: `overlay.test.tsx` asserts all six backdrops resolve to one identical class string, and that a plain popover stays scrim-free.

<details>
<summary>Manual test in the app</summary>

**Dialog**

- Go to Address book
- Click "New entry"
- Observe the page behind the dialog
- It should be blurred with a light tint, not a flat grey wash

**Popover panels (the ones that had no scrim at all)**

- Click the Nested Safes button in the header
- Observe the page behind the panel
- It should now be blurred. Before this PR it was untouched, so the panel floated on a page that looked live.
- Repeat for: the notifications bell, the connected-wallet button, the wallet panel, and the WalletConnect popup

**Dropdowns must NOT have gained a scrim**

- Open the accounts list 3-dots menu, the help menu (sidebar footer), a date picker, and the Filter popover on Transactions → History
- Observe the page behind each
- It should be untouched. These belong to the control that opened them.

**Alert dialog (and the z-index fix)**

- Open Assets, click Send, start a token transfer
- Click the X to close the flow
- Observe the "Discard this transaction?" confirmation
- It should sit above the tx flow with the flow blurred underneath. Before this PR the scrim was stuck behind the tx modal, so nothing dimmed.
- Repeat below 900px width, where the tx modal is `z-index: 1300`. Same result.

**Sheet (mobile sidebar)**

- Narrow the window below 900px
- Click the hamburger in the topbar ("Open sidebar menu")
- Observe the page next to the sidebar
- It should be blurred. Unchanged from before, this one is the regression check.
- Close it, then click the hamburger again. It should still open (a closed backdrop must not swallow clicks).

**Sheet (batch)**

- On a Safe route, click the batch button in the topbar ("Batch transactions")
- Observe the page behind the sidebar
- It should be blurred, and the sidebar should stay above its own scrim

**Drawer (Safe App preview)**

- Go to Safe Apps
- Click an app you have not opened before (already-opened apps launch straight away instead)
- Observe the drawer sliding in from the right
- It should be blurred behind, and the drawer should now cover the topbar instead of sliding under it

**Role select inside a dialog (the nested-scrim fix)**

- Open a space, go to Members, edit a member (or click Add member)
- Open the "Role" dropdown
- Observe the form behind the dropdown
- It should stay fully readable. There is one scrim now, the dialog's. Before this PR a second scrim painted over the dialog.

**Select with a scrim, standalone**

- Open the Safe selector dropdown in the spaces sidebar
- Observe the page behind it
- It should be blurred. This one is not inside a dialog, so it keeps `showBackdrop`.

**Support chat**

- Click the help button in the sidebar footer, then "Contact support"
- Observe the page behind the chat panel
- It should be blurred, matching the dialogs. It used to be a plain 20% black with no blur.

**Dark mode**

- Switch to dark mode and repeat the dialog, panel and sidebar cases
- At 10% black the blur is doing the separating, not the tint. The dialog surface (`#1c1c1c` plus its ring) should still read clearly against the page.

**Known gap**

- Connect a wallet and observe the web3-onboard modal
- It still has the old grey, no blur. Onboard renders in shadow DOM and only exposes a colour variable, so `backdrop-filter` can't reach it.

</details>

## Affected flows

- Every dialog in the app: 24 direct `Dialog` consumers plus 39 via `ModalDialog`, so all tx flows, address book, settings, spaces
- Header panels: Nested Safes, notifications (topbar and centre), wallet, connected-wallet, WalletConnect
- Discard confirmation when closing a tx flow, batch execute confirmation, delete and leave space
- Mobile sidebar, batch sidebar, security report drawer
- Safe App preview drawer
- Member role select (Add member, Edit member), safe selector dropdown
- Support chat panel

## Blast radius

- `components/ui/overlay.ts` (new) is imported by `dialog`, `alert-dialog`, `sheet`, `drawer`, `select`, `popover` and `SupportChatDrawer`. Anything that opens a modal surface picks up the new scrim.
- `--backdrop` in `styles/shadcn.css` (light and dark). Only read via `bg-backdrop`, which after this PR only exists inside `overlayVariants()`. `--color-backdrop-main` in `vars.css` is a different token and is untouched.
- `PopoverContent` gains an opt-in `showBackdrop`. Default is `false`, so the other eight popover consumers are unchanged.
- z-index: `AlertDialogContent` and `DrawerContent` move from `z-50` to `--z-overlay` (1400). Consumers that override the layer still win through tailwind-merge: `SpaceSafeBar`, `SafeListContextMenu`, `SafeAccountsTable` rename, `PkModulePopup` (`--z-above-onboard`), `BatchSidebar` (`z-[100]`), tx-flow discard (`--z-nested-overlay`).
- Three storybook snapshots capture the overlay class string and are updated. Note `yarn verify:web` does not run `test:storybook`, so a local green there does not cover them.
- No API, store, feature flag, route or persistence change. No shared package touched, so no mobile impact.
- `apps/web/AGENTS.md` gains one rule so the next person reaches for the shared scrim instead of copying classes.

## Risks / not checked

- **Only tested in Storybook.** The staging backend is unreachable from the environment this was built in, so no flow was exercised against a real Safe, a real wallet, or a real device. What was checked: 64 story/theme combinations asserting computed `background-color`, `backdrop-filter` and z-index (0 failures), negative checks on five dropdown surfaces, an open/close/reopen cycle on the mobile sidebar, and eyeballed screenshots over dense content in both themes.
- The Safe App preview drawer now paints over the topbar (it was at `z-50` before, under it). That's consistent with every Sheet, but it is a visible change beyond the backdrop and worth a look.
- Dialogs are noticeably lighter behind now. That is the point of the change, but it is a call worth a designer's eye. If more separation is wanted, `--backdrop` is the single knob.
- Which popovers count as "panel" versus "dropdown" is a judgement call. I put the five header panels in and left menus, selects, the date picker, the tx filter, the help menu and the spaces profile menu out. Say the word if any of those should flip.
- The wallet-connect modal is unchanged, so the app is still not 100% uniform. See "Known gap" above. Needs its own ticket if we want it.
- `Select` mounted already open renders its portal outside `.shadcn-scope` and loses every CSS var, scrim and popup alike. Pre-existing Base UI portal timing issue, unreachable in the app since both `showBackdrop` consumers open on click, but it will bite anyone who ships a select that starts open.

## Visual summary

Argos will post the pixel diff on this PR (it runs on every `apps/web/**` change and shoots every story in light and dark). The new **UI / Overlay** stories are what it will pick up.

```mermaid
flowchart TB
  subgraph Before["Before: 5 hand-copied scrims, 1 group with none"]
    D1["dialog.tsx<br/>grey 75%, no blur, z1400"]
    A1["alert-dialog.tsx<br/>black 10%, blur, z50"]
    S1["sheet.tsx<br/>black 10%, blur, z1400"]
    W1["drawer.tsx<br/>black 10%, blur, z50"]
    E1["select.tsx<br/>grey 75%, no blur"]
    C1["SupportChatDrawer<br/>black 20/40%, no blur, z1300"]
    P1["popover panels<br/>no scrim at all"]
  end

  subgraph After["After: one definition"]
    OV["overlayVariants()<br/>bg-backdrop + blur 4px + z1400"]
    TOK["--backdrop token<br/>shadcn.css"]
    OV --> TOK
    D2["dialog"] --> OV
    A2["alert-dialog"] --> OV
    S2["sheet"] --> OV
    W2["drawer"] --> OV
    E2["select (showBackdrop)"] --> OV
    P2["popover (showBackdrop)"] --> OV
    C2["support chat"] --> OV
    T["overlay.test.tsx<br/>all 6 resolve to one class string"] -.guards.-> OV
    G["overlay.stories.tsx<br/>Argos sees the pixels"] -.guards.-> OV
  end

  subgraph Untouched["Deliberately no scrim"]
    M["menus, selects, date picker,<br/>tx filter, tooltips, help menu"]
    X["tx-flow modal<br/>opaque full-page panel"]
  end

  Before ==> After
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics touched)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 (`overlay.test.tsx`, `MemberInfoForm.test.tsx`, `overlay.stories.tsx` for Argos)
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).