### PR TITLE
chore: drop outdated MUI references from AGENTS.md and web docs

### DIFF
--- a/.cursor/rules/safe-monorepo.mdc
+++ b/.cursor/rules/safe-monorepo.mdc
@@ -39,7 +39,7 @@ Syntax and Formatting
 
 UI and Styling
 - in the mobile project utilise Tamagui for UI compoentns and styling
-- in the nextjs project use Mui
+- in the nextjs project use shadcn/ui + Tailwind (primitives live in `apps/web/src/components/ui/`)
 - Implement responsive design with a mobile-first approach.
 - Ensure styling consistency between web and native applications.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,22 +288,12 @@ Before writing code for any non-trivial change (anything beyond a typo, doc twea
 
    Then verify with `yarn workspace @safe-global/web prettier` (the check-only command). **CI will reject unformatted code.**
 
-4. **Linting and tests**: when you change any source code under `apps/` or `packages/`, execute, for web:
+4. **Linting and tests**: when you change any source code under `apps/` or `packages/`, run the `verify` scripts from the "Fast Feedback Loop" section above — they run type-check, lint, prettier and tests for you:
 
    ```bash
-   yarn workspace @safe-global/web type-check
-   yarn workspace @safe-global/web lint
-   yarn workspace @safe-global/web prettier   # verify formatting (CI runs this)
-   yarn workspace @safe-global/web test
-   ```
-
-   For mobile:
-
-   ```bash
-   yarn workspace @safe-global/mobile type-check
-   yarn workspace @safe-global/mobile lint
-   yarn workspace @safe-global/mobile prettier
-   yarn workspace @safe-global/mobile test
+   yarn verify:changed:web                        # scoped to your changed files
+   yarn verify:web                                # full check before committing
+   node scripts/verify.mjs --changed --workspace=mobile   # same, for mobile
    ```
 
 5. **Commit messages**: use [semantic commit messages](https://www.conventionalcommits.org/en/v1.0.0/) as described in `CONTRIBUTING.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,32 +149,33 @@ The project uses `@safe-global/theme` package as a single source of truth for al
 
 - **Unified Palettes**: Light and dark mode color palettes shared between platforms
 - **Dual Spacing Systems**: 4px base for mobile, 8px base for web (with overlapping values using same names)
-- **Platform Generators**: Automatic generation of MUI themes (web) and Tamagui tokens (mobile)
+- **Platform Generators**: Automatic generation of CSS variables (web) and Tamagui tokens (mobile)
 - **Static Colors**: Theme-independent brand colors available to both platforms
 
 ### Usage
 
-**Web (MUI)**:
+The package has no barrel export — always import from a sub-path.
+
+**Web (shadcn/ui + Tailwind)**:
+
+Web consumes the theme as CSS variables, not a JS theme object: `packages/theme` → `yarn css-vars` → `src/styles/vars.css` → `src/styles/shadcn.css` → Tailwind utilities. Style with Tailwind classes and the `cva` variants on the `@/components/ui/*` primitives. Read a palette in JS only for non-CSS consumers (canvas, QR codes, meta tags, third-party widgets):
 
 ```typescript
-import { generateMuiTheme } from '@safe-global/theme'
-
-const theme = generateMuiTheme('light') // or 'dark'
+import { lightPalette, darkPalette } from '@safe-global/theme/palettes'
 ```
 
 **Mobile (Tamagui)**:
 
 ```typescript
-import { generateTamaguiTokens, generateTamaguiThemes } from '@safe-global/theme'
-
-const tokens = generateTamaguiTokens()
-const themes = generateTamaguiThemes()
+import { generateTamaguiColorTokens, generateTamaguiFontSizes } from '@safe-global/theme/generators/tamagui'
 ```
 
 **Direct Token Access**:
 
 ```typescript
-import { lightPalette, darkPalette, spacingMobile, spacingWeb, typography } from '@safe-global/theme'
+import { lightPalette, darkPalette } from '@safe-global/theme/palettes'
+import { spacingMobile, spacingWeb } from '@safe-global/theme/tokens/spacing'
+import { typography } from '@safe-global/theme/tokens/typography'
 ```
 
 ### Modifying Theme
@@ -202,7 +203,7 @@ To add or modify colors/tokens:
 - Treat code comments as tech debt! Add them only when really necessary & the code at hand is hard to understand.
 - **Use sentence case for UI text** – Buttons, headings, labels, warnings, and other UI copy should use sentence case (e.g., "Add new owner") not Title Case (e.g., "Add New Owner")
 
-Web-specific principles (feature architecture, MUI theme, vars.css, feature flags, Storybook story requirement) live in [apps/web/AGENTS.md](apps/web/AGENTS.md). Mobile-specific principles live in [apps/mobile/AGENTS.md](apps/mobile/AGENTS.md).
+Web-specific principles (feature architecture, shadcn/ui + Tailwind styling, vars.css, feature flags, Storybook story requirement) live in [apps/web/AGENTS.md](apps/web/AGENTS.md). Mobile-specific principles live in [apps/mobile/AGENTS.md](apps/mobile/AGENTS.md).
 
 ## Testing Requirements
 

--- a/apps/web/.storybook/AGENTS.md
+++ b/apps/web/.storybook/AGENTS.md
@@ -296,7 +296,6 @@ When you discover new patterns, gotchas, or fixes while working on Storybook sto
 import type { Meta, StoryObj } from '@storybook/react'
 import { http, HttpResponse } from 'msw'
 import { mswLoader } from 'msw-storybook-addon'
-import { Paper } from '@mui/material'
 import { StoreDecorator } from '@/stories/storeDecorator'
 import { TOKEN_LISTS } from '@/store/settingsSlice'
 import { safeFixtures, chainFixtures, balancesFixtures } from '../../../../../../config/test/msw/fixtures'
@@ -352,9 +351,9 @@ const meta = {
             },
           }}
         >
