### PR TITLE
fix(UI): align buttons positioning

### DIFF
--- a/apps/web/src/components/address-book/EntryDialog/index.tsx
+++ b/apps/web/src/components/address-book/EntryDialog/index.tsx
@@ -100,7 +100,7 @@ function EntryDialog({
             confirmType="submit"
             confirmTestId="save-btn"
             confirmDisabled={!formState.isValid}
-            className="p-2"
+            className="p-6 pt-2"
           />
         </form>
       </FormProvider>

--- a/apps/web/src/components/address-book/ExportDialog/index.tsx
+++ b/apps/web/src/components/address-book/ExportDialog/index.tsx
@@ -79,7 +79,7 @@ function ExportDialog({
         </Typography>
       </div>
 
-      <div className="flex items-center justify-end gap-2 p-2">
+      <div className="flex items-center justify-between gap-2 p-6 pt-2">
         <Button variant="ghost" onClick={handleClose}>
           Cancel
         </Button>

--- a/apps/web/src/components/address-book/ImportDialog/index.tsx
+++ b/apps/web/src/components/address-book/ImportDialog/index.tsx
@@ -165,7 +165,7 @@ const ImportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
         </Typography>
       </div>
       <DialogActions
-        className="p-2"
+        className="p-6 pt-2"
         onCancel={handleClose}
         cancelTestId="cancel-btn"
         confirmLabel="Import"

--- a/apps/web/src/components/address-book/RemoveDialog/index.tsx
+++ b/apps/web/src/components/address-book/RemoveDialog/index.tsx
@@ -28,7 +28,7 @@ const RemoveDialog = ({ handleClose, address }: { handleClose: () => void; addre
         </Typography>
       </div>
 
-      <div className="flex items-center justify-between gap-2 p-2">
+      <div className="flex items-center justify-between gap-2 p-6 pt-2">
         <Button variant="ghost" onClick={handleClose}>
           Cancel
         </Button>

--- a/apps/web/src/components/address-book/RemoveDialog/index.tsx
+++ b/apps/web/src/components/address-book/RemoveDialog/index.tsx
@@ -28,7 +28,7 @@ const RemoveDialog = ({ handleClose, address }: { handleClose: () => void; addre
         </Typography>
       </div>
 
-      <div className="flex items-center justify-end gap-2 p-2">
+      <div className="flex items-center justify-between gap-2 p-2">
         <Button variant="ghost" onClick={handleClose}>
           Cancel
         </Button>

--- a/apps/web/src/components/common/DialogActions/index.tsx
+++ b/apps/web/src/components/common/DialogActions/index.tsx
@@ -41,8 +41,8 @@ type DialogActionsProps = {
  * Owns the button order, variants, sizes and responsive layout so every dialog
  * footer looks and behaves the same: Cancel is `variant="outline"`, Confirm is
  * `default` (or `destructive`), both `size="submit"`. On mobile they stack with
- * the confirm on top; on desktop they sit in a right-aligned row. Reach for this
- * instead of hand-building a Cancel/Confirm row.
+ * the confirm on top; on desktop Cancel sits at the left and Confirm at the
+ * right. Reach for this instead of hand-building a Cancel/Confirm row.
  *
  * Set `confirmCheckWallet` to gate the confirm on the connected wallet, and
  * `confirmTooltip` to explain a disabled confirm for non-wallet reasons.
@@ -105,6 +105,7 @@ const DialogActions = ({
           onClick={onCancel}
           disabled={cancelDisabled || confirmLoading}
           data-testid={cancelTestId}
+          className="sm:mr-auto"
         >
           {cancelLabel}
         </Button>

--- a/apps/web/src/components/nested-safes/NestedSafesList/SimilarityConfirmDialog.tsx
+++ b/apps/web/src/components/nested-safes/NestedSafesList/SimilarityConfirmDialog.tsx
@@ -65,7 +65,7 @@ export function SimilarityConfirmDialog({
             Please verify this is the correct address before proceeding.
           </Typography>
         </div>
-        <div className="flex justify-between gap-2 p-4 pt-0">
+        <div className="flex justify-between gap-2 p-4 pt-0 pb-6">
           <Button variant="outline" onClick={onCancel} data-testid="similarity-cancel-button">
             Cancel
           </Button>

--- a/apps/web/src/components/nested-safes/NestedSafesList/SimilarityConfirmDialog.tsx
+++ b/apps/web/src/components/nested-safes/NestedSafesList/SimilarityConfirmDialog.tsx
@@ -65,7 +65,7 @@ export function SimilarityConfirmDialog({
             Please verify this is the correct address before proceeding.
           </Typography>
         </div>
-        <div className="flex justify-end gap-2 p-4 pt-0">
+        <div className="flex justify-between gap-2 p-4 pt-0">
           <Button variant="outline" onClick={onCancel} data-testid="similarity-cancel-button">
             Cancel
           </Button>

--- a/apps/web/src/components/new-safe/load/steps/SafeOwnerStep/index.tsx
+++ b/apps/web/src/components/new-safe/load/steps/SafeOwnerStep/index.tsx
@@ -72,7 +72,7 @@ const SafeOwnerStep = ({ data, onSubmit, onBack }: StepRenderProps<LoadSafeFormD
         </div>
         <Separator />
         <div className={layoutCss.row}>
-          <div className="flex justify-end gap-2">
+          <div className="flex justify-between gap-2">
             <Button type="button" variant="outline" size="lg" onClick={handleBack}>
               Back
             </Button>

--- a/apps/web/src/components/new-safe/load/steps/SafeReviewStep/index.tsx
+++ b/apps/web/src/components/new-safe/load/steps/SafeReviewStep/index.tsx
@@ -128,7 +128,7 @@ const SafeReviewStep = ({ data, onBack }: StepRenderProps<LoadSafeFormData>) => 
       </div>
       <Separator />
       <div className={layoutCss.row}>
-        <div className="flex justify-end gap-2">
+        <div className="flex justify-between gap-2">
           <Button type="button" variant="outline" size="lg" onClick={handleBack}>
             Back
           </Button>

--- a/apps/web/src/components/new-safe/load/steps/SetAddressStep/index.tsx
+++ b/apps/web/src/components/new-safe/load/steps/SetAddressStep/index.tsx
@@ -154,7 +154,7 @@ const SetAddressStep = ({ data, onSubmit, onBack }: StepRenderProps<LoadSafeForm
         <Separator />
 
         <div className={layoutCss.row}>
-          <div className="flex justify-end gap-2">
+          <div className="flex justify-between gap-2">
             <Button type="button" variant="outline" size="lg" onClick={handleBack}>
               Back
             </Button>

--- a/apps/web/src/components/safe-apps/AddCustomAppModal/index.tsx
+++ b/apps/web/src/components/safe-apps/AddCustomAppModal/index.tsx
@@ -159,7 +159,7 @@ export const AddCustomAppModal = ({ open, onClose, onSave, safeAppsList }: Props
           </div>
         </div>
 
-        <div className="flex justify-end gap-2 p-6 pt-2">
+        <div className="flex justify-between gap-2 p-6 pt-2">
           <Button variant="ghost" onClick={handleClose}>
             Cancel
           </Button>

--- a/apps/web/src/components/safe-apps/RemoveCustomAppModal.tsx
+++ b/apps/web/src/components/safe-apps/RemoveCustomAppModal.tsx
@@ -18,7 +18,7 @@ const RemoveCustomAppModal = ({ open, onClose, onConfirm, app }: Props) => (
         Are you sure you want to remove the <b>{app.name}</b> app?
       </Typography>
     </div>
-    <div className="flex justify-end gap-2 p-6 pt-2">
+    <div className="flex justify-between gap-2 p-6 pt-2">
       <Button variant="ghost" onClick={onClose}>
         Cancel
       </Button>

--- a/apps/web/src/components/settings/owner/EditOwnerDialog/index.tsx
+++ b/apps/web/src/components/settings/owner/EditOwnerDialog/index.tsx
@@ -78,7 +78,7 @@ export const EditOwnerDialog = ({ chainId, address, name }: { chainId: string; a
               </div>
             </div>
 
-            <div className="flex justify-end gap-2 p-6 pt-0">
+            <div className="flex justify-between gap-2 p-6 pt-0">
               <Button variant="outline" onClick={handleClose}>
                 Cancel
               </Button>

--- a/apps/web/src/components/tx-flow/actions/Execute/ExecuteForm.tsx
+++ b/apps/web/src/components/tx-flow/actions/Execute/ExecuteForm.tsx
@@ -318,7 +318,7 @@ export const ExecuteForm = ({
             fee. You can run the simulation yourself from the Safe Shield panel before deciding.
           </div>
 
-          <div className="flex justify-end gap-2 p-6 pt-2">
+          <div className="flex justify-between gap-2 p-6 pt-2">
             <Button data-testid="relay-go-back-btn" variant="ghost" onClick={() => setRelaySimError(undefined)}>
               Back
             </Button>

--- a/apps/web/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
+++ b/apps/web/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
@@ -182,7 +182,7 @@ const SuccessCard = ({ safeMessage, onContinue }: { safeMessage: MessageItem; on
         Message successfully signed
       </Typography>
       <MsgSigners msg={safeMessage} showOnlyConfirmations showMissingSignatures />
-      <div className="flex items-center p-2">
+      <div className="flex items-center justify-end p-2">
         <Button onClick={onContinue} disabled={!safeMessage.preparedSignature}>
           Continue
         </Button>
@@ -359,7 +359,7 @@ const SignMessage = ({ message, origin, requestId }: SignMessageProps): ReactEle
             {!safe.deployed && <ErrorMessage>Your Safe account is not activated yet.</ErrorMessage>}
           </TxCard>
           <TxCard>
-            <div className="flex items-center p-2">
+            <div className="flex items-center justify-end p-2">
               <CheckWallet checkNetwork={!isDisabled}>
                 {(isOk) => (
                   <Button onClick={handleSign} disabled={!isOk || isDisabled}>

--- a/apps/web/src/components/tx/AdvancedParams/AdvancedParamsForm.tsx
+++ b/apps/web/src/components/tx/AdvancedParams/AdvancedParamsForm.tsx
@@ -133,7 +133,7 @@ const AdvancedParamsForm = ({ params, ...props }: AdvancedParamsFormProps) => {
           </div>
 
           {/* Buttons */}
-          <div className="flex justify-end gap-2 px-6 pb-6">
+          <div className="flex justify-between gap-2 px-6 pb-6">
             <Button variant="ghost" onClick={onBack}>
               Back
             </Button>

--- a/apps/web/src/features/myAccounts/components/NonPinnedWarning/AddTrustedSafeDialog.tsx
+++ b/apps/web/src/features/myAccounts/components/NonPinnedWarning/AddTrustedSafeDialog.tsx
@@ -102,7 +102,7 @@ const AddTrustedSafeDialog = ({
             </div>
           </div>
 
-          <div className="flex justify-end gap-2 p-6 pt-0">
+          <div className="flex justify-between gap-2 p-6 pt-0">
             <Button onClick={onCancel} variant="outline">
               Cancel
             </Button>

--- a/apps/web/src/features/safe-shield/components/ReportFalseResultModal/ReportFalseResultModal.tsx
+++ b/apps/web/src/features/safe-shield/components/ReportFalseResultModal/ReportFalseResultModal.tsx
@@ -83,7 +83,7 @@ export const ReportFalseResultModal = ({ open, onClose, requestId }: ReportFalse
         </div>
       </div>
 
-      <div className="flex flex-row justify-end gap-2 p-6 pt-0">
+      <div className="flex flex-row justify-between gap-2 p-6 pt-0">
         <Button variant="ghost" onClick={onClose} disabled={isLoading}>
           Cancel
         </Button>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/DeleteContactDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/DeleteContactDialog.tsx
@@ -86,7 +86,7 @@ const DeleteContactDialog = ({ name, address, networks, onClose }: DeleteContact
           )}
         </div>
 
-        <div className="flex justify-end gap-2 p-4 pt-0">
+        <div className="flex justify-between gap-2 p-4 pt-0">
           <Button variant="ghost" onClick={onClose}>
             Cancel
           </Button>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/DeleteContactDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/DeleteContactDialog.tsx
@@ -86,7 +86,7 @@ const DeleteContactDialog = ({ name, address, networks, onClose }: DeleteContact
           )}
         </div>
 
-        <div className="flex justify-between gap-2 p-4 pt-0">
+        <div className="flex justify-between gap-2 p-4 pt-0 pb-6">
           <Button variant="ghost" onClick={onClose}>
             Cancel
           </Button>

--- a/apps/web/src/features/speedup/components/SpeedUpModal/index.tsx
+++ b/apps/web/src/features/speedup/components/SpeedUpModal/index.tsx
@@ -197,7 +197,7 @@ const SpeedUpModal = ({ open, handleClose, pendingTx, txId, txHash, signerAddres
           </div>
         </div>
 
-        <div className="flex items-center justify-between gap-2 p-4">
+        <div className="flex items-center justify-between gap-2 p-4 pb-6">
           <Button variant="ghost" onClick={onCancel}>
             Cancel
           </Button>

--- a/apps/web/src/features/speedup/components/SpeedUpModal/index.tsx
+++ b/apps/web/src/features/speedup/components/SpeedUpModal/index.tsx
@@ -197,7 +197,7 @@ const SpeedUpModal = ({ open, handleClose, pendingTx, txId, txHash, signerAddres
           </div>
         </div>
 
-        <div className="flex items-center justify-end gap-2 p-4">
+        <div className="flex items-center justify-between gap-2 p-4">
           <Button variant="ghost" onClick={onCancel}>
             Cancel
           </Button>

--- a/apps/web/src/features/spending-limits/components/CreateSpendingLimit/index.tsx
+++ b/apps/web/src/features/spending-limits/components/CreateSpendingLimit/index.tsx
@@ -88,7 +88,7 @@ const CreateSpendingLimit = () => {
           <Typography>
             Set a reset time so the allowance automatically refills after the defined time period.
           </Typography>
-          <div className="mt-2 flex w-full items-center justify-between gap-2">
+          <div className="mt-2 flex items-center justify-start gap-2">
             <Label>Time Period</Label>
             <Controller
               rules={{ required: true }}
@@ -111,7 +111,7 @@ const CreateSpendingLimit = () => {
             />
           </div>
 
-          <div className="flex p-2">
+          <div className="flex justify-end p-2">
             <Button data-testid="next-btn" type="submit">
               Next
             </Button>


### PR DESCRIPTION
## What it solves

Resolves: [WA-3234](https://linear.app/safe-global/issue/WA-3234/align-action-button-placement-across-the-app)

Action buttons in dialogs and flows were placed inconsistently — some had Cancel/Back and the primary action both crammed on the right, some had the primary action stuck on the left. This standardizes button placement across the app.

## How this PR fixes it

Adopts one rule everywhere: secondary action (Cancel/Back) on the left, primary action (Confirm/Next/Execute/Sign/Save/Delete) on the right — and the primary stays on the right even when it's the only button.

- Shared `DialogActions`: Cancel gets `sm:mr-auto` so it moves left while confirm stays right (cascades to all standard dialogs).
- Hand-coded footers: two-button rows switched `justify-end` → `justify-between`; left-aligned single-primary rows got `justify-end`.
- Grouped the spending-limit "Time Period" row on the left (removed `w-full justify-between`).
- Bumped thin footer bottom padding (`p-2`/`p-4`) up to the 24px standard on a few popups.

The tx-flow wizard footer (absolute bottom-left Back + right-aligned primary) already matched the rule and was left untouched.

## How to test it

Open and eyeball: address-book create/delete entry, Advanced parameters, settings → owner edit, load-safe flow steps, spending-limit flow, speed-up modal, safe-apps add/remove. Cancel/Back should sit at the far left, the primary action at the far right; confirm-only dialogs keep the primary on the right.

## Affected flows

- Address book: create/delete entry
- New Safe: load-safe steps (address / owner / review)
- Tx flows: Execute (relay confirm), Sign message, Advanced parameters, Speed up
- Settings: edit owner
- Safe Apps: add/remove custom app
- Spending limits: create (reset timer step)
- Spaces address book: delete contact; Nested safes: similar-address confirm; Report false result; Add trusted safe

## Blast radius

- `components/common/DialogActions` — shared dialog footer; layout-only change (adds `sm:mr-auto` to Cancel). All consumers get Cancel-left/confirm-right; confirm-only footers unchanged.
- All other changes are per-component Tailwind class tweaks (`justify-*`, padding) — no logic, props, or API changes.
- No shared hooks/selectors/slices, RTK Query endpoints, feature flags, routes, or persisted state touched. No mobile/shared-package impact.

## Risks / not checked

- Pixel-perfect mobile spacing of the `justify-between` rows was not visually verified.
- No new unit tests — changes are className-only visual tweaks; existing tests for touched files pass and assert no layout classes.
- Did not audit footers rendered via non-flex MUI `Grid`/`Stack` containers (none surfaced in the sweep).

## Visual summary

Before:
<img width="648" height="170" alt="image" src="https://github.com/user-attachments/assets/39be4401-ee29-434a-8380-0bf5d2377f42" />
</br>
After:
<img width="660" height="174" alt="image" src="https://github.com/user-attachments/assets/5d391079-1712-4783-af85-d2ff84d07a67" />
</br>

Before:
<img width="639" height="418" alt="image" src="https://github.com/user-attachments/assets/d51a0515-1cc2-439d-aaea-7b2cf5b97a2f" />
</br>
After:
<img width="649" height="421" alt="image" src="https://github.com/user-attachments/assets/9dab749b-d7f4-4576-924a-4be018c48e80" />



```mermaid
flowchart TB
  subgraph Before
    B1["[ ....... Cancel ][ Confirm ]"]
  end
  subgraph After
    A1["[ Cancel ] ....... [ Confirm ]"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
