### PR TITLE
fix(web): restore version-upgrade indicators for 1.5.0 migrations (WA-3261)

### DIFF
--- a/apps/web/src/components/tx-flow/flows/MigrateSafeL2/MigrateSafeL2Review.tsx
+++ b/apps/web/src/components/tx-flow/flows/MigrateSafeL2/MigrateSafeL2Review.tsx
@@ -23,17 +23,15 @@ export const MigrateSafeL2Review = ({ children, ...props }: ReviewTransactionPro
   }, [chain, safe.version, safe.fallbackHandler?.value, safe.implementation?.value, setSafeTx, setSafeTxError, safeSDK])
 
   return (
-    <div>
-      <ReviewTransaction {...props}>
-        <ErrorMessage level="warning" title="Migration transaction">
-          <Typography>
-            The migration may take a few minutes. Transactions made before or during the migration won&apos;t show up in
-            your transaction history, but all future transactions will appear as usual.
-          </Typography>
-        </ErrorMessage>
+    <ReviewTransaction {...props}>
+      <ErrorMessage level="warning" title="Migration transaction">
+        <Typography>
+          The migration may take a few minutes. Transactions made before or during the migration won&apos;t show up in
+          your transaction history, but all future transactions will appear as usual.
+        </Typography>
+      </ErrorMessage>
 
-        {children}
-      </ReviewTransaction>
-    </div>
+      {children}
+    </ReviewTransaction>
   )
 }

--- a/apps/web/src/utils/__tests__/transaction-guards.test.ts
+++ b/apps/web/src/utils/__tests__/transaction-guards.test.ts
@@ -202,6 +202,36 @@ describe('transaction-guards', () => {
       expect(isSafeUpdateTxData(mockTxData)).toBeTruthy()
     })
 