-          <Paper sx={{ p: 2 }}>
+          <div className="bg-card rounded-lg p-4">
             <Story />
-          </Paper>
+          </div>
         </StoreDecorator>
       )
     },

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -226,6 +226,6 @@ This app is built using the following frameworks:
 - [Next.js 15](https://nextjs.org/)
 - [React 19](https://react.dev/)
 - [Redux Toolkit](https://redux-toolkit.js.org/)
-- [MUI v6](https://mui.com/)
+- [shadcn/ui](https://ui.shadcn.com/) + [Tailwind CSS v4](https://tailwindcss.com/)
 - [ethers.js v6](https://docs.ethers.org/v6/)
 - [web3-onboard](https://onboard.blocknative.com/)

--- a/apps/web/src/components/ui/README.md
+++ b/apps/web/src/components/ui/README.md
@@ -1,6 +1,6 @@
 # shadcn/ui Components
 
-This directory contains UI components from [shadcn/ui](https://ui.shadcn.com/), a collection of re-usable components built with Radix UI and Tailwind CSS.
+This directory contains UI components from [shadcn/ui](https://ui.shadcn.com/), a collection of re-usable components built with Base UI (`@base-ui/react`) and Tailwind CSS.
 
 ## ⚠️ Semi-Auto Generated Code
 


### PR DESCRIPTION
The MUI/Emotion → shadcn/ui + Tailwind migration (#8040) left the docs describing the old stack:

- Root AGENTS.md "Unified Theme System" advertised a MUI theme generator for web and imported everything from the `@safe-global/theme` barrel, which is intentionally empty (sub-path imports only). The mobile example named generators the app doesn't use.
- The Storybook story template imported `Paper` from `@mui/material`.
- apps/web/README.md still listed MUI v6 as a framework.
- components/ui/README.md credited Radix UI; the app is on Base UI.