### PR TITLE
fix: align Airdrop icon

### DIFF
--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/CSVAirdropAppModal/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/CSVAirdropAppModal/index.tsx
@@ -18,10 +18,11 @@ const CSVAirdropAppModal = ({ onClose, appUrl }: { onClose: () => void; appUrl?:
       dialogTitle="Limit reached"
       hideChainIndicator
       maxWidth="xs"
+      forceBackdrop
     >
       <div className="mt-6 px-6 pb-5 text-center">
         <div>
-          <CSVAirdropLogo />
+          <CSVAirdropLogo className="mx-auto" />
           <Typography variant="paragraph-bold" className="mt-4 mb-4">
             Use CSV Airdrop
           </Typography>


### PR DESCRIPTION
## What it solves

Resolves: regression from shadcn migration

## How this PR fixes it
- aligns the icon to the center
- adds the blur on dialog open
<img width="1252" height="574" alt="Screenshot 2026-08-21 at 2 36 38 PM" src="https://github.com/user-attachments/assets/5b3c8d53-2595-4593-95b0-9c7ca00c643e" />

## How to test it

## Affected flows

<!-- The primary user journey(s) this PR intentionally changes. One bullet per flow. Example: "Owner adds a new signer from Settings > Signers". -->

## Blast radius

<!--
List the surfaces touched by this change and who else depends on them. Think in dependency terms, not files.
Include where relevant:
- Shared hooks / components / selectors / slices touched and their known consumers
- RTK Query endpoints / API contracts
- Feature flags / chain configs
- Persistence / cache / migration implications
- Routes or layouts affected indirectly
- Mobile impact (shared packages)
-->

## Risks / not checked

<!--
Be explicit about what you did NOT verify. This exposes false confidence and helps reviewers target their attention.
Example:
- Did not verify behavior with feature flag X disabled
- Did not test on mobile
- Did not exercise the retry / error path manually
-->

## Visual summary

<!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