+    it('should return true for 1.5.0 migrations', () => {
+      const mockTxData = {
+        hexData: '0x68cb3d94', // migrateL2WithFallbackHandler
+        to: {
+          value: '0x6439e7ABD8Bb915A5263094784C5CF561c4172AC',
+          name: 'SafeMigration 1.5.0',
+          logoUri: '',
+        },
+        value: '0',
+        operation: 1 as Operation,
+        trustedDelegateCallTarget: true,
+      }
+      expect(isSafeUpdateTxData(mockTxData)).toBeTruthy()
+    })
+
+    it('should return false for non-migration calldata sent to a SafeMigration contract', () => {
+      const mockTxData = {
+        hexData: '0xdeadbeef',
+        to: {
+          value: '0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6',
+          name: 'SafeMigration 1.4.1',
+          logoUri: '',
+        },
+        value: '0',
+        operation: 1 as Operation,
+        trustedDelegateCallTarget: true,
+      }
+      expect(isSafeUpdateTxData(mockTxData)).toBeFalsy()
+    })
+
     it('should return false for arbitrary txData', () => {
       expect(
         isSafeUpdateTxData({

--- a/apps/web/src/utils/__tests__/transaction-guards.test.ts
+++ b/apps/web/src/utils/__tests__/transaction-guards.test.ts
@@ -217,6 +217,36 @@ describe('transaction-guards', () => {
       expect(isSafeUpdateTxData(mockTxData)).toBeTruthy()
     })
 
+    it('should return true for migrations via the zksync SafeMigration variant', () => {
+      const mockTxData = {
+        hexData: '0x07f464a4', // migrateL2Singleton
+        to: {
+          value: '0x817756C6c555A94BCEE39eB5a102AbC1678b09A7',
+          name: 'SafeMigration 1.4.1 (zksync)',
+          logoUri: '',
+        },
+        value: '0',
+        operation: 1 as Operation,
+        trustedDelegateCallTarget: true,
+      }
+      expect(isSafeUpdateTxData(mockTxData)).toBeTruthy()
+    })
+
+    it('should return false for migration calldata sent to a non-SafeMigration contract', () => {
+      const mockTxData = {
+        hexData: '0xed007fc6', // migrateWithFallbackHandler
+        to: {
+          value: faker.finance.ethereumAddress(),
+          name: 'Some contract',
+          logoUri: '',
+        },
+        value: '0',
+        operation: 1 as Operation,
+        trustedDelegateCallTarget: true,
+      }
+      expect(isSafeUpdateTxData(mockTxData)).toBeFalsy()
+    })
+
     it('should return false for non-migration calldata sent to a SafeMigration contract', () => {
       const mockTxData = {
         hexData: '0xdeadbeef',

--- a/apps/web/src/utils/safe-migrations.ts
+++ b/apps/web/src/utils/safe-migrations.ts
@@ -29,6 +29,17 @@ const MIGRATION_METHOD_BY_FLAVOUR = {
   l2: { keep: 'migrateL2Singleton', reset: 'migrateL2WithFallbackHandler' },
 } as const satisfies Record<'l1' | 'l2', Record<'keep' | 'reset', MigrationMethod>>
 
+const SAFE_MIGRATION_INTERFACE = Safe_migration__factory.createInterface()
+
+const MIGRATION_METHOD_SELECTORS = MIGRATION_METHODS.map(
+  (method) => SAFE_MIGRATION_INTERFACE.getFunction(method).selector,
+)
+
+// Official SafeMigration addresses across every version and variant (canonical / zksync)
+const SAFE_MIGRATION_ADDRESSES = SAFE_VERSIONS.flatMap((version) =>
+  Object.values(getSafeMigrationDeployments({ version })?.deployments ?? {}).map((variant) => variant?.address),
+)
+
 /**
  * Resolves the SafeMigration contract address for the chain and master copy.
  *
@@ -88,11 +99,9 @@ export const createUpdateMigration = (
 
   const method = MIGRATION_METHOD_BY_FLAVOUR[chain.l2 ? 'l2' : 'l1'][keepFallbackHandler ? 'keep' : 'reset']
 
-  const interfce = Safe_migration__factory.createInterface()
-
   return {
     operation: OperationType.DelegateCall, // delegate call required
-    data: interfce.encodeFunctionData(method as 'migrateSingleton'), // appease typescript overloads
+    data: SAFE_MIGRATION_INTERFACE.encodeFunctionData(method as 'migrateSingleton'), // appease typescript overloads
     to,
     value: '0',
   }
@@ -110,13 +119,9 @@ export const isSafeMigrationCall = (txData: TransactionData): boolean => {
     return false
   }
 
-  const migrationAddresses = SAFE_VERSIONS.flatMap((version) =>
-    Object.values(getSafeMigrationDeployments({ version })?.deployments ?? {}).map((variant) => variant?.address),
-  )
-  if (!migrationAddresses.some((address) => sameAddress(txData.to.value, address))) {
+  if (!SAFE_MIGRATION_ADDRESSES.some((address) => sameAddress(txData.to.value, address))) {
     return false
   }
 
-  const safeMigrationInterface = Safe_migration__factory.createInterface()
-  return MIGRATION_METHODS.some((method) => hexData.startsWith(safeMigrationInterface.getFunction(method).selector))
+  return MIGRATION_METHOD_SELECTORS.some((selector) => hexData.startsWith(selector))
 }

--- a/apps/web/src/utils/transaction-guards.ts
+++ b/apps/web/src/utils/transaction-guards.ts
@@ -62,10 +62,10 @@ import type { RecoveryQueueItem } from '@/features/recovery'
 import { id } from 'ethers'
 import {
   getSafeToL2MigrationDeployment,
-  getSafeMigrationDeployment,
   getMultiSendDeployments,
   getSignMessageLibDeployments,
 } from '@safe-global/safe-deployments'
+import { isSafeMigrationCall } from '@/utils/safe-migrations'
 import {
   Safe__factory,
   Safe_to_l2_migration__factory,
@@ -75,7 +75,6 @@ import { hasMatchingDeployment, TRUSTED_DEPLOYMENT_VERSIONS } from '@safe-global
 import { isMultiSendCalldata } from './transaction-calldata'
 import { decodeMultiSendData } from '@safe-global/protocol-kit'
 import { OperationType } from '@safe-global/types-kit'
-import { LATEST_SAFE_VERSION } from '@safe-global/utils/config/constants'
 import type {
   BridgeAndSwapTransactionInfo,
   SwapTransactionInfo,
@@ -448,9 +447,9 @@ export const isSafeUpdateTxData = (data?: TransactionData | null): boolean => {
     return false
   }
 
-  // For 1.3.0+ Safes
-  const migrationContract = getSafeMigrationDeployment({ version: LATEST_SAFE_VERSION })
-  if (migrationContract && sameAddress(data.to.value, migrationContract.defaultAddress)) {
+  // For 1.3.0+ Safes: a delegate call to any official SafeMigration deployment
+  // (any version, canonical or zksync variant) calling one of its migrate methods
+  if (isSafeMigrationCall(data)) {
     return true
   }
 


### PR DESCRIPTION
## What it solves

Resolves: WA-3261

Upgrading a Safe to v1.5.0 lost both version-upgrade indicators that v1.4.1 upgrades still show:

- the confirmation view no longer showed the "Current version X → New version Y" banner (and the changelog link),
- the transaction-history details for a migration no longer showed the version-upgrade info box.

Both fell back to the generic decoded-data view instead.

Additionally, in the "Update Safe account base contract" flow (`MigrateSafeL2`), the header card and the content card were rendered as two disconnected cards with a gap, instead of one joined card like every other flow.

## How this PR fixes it

**Version indicators:** `isSafeUpdateTxData` only matched the SafeMigration deployment of the hardcoded `LATEST_SAFE_VERSION` (1.4.1) — and only its canonical `defaultAddress`. Transaction *creation* is chain-aware (`getLatestSafeVersion(chain)`), so on chains recommending 1.5.0 the tx delegate-calls the 1.5.0 SafeMigration contract, which the guard didn't recognise. The guard now reuses the existing `isSafeMigrationCall` helper, which matches **any** official SafeMigration deployment (any version, canonical or zksync variant) and additionally verifies the calldata is one of the four migrate method selectors — so arbitrary calldata sent to a SafeMigration address is no longer misclassified as an upgrade (a slight tightening over the old behaviour).

**Card gap:** `MigrateSafeL2Review` wrapped `<ReviewTransaction>` in a functionless `<div>`, which broke the `.step > .txCardRoot:first-child` card-joining CSS in `TxLayoutBase` (it requires the card to be a *direct* child). Removed the wrapper, aligning it with `UpdateSafeReview`.

## How to test it

1. On a chain whose recommended Safe version is 1.5.0, open a Safe on an older version (e.g. 1.3.0) and start the contract update flow.
2. The review screen shows the "Current version: X → New version: 1.5.0" banner with the changelog link (previously: raw decoded data only).
3. In the `MigrateSafeL2` flow, the header card and content card are joined with no gap.
4. Queue/execute the migration and open it in the transaction list — the details show the Safe update info instead of raw decoded data.
5. Regression: a 1.4.1 upgrade still renders both indicators unchanged, and the pre-1.3.0 path (e.g. 1.1.1 → 1.5.0 via `changeMasterCopy` multisend) was manually verified to render correctly.

Unit tests: `apps/web/src/utils/__tests__/transaction-guards.test.ts` adds a 1.5.0 recognition case and a negative case (non-migrate calldata to a SafeMigration address).

## Affected flows

- Owner upgrades a Safe's base contract from the update banner / Settings (review + confirmation view)
- Anyone views a queued or executed base-contract upgrade in the transaction list (details view)
- Owner migrates an unsupported L2 base contract ("Update Safe account base contract" flow — layout only)

## Blast radius

- `isSafeUpdateTxData` (`transaction-guards.ts`) — consumers: `confirmation-views/index.tsx` (review screen) and `TxDetails/TxData/index.tsx` (queue/history details). Behaviour widens to all official SafeMigration versions/variants and narrows to migrate-method calldata only.
- `MigrateSafeL2Review` — layout-only change; no logic touched.
- No RTK Query endpoints, feature flags, chain configs, persistence, or routes touched.
- Mobile: not affected — change is in `apps/web` only; the shared guard lives in the web app, not a shared package.

## Risks / not checked

- Did not test the zksync SafeMigration variant on a live zksync chain (covered by the variant-matching logic in `isSafeMigrationCall` and its tests).
- Did not verify on mobile (web-only change).
- The guard no longer matches arbitrary calldata delegate-called to a SafeMigration address; such txs now render as generic decoded data. This is intended, but no real-world tx of that shape was checked.

## Visual summary

```mermaid
flowchart TD
    A[txData: delegate call, trusted target] --> B{old guard}
    B -->|to == SafeMigration of LATEST_SAFE_VERSION 1.4.1 only| C[UpdateSafe banner + history info box]
    B -->|SafeMigration 1.5.0| D[❌ generic decoded data]

    A --> E{new guard: isSafeMigrationCall}
    E -->|to == any official SafeMigration version/variant AND calldata is a migrate method| C
    E -->|otherwise| F[generic decoded data]
```
Before:
<img width="1145" height="544" alt="Screenshot 2026-08-24 at 14 00 58" src="https://github.com/user-attachments/assets/0500f3e8-866d-4428-82a0-6defdf262b3a" />

After:
<img width="1154" height="596" alt="Screenshot 2026-08-24 at 14 00 52" src="https://github.com/user-attachments/assets/5437ea85-0fa6-4403-aced-18c426c5dd7e" />

Before:
<img width="1265" height="381" alt="Screenshot 2026-08-24 at 14 03 09" src="https://github.com/user-attachments/assets/e77df0d6-3e90-46f6-b354-ce048a51e5eb" />

After:
<img width="1275" height="463" alt="Screenshot 2026-08-24 at 14 02 08" src="https://github.com/user-attachments/assets/1e249221-7785-4dc4-8471-565a67d69798" />



## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
