### PR TITLE
fix(UI): restore copy animation, links styling, Add Safe flow layout fixes

### DIFF
--- a/apps/web/src/components/common/CopyButton/index.test.tsx
+++ b/apps/web/src/components/common/CopyButton/index.test.tsx
@@ -1,0 +1,35 @@
+import { act, fireEvent, mockClipboard, render, waitFor } from '@/tests/test-utils'
+import CopyButton from '.'
+
+describe('CopyButton', () => {
+  beforeEach(() => {
+    mockClipboard()
+  })
+
+  it('shows the copy icon initially', () => {
+    const { getByTestId, queryByTestId } = render(<CopyButton text="0x123" />)
+
+    expect(getByTestId('copy-btn-icon')).toBeInTheDocument()
+    expect(queryByTestId('copy-btn-check')).not.toBeInTheDocument()
+  })
+
+  it('swaps to a checkmark after clicking, then reverts', async () => {
+    jest.useFakeTimers()
+
+    const { getByTestId, queryByTestId } = render(<CopyButton text="0x123" />)
+
+    fireEvent.click(getByTestId('copy-btn-icon'))
+
+    await waitFor(() => expect(getByTestId('copy-btn-check')).toBeInTheDocument())
+    expect(queryByTestId('copy-btn-icon')).not.toBeInTheDocument()
+
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
+
+    await waitFor(() => expect(getByTestId('copy-btn-icon')).toBeInTheDocument())
+    expect(queryByTestId('copy-btn-check')).not.toBeInTheDocument()
+
+    jest.useRealTimers()
+  })
+})

--- a/apps/web/src/components/common/CopyButton/index.tsx
+++ b/apps/web/src/components/common/CopyButton/index.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
-import React, { type ReactElement } from 'react'
+import React, { type ReactElement, useCallback, useEffect, useRef, useState } from 'react'
+import { Check } from 'lucide-react'
 import CopyIcon from '@/public/images/common/copy.svg'
 import { Button } from '@/components/ui/button'
 import CopyTooltip from '../CopyTooltip'
@@ -14,6 +15,8 @@ export interface ButtonProps {
   dialogContent?: ReactElement
 }
 
