### PR TITLE
fix(UI): adjust alert colors as per the latest design

### DIFF
--- a/apps/web/src/components/common/ChainSwitcher/index.tsx
+++ b/apps/web/src/components/common/ChainSwitcher/index.tsx
@@ -33,7 +33,7 @@ const ChainSwitcher = ({
     <Button
       onClick={handleChainSwitch}
       variant={primaryCta ? 'default' : 'outline'}
-      className={cn('min-w-[200px]', fullWidth && 'w-full')}
+      className={cn('min-w-[200px]', !primaryCta && 'text-foreground', fullWidth && 'w-full')}
       size={primaryCta ? 'default' : 'sm'}
       disabled={loading}
     >

--- a/apps/web/src/components/common/ConnectWallet/ConnectWalletButton.tsx
+++ b/apps/web/src/components/common/ConnectWallet/ConnectWalletButton.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/utils/cn'
 const ConnectWalletButton = ({
   onConnect,
   contained = true,
+  variant,
   size = 'default',
   text,
   className,
@@ -12,6 +13,7 @@ const ConnectWalletButton = ({
 }: {
   onConnect?: () => void
   contained?: boolean
+  variant?: React.ComponentProps<typeof Button>['variant']
   size?: React.ComponentProps<typeof Button>['size']
   text?: string
   className?: string
@@ -28,7 +30,7 @@ const ConnectWalletButton = ({
     <Button
       data-testid="connect-wallet-btn"
       onClick={handleConnect}
-      variant={contained ? 'default' : 'ghost'}
+      variant={variant ?? (contained ? 'default' : 'ghost')}
       size={size}
       className={cn(fullWidth && 'w-full', className)}
     >

--- a/apps/web/src/components/common/Notifications/index.tsx
+++ b/apps/web/src/components/common/Notifications/index.tsx
@@ -156,19 +156,21 @@ const Toast = ({
           <X />
         </Button>
       </AlertAction>
-      {title && <AlertTitle>{title}</AlertTitle>}
+      <AlertTitle>{title || message}</AlertTitle>
 
-      <AlertDescription>
-        {message}
+      {(title || detailedMessage || link) && (
+        <AlertDescription>
+          {title && message}
 
-        {detailedMessage && (
-          <details>
-            <Link render={<summary />}>Details</Link>
-            <pre>{detailedMessage}</pre>
-          </details>
-        )}
-        <NotificationLink link={link} onClick={handleManualClose} />
-      </AlertDescription>
+          {detailedMessage && (
+            <details>
+              <Link render={<summary />}>Details</Link>
+              <pre>{detailedMessage}</pre>
+            </details>
+          )}
+          <NotificationLink link={link} onClick={handleManualClose} />
+        </AlertDescription>
+      )}
     </Alert>
   )
 }

--- a/apps/web/src/components/common/Notifications/styles.module.css
+++ b/apps/web/src/components/common/Notifications/styles.module.css
@@ -51,11 +51,7 @@
   display: none;
 }
 
-[data-theme='dark'] .container .errorToast [data-slot='alert-description'] {
-  color: var(--color-error-main);
-}
-
 .container .errorToast [data-slot='alert-description'] summary {
-  color: inherit;
+  color: var(--foreground);
   font-weight: 700;
 }

--- a/apps/web/src/components/new-safe/create/NoWalletConnectedWarning/index.tsx
+++ b/apps/web/src/components/new-safe/create/NoWalletConnectedWarning/index.tsx
@@ -16,7 +16,7 @@ const NoWalletConnectedWarning = () => {
       <AlertDescription>
         You need to connect a wallet to create a Safe account.
         <div className="mt-4">
-          <ConnectWalletButton />
+          <ConnectWalletButton variant="outline" className="text-foreground" />
         </div>
       </AlertDescription>
     </Alert>

--- a/apps/web/src/components/notification-center/NotificationRenewal/index.tsx
+++ b/apps/web/src/components/notification-center/NotificationRenewal/index.tsx
@@ -39,9 +39,9 @@ const NotificationRenewal = (): ReactElement => {
         >
           {(isOk) => (
             <Button
-              variant="default"
+              variant="outline"
               size="sm"
-              className="w-[200px]"
+              className="w-[200px] text-foreground"
               onClick={handeSignClick}
               disabled={!isOk || isRegistering || !safe.deployed}
             >

--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/__tests__/CreateTokenTransfer.test.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/__tests__/CreateTokenTransfer.test.tsx
@@ -565,7 +565,7 @@ describe('CreateTokenTransfer', () => {
       }
 
       const maxReached = getByTestId('max-recipients-reached')
-      expect(maxReached).toHaveClass('bg-warning-subtle', 'border-transparent', 'text-warning-strong')
+      expect(maxReached).toHaveClass('bg-warning-subtle', 'border-transparent', 'text-foreground')
       expect(maxReached).not.toHaveClass('bg-card')
     })
   })
@@ -665,7 +665,7 @@ describe('CreateTokenTransfer', () => {
       })
 
       const alert = getByTestId('insufficient-balance-error')
-      expect(alert).toHaveClass('bg-error-subtle', 'border-transparent', 'text-error-strong')
+      expect(alert).toHaveClass('bg-error-subtle', 'border-transparent', 'text-foreground')
       expect(alert).not.toHaveClass('bg-card')
     })
   })

--- a/apps/web/src/components/ui/alert.test.tsx
+++ b/apps/web/src/components/ui/alert.test.tsx
@@ -47,7 +47,8 @@ describe('Alert', () => {
     )
 
     const alert = screen.getByRole('alert')
-    expect(alert).toHaveClass('bg-card', 'text-error-strong')
+    expect(alert).toHaveClass('bg-card', 'text-foreground')
+    expect(alert.className).toContain('*:data-[slot=alert-description]:text-muted-foreground')
     expect(alert.className).toContain('*:[svg]:text-destructive')
   })
 
@@ -59,7 +60,7 @@ describe('Alert', () => {
     )
 
     const alert = screen.getByRole('alert')
-    expect(alert).toHaveClass('bg-error-subtle', 'border-transparent', 'text-error-strong')
+    expect(alert).toHaveClass('bg-error-subtle', 'border-transparent', 'text-foreground')
     expect(alert).not.toHaveClass('bg-card')
   })
 

--- a/apps/web/src/components/ui/alert.test.tsx
+++ b/apps/web/src/components/ui/alert.test.tsx
@@ -72,7 +72,8 @@ describe('Alert', () => {
     )
 
     const alert = screen.getByRole('alert')
-    expect(alert).toHaveClass('bg-card', 'text-warning-strong')
+    expect(alert).toHaveClass('bg-card', 'text-foreground')
+    expect(alert.className).toContain('*:data-[slot=alert-description]:text-muted-foreground')
     expect(alert.className).toContain('*:[svg]:text-warning-accent')
     expect(alert.className).not.toContain('yellow')
   })
@@ -85,7 +86,7 @@ describe('Alert', () => {
     )
 
     const alert = screen.getByRole('alert')
-    expect(alert).toHaveClass('bg-warning-subtle', 'border-transparent', 'text-warning-strong')
+    expect(alert).toHaveClass('bg-warning-subtle', 'border-transparent', 'text-foreground')
     expect(alert).not.toHaveClass('bg-card')
   })
 

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -42,7 +42,7 @@ const alertVariants = cva(
         destructive: 'text-foreground *:data-[slot=alert-description]:text-muted-foreground *:[svg]:text-destructive',
         warning: 'text-foreground *:data-[slot=alert-description]:text-muted-foreground *:[svg]:text-warning-accent',
         success:
-          'bg-success-subtle text-success-strong border-success-muted *:data-[slot=alert-description]:text-success-strong *:[svg]:text-current',
+          'bg-success-subtle text-foreground border-success-muted *:data-[slot=alert-description]:text-muted-foreground *:[svg]:text-success-strong',
         info: 'bg-[var(--color-info-background)] text-foreground border-transparent *:data-[slot=alert-description]:text-foreground [&>svg]:text-[var(--color-info-dark)]',
       },
       // Only `destructive` and `warning` have both designs (see compoundVariants); the other

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -40,7 +40,7 @@ const alertVariants = cva(
       variant: {
         default: 'bg-card text-card-foreground',
         destructive: 'text-error-strong *:data-[slot=alert-description]:text-error-strong *:[svg]:text-destructive',
-        warning: 'text-warning-strong *:data-[slot=alert-description]:text-warning-strong *:[svg]:text-warning-accent',
+        warning: 'text-foreground *:data-[slot=alert-description]:text-muted-foreground *:[svg]:text-warning-accent',
         success:
           'bg-success-subtle text-success-strong border-success-muted *:data-[slot=alert-description]:text-success-strong *:[svg]:text-current',
         info: 'bg-[var(--color-info-background)] text-foreground border-transparent *:data-[slot=alert-description]:text-foreground [&>svg]:text-[var(--color-info-dark)]',

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -39,7 +39,7 @@ const alertVariants = cva(
     variants: {
       variant: {
         default: 'bg-card text-card-foreground',
-        destructive: 'text-error-strong *:data-[slot=alert-description]:text-error-strong *:[svg]:text-destructive',
+        destructive: 'text-foreground *:data-[slot=alert-description]:text-muted-foreground *:[svg]:text-destructive',
         warning: 'text-foreground *:data-[slot=alert-description]:text-muted-foreground *:[svg]:text-warning-accent',
         success:
           'bg-success-subtle text-success-strong border-success-muted *:data-[slot=alert-description]:text-success-strong *:[svg]:text-current',

--- a/apps/web/src/features/multichain/components/MastercopyWarning/MastercopyWarning.tsx
+++ b/apps/web/src/features/multichain/components/MastercopyWarning/MastercopyWarning.tsx
@@ -103,10 +103,14 @@ export const MastercopyWarning = ({ variant = 'dashboard' }: MastercopyWarningPr
     // Settings intentionally prompts non-critical updates too, hence no `isCritical` gate here.
     if (variant === 'settings') {
       return (
-        <Alert>
-          <InfoIcon className="size-4 text-[var(--color-secondary-main)]" />
+        <Alert variant="success">
+          <InfoIcon className="size-4" />
           <AlertTitle>
-            New version is available: {latestVersion} (<ExternalLink href={changelogUrl}>changelog</ExternalLink>)
+            New version is available: {latestVersion} (
+            <ExternalLink href={changelogUrl} className="font-bold [&_span]:underline">
+              changelog
+            </ExternalLink>
+            )
           </AlertTitle>
 
           <AlertDescription>

--- a/apps/web/src/features/multichain/components/MastercopyWarning/MastercopyWarning.tsx
+++ b/apps/web/src/features/multichain/components/MastercopyWarning/MastercopyWarning.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useContext } from 'react'
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Alert, AlertDescription, AlertTitle, AlertSeverityIcon } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { TxModalContext } from '@/components/tx-flow'
 import { MigrateSafeL2Flow, UpdateSafeFlow } from '@/components/tx-flow/flows'
@@ -8,6 +8,7 @@ import ExternalLink from '@/components/common/ExternalLink'
 import CheckWallet from '@/components/common/CheckWallet'
 import InfoIcon from '@/public/images/notifications/info.svg'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
+import { trackEvent } from '@/services/analytics'
 import { ATTENTION_PANEL_EVENTS } from '@/services/analytics/events/attention-panel'
 import { useMastercopyMigration } from '../../hooks/useMastercopyMigration'
 
@@ -35,38 +36,66 @@ export const MastercopyWarning = ({ variant = 'dashboard' }: MastercopyWarningPr
 
   if (action === 'migrate') {
     return (
-      <ActionCard
-        severity="warning"
-        title="This Safe is running an unsupported version "
-        content="and may miss security fixes and improvements. You should migrate it to a compatible version."
-        action={{ label: 'Migrate', onClick: openMigrateModal }}
-        trackingEvent={ATTENTION_PANEL_EVENTS.MIGRATE_MASTERCOPY}
-        actionTestId="migrate-mastercopy-btn"
-      />
+      <Alert variant="warning" outlined={false} data-testid="action-card">
+        <AlertSeverityIcon variant="warning" />
+        <AlertTitle className="font-bold">This Safe is running an unsupported version</AlertTitle>
+        <AlertDescription>
+          It may miss security fixes and improvements. You should migrate it to a compatible version.
+          <div className="mt-4">
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-foreground"
+              data-testid="migrate-mastercopy-btn"
+              onClick={() => {
+                trackEvent(ATTENTION_PANEL_EVENTS.MIGRATE_MASTERCOPY)
+                openMigrateModal()
+              }}
+            >
+              Migrate
+            </Button>
+          </div>
+        </AlertDescription>
+      </Alert>
     )
   }
 
   if (action === 'redeploy') {
     return (
-      <ActionCard
-        severity="warning"
-        title={`This Safe can't be upgraded to ${latestVersion} on this network.`}
-        content="zkSync Safes created before the EVM upgrade can't move to the new contracts in place. To use the latest version, create a new Safe and transfer your assets to it."
-        testId="redeploy-mastercopy-warning"
-      />
+      <Alert variant="warning" outlined={false} data-testid="redeploy-mastercopy-warning">
+        <AlertSeverityIcon variant="warning" />
+        <AlertTitle className="font-bold">
+          This Safe can&apos;t be upgraded to {latestVersion} on this network.
+        </AlertTitle>
+        <AlertDescription>
+          zkSync Safes created before the EVM upgrade can&apos;t move to the new contracts in place. To use the latest
+          version, create a new Safe and transfer your assets to it.
+        </AlertDescription>
+      </Alert>
     )
   }
 
   if (action === 'cli') {
     return (
-      <ActionCard
-        severity="warning"
-        title="This Safe is running an unsupported version "
-        content="and may miss security fixes and improvements. You must use our CLI tool to migrate."
-        action={{ label: 'Get CLI', href: CLI_LINK, target: '_blank', rel: 'noopener noreferrer' }}
-        trackingEvent={ATTENTION_PANEL_EVENTS.GET_CLI_MASTERCOPY}
-        actionTestId="get-cli-link"
-      />
+      <Alert variant="warning" outlined={false} data-testid="action-card">
+        <AlertSeverityIcon variant="warning" />
+        <AlertTitle className="font-bold">This Safe is running an unsupported version</AlertTitle>
+        <AlertDescription>
+          It may miss security fixes and improvements. You must use our CLI tool to migrate.
+          <div className="mt-4">
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-foreground"
+              data-testid="get-cli-link"
+              render={<a href={CLI_LINK} target="_blank" rel="noopener noreferrer" />}
+              onClick={() => trackEvent(ATTENTION_PANEL_EVENTS.GET_CLI_MASTERCOPY)}
+            >
+              Get CLI
+            </Button>
+          </div>
+        </AlertDescription>
+      </Alert>
     )
   }
 

--- a/apps/web/src/features/multichain/components/SignerSetupWarning/InconsistentSignerSetupWarning.tsx
+++ b/apps/web/src/features/multichain/components/SignerSetupWarning/InconsistentSignerSetupWarning.tsx
@@ -1,6 +1,8 @@
 import { useIsMultichainSafe } from '../../hooks/useIsMultichainSafe'
 import useChains, { useCurrentChain } from '@/hooks/useChains'
-import { ActionCard } from '@/components/common/ActionCard'
+import { Alert, AlertTitle, AlertDescription, AlertSeverityIcon } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { trackEvent } from '@/services/analytics'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import { useAppSelector } from '@/store'
 import { selectCurrency, selectUndeployedSafes, useGetMultipleSafeOverviewsQuery } from '@/store/slices'
@@ -75,13 +77,27 @@ export const InconsistentSignerSetupWarning = () => {
   }
 
   return (
-    <ActionCard
-      severity="warning"
-      title="You have different signers across different networks."
-      content="This could break approvals and you may risk losing control of this Safe. First, switch to the affected network and review the signer setup for this Safe."
-      action={{ label: 'Review signers', onClick: handleReviewSigners }}
-      trackingEvent={ATTENTION_PANEL_EVENTS.REVIEW_SIGNERS}
-      actionTestId="review-signers-btn"
-    />
+    <Alert variant="warning" outlined={false}>
+      <AlertSeverityIcon variant="warning" />
+      <AlertTitle className="font-bold">You have different signers across different networks.</AlertTitle>
+      <AlertDescription>
+        This could break approvals and you may risk losing control of this Safe. First, switch to the affected network
+        and review the signer setup for this Safe.
+        <div className="mt-4">
+          <Button
+            variant="outline"
+            size="sm"
+            className="text-foreground"
+            data-testid="review-signers-btn"
+            onClick={() => {
+              trackEvent(ATTENTION_PANEL_EVENTS.REVIEW_SIGNERS)
+              handleReviewSigners()
+            }}
+          >
+            Review signers
+          </Button>
+        </div>
+      </AlertDescription>
+    </Alert>
   )
 }

--- a/apps/web/src/features/myAccounts/components/NonPinnedWarning/index.tsx
+++ b/apps/web/src/features/myAccounts/components/NonPinnedWarning/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
-import { ActionCard } from '@/components/common/ActionCard'
+import { Alert, AlertTitle, AlertDescription, AlertSeverityIcon } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
 import { trackEvent, OVERVIEW_EVENTS } from '@/services/analytics'
 import { ATTENTION_PANEL_EVENTS } from '@/services/analytics/events/attention-panel'
 import useNonPinnedSafeWarning from '../../hooks/useNonPinnedSafeWarning'
@@ -39,18 +40,28 @@ const NonPinnedWarning = () => {
 
   return (
     <>
-      <ActionCard
-        severity="warning"
-        title="Not in your accounts"
-        content="You're a signer of this Safe, but you haven't added it to your accounts yet. Adding it helps you recognize it and reduces the risk of impersonation."
-        action={{
-          label: 'Add to my accounts',
-          onClick: openConfirmDialog,
-        }}
-        trackingEvent={ATTENTION_PANEL_EVENTS.TRUST_SAFE}
-        testId="non-pinned-warning"
-        actionTestId="trust-this-safe-button"
-      />
+      <Alert variant="warning" outlined={false} data-testid="non-pinned-warning">
+        <AlertSeverityIcon variant="warning" />
+        <AlertTitle className="font-bold">Not in your accounts</AlertTitle>
+        <AlertDescription>
+          You&apos;re a signer of this Safe, but you haven&apos;t added it to your accounts yet. Adding it helps you
+          recognize it and reduces the risk of impersonation.
+          <div className="mt-4">
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-foreground"
+              data-testid="trust-this-safe-button"
+              onClick={() => {
+                trackEvent(ATTENTION_PANEL_EVENTS.TRUST_SAFE)
+                openConfirmDialog()
+              }}
+            >
+              Add to my accounts
+            </Button>
+          </div>
+        </AlertDescription>
+      </Alert>
 
       <AddTrustedSafeDialog
         open={isConfirmDialogOpen}

--- a/apps/web/src/features/speedup/components/SpeedUpMonitor/index.tsx
+++ b/apps/web/src/features/speedup/components/SpeedUpMonitor/index.tsx
@@ -70,7 +70,7 @@ const SpeedUpMonitor = ({ txId, pendingTx, modalTrigger = 'alertBox' }: SpeedUpM
           </AlertTitle>
           <AlertDescription>Try to speed up with better gas parameters.</AlertDescription>
           <AlertAction>
-            <Button variant="ghost" onClick={onOpen}>{`Speed up >`}</Button>
+            <Button variant="outline" className="text-foreground" onClick={onOpen}>{`Speed up >`}</Button>
           </AlertAction>
         </Alert>
       ) : (

--- a/apps/web/src/features/swap/components/SwapOrderConfirmationView/__snapshots__/index.stories.test.tsx.snap
+++ b/apps/web/src/features/swap/components/SwapOrderConfirmationView/__snapshots__/index.stories.test.tsx.snap
@@ -514,7 +514,7 @@ exports[`./index.stories CustomRecipient 1`] = `
         </div>
         <div>
           <div
-            class="grid gap-0.5 rounded-md border px-4 py-4 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-14 has-[>svg]:grid-cols-[auto_minmax(0,1fr)] has-[>svg]:gap-x-3 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg:not([class*='size-'])]:size-4 w-full relative group/alert text-warning-strong *:data-[slot=alert-description]:text-warning-strong *:[svg]:text-warning-accent bg-warning-subtle border-transparent"
+            class="grid gap-0.5 rounded-md border px-4 py-4 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-14 has-[>svg]:grid-cols-[auto_minmax(0,1fr)] has-[>svg]:gap-x-3 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg:not([class*='size-'])]:size-4 w-full relative group/alert text-foreground *:data-[slot=alert-description]:text-muted-foreground *:[svg]:text-warning-accent bg-warning-subtle border-transparent"
             data-slot="alert"
             data-testid="recipient-alert"
             role="alert"


### PR DESCRIPTION
## What it solves

Aligns alerts, warnings, and toasts with the latest design: readable font colors, corrected buttons, and a redesigned success toast.

Resolves: [WA-3238](https://linear.app/safe-global/issue/WA-3238/adjust-the-color-scheme-for-warnings-move-everything-to-the-new-alert)
Resolves:[ WA-3216
](https://linear.app/safe-global/issue/WA-3216/settings-setup-new-version-is-available-contract-upgrade-prompt-lost)

## How this PR fixes it

- Reworked `alert` variants so titles use `text-foreground` and descriptions use `text-muted-foreground` (was `*-strong`), keeping only the icon colored per severity.
- Replaced the legacy `ActionCard` warnings (Mastercopy, inconsistent signer setup, non-pinned) with the new `Alert` component, wiring tracking into the action buttons.
- Redesigned the toast so the message becomes the title when no explicit title is set, and the description is only rendered when there's extra content.

## How to test it

1. Trigger a success toast → verify the redesigned layout and colors.
2. Open a Safe on an unsupported version → verify the Mastercopy migrate/redeploy/CLI warnings render with the new alert and working buttons.
3. Check inconsistent-signer-setup and non-pinned warnings for correct colors and actions.

## Affected flows

- Toast notifications (all success/error/info toasts)
- Mastercopy warning (migrate / redeploy / CLI / settings variants)
- Inconsistent signer setup warning
- Non-pinned Safe warning

## Blast radius

- Shared `@/components/ui/alert` variant classes — consumed by all `Alert`/`AlertDescription`/`AlertTitle` usages app-wide.
- Shared `Notifications/Toast` component — every toast in the app.
- Removed `ActionCard` usage from the multichain/signer warning components.

## Risks / not checked

- Did not test on mobile.
- Did not exercise every alert consumer across the app — relied on the shared variant change.
- Did not manually verify the zkSync redeploy path (requires specific chain state).

## Visual summary

**Before:**
<img width="946" height="654" alt="image" src="https://github.com/user-attachments/assets/3aed07b5-3c35-4ba5-8fac-6cae14d09f89" />

</br>
<img width="1378" height="316" alt="image" src="https://github.com/user-attachments/assets/ac2bb8b8-8f8d-443b-8343-7b256a365d1d" />

</br>
<img width="363" height="145" alt="image" src="https://github.com/user-attachments/assets/9c05f808-bfd1-49c2-8f19-b1bd0f1e2e1d" />

</br>
<img width="802" height="292" alt="image" src="https://github.com/user-attachments/assets/ee24d0a6-5927-47d7-81a1-e0bf32a4a9db" />

</br>

**After:** 

<img width="756" height="526" alt="image" src="https://github.com/user-attachments/assets/8b38f072-7b3d-4ade-85a1-96b101065049" />

</br>
<img width="1404" height="344" alt="image" src="https://github.com/user-attachments/assets/10f4e61c-55b8-4aa6-8d24-46abf36522f8" />

</br>
<img width="744" height="244" alt="image" src="https://github.com/user-attachments/assets/0395f3b5-d4b3-489d-a68b-3fcd424cd7c2" />

</br>
<img width="791" height="289" alt="image" src="https://github.com/user-attachments/assets/f0fb7eab-d5fa-4adb-acca-e4d88e102e85" />

</br>




```mermaid
flowchart LR
  A[alert.tsx variants] -->|foreground / muted-foreground| B[All Alerts]
  C[ActionCard warnings] -->|replaced by| D[Alert component]
  E[Toast] -->|message as title, conditional description| F[Redesigned toast]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
