### PR TITLE
fix: align 2FA status badge colours and tooltip copy with the Figma spec

### DIFF
--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -64,6 +64,13 @@ const badgeVariants = cva(
         status: 'rounded-lg',
       },
     },
+    // The Obra DS status badge recolours the shared tints (Figma nodes 4033-8332 / 4033-8415):
+    // success is the brand success pairing (theme-flipping), warning gets a badge-scoped dark
+    // pairing. Scoped to `size="status"` so the plain variants stay as they are everywhere else.
+    compoundVariants: [
+      { variant: 'success', size: 'status', className: 'bg-success-subtle text-success-strong' },
+      { variant: 'warning', size: 'status', className: 'bg-badge-warning-subtle text-badge-warning-strong' },
+    ],
     defaultVariants: {
       variant: 'default',
       size: 'default',

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -51,7 +51,9 @@ function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
 function TooltipContent({
   className,
   side = 'top',
-  sideOffset = 4,
+  // The arrow tip protrudes ~4px past the popup edge, so the DS's 4px visual gap
+  // between tooltip and trigger needs an 8px offset on the popup box.
+  sideOffset = 8,
   align = 'center',
   alignOffset = 0,
   children,

--- a/apps/web/src/features/oidc-auth/components/WorkspaceTwoFactorSection/__tests__/index.test.tsx
+++ b/apps/web/src/features/oidc-auth/components/WorkspaceTwoFactorSection/__tests__/index.test.tsx
@@ -51,6 +51,22 @@ describe('WorkspaceTwoFactorSection', () => {
     expect(screen.getByTestId('workspace-2fa-count')).toHaveTextContent('2/3 users have 2FA enabled')
   })
 
+  it('explains why wallet signers are not counted, with singular and plural copy', () => {
+    const { rerender } = render(<WorkspaceTwoFactorSection members={[oidcMember(1), walletMember(2)]} />)
+
+    expect(screen.getByTestId('workspace-2fa-coverage-info')).toHaveAccessibleName("Why 1 signer can't enable 2FA")
+
+    rerender(<WorkspaceTwoFactorSection members={[oidcMember(1), walletMember(2), walletMember(3)]} />)
+
+    expect(screen.getByTestId('workspace-2fa-coverage-info')).toHaveAccessibleName("Why 2 signers can't enable 2FA")
+  })
+
+  it('hides the coverage info icon when every member can enable 2FA', () => {
+    render(<WorkspaceTwoFactorSection members={[oidcMember(1), oidcMember(2)]} />)
+
+    expect(screen.queryByTestId('workspace-2fa-coverage-info')).not.toBeInTheDocument()
+  })
+
   it('handles a workspace with no members', () => {
     render(<WorkspaceTwoFactorSection members={[]} />)
 

--- a/apps/web/src/features/oidc-auth/components/WorkspaceTwoFactorSection/index.tsx
+++ b/apps/web/src/features/oidc-auth/components/WorkspaceTwoFactorSection/index.tsx
@@ -61,15 +61,15 @@ const WorkspaceTwoFactorSection = ({
           {walletOnly > 0 && (
             <Tooltip>
               <TooltipTrigger
-                aria-label={`Why ${walletOnly} ${walletOnly === 1 ? 'member cannot' : 'members cannot'} enable 2FA`}
+                aria-label={`Why ${walletOnly} ${walletOnly === 1 ? 'signer' : 'signers'} can't enable 2FA`}
                 data-testid="workspace-2fa-coverage-info"
                 className="text-muted-foreground flex items-center"
               >
                 <Info className="size-4" />
               </TooltipTrigger>
               <TooltipContent>
-                {walletOnly} {walletOnly === 1 ? 'member cannot' : 'members cannot'} enable 2FA. 2FA not supported for
-                wallet login.
+                {walletOnly} {walletOnly === 1 ? 'signer' : 'signers'} can&apos;t enable 2FA because wallet login
+                doesn&apos;t support it.
               </TooltipContent>
             </Tooltip>
           )}

--- a/apps/web/src/styles/shadcn.css
+++ b/apps/web/src/styles/shadcn.css
@@ -73,9 +73,11 @@
   /* Figma error/background (alert node 1255-183763) — the brand token drifted to #ffe6ea, so the
      Figma hex is pinned here. Dark mode below keeps the brand tint (no dark spec in the file). */
   --error-subtle: #fff4f6;
-  /* Obra DS Badge status dots (nodes 4033-8332 / 4033-8415). One value per status, shared by both
-     themes: in dark the nearest theme tokens drift off the DS hue. */
-  --badge-dot-success: #22c55e; /* green-500 */
+  /* Obra DS Badge status colours (nodes 4033-8332 / 4033-8415). The warning pairing needs its own
+     dark values (below) — the shared warning tokens go brand-amber in dark, off the DS spec. */
+  --badge-warning-subtle: var(--warning-subtle);
+  --badge-warning-strong: var(--warning-strong);
+  --badge-dot-success: #22c55e; /* green-500, both themes */
   --badge-dot-warning: #eab308; /* yellow-500 */
   --z-sidebar: 1300;
   --z-overlay: 1400;
@@ -137,6 +139,10 @@
   --warning-strong: var(--color-warning1-text);
   --warning-accent: var(--color-warning-main);
   --error-subtle: var(--color-error-background);
+  /* Obra DS Badge status colours, dark spec. */
+  --badge-warning-subtle: #301d02;
+  --badge-warning-strong: #eab308; /* yellow-500 */
+  --badge-dot-warning: #facc15; /* yellow-400 */
 }
 
 @theme inline {
@@ -191,6 +197,8 @@
   /* Icon accent on the warning tint — brighter than the `warning-strong` ink, mirroring how
      `destructive` pairs its icon accent with `error-strong` text. */
   --color-warning-accent: var(--warning-accent);
+  --color-badge-warning-subtle: var(--badge-warning-subtle);
+  --color-badge-warning-strong: var(--badge-warning-strong);
   --color-badge-dot-success: var(--badge-dot-success);
   --color-badge-dot-warning: var(--badge-dot-warning);
   --color-info-subtle: var(--color-info-background);


### PR DESCRIPTION
## How it looks

<img width="3024" height="1612" alt="1-workspace-2fa-tooltip-light" src="https://github.com/user-attachments/assets/6239f193-c05a-45f7-8710-49e24591d152" />
<img width="3024" height="1612" alt="2-workspace-2fa-tooltip-dark" src="https://github.com/user-attachments/assets/fba09eed-7c23-42c4-944a-7221dcb540fc" />
<img width="3024" height="1612" alt="3-team-member-badges-dark" src="https://github.com/user-attachments/assets/6151019f-25c3-47fe-9779-08f1a0c05d8c" />
<img width="3024" height="1612" alt="4-team-member-badges-light" src="https://github.com/user-attachments/assets/b9b0394c-5736-465a-acaf-ccb23ca89652" />
<img width="3024" height="1612" alt="5-account-2fa-light" src="https://github.com/user-attachments/assets/00518dff-7ae8-4128-802e-f20822fa7b08" />
<img width="3024" height="1612" alt="6-account-2fa-dark" src="https://github.com/user-attachments/assets/171c1465-d1bf-4695-829b-3b326262a0af" />
<img width="3024" height="1612" alt="7-wallet-2fa-account-dark" src="https://github.com/user-attachments/assets/111dda9d-334d-42a6-88bb-fd96f68849d9" />
<img width="3024" height="1612" alt="8-wallet-2fa-account-light" src="https://github.com/user-attachments/assets/ca39bd5e-51c3-40e1-9616-199f30f51434" />