+const RESET_DELAY = 500
+
 const CopyButton = ({
   text,
   className,
@@ -22,11 +25,27 @@ const CopyButton = ({
   onCopy,
   dialogContent,
 }: ButtonProps): ReactElement => {
+  const [isCopied, setIsCopied] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  useEffect(() => () => clearTimeout(timeoutRef.current), [])
+
+  const handleCopy = useCallback(() => {
+    setIsCopied(true)
+    clearTimeout(timeoutRef.current)
+    timeoutRef.current = setTimeout(() => setIsCopied(false), RESET_DELAY)
+    onCopy?.()
+  }, [onCopy])
+
   return (
-    <CopyTooltip text={text} onCopy={onCopy} initialToolTipText={initialToolTipText} dialogContent={dialogContent}>
+    <CopyTooltip text={text} onCopy={handleCopy} initialToolTipText={initialToolTipText} dialogContent={dialogContent}>
       {children ?? (
         <Button variant="ghost" size="icon-xs" aria-label={initialToolTipText} className={className}>
-          <CopyIcon data-testid="copy-btn-icon" className="size-4 text-[var(--color-border-main)]" />
+          {isCopied ? (
+            <Check data-testid="copy-btn-check" className="size-4 text-green-600" />
+          ) : (
+            <CopyIcon data-testid="copy-btn-icon" className="size-4 text-[var(--color-border-main)]" />
+          )}
         </Button>
       )}
     </CopyTooltip>

--- a/apps/web/src/components/common/ExternalLink/__snapshots__/ExternalLink.stories.test.tsx.snap
+++ b/apps/web/src/components/common/ExternalLink/__snapshots__/ExternalLink.stories.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`./ExternalLink.stories ButtonMode 1`] = `
 <div
@@ -55,7 +55,7 @@ exports[`./ExternalLink.stories Default 1`] = `
     class="shadcn-scope"
   >
     <a
-      class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+      class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
       data-slot="link"
       data-variant="default"
       href="https://safe.global"
@@ -115,7 +115,7 @@ exports[`./ExternalLink.stories NoChildren 1`] = `
     class="shadcn-scope"
   >
     <a
-      class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+      class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
       data-slot="link"
       data-variant="default"
       href="https://safe.global"
@@ -163,7 +163,7 @@ exports[`./ExternalLink.stories WithCustomStyling 1`] = `
     class="shadcn-scope"
   >
     <a
-      class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 underline decoration-primary/40 hover:decoration-current text-[var(--color-secondary-main)] font-bold"
+      class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current text-[var(--color-secondary-main)] font-bold"
       data-slot="link"
       data-variant="default"
       href="https://etherscan.io"
@@ -211,7 +211,7 @@ exports[`./ExternalLink.stories WithoutIcon 1`] = `
     class="shadcn-scope"
   >
     <a
-      class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+      class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
       data-slot="link"
       data-variant="default"
       href="https://safe.global"

--- a/apps/web/src/components/new-safe/OwnerRow/index.tsx
+++ b/apps/web/src/components/new-safe/OwnerRow/index.tsx
@@ -108,9 +108,12 @@ const OwnerRow = ({
           />
         </div>
       </div>
-      {/* `self-end` in read-only mode: the address readout carries no label of its own, so it can't
-          share the row's top baseline — it has to hang off the bottom to sit level with the name box. */}
-      <div className={classNames('col-span-11 md:col-span-7', readOnly && `${largeFormFieldRowClassName} self-end`)}>
+      <div
+        className={classNames(
+          'col-span-11 md:col-span-7',
+          readOnly && `${largeFormFieldRowClassName} mt-[calc(0.875rem*1.375+0.75rem)]`,
+        )}
+      >
         {readOnly ? (
           <EthHashInfo address={owner.address} shortAddress hasExplorer showCopyButton />
         ) : (

--- a/apps/web/src/components/transactions/HexEncodedData/__snapshots__/HexEncodedData.test.tsx.snap
+++ b/apps/web/src/components/transactions/HexEncodedData/__snapshots__/HexEncodedData.test.tsx.snap
@@ -141,7 +141,7 @@ exports[`HexEncodedData should render the default component markup 1`] = `
           </span>
         </span>
         <button
-          class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current showMore"
+          class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current showMore"
           data-slot="link"
           data-testid="show-more"
           data-variant="default"

--- a/apps/web/src/components/ui/link.test.tsx
+++ b/apps/web/src/components/ui/link.test.tsx
@@ -8,6 +8,13 @@ describe('Link', () => {
     expect(link).toHaveAttribute('href', 'https://safe.global')
   })
 
+  it('applies bold weight and hover color on the default variant', () => {
+    render(<Link href="#">Default</Link>)
+    const { className } = screen.getByRole('link', { name: 'Default' })
+    expect(className).toContain('font-bold')
+    expect(className).toContain('hover:text-[var(--color-primary-light)]')
+  })
+
   it('applies the muted variant classes', () => {
     render(
       <Link href="#" variant="muted">

--- a/apps/web/src/components/ui/link.tsx
+++ b/apps/web/src/components/ui/link.tsx
@@ -28,7 +28,8 @@ const linkVariants = cva(
       variant: {
         // Rest-state underline: in light mode `text-primary` is the body-text color, so
         // without it links have zero affordance (dark mode gets the green for free).
-        default: 'text-primary underline decoration-primary/40 hover:decoration-current',
+        default:
+          'font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current',
         muted: 'text-muted-foreground hover:text-foreground',
         inherit: 'text-inherit',
       },

--- a/apps/web/src/features/hypernative/components/HnSecurityReportBtn/__snapshots__/HnSecurityReportBtn.stories.test.tsx.snap
+++ b/apps/web/src/features/hypernative/components/HnSecurityReportBtn/__snapshots__/HnSecurityReportBtn.stories.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`./HnSecurityReportBtn.stories Default 1`] = `
 <div
@@ -11,7 +11,7 @@ exports[`./HnSecurityReportBtn.stories Default 1`] = `
       class="max-w-[600px] p-4"
     >
       <a
-        class="underline-offset-4 hover:underline [&>svg]:inline [&>svg]:size-4 underline decoration-primary/40 hover:decoration-current focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none bg-secondary text-secondary-foreground hover:bg-secondary-hover aria-expanded:bg-secondary-hover aria-expanded:text-secondary-foreground h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full"
+        class="underline-offset-4 hover:underline [&>svg]:inline [&>svg]:size-4 underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none bg-secondary text-secondary-foreground hover:bg-secondary-hover aria-expanded:bg-secondary-hover aria-expanded:text-secondary-foreground h-9 gap-1.5 px-4 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full"
         data-slot="button"
         data-variant="default"
         href="https://app.hypernative.xyz/guardian/alert?chain=evm%3A1&safe=0x123&tx=0x456&referrer=safe"

--- a/apps/web/src/features/multichain/components/MastercopyWarning/MastercopyWarning.tsx
+++ b/apps/web/src/features/multichain/components/MastercopyWarning/MastercopyWarning.tsx
@@ -107,7 +107,7 @@ export const MastercopyWarning = ({ variant = 'dashboard' }: MastercopyWarningPr
           <InfoIcon className="size-4" />
           <AlertTitle>
             New version is available: {latestVersion} (
-            <ExternalLink href={changelogUrl} className="font-bold [&_span]:underline">
+            <ExternalLink href={changelogUrl} className="font-bold hover:!text-[var(--color-primary-light)]">
               changelog
             </ExternalLink>
             )

--- a/apps/web/src/features/safe-shield/__snapshots__/SafeShield.stories.test.tsx.snap
+++ b/apps/web/src/features/safe-shield/__snapshots__/SafeShield.stories.test.tsx.snap
@@ -321,7 +321,7 @@ exports[`./SafeShield.stories ChecksPassed 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -406,7 +406,7 @@ exports[`./SafeShield.stories Empty 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -734,7 +734,7 @@ exports[`./SafeShield.stories FailedThreatAnalysis 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -979,7 +979,7 @@ exports[`./SafeShield.stories HypernativeCustomCheckFailed 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -1224,7 +1224,7 @@ exports[`./SafeShield.stories HypernativeGuardActive 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -1683,7 +1683,7 @@ exports[`./SafeShield.stories HypernativeMaliciousThreat 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -1885,7 +1885,7 @@ exports[`./SafeShield.stories HypernativeNotLoggedIn 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -2025,7 +2025,7 @@ exports[`./SafeShield.stories Loading 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -2567,7 +2567,7 @@ exports[`./SafeShield.stories MaliciousThreat 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -2931,7 +2931,7 @@ exports[`./SafeShield.stories MastercopyChange 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -3279,7 +3279,7 @@ exports[`./SafeShield.stories ModerateThreat 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -3607,7 +3607,7 @@ exports[`./SafeShield.stories ModulesChange 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -4376,7 +4376,7 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                 >
                                   Verify the 
                                   <a
-                                    class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 underline decoration-primary/40 hover:decoration-current text-inherit [&>span]:underline"
+                                    class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current text-inherit [&>span]:underline"
                                     data-slot="link"
                                     data-variant="default"
                                     href="https://help.safe.global/articles/9256158266-what-is-a-fallback-handler-and-how-does-it-relate-to-safe"
@@ -4585,7 +4585,7 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                 >
                                   This transaction calls a smart contract that will be able to modify your Safe account. 
                                   <a
-                                    class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+                                    class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
                                     data-slot="link"
                                     data-variant="default"
                                     href="https://help.safe.global/articles/4308960633-why-do-i-see-an-unexpected-delegate-call-warning-in-my-transaction"
@@ -5253,7 +5253,7 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -5540,7 +5540,7 @@ exports[`./SafeShield.stories MultipleIssues 1`] = `
                                 >
                                   Verify the 
                                   <a
-                                    class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 underline decoration-primary/40 hover:decoration-current text-inherit [&>span]:underline"
+                                    class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current text-inherit [&>span]:underline"
                                     data-slot="link"
                                     data-variant="default"
                                     href="https://help.safe.global/articles/9256158266-what-is-a-fallback-handler-and-how-does-it-relate-to-safe"
@@ -5597,7 +5597,7 @@ exports[`./SafeShield.stories MultipleIssues 1`] = `
                                 >
                                   This transaction calls a smart contract that will be able to modify your Safe account. 
                                   <a
-                                    class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+                                    class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
                                     data-slot="link"
                                     data-variant="default"
                                     href="https://help.safe.global/articles/4308960633-why-do-i-see-an-unexpected-delegate-call-warning-in-my-transaction"
@@ -5747,7 +5747,7 @@ exports[`./SafeShield.stories MultipleIssues 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -6007,7 +6007,7 @@ exports[`./SafeShield.stories OverflowFindings 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -6335,7 +6335,7 @@ exports[`./SafeShield.stories OwnershipChange 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -6565,7 +6565,7 @@ exports[`./SafeShield.stories ThreatAnalysisWithError 1`] = `
                                 >
                                   Verify the 
                                   <a
-                                    class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 underline decoration-primary/40 hover:decoration-current text-inherit [&>span]:underline"
+                                    class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current text-inherit [&>span]:underline"
                                     data-slot="link"
                                     data-variant="default"
                                     href="https://help.safe.global/articles/9256158266-what-is-a-fallback-handler-and-how-does-it-relate-to-safe"
@@ -6622,7 +6622,7 @@ exports[`./SafeShield.stories ThreatAnalysisWithError 1`] = `
                                 >
                                   This transaction calls a smart contract that will be able to modify your Safe account. 
                                   <a
-                                    class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+                                    class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
                                     data-slot="link"
                                     data-variant="default"
                                     href="https://help.safe.global/articles/4308960633-why-do-i-see-an-unexpected-delegate-call-warning-in-my-transaction"
@@ -6835,7 +6835,7 @@ exports[`./SafeShield.stories ThreatAnalysisWithError 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -7182,7 +7182,7 @@ exports[`./SafeShield.stories UnableToVerifyContract 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -7348,7 +7348,7 @@ exports[`./SafeShield.stories UnofficialFallbackHandler 1`] = `
                                 >
                                   Verify the 
                                   <a
-                                    class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 underline decoration-primary/40 hover:decoration-current text-inherit [&>span]:underline"
+                                    class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current text-inherit [&>span]:underline"
                                     data-slot="link"
                                     data-variant="default"
                                     href="https://help.safe.global/articles/9256158266-what-is-a-fallback-handler-and-how-does-it-relate-to-safe"
@@ -7503,7 +7503,7 @@ exports[`./SafeShield.stories UnofficialFallbackHandler 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"
@@ -7748,7 +7748,7 @@ exports[`./SafeShield.stories UnverifiedContract 1`] = `
             class="flex flex-row items-center self-end"
           >
             <a
-              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 text-primary underline decoration-primary/40 hover:decoration-current"
+              class="underline-offset-4 transition-colors hover:underline outline-none rounded-xs focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:inline [&>svg]:size-4 font-bold text-primary underline decoration-primary/40 hover:text-[var(--color-primary-light)] hover:decoration-current"
               data-slot="link"
               data-variant="default"
               href="https://help.safe.global/articles/6128275759-security-hub"


### PR DESCRIPTION
## What it solves

Resolves: [WA-3249](https://linear.app/safe-global/issue/WA-3249/add-safe-acc-flow-owner-row-missaligned-if-the-name-is-too-long)
Resolves: [WA-3232](https://linear.app/safe-global/issue/WA-3232/copy-icon-doesnt-show-animation-when-clicked-or-the-copied-tooltip)

A batch of minor UI fixes:

- **Copy button** – restores the green checkmark animation on copy (was reduced to a static icon).
- **Default links styling** – now bold with a hover color for clearer affordance.
- **Add Existing Safe flow** – fixes read-only owner address alignment so it sits level with the name field.

## How this PR fixes it

- `CopyButton` tracks a short-lived `isCopied` state and swaps `CopyIcon` for a `Check` icon for 500ms, cleaning up the timeout on unmount.
- `link.tsx` default variant gains `font-bold` and a `hover:text-[var(--color-primary-light)]`.
- `OwnerRow` replaces the fragile `self-end` alignment with an explicit top margin so the address readout lines up with the name box.

## How to test it

1. Click any copy button → the icon briefly turns into a green checkmark.
2. Hover a default link → it turns to the primary-light color; links render bold.
3. Open **Add Existing Safe** → the read-only owner address aligns with the name field.

## Affected flows

- Copy-to-clipboard across the app (any `CopyButton` without custom children).
- Add Existing Safe – owner row layout.
- Default `<Link>` / `ExternalLink` appearance app-wide.

## Blast radius

- `CopyButton` and `ui/link` are shared primitives used widely; changes are visual only (icon swap on copy, link styling).
- No API, state, or feature-flag changes.

## Risks / not checked

- Did not verify every downstream consumer of the default link variant visually.


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
