### PR TITLE
fix: give data-less batch reverts a readable error and pre-check the batch (WA-3267)

### DIFF
--- a/apps/web/src/components/tx-flow/flows/ExecuteBatch/ReviewBatch.tsx
+++ b/apps/web/src/components/tx-flow/flows/ExecuteBatch/ReviewBatch.tsx
@@ -42,6 +42,7 @@ import { FEATURES, getLatestSafeVersion, hasFeature } from '@safe-global/utils/u
 import { useSafeShield, useSafeShieldForTxData } from '@/features/safe-shield/SafeShieldContext'
 import type { SafeTransaction } from '@safe-global/types-kit'
 import { fetchRecommendedParams } from '@/services/tx/tx-sender/recommendedNonce'
+import { runBatchExecutionPreChecks } from '@/services/tx/executionPreChecks'
 import { useMultiSendContract } from './useMultiSendContract'
 
 /**
@@ -181,6 +182,14 @@ export const ReviewBatch = ({ params }: { params: ExecuteBatchFlowProps }) => {
     setIsRejectedByUser(false)
 
     try {
+      // MultiSendCallOnly reverts with no data when an inner execTransaction
+      // fails, so a broken batch costs gas and tells the user nothing. Catch
+      // the causes we can name — a queue that moved, a signature that no longer
+      // verifies — before broadcasting either way (WA-3267).
+      if (txsWithDetails) {
+        await runBatchExecutionPreChecks({ txs: txsWithDetails, safe })
+      }
+
       await (willRelay ? onRelay() : onExecute())
       setTxFlow(undefined)
     } catch (_err) {

--- a/apps/web/src/components/tx-flow/flows/ExecuteBatch/__tests__/ReviewBatch.test.tsx
+++ b/apps/web/src/components/tx-flow/flows/ExecuteBatch/__tests__/ReviewBatch.test.tsx
@@ -1,0 +1,156 @@
+import type { ReactElement } from 'react'
+import { render, fireEvent, waitFor } from '@/tests/test-utils'
+import { mockCurrentChain, mockSafeInfo } from '@/tests/mocks/hooks'
+import { getGs026BatchMessage } from '@safe-global/utils/services/exceptions/contractErrors'
+import { Gs026PreCheckError, runBatchExecutionPreChecks } from '@/services/tx/executionPreChecks'
+import { dispatchBatchExecution, dispatchBatchExecutionRelay } from '@/services/tx/tx-sender'
+import { ReviewBatch } from '../ReviewBatch'
+
+jest.mock('@/services/tx/executionPreChecks', () => ({
+  ...jest.requireActual('@/services/tx/executionPreChecks'),
+  runBatchExecutionPreChecks: jest.fn(),
+}))
+
+jest.mock('@/services/tx/tx-sender', () => ({
+  createMultiSendCallOnlyTx: jest.fn().mockResolvedValue(undefined),
+  dispatchBatchExecution: jest.fn().mockResolvedValue('0xhash'),
+  dispatchBatchExecutionRelay: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('@/utils/transactions', () => ({
+  ...jest.requireActual('@/utils/transactions'),
+  getMultiSendTxs: jest
+    .fn()
+    .mockResolvedValue([{ to: '0x1234567890123456789012345678901234567890', value: '0', data: '0x', operation: 0 }]),
+}))
+
+jest.mock('@/components/common/CheckWallet', () => ({
+  __esModule: true,
+  default: ({ children }: { children: (ok: boolean) => ReactElement }) => children(true),
+}))
+
+jest.mock('@/components/tx-flow/flows/ExecuteBatch/DecodedTxs', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+jest.mock('./../useMultiSendContract', () => ({
+  useMultiSendContract: () => ({
+    multiSendContract: { getAddress: () => '0x0000000000000000000000000000000000009641', encode: () => '0x' },
+    multiSendContractAddress: '0x0000000000000000000000000000000000009641',
+  }),
+}))
+
+jest.mock('@/hooks/useGasPrice', () => ({
+  __esModule: true,
+  default: () => [{ maxFeePerGas: 1n, maxPriorityFeePerGas: 1n }, undefined, false],
+}))
+
+jest.mock('@/components/tx/AdvancedParams/useUserNonce', () => ({
+  __esModule: true,
+  default: () => 5,
+}))
+
+jest.mock('@/hooks/useChains')
+jest.mock('@/hooks/useSafeInfo')
+
+jest.mock('@/hooks/wallets/useWallet', () => ({
+  __esModule: true,
+  default: () => ({ address: '0x0000000000000000000000000000000000000011', provider: {}, chainId: '1' }),
+}))
+
+jest.mock('@/hooks/wallets/useOnboard', () => ({
+  __esModule: true,
+  default: () => ({}),
+}))
+
+jest.mock('@/hooks/useRemainingRelays', () => ({
+  useRelaysBySafe: () => [undefined, undefined, false],
+}))
+
+jest.mock('@/services/tx/tx-sender/recommendedNonce', () => ({
+  fetchRecommendedParams: jest.fn().mockResolvedValue({ safeTxGas: '0' }),
+}))
+
+jest.mock('@/features/safe-shield/SafeShieldContext', () => ({
+  useSafeShield: () => ({ needsRiskConfirmation: false, isRiskConfirmed: true }),
+  useSafeShieldForTxData: jest.fn(),
+}))
+
+jest.mock('@safe-global/store/gateway/transactions', () => ({
+  useTransactionsGetMultipleTransactionDetailsQuery: () => ({
+    data: [
+      {
+        txId: 'multisig_0x5AFE_17',
+        detailedExecutionInfo: { type: 'MULTISIG', nonce: 17, safeTxHash: '0xabc', confirmations: [] },
+      },
+      {
+        txId: 'multisig_0x5AFE_18',
+        detailedExecutionInfo: { type: 'MULTISIG', nonce: 18, safeTxHash: '0xdef', confirmations: [] },
+      },
+    ],
+    error: undefined,
+    isLoading: false,
+  }),
+}))
+
+const mockPreChecks = runBatchExecutionPreChecks as jest.MockedFunction<typeof runBatchExecutionPreChecks>
+
+const params = {
+  txs: [{ transaction: { id: 'multisig_0x5AFE_17' } }, { transaction: { id: 'multisig_0x5AFE_18' } }],
+} as unknown as Parameters<typeof ReviewBatch>[0]['params']
+
+const submit = async (getByText: (text: string) => HTMLElement) => {
+  // The encoded batch data is built asynchronously; its heading only renders
+  // once it is ready, which is also when the submit handler can do anything
+  await waitFor(() => expect(getByText('Data')).toBeInTheDocument())
+  await waitFor(() => expect(getByText('Submit')).toBeEnabled())
+  fireEvent.click(getByText('Submit'))
+}
+
+describe('ReviewBatch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // NetworkWarning reads the chain list; the auto-mock returns undefined
+    ;(jest.requireMock('@/hooks/useChains').default as jest.Mock).mockReturnValue({
+      configs: [],
+      error: undefined,
+      loading: false,
+    })
+    mockCurrentChain({ chainId: '1', chainName: 'Ethereum' })
+    mockSafeInfo({ chainId: '1', nonce: 17, version: '1.4.1', deployed: true })
+    mockPreChecks.mockResolvedValue(undefined)
+  })
+
+  it('broadcasts once the pre-checks pass', async () => {
+    const { getByText } = render(<ReviewBatch params={params} />)
+
+    await submit(getByText)
+
+    await waitFor(() => expect(dispatchBatchExecution).toHaveBeenCalled())
+    expect(mockPreChecks).toHaveBeenCalled()
+  })
+
+  it('never broadcasts when a pre-check blocks the batch', async () => {
+    mockPreChecks.mockRejectedValue(new Gs026PreCheckError('STALE_NONCE', getGs026BatchMessage('STALE_NONCE', 2)))
+
+    const { getByText } = render(<ReviewBatch params={params} />)
+
+    await submit(getByText)
+
+    await waitFor(() => expect(getByText(getGs026BatchMessage('STALE_NONCE', 2))).toBeInTheDocument())
+    expect(dispatchBatchExecution).not.toHaveBeenCalled()
+    expect(dispatchBatchExecutionRelay).not.toHaveBeenCalled()
+  })
+
+  it('runs the pre-checks before the relay path too', async () => {
+    mockPreChecks.mockRejectedValue(new Gs026PreCheckError('BAD_SIGNATURE', getGs026BatchMessage('BAD_SIGNATURE', 1)))
+
+    const { getByText } = render(<ReviewBatch params={params} />)
+
+    await submit(getByText)
+
+    await waitFor(() => expect(getByText(getGs026BatchMessage('BAD_SIGNATURE', 1))).toBeInTheDocument())
+    expect(dispatchBatchExecutionRelay).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/tx/ErrorMessage/__tests__/ErrorMessage.test.tsx
+++ b/apps/web/src/components/tx/ErrorMessage/__tests__/ErrorMessage.test.tsx
@@ -59,4 +59,45 @@ describe('ErrorMessage', () => {
     // The selector belongs in the support reference, never in the message body
     expect(queryByText(/0xdeadbeef.*failed|failed.*0xdeadbeef/)).not.toBeInTheDocument()
   })
+  it('offers no Details for a revert that carries no decodable payload', () => {
+    // MultiSendCallOnly swallows the inner reason, so ethers hands us the whole
+    // request as the message. There is nothing to reference and nothing safe to
+    // show (WA-3267).
+    const error = Object.assign(
+      new Error(
+        'execution reverted (no data present; likely require(false) occurred (action="estimateGas", data="0x", reason="require(false)", transaction={ "data": "0x0075fe14a68278bda1623e877aa155a9c97d106e7", "to": "0x9641d764fc13c8B624cO4430C7356C1C7C8102e2" }, code=CALL_EXCEPTION, version=6.17.0)',
+      ),
+      { code: 'CALL_EXCEPTION', data: '0x', reason: 'require(false)' },
+    )
+
+    const { getByText, queryByText } = render(
+      <ErrorMessage error={error}>Could not submit the transaction.</ErrorMessage>,
+    )
+
+    expect(getByText('Could not submit the transaction.')).toBeInTheDocument()
+    expect(queryByText('Details')).not.toBeInTheDocument()
+    expect(queryByText(/require\(false\)/)).not.toBeInTheDocument()
+    expect(queryByText(/version=6\.17\.0/)).not.toBeInTheDocument()
+    expect(queryByText(/0x9641d764/)).not.toBeInTheDocument()
+  })
+  it('keeps a decoded revert reason but not the payload around it', () => {
+    const error = Object.assign(
+      new Error(
+        'execution reverted: ERC20: transfer amount exceeds balance (action="estimateGas", data="0x08c379a0deadbeef", code=CALL_EXCEPTION, version=6.17.0)',
+      ),
+      {
+        code: 'CALL_EXCEPTION',
+        data: `0x08c379a0${'00'.repeat(64)}`,
+        reason: 'ERC20: transfer amount exceeds balance',
+      },
+    )
+
+    const { getByText, queryByText } = render(<ErrorMessage error={error}>Could not submit.</ErrorMessage>)
+
+    fireEvent.click(getByText('Details'))
+
+    expect(getByText('ERC20: transfer amount exceeds balance')).toBeInTheDocument()
+    expect(queryByText(/version=6\.17\.0/)).not.toBeInTheDocument()
+    expect(queryByText(/0x08c379a0deadbeef/)).not.toBeInTheDocument()
+  })
 })

--- a/apps/web/src/components/tx/ErrorMessage/index.tsx
+++ b/apps/web/src/components/tx/ErrorMessage/index.tsx
@@ -1,6 +1,6 @@
 import { type ReactElement, type ReactNode, type SyntheticEvent, useState } from 'react'
 import { getGsCodeFromError } from '@safe-global/utils/services/exceptions/contractErrors'
-import { getGuardErrorInfo, isRevertError } from '@/utils/transaction-errors'
+import { getErrorReference, getGuardErrorInfo, isRevertError } from '@/utils/transaction-errors'
 import { decodeCustomError } from '@/utils/customErrorRegistry'
 import { getBlockExplorerLink } from '@/utils/chains'
 import useSafeInfo from '@/hooks/useSafeInfo'
@@ -52,6 +52,12 @@ const ErrorMessage = ({
     error && (gsCode === 'GS013' || (!gsCode && isRevertError(error))) ? decodeCustomError(error) : undefined
   const effectiveGsCode = gsCode ?? (customError ? 'GS013' : undefined)
 
+  // What is safe to show behind "Details" — the same rule the transaction
+  // toast follows, so the two surfaces cannot drift (WA-3267). A revert never
+  // yields its raw dump; when there is nothing left to reference the
+  // affordance is hidden rather than offered empty.
+  const reference = error ? getErrorReference(error) : undefined
+
   // Check if this is a Guard error that should get special treatment
   const guardErrorName = error && context ? getGuardErrorInfo(error) : undefined
   const guardExplorerLink =
@@ -92,7 +98,7 @@ const ErrorMessage = ({
             </span>
           )}
 
-          {error && !effectiveGsCode && (
+          {error && !effectiveGsCode && reference && (
             <Link
               render={<button type="button" />}
               onClick={onDetailsToggle}
@@ -106,10 +112,10 @@ const ErrorMessage = ({
         {effectiveGsCode ? (
           <ErrorDetails code={effectiveGsCode} customError={customError} />
         ) : (
-          error &&
+          reference &&
           showDetails && (
             <Typography variant="paragraph-small" color="muted" className="mt-2 block break-words">
-              {error.message.replace(ETHERS_PREFIX, '').trim().slice(0, 500)}
+              {reference.replace(ETHERS_PREFIX, '').trim().slice(0, 500)}
             </Typography>
           )
         )}

--- a/apps/web/src/components/tx/TxSubmitError/__tests__/TxSubmitError.test.tsx
+++ b/apps/web/src/components/tx/TxSubmitError/__tests__/TxSubmitError.test.tsx
@@ -3,6 +3,7 @@ import type { EthersError } from '@/utils/ethers-utils'
 import type { TransactionReceipt } from 'ethers'
 import { Gs026PreCheckError } from '@/services/tx/executionPreChecks'
 import TxSubmitError from '..'
+import { OPAQUE_REVERT_MESSAGE } from '@safe-global/utils/services/exceptions/contractErrors'
 
 describe('TxSubmitError', () => {
   it('shows the cause-specific message for a failed GS026 pre-check', () => {
@@ -65,5 +66,21 @@ describe('TxSubmitError', () => {
     const { getByText } = render(<TxSubmitError error={error} />)
 
     expect(getByText('Could not submit the transaction. Try again.')).toBeInTheDocument()
+  })
+  it('gives a data-less revert the same explanation as the toast', () => {
+    // Both surfaces render together on a failed bulk execution — one failure
+    // must not produce two different stories (WA-3267).
+    const error = Object.assign(
+      new Error(
+        'execution reverted (no data present; likely require(false) occurred (action="estimateGas", data="0x")',
+      ),
+      { code: 'CALL_EXCEPTION', data: '0x', reason: 'require(false)' },
+    )
+
+    const { getByText, queryByText } = render(<TxSubmitError error={error} />)
+
+    expect(getByText(OPAQUE_REVERT_MESSAGE)).toBeInTheDocument()
+    expect(queryByText('Could not submit the transaction.')).not.toBeInTheDocument()
+    expect(queryByText(/require\(false\)/)).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/tx/TxSubmitError/index.tsx
+++ b/apps/web/src/components/tx/TxSubmitError/index.tsx
@@ -1,8 +1,9 @@
 import type { ReactElement } from 'react'
 import { useCurrentChain } from '@/hooks/useChains'
-import { getGs026Message } from '@safe-global/utils/services/exceptions/contractErrors'
+import { getGs026Message, OPAQUE_REVERT_MESSAGE } from '@safe-global/utils/services/exceptions/contractErrors'
 import {
   isNonceTooLowError,
+  isOpaqueRevertError,
   isRateLimitError,
   isRevertError,
   RATE_LIMIT_USER_MESSAGE,
@@ -70,6 +71,18 @@ const TxSubmitError = ({
     return (
       <ErrorMessage error={error} level="error" context={context}>
         {getRevertedMessage(chain?.chainName)}
+      </ErrorMessage>
+    )
+  }
+
+  // A revert with no decodable reason. The toast says the same thing, and the
+  // two render together on a failed bulk execution — they must not offer two
+  // different explanations for one failure (WA-3267). Checked after the receipt
+  // so a mined revert keeps its gas-was-spent copy if it ever matches both.
+  if (isOpaqueRevertError(error)) {
+    return (
+      <ErrorMessage error={error} level="error" context={context}>
+        {OPAQUE_REVERT_MESSAGE}
       </ErrorMessage>
     )
   }

--- a/apps/web/src/hooks/__tests__/useTxNotifications.test.ts
+++ b/apps/web/src/hooks/__tests__/useTxNotifications.test.ts
@@ -1,0 +1,108 @@
+import { renderHook, waitFor } from '@/tests/test-utils'
+import { OPAQUE_REVERT_MESSAGE } from '@safe-global/utils/services/exceptions/contractErrors'
+import { mockCurrentChain } from '@/tests/mocks/hooks'
+import { useAppSelector } from '@/store'
+import { selectNotifications } from '@/store/notificationsSlice'
+import { TxEvent, txDispatch } from '@/services/tx/txEvents'
+import useTxNotifications from '../useTxNotifications'
+
+jest.mock('@/hooks/useChains')
+
+jest.mock('@/hooks/useTxQueue', () => ({
+  __esModule: true,
+  default: () => ({ page: undefined, loading: false }),
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/transactions', () => ({
+  __esModule: true,
+  useLazyTransactionsGetTransactionByIdV1Query: () => [jest.fn().mockResolvedValue({ data: undefined })],
+}))
+
+// The exact shape ethers produces when MultiSendCallOnly does `revert(0, 0)`
+const opaqueRevert = () =>
+  Object.assign(
+    new Error(
+      'execution reverted (no data present; likely require(false) occurred (action="estimateGas", data="0x", reason="require(false)", transaction={ "data": "0x0075fe14a68278bda1623e877aa155a9c97d106e7" }, code=CALL_EXCEPTION, version=6.17.0)',
+    ),
+    { code: 'CALL_EXCEPTION', data: '0x', reason: 'require(false)' },
+  )
+
+const renderNotifications = () =>
+  renderHook(() => {
+    useTxNotifications()
+    return useAppSelector(selectNotifications)
+  })
+
+const eventPayload = {
+  txId: 'multisig_0x5AFE_0x1',
+  groupKey: 'batch',
+  chainId: '1',
+  safeAddress: '0x0000000000000000000000000000000000005AFE',
+}
+
+describe('useTxNotifications', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCurrentChain({ chainId: '1', chainName: 'Ethereum' })
+  })
+
+  it('replaces a data-less revert with the shared copy instead of "Require(false)"', async () => {
+    const { result } = renderNotifications()
+
+    txDispatch(TxEvent.FAILED, { ...eventPayload, error: opaqueRevert() })
+
+    await waitFor(() => expect(result.current).toHaveLength(1))
+
+    expect(result.current[0].message).toBe(OPAQUE_REVERT_MESSAGE)
+    expect(result.current[0].message).not.toMatch(/require\(false\)/i)
+  })
+
+  it('never puts the raw revert payload behind Details', async () => {
+    const { result } = renderNotifications()
+
+    txDispatch(TxEvent.FAILED, { ...eventPayload, error: opaqueRevert() })
+
+    await waitFor(() => expect(result.current).toHaveLength(1))
+
+    // Nothing to reference: no GS code, and the raw dump must never be shown
+    expect(result.current[0].detailedMessage).toBeUndefined()
+  })
+
+  it('keeps the code-only support reference for a revert we can name', async () => {
+    const { result } = renderNotifications()
+
+    const gsRevert = Object.assign(new Error('execution reverted: GS013 (data="0x...", version=6.17.0)'), {
+      code: 'CALL_EXCEPTION',
+      reason: 'GS013',
+    })
+    txDispatch(TxEvent.FAILED, { ...eventPayload, error: gsRevert })
+
+    await waitFor(() => expect(result.current).toHaveLength(1))
+
+    expect(result.current[0].detailedMessage).toBe('Error code GS013')
+    expect(result.current[0].detailedMessage).not.toMatch(/version=/)
+  })
+
+  it('keeps our own hand-written copy for a non-revert failure', async () => {
+    const { result } = renderNotifications()
+
+    // The relay timeout message is the only explanation the user gets — it is
+    // not a chain payload and must survive
+    const timeout = new Error('Transaction not relayed in 3 minutes. Be aware that it might still be relayed.')
+    txDispatch(TxEvent.FAILED, { ...eventPayload, error: timeout })
+
+    await waitFor(() => expect(result.current).toHaveLength(1))
+
+    expect(result.current[0].detailedMessage).toBe(timeout.message)
+  })
+
+  it('lets a mined revert keep its own message', async () => {
+    const { result } = renderNotifications()
+
+    txDispatch(TxEvent.REVERTED, { ...eventPayload, error: opaqueRevert() })
+
+    await waitFor(() => expect(result.current).toHaveLength(1))
+
+    expect(result.current[0].message).toBe('Transaction reverted on Ethereum. Gas was spent.')
+  })
+})

--- a/apps/web/src/hooks/useTxNotifications.ts
+++ b/apps/web/src/hooks/useTxNotifications.ts
@@ -16,12 +16,14 @@ import { getTxLink } from '@/utils/tx-link'
 import { useLazyTransactionsGetTransactionByIdV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { getExplorerLink } from '@safe-global/utils/utils/gateway'
 import {
+  getErrorReference,
   getGuardErrorInfo,
   isNonceTooLowError,
+  isOpaqueRevertError,
   isRateLimitError,
   RATE_LIMIT_USER_MESSAGE,
 } from '@/utils/transaction-errors'
-import { getGs026Message } from '@safe-global/utils/services/exceptions/contractErrors'
+import { getGs026Message, OPAQUE_REVERT_MESSAGE } from '@safe-global/utils/services/exceptions/contractErrors'
 
 const TxNotifications = {
   [TxEvent.SIGN_FAILED]: 'Failed to sign. Please try again.',
@@ -91,6 +93,12 @@ const useTxNotifications = (): void => {
           // being rate limited"); we replace the message but keep the original
           // in detailedMessage for debugging.
           message = RATE_LIMIT_USER_MESSAGE
+        } else if (isError && isOpaqueRevertError(detail.error)) {
+          // A revert with no decodable payload — typically MultiSend swallowing
+          // an inner failure. Checked last so every branch that CAN name a
+          // cause wins; `formatError` would otherwise surface the raw
+          // "Require(false)" here (WA-3267).
+          message = OPAQUE_REVERT_MESSAGE
         }
 
         const txId = 'txId' in detail ? detail.txId : undefined
@@ -110,7 +118,7 @@ const useTxNotifications = (): void => {
           showNotification({
             title: humanDescription,
             message,
-            detailedMessage: isError ? detail.error.message : undefined,
+            detailedMessage: isError ? getErrorReference(detail.error) : undefined,
             groupKey,
             variant: isError ? Variant.ERROR : isSuccess ? Variant.SUCCESS : Variant.INFO,
             link: txId

--- a/apps/web/src/services/tx/__tests__/executionPreChecks.test.ts
+++ b/apps/web/src/services/tx/__tests__/executionPreChecks.test.ts
@@ -1,9 +1,12 @@
 import { ethers } from 'ethers'
 import type { SafeTransaction, SafeSignature } from '@safe-global/types-kit'
-import { GS026_MESSAGES } from '@safe-global/utils/services/exceptions/contractErrors'
+import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { DetailedExecutionInfoType } from '@safe-global/store/gateway/types'
+import { getGs026BatchMessage, GS026_MESSAGES } from '@safe-global/utils/services/exceptions/contractErrors'
 import {
   Gs026PreCheckError,
   isGs026PreCheckError,
+  runBatchExecutionPreChecks,
   runExecutionPreChecks,
   validateTxSignatures,
 } from '../executionPreChecks'
@@ -240,6 +243,114 @@ describe('executionPreChecks', () => {
       expect(isGs026PreCheckError(new Gs026PreCheckError('STALE_NONCE'))).toBe(true)
       expect(isGs026PreCheckError(new Error(GS026_MESSAGES.STALE_NONCE))).toBe(false)
       expect(isGs026PreCheckError(undefined)).toBe(false)
+    })
+  })
+  const createBatchTx = (
+    nonce: number,
+    signatures: SafeSignature[] = [validSignature()],
+    safeTxHash: string = SAFE_TX_HASH,
+  ): TransactionDetails =>
+    ({
+      txId: `multisig_0x5AFE_${nonce}`,
+      detailedExecutionInfo: {
+        type: DetailedExecutionInfoType.MULTISIG,
+        nonce,
+        safeTxHash,
+        confirmations: signatures.map((sig) => ({ signer: { value: sig.signer }, signature: sig.staticPart() })),
+      },
+    }) as unknown as TransactionDetails
+
+  describe('runBatchExecutionPreChecks', () => {
+    const safe = createSafe()
+
+    it('passes a batch whose nonces start at the chain nonce and run sequentially', async () => {
+      mockGetNonces.mockResolvedValue({ currentNonce: 17, recommendedNonce: 19 })
+
+      await expect(
+        runBatchExecutionPreChecks({ txs: [createBatchTx(17), createBatchTx(18)], safe }),
+      ).resolves.toBeUndefined()
+    })
+
+    it('blocks a batch whose first transaction already used its nonce', async () => {
+      mockGetNonces.mockResolvedValue({ currentNonce: 18, recommendedNonce: 20 })
+
+      await expect(runBatchExecutionPreChecks({ txs: [createBatchTx(17), createBatchTx(18)], safe })).rejects.toThrow(
+        getGs026BatchMessage('STALE_NONCE', 1),
+      )
+    })
+
+    it('names the offending position when a later nonce is out of sequence', async () => {
+      mockGetNonces.mockResolvedValue({ currentNonce: 17, recommendedNonce: 20 })
+
+      // 17, then 19 — the queue moved under us and 18 is gone
+      await expect(runBatchExecutionPreChecks({ txs: [createBatchTx(17), createBatchTx(19)], safe })).rejects.toThrow(
+        getGs026BatchMessage('STALE_NONCE', 2),
+      )
+    })
+
+    it('blocks a batch carrying a signature that does not recover to its signer', async () => {
+      mockGetNonces.mockResolvedValue({ currentNonce: 17, recommendedNonce: 19 })
+
+      await expect(
+        runBatchExecutionPreChecks({
+          txs: [createBatchTx(17), createBatchTx(18, [wrongSignerSignature()])],
+          safe,
+        }),
+      ).rejects.toThrow(getGs026BatchMessage('BAD_SIGNATURE', 2))
+    })
+
+    it('throws an error the UI can recognise as a GS026 pre-check', async () => {
+      mockGetNonces.mockResolvedValue({ currentNonce: 18, recommendedNonce: 20 })
+
+      const error = await runBatchExecutionPreChecks({ txs: [createBatchTx(17)], safe }).catch((e) => e)
+
+      expect(isGs026PreCheckError(error)).toBe(true)
+      expect(error.reason).toBe('STALE_NONCE')
+      expect(error.code).toBe('GS026')
+    })
+
+    it('skips the nonce check rather than blocking when the nonce cannot be fetched', async () => {
+      mockGetNonces.mockResolvedValue(undefined)
+
+      await expect(runBatchExecutionPreChecks({ txs: [createBatchTx(99)], safe })).resolves.toBeUndefined()
+    })
+
+    it('skips the nonce check for a counterfactual Safe, which has no chain nonce', async () => {
+      await expect(
+        runBatchExecutionPreChecks({ txs: [createBatchTx(3)], safe: createSafe({ deployed: false }) }),
+      ).resolves.toBeUndefined()
+      expect(mockGetNonces).not.toHaveBeenCalled()
+    })
+
+    it('does not flag a nested-Safe (contract) signature it cannot verify locally', async () => {
+      mockGetNonces.mockResolvedValue({ currentNonce: 17, recommendedNonce: 18 })
+
+      // CGW returns the full dynamic blob for a contract signature; its trailing
+      // byte is data, not a `v` value, so it must not be read as one
+      const nestedSafeSig: SafeSignature = {
+        ...validSignature(),
+        staticPart: () => `${validSignature().staticPart()}${'ab'.repeat(32)}`,
+      }
+
+      await expect(
+        runBatchExecutionPreChecks({ txs: [createBatchTx(17, [nestedSafeSig])], safe }),
+      ).resolves.toBeUndefined()
+    })
+
+    it('does not flag an on-chain approval, which carries no signature to verify', async () => {
+      mockGetNonces.mockResolvedValue({ currentNonce: 17, recommendedNonce: 18 })
+
+      const approved = {
+        txId: 'multisig_0x5AFE_17',
+        detailedExecutionInfo: {
+          type: DetailedExecutionInfoType.MULTISIG,
+          nonce: 17,
+          safeTxHash: SAFE_TX_HASH,
+          confirmations: [{ signer: { value: signerWallet.address }, signature: null }],
+        },
+      } as unknown as TransactionDetails
+
+      await expect(runBatchExecutionPreChecks({ txs: [approved], safe })).resolves.toBeUndefined()
     })
   })
 })

--- a/apps/web/src/services/tx/executionPreChecks.ts
+++ b/apps/web/src/services/tx/executionPreChecks.ts
@@ -8,20 +8,26 @@
 import { ethers } from 'ethers'
 import type { SafeTransaction } from '@safe-global/types-kit'
 import type { ExtendedSafeInfo } from '@safe-global/store/slices/SafeInfo/types'
-import { getGs026Message, type Gs026Reason } from '@safe-global/utils/services/exceptions/contractErrors'
+import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import {
+  getGs026BatchMessage,
+  getGs026Message,
+  type Gs026Reason,
+} from '@safe-global/utils/services/exceptions/contractErrors'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
 import ErrorCodes from '@safe-global/utils/services/exceptions/ErrorCodes'
 import { logError } from '@/services/exceptions'
 import { getNonces } from '@/services/tx/tx-sender/recommendedNonce'
 import { getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
-import { isOwner } from '@/utils/transaction-guards'
+import { isMultisigDetailedExecutionInfo, isOwner } from '@/utils/transaction-guards'
 
 export class Gs026PreCheckError extends Error {
   /** The GS code this pre-check prevents — lets the Details panel show it. */
   code = 'GS026' as const
   reason: Gs026Reason
 
-  constructor(reason: Gs026Reason) {
-    super(getGs026Message(reason))
+  constructor(reason: Gs026Reason, message: string = getGs026Message(reason)) {
+    super(message)
     this.name = 'Gs026PreCheckError'
     this.reason = reason
   }
@@ -47,6 +53,63 @@ const ETH_SIGN_V_OFFSET = 4
 
 const getSignatureType = (staticPart: string): number => parseInt(staticPart.slice(-2), 16)
 
+/** A 65-byte signature: 0x + r (32) + s (32) + v (1), hex-encoded. */
+const ECDSA_SIG_LENGTH = 132
+
+/**
+ * Recover one collected signature against a hash. Returns false only on
+ * positive proof that it does not verify — anything we cannot check
+ * client-side (contract/EIP-1271, pre-validated, an unrecognised type) counts
+ * as valid, because the on-chain validation stays the final authority and a
+ * false block is worse than a missed one.
+ *
+ * A blob longer than 65 bytes is a contract signature carrying its dynamic
+ * part, whose trailing byte is arbitrary data rather than a `v` value. Reading
+ * a signature type off it would recover a random address and wrongly flag a
+ * nested-Safe signer, so it is skipped. A shorter blob still goes through
+ * recovery and fails there, as long as its trailing byte names a type we
+ * verify; one that does not falls through to the same permissive default.
+ */
+const isSignatureValid = (
+  { signer, staticPart, isContractSignature }: { signer: string; staticPart: string; isContractSignature?: boolean },
+  hash: string,
+): boolean => {
+  // An on-chain approval (approveHash) is confirmed without a signature at
+  // all, so there is nothing here to recover
+  if (!staticPart) return true
+
+  // Verified on-chain only; nothing to recover locally
+  if (isContractSignature || staticPart.length > ECDSA_SIG_LENGTH) return true
+
+  const signatureType = getSignatureType(staticPart)
+
+  if (signatureType === SIG_TYPE_CONTRACT || signatureType === SIG_TYPE_PRE_VALIDATED) return true
+
+  if (SIG_TYPE_ECDSA.includes(signatureType)) {
+    try {
+      return sameAddress(ethers.recoverAddress(hash, staticPart), signer)
+    } catch (e) {
+      logError(ErrorCodes._818, e)
+      return false
+    }
+  }
+
+  if (SIG_TYPE_ETH_SIGN.includes(signatureType)) {
+    try {
+      // Undo Safe's +4 offset to get a standard v, then verify as an
+      // EIP-191 personal_sign message over the hash
+      const standardV = signatureType - ETH_SIGN_V_OFFSET
+      const standardSig = `${staticPart.slice(0, -2)}${standardV.toString(16)}`
+      return sameAddress(ethers.verifyMessage(ethers.getBytes(hash), standardSig), signer)
+    } catch (e) {
+      logError(ErrorCodes._818, e)
+      return false
+    }
+  }
+
+  return true
+}
+
 /**
  * Locally recover every collected ECDSA/eth_sign signature against the
  * transaction hash. Contract (EIP-1271) and pre-validated signatures are
@@ -55,45 +118,16 @@ const getSignatureType = (staticPart: string): number => parseInt(staticPart.sli
  */
 export const validateTxSignatures = (safeTx: SafeTransaction, safeTxHash: string): string | undefined => {
   for (const signature of safeTx.signatures.values()) {
-    if (signature.isContractSignature) {
-      continue
-    }
+    const valid = isSignatureValid(
+      {
+        signer: signature.signer,
+        staticPart: signature.staticPart(),
+        isContractSignature: signature.isContractSignature,
+      },
+      safeTxHash,
+    )
 
-    const sig = signature.staticPart()
-    const signatureType = getSignatureType(sig)
-
-    if (signatureType === SIG_TYPE_CONTRACT || signatureType === SIG_TYPE_PRE_VALIDATED) {
-      // Verified on-chain only; nothing to recover locally
-      continue
-    }
-
-    if (SIG_TYPE_ECDSA.includes(signatureType)) {
-      try {
-        const recoveredAddress = ethers.recoverAddress(safeTxHash, sig)
-        if (recoveredAddress !== signature.signer) {
-          return getGs026Message('BAD_SIGNATURE')
-        }
-      } catch (e) {
-        logError(ErrorCodes._818, e)
-        return getGs026Message('BAD_SIGNATURE')
-      }
-    }
-
-    if (SIG_TYPE_ETH_SIGN.includes(signatureType)) {
-      try {
-        // Undo Safe's +4 offset to get a standard v, then verify as an
-        // EIP-191 personal_sign message over the safeTxHash
-        const standardV = signatureType - ETH_SIGN_V_OFFSET
-        const standardSig = `${sig.slice(0, -2)}${standardV.toString(16)}`
-        const recoveredAddress = ethers.verifyMessage(ethers.getBytes(safeTxHash), standardSig)
-        if (recoveredAddress !== signature.signer) {
-          return getGs026Message('BAD_SIGNATURE')
-        }
-      } catch (e) {
-        logError(ErrorCodes._818, e)
-        return getGs026Message('BAD_SIGNATURE')
-      }
-    }
+    if (!valid) return getGs026Message('BAD_SIGNATURE')
   }
 }
 
@@ -136,4 +170,65 @@ export const runExecutionPreChecks = async ({
       throw new Gs026PreCheckError('BAD_SIGNATURE')
     }
   }
+}
+
+/**
+ * The bulk-execution counterpart of `runExecutionPreChecks`.
+ *
+ * MultiSendCallOnly does `revert(0, 0)` when an inner `execTransaction` fails,
+ * so a batch that breaks on-chain gives back nothing to decode — the user pays
+ * gas for an error we cannot even name (WA-3267). These checks catch the two
+ * causes that are knowable client-side before anything is broadcast.
+ *
+ * `NOT_SIGNER` is not checked: every batched transaction is already fully
+ * signed and the executor is MultiSendCallOnly, not the connected wallet.
+ *
+ * Signatures are verified against the `safeTxHash` the backend collected them
+ * for, not a locally recomputed one. That makes the check cheap and free of SDK
+ * setup, at the cost of missing a hash mismatch — a miss, never a false block,
+ * which is the right side to err on when on-chain validation is the authority.
+ */
+export const runBatchExecutionPreChecks = async ({
+  txs,
+  safe,
+}: {
+  txs: TransactionDetails[]
+  safe: Pick<ExtendedSafeInfo, 'chainId' | 'address' | 'deployed'>
+}): Promise<void> => {
+  const execInfos = txs.map((tx) =>
+    isMultisigDetailedExecutionInfo(tx.detailedExecutionInfo) ? tx.detailedExecutionInfo : undefined,
+  )
+
+  // STALE_NONCE: the batch is signed for a fixed run of nonces starting at the
+  // Safe's current one. If the queue moved since it was built — another
+  // execution landed, a transaction was deleted — every hash from the break
+  // onwards is wrong and the whole batch reverts.
+  if (safe.deployed) {
+    const nonces = await getNonces(safe.chainId, safe.address.value)
+
+    if (nonces) {
+      const staleIndex = execInfos.findIndex((info, index) => info && info.nonce !== nonces.currentNonce + index)
+
+      if (staleIndex !== -1) {
+        throw new Gs026PreCheckError('STALE_NONCE', getGs026BatchMessage('STALE_NONCE', staleIndex + 1))
+      }
+    }
+  }
+
+  // BAD_SIGNATURE: a collected signature no longer recovers to its signer
+  execInfos.forEach((info, index) => {
+    if (!info) return
+
+    const hasInvalidSignature = info.confirmations.some(
+      (confirmation) =>
+        !isSignatureValid(
+          { signer: confirmation.signer.value, staticPart: confirmation.signature ?? '' },
+          info.safeTxHash,
+        ),
+    )
+
+    if (hasInvalidSignature) {
+      throw new Gs026PreCheckError('BAD_SIGNATURE', getGs026BatchMessage('BAD_SIGNATURE', index + 1))
+    }
+  })
 }

--- a/apps/web/src/utils/__tests__/transaction-errors.test.ts
+++ b/apps/web/src/utils/__tests__/transaction-errors.test.ts
@@ -1,4 +1,4 @@
-import { BaseError } from 'viem'
+import { BaseError, ExecutionRevertedError } from 'viem'
 import {
   isGuardError,
   extractGuardErrorCode,
@@ -7,6 +7,8 @@ import {
   isNonceTooLowError,
   isRateLimitError,
   isRevertError,
+  isOpaqueRevertError,
+  getErrorReference,
   GUARD_ERROR_CODES,
 } from '../transaction-errors'
 
@@ -172,6 +174,114 @@ describe('transaction-errors', () => {
       const inner = Object.assign(new BaseError('inner'), { code: -32602 })
       const outer = new BaseError('outer', { cause: inner })
       expect(isRateLimitError(outer)).toBe(false)
+    })
+  })
+  // The real shape ethers produces when MultiSendCallOnly does `revert(0, 0)`:
+  // a revert with an empty data payload, so there is nothing to decode.
+  const dataLessRevert = () =>
+    Object.assign(
+      new Error(
+        'execution reverted (no data present; likely require(false) occurred (action="estimateGas", data="0x", reason="require(false)", code=CALL_EXCEPTION, version=6.17.0)',
+      ),
+      { code: 'CALL_EXCEPTION', data: '0x', reason: 'require(false)' },
+    )
+
+  describe('isOpaqueRevertError', () => {
+    it('detects a revert that carries no decodable payload', () => {
+      expect(isOpaqueRevertError(dataLessRevert())).toBe(true)
+    })
+
+    it('detects an empty revert payload even without the explanatory message text', () => {
+      expect(
+        isOpaqueRevertError(Object.assign(new Error('execution reverted'), { code: 'CALL_EXCEPTION', data: '0x' })),
+      ).toBe(true)
+    })
+
+    it('does not match a revert we can already decode', () => {
+      // GS013: the code is in the message, so the GS mapping handles it
+      expect(
+        isOpaqueRevertError(Object.assign(new Error('execution reverted: GS013'), { code: 'CALL_EXCEPTION' })),
+      ).toBe(false)
+      // A GS revert carrying its Error(string) payload
+      expect(
+        isOpaqueRevertError(
+          Object.assign(new Error('execution reverted'), {
+            code: 'CALL_EXCEPTION',
+            reason: 'GS026',
+            data: '0x08c379a000000000000000000000000000000000000000000000000000000000000000204753303236',
+          }),
+        ),
+      ).toBe(false)
+      // A module/guard custom error — the selector is shown in the support reference
+      expect(
+        isOpaqueRevertError(
+          Object.assign(new Error('execution reverted'), { code: 'CALL_EXCEPTION', data: '0x70cc6907' }),
+        ),
+      ).toBe(false)
+    })
+
+    it('does not match an infrastructure failure', () => {
+      expect(isOpaqueRevertError(new Error('The request timed out.'))).toBe(false)
+      expect(isOpaqueRevertError(Object.assign(new Error('HTTP request failed.'), { status: 429 }))).toBe(false)
+      expect(isOpaqueRevertError(null)).toBe(false)
+      expect(isOpaqueRevertError(undefined)).toBe(false)
+    })
+
+    it('does not match a wallet rejection', () => {
+      expect(isOpaqueRevertError(Object.assign(new Error('user rejected action'), { code: 'ACTION_REJECTED' }))).toBe(
+        false,
+      )
+    })
+    it('detects the viem shape too — protocol-kit execution paths never throw ethers errors', () => {
+      // viem folds a missing reason into the message rather than a field
+      const executionReverted = new ExecutionRevertedError({})
+
+      expect(executionReverted.message).toContain('for an unknown reason')
+      expect(isOpaqueRevertError(executionReverted)).toBe(true)
+    })
+
+    it('does not match a viem revert that reports a reason', () => {
+      const withReason = new ExecutionRevertedError({ message: 'execution reverted: GS013' })
+      expect(isOpaqueRevertError(withReason)).toBe(false)
+    })
+  })
+
+  describe('getErrorReference', () => {
+    it('keeps our own message for a non-revert failure', () => {
+      const timeout = new Error('Transaction not relayed in 3 minutes.')
+      expect(getErrorReference(timeout)).toBe(timeout.message)
+    })
+
+    it('reduces a GS revert to its code, dropping the payload', () => {
+      const gs = Object.assign(new Error('execution reverted: GS013 (data="0xdead", version=6.17.0)'), {
+        code: 'CALL_EXCEPTION',
+        reason: 'GS013',
+      })
+      expect(getErrorReference(gs)).toBe('Error code GS013')
+    })
+
+    it('keeps a decoded Error(string) reason — the chain wrote it for a human', () => {
+      const stringRevert = Object.assign(
+        new Error('execution reverted: ERC20: transfer amount exceeds balance (data="0x08c379a0...", version=6.17.0)'),
+        {
+          code: 'CALL_EXCEPTION',
+          data: `0x08c379a0${'00'.repeat(64)}`,
+          reason: 'ERC20: transfer amount exceeds balance',
+        },
+      )
+      expect(getErrorReference(stringRevert)).toBe('ERC20: transfer amount exceeds balance')
+    })
+
+    it('gives nothing at all for a revert with no decodable reason', () => {
+      expect(getErrorReference(dataLessRevert())).toBeUndefined()
+    })
+
+    it('never returns a payload, address or library version for any revert', () => {
+      const custom = Object.assign(new Error('execution reverted (unknown custom error) version=6.17.0'), {
+        code: 'CALL_EXCEPTION',
+        data: '0x1234abcd',
+      })
+      expect(getErrorReference(custom)).toBeUndefined()
     })
   })
 })

--- a/apps/web/src/utils/transaction-errors.ts
+++ b/apps/web/src/utils/transaction-errors.ts
@@ -2,7 +2,7 @@
  * Utilities for detecting and handling specific transaction errors
  */
 import { BaseError } from 'viem'
-import { getKnownCustomError } from '@/utils/customErrorRegistry'
+import { extractRevertSelector, getKnownCustomError } from '@/utils/customErrorRegistry'
 import { getGsCodeFromError } from '@safe-global/utils/services/exceptions/contractErrors'
 
 /**
@@ -97,6 +97,71 @@ export const isRateLimitError = (error: unknown): boolean => {
   }
 
   return false
+}
+
+/**
+ * Detects a revert that carries no reason anyone can decode.
+ *
+ * MultiSend and MultiSendCallOnly do `revert(0, 0)` when an inner call fails,
+ * destroying the child's revert data. A failing batch therefore reaches us as a
+ * bare `require(false)` with an empty payload: no GS code, no custom-error
+ * selector, nothing to look up. The only honest thing we can tell the user is
+ * that something in the transaction fails on-chain, and that splitting the
+ * batch is what surfaces the real reason.
+ *
+ * Deliberately narrow — it demands positive proof that the payload is empty.
+ * A revert with anything decodable (a GS code, an `Error(string)`, a module or
+ * guard custom error) keeps its own specific message.
+ */
+export const isOpaqueRevertError = (error: unknown): boolean => {
+  if (!isRevertError(error)) return false
+
+  // Anything we can name is not opaque.
+  if (getGsCodeFromError(error as { message?: string; reason?: string; code?: unknown })) return false
+  if (extractRevertSelector(error)) return false
+
+  const { data, message } = error as { data?: unknown; message?: string }
+
+  // ethers: an empty revert payload, reported either structurally or in text
+  if (data === '0x') return true
+
+  // viem: `ExecutionRevertedError` folds the missing reason into its message
+  // ("Execution reverted for an unknown reason.") rather than a field. It is
+  // the shape the protocol-kit execution paths throw, where ethers' never
+  // reach us.
+  return typeof message === 'string' && /no data present|require\(false\)|for an unknown reason/i.test(message)
+}
+
+/**
+ * The `Error(string)` selector: a plain `require(cond, "reason")` revert, which
+ * ethers and viem both decode into a human sentence on the error itself.
+ */
+const STRING_REVERT_SELECTOR = '0x08c379a0'
+
+/**
+ * What may be shown behind "Details" for an error — the one rule both the toast
+ * and the inline alert follow, so the two surfaces cannot drift (WA-3267).
+ *
+ * A revert never gets its raw message: that string is the ethers/viem dump,
+ * carrying calldata, contract addresses and the library version (WA-3005 #6).
+ * What survives is what we can name — the GS code, or a decoded
+ * `Error(string)` reason, which the chain wrote for a human to read. Anything
+ * else gets no Details at all rather than an empty one.
+ *
+ * Non-revert errors keep their message: those are usually sentences we wrote
+ * ourselves (a relay timeout, "transaction not found") and are the only
+ * explanation the user gets.
+ */
+export const getErrorReference = (error: Error): string | undefined => {
+  if (!isRevertError(error)) return error.message
+
+  const gsCode = getGsCodeFromError(error)
+  if (gsCode) return `Error code ${gsCode}`
+
+  if (extractRevertSelector(error) === STRING_REVERT_SELECTOR) {
+    const { reason } = error as Error & { reason?: string }
+    return reason || undefined
+  }
 }
 
 /**

--- a/packages/utils/src/services/exceptions/__tests__/contractErrors.test.ts
+++ b/packages/utils/src/services/exceptions/__tests__/contractErrors.test.ts
@@ -3,9 +3,11 @@ import CONTRACT_ERRORS, {
   GS026_MESSAGES,
   getContractErrorHandling,
   getContractErrorMessage,
+  getGs026BatchMessage,
   getGs026Message,
   getGsCodeFromError,
   isGsCode,
+  OPAQUE_REVERT_MESSAGE,
   type GsCode,
 } from '../contractErrors'
 
@@ -16,6 +18,10 @@ const ALL_USER_FACING_STRINGS = [
   ...Object.values(CONTRACT_ERRORS).map((meta) => meta.message),
   ...Object.values(GS026_MESSAGES),
   CONTRACT_ERROR_FALLBACK,
+  OPAQUE_REVERT_MESSAGE,
+  // Rendered, so the content rules run over the text a user actually sees
+  getGs026BatchMessage('STALE_NONCE', 2),
+  getGs026BatchMessage('BAD_SIGNATURE', 2),
 ]
 
 describe('contractErrors', () => {
@@ -49,6 +55,32 @@ describe('contractErrors', () => {
       expect(message).not.toMatch(/GS\d{3}/) // no GS code in the body
       expect(message).not.toMatch(/eth_[a-z]/i) // no RPC method names
       expect(message).not.toMatch(/0x[0-9a-f]{4,}/i) // no hex blobs / selectors
+    })
+  })
+
+  describe('getGs026BatchMessage', () => {
+    it('names the offending transaction by its position in the batch', () => {
+      expect(getGs026BatchMessage('STALE_NONCE', 2)).toBe(
+        'Transaction 2 in this batch no longer matches the queue. Refresh to get the current one.',
+      )
+      expect(getGs026BatchMessage('BAD_SIGNATURE', 1)).toBe(
+        'Could not verify a signature on transaction 1 in this batch. It has to be signed again.',
+      )
+    })
+
+    it('reads differently from the single-transaction message for the same cause', () => {
+      expect(getGs026BatchMessage('STALE_NONCE', 1)).not.toBe(getGs026Message('STALE_NONCE'))
+    })
+  })
+
+  describe('OPAQUE_REVERT_MESSAGE', () => {
+    it('does not claim anything about gas, which is unknowable at that point', () => {
+      expect(OPAQUE_REVERT_MESSAGE).not.toMatch(/gas/i)
+    })
+
+    it('never leaks the raw revert wording', () => {
+      expect(OPAQUE_REVERT_MESSAGE).not.toMatch(/require\(false\)/i)
+      expect(OPAQUE_REVERT_MESSAGE).not.toMatch(/revert/i)
     })
   })
 

--- a/packages/utils/src/services/exceptions/contractErrors.ts
+++ b/packages/utils/src/services/exceptions/contractErrors.ts
@@ -79,6 +79,26 @@ export const GS026_MESSAGES: Record<Gs026Reason, string> = {
   BAD_SIGNATURE: 'Could not verify your signature. Sign the transaction again.',
 }
 
+export const OPAQUE_REVERT_MESSAGE =
+  'This transaction fails on-chain without reporting a reason. If it bundles several transactions, execute them one at a time to find the one that fails.'
+
+/**
+ * The GS026 causes that are detectable per transaction inside a bulk
+ * execution. `NOT_SIGNER` is absent by construction: every batched transaction
+ * is already fully signed, and the batch is executed by MultiSendCallOnly
+ * rather than by the connected wallet, so the executor is never a signer.
+ *
+ * These name the offending transaction by its position in the batch — the same
+ * number the review screen shows — because the batch fails as a whole and the
+ * user otherwise cannot tell which one to fix.
+ */
+export type Gs026BatchReason = Extract<Gs026Reason, 'STALE_NONCE' | 'BAD_SIGNATURE'>
+
+const GS026_BATCH_MESSAGES: Record<Gs026BatchReason, string> = {
+  STALE_NONCE: 'Transaction {position} in this batch no longer matches the queue. Refresh to get the current one.',
+  BAD_SIGNATURE: 'Could not verify a signature on transaction {position} in this batch. It has to be signed again.',
+}
+
 const CONTRACT_ERRORS: Record<GsCode, ContractErrorMeta> = {
   // --- Bucket A: inline field validation, never an error state ---
   GS001: { message: 'Set a threshold before you continue', handling: 'inline-validation' },
@@ -181,5 +201,12 @@ export const getContractErrorHandling = (code: GsCode): ContractErrorHandling =>
 
 /** Resolve a specific GS026 cause to its message. */
 export const getGs026Message = (reason: Gs026Reason): string => GS026_MESSAGES[reason]
+
+/**
+ * Resolve a GS026 cause detected inside a bulk execution, naming the offending
+ * transaction by its 1-based position in the batch.
+ */
+export const getGs026BatchMessage = (reason: Gs026BatchReason, position: number): string =>
+  GS026_BATCH_MESSAGES[reason].replace('{position}', String(position))
 
 export default CONTRACT_ERRORS


### PR DESCRIPTION
## What it solves

Resolves: WA-3267

A user bulk-executed 2 queued transactions through MultiSendCallOnly 1.4.1. One inner `execTransaction` reverted. MultiSendCallOnly does `revert(0, 0)` — it destroys the child's revert reason — so the client got a data-less `CALL_EXCEPTION` with nothing to decode.

What they saw:

- **Toast:** `Execution failed. Require(false).` followed by a ~4KB raw ethers dump — full calldata, contract addresses, `version=6.17.0` — rendered verbatim in a `<pre>`.
- **Inline:** `Error submitting the transaction. Please try again.`

Two separate defects behind that:

1. **Data-less reverts were never classified.** `useTxNotifications.ts` built `` `${baseMessage} ${formatError(error)}` ``, and `formatError` just capitalizes `error.reason` → `Require(false).`. The override chain below it matched only `REVERTED`, guard errors, nonce-too-low and rate-limit, so a revert with no decodable payload fell straight through to the raw string. This breaks WA-3005 guideline #1 (never show a technical string) and #6 (Details is a support reference, never a payload).

2. **The bulk flow never ran the GS026 pre-checks.** `runExecutionPreChecks` (#8499) was wired only into the single-transaction path at `components/tx/shared/hooks.ts:27`. `ExecuteBatch/ReviewBatch.tsx` never called it, so the two most likely causes of this revert — the Safe nonce advanced since the queue loaded, or a collected signature no longer verifies — were caught before broadcast in a normal execution and completely invisible in bulk. The user paid gas for a failure that was detectable client-side.

The inline half was already fixed on `dev` by WA-3005 (`d74c47cc8`, #8484) → `Could not submit the transaction.` Note that commit is **not** in v1.99.0: `release` branched at `3c678cb48` on Aug 11, that commit landed Aug 13.

**Out of scope:** MultiSendCallOnly's `revert(0, 0)` (the reason is destroyed on-chain, no client fix exists), off-chain copy (WA-3006), the rest of WA-3005.

## How this PR fixes it

**Classify the failure.** `isOpaqueRevertError` in `transaction-errors.ts` matches a revert with no GS code, no custom-error selector, and positive proof of an empty payload — `data === '0x'`, ethers' "no data present", or viem's "for an unknown reason". Deliberately narrow: a GS revert, an `Error(string)` revert, a guard custom error, an RPC timeout and a rate-limit all stay on their existing paths.

**Say something honest.** `OPAQUE_REVERT_MESSAGE` lives in the shared code-keyed source that web and mobile both read:

> This transaction fails on-chain without reporting a reason. If it bundles several transactions, execute them one at a time to find the one that fails.

Splitting the batch is the genuinely useful advice — a single `execTransaction` bubbles its GS code where MultiSendCallOnly discards it. The copy claims nothing about gas, because `TxEvent.FAILED` fires both pre-broadcast and from `txMonitor`; mined reverts go to `TxEvent.REVERTED`, which already says gas was spent. Both the toast and the inline alert render it, so one failure no longer tells two stories.

**Sanitise Details once.** A single shared `getErrorReference` drives both surfaces so they cannot drift: a non-revert keeps its message (usually copy we wrote — relay timeouts, "transaction not found"); a GS revert reduces to `Error code GS0xx`; a revert whose selector is exactly `Error(string)` yields the already-decoded reason; anything else yields nothing and the affordance is hidden rather than offered empty.

This is deliberately **not** a blanket suppression of every revert. `ERC20: transfer amount exceeds balance` is a sentence the chain wrote for a human to read — hiding it would satisfy the acceptance criteria while making the product worse. The gate is the structural `0x08c379a0` selector, not a regex over the message.

**Prevent what we can.** `runBatchExecutionPreChecks` checks that the batch's nonces still line up with the chain and that every collected signature still recovers to its signer, naming the offender by its position in the batch — the same number the review screen shows. Wired into `ReviewBatch` ahead of both the wallet and the relay path. This also covers the symptom reported in WA-49: a stale `safe.nonce` from the CGW cache produces a batch whose nonces no longer match the chain.

Three deliberate calls inside it:

- Signatures are verified against the CGW-provided `safeTxHash` rather than a recomputed one. Cheaper and SDK-free, at the cost of missing a hash mismatch — a miss, never a false block, which is the right side to err on when on-chain validation is the authority.
- Blobs longer than 65 bytes are skipped. CGW returns a contract signature's dynamic part, whose trailing byte is data rather than a `v` value; reading a signature type off it would recover a random address and falsely flag a nested-Safe signer.
- `sameAddress` replaced a case-sensitive `!==` in `validateTxSignatures`. Incidental bugfix: `ethers.recoverAddress` returns checksummed, so a lowercase signer previously produced a false `BAD_SIGNATURE` block in the single-tx flow and in `ComboSubmit` too.

## How to test it

**Unit:** `yarn workspace @safe-global/web test src/utils/__tests__/transaction-errors.test.ts src/services/tx/__tests__/executionPreChecks.test.ts src/hooks/__tests__/useTxNotifications.test.ts src/components/tx-flow/flows/ExecuteBatch src/components/tx/ErrorMessage src/components/tx/TxSubmitError`

**Manually, the opaque revert:** queue two transactions where the second is guaranteed to revert (e.g. an ERC-20 transfer exceeding the Safe's balance), fully sign both, and use Bulk execute. Estimation fails; the toast and the inline alert should both show the message above, with no `Require(false)`, no hex, no `version=`, and no Details affordance.

**Manually, the pre-check:** build a batch, then execute one of its transactions from another tab (or have a co-signer do it) so the Safe nonce advances. Submit the batch. It should block before the wallet opens, naming the offending position — "Transaction 1 in this batch no longer matches the queue. Refresh to get the current one." — instead of burning gas on an opaque revert.

**Regression:** confirm a GS revert still shows its mapped copy and the code-only reference, an `Error(string)` revert still shows its reason behind Details, and an RPC failure still says "could not check" rather than predicting failure.

## Affected flows

- Bulk execute from the transaction queue — now blocked pre-broadcast on a stale nonce or an unverifiable signature, on both the wallet and relay paths
- Any transaction failure toast — a data-less revert gets new copy; every revert loses its raw Details payload
- Inline submit errors (`TxSubmitError`) — a data-less revert now matches the toast instead of saying "Could not submit the transaction."
- Inline error Details (`ErrorMessage`, 41 call sites) — behaviour changes only for errors that pass `isRevertError`

## Blast radius

- **`packages/utils/.../contractErrors.ts`** — the shared code-keyed copy source, read by **web and mobile**. Additive only: `OPAQUE_REVERT_MESSAGE`, `Gs026BatchReason`, `getGs026BatchMessage`. No existing export changed; the mobile parity test passes untouched. New strings are covered by the existing content-rule test (no URLs, versions, "please", exclamation marks, hex blobs).
- **`transaction-errors.ts`** — consumed by `TxSubmitError`, `TxCheckError`, `ErrorMessage`, `useTxNotifications`. `isRevertError` is unchanged; the new exports are additive.
- **`ErrorMessage`** — 41 call sites. Non-transaction consumers (`ImportDialog`, spaces dialogs, proposers, `NftCollections`, `PaginatedTxns`) pass HTTP/validation errors, which are not reverts and keep their message unchanged. `ExecuteThroughRoleForm`'s Zodiac Roles custom errors still take the GS013 + decoded-name path.
- **`executionPreChecks.ts`** — `validateTxSignatures` is also consumed by `useValidateTxData` → `ComboSubmit`. Refactored to share one verification helper; all 16 pre-existing tests pass unchanged, and both consumers become strictly *more* permissive (the `sameAddress` fix and the over-long-blob skip only remove false blocks).
- **`useTxNotifications`** — single consumer (`_app.tsx:116`), but it handles every transaction lifecycle event. `formatError` itself was left untouched, so the recovery, counterfactual and safe-message notification hooks are unaffected.
- No RTK Query contract, feature flag, chain config, route, or persisted state is touched. `getNonces` is called once per batch submit, with `forceRefetch`.

## Risks / not checked

- **No on-chain reproduction.** I could not re-run the user's failed batch; the ethers error shape is reproduced from the reported dump and from ethers' own `getBuiltinCallException`, not from a live revert.
- **Not tested on mobile.** `packages/utils` is shared and type-checks, and the parity test passes, but no mobile surface renders the new copy yet.
- **The batch nonce check is strict** (`nonce !== currentNonce + index`) rather than tolerant. Justified by the `useBatchedTxs` invariant and the single entry point via `BatchExecuteButton`. If CGW's `/nonces` ever lags the cached `safe.nonce`, the user gets a hard block whose remedy ("Refresh") will not help.
- **Owner/threshold changes inside a batch** invalidate the signature set for every subsequent inner `execTransaction` and land as the same opaque revert. Not detectable by these pre-checks; the fallback copy reaching both surfaces is the mitigation, not a fix.
- **`SpeedUpModal`** still passes a raw `error.message` to `detailedMessage` — same defect class, deliberately out of scope.
- **Two follow-ups found and left alone,** both recorded on the ticket:
  1. `isRevertError` classifies viem contract reverts backwards. `viem/errors/contract.js:199` builds "…reverted with the following reason:" for the case that *has* a reason, which matches `/reverted with/`; `:202` builds "The contract function "X" reverted." for the reasonless case, which matches nothing. So a viem revert *with* a reason is treated as "will most likely fail" and one *without* as "could not check" — backwards, since the reasonless case is the one we are most certain reverted. Fixing it flips a class of errors between two states WA-3005 deliberately separated, so it needs its own ticket rather than a side-effect change here.
  2. `Panic(uint256)` (`0x4e487b71`) is a standard selector, so it is neither decoded as a custom error nor matched as `Error(string)`. An arithmetic overflow in a target contract surfaces with nothing behind Details. The panic codes are a finite documented set — the natural next candidate.

## Visual summary

Before — the reason is destroyed on-chain and the raw dump reaches the user:

```mermaid
flowchart TB
  A["Bulk execute<br/>2 queued txs"] --> B["MultiSendCallOnly.multiSend"]
  B --> C["execTransaction #1"]
  B --> D["execTransaction #2 reverts<br/>(stale nonce / bad signature)"]
  D --> E["revert(0, 0)<br/>reason destroyed"]
  E --> F["ethers CALL_EXCEPTION<br/>data = 0x"]
  F --> G["formatError(error.reason)"]
  G --> H["Toast: 'Execution failed. Require(false).'<br/>+ 4KB hex dump in Details"]
  F --> I["Inline: 'Error submitting the transaction.'"]
```

After — detectable causes are stopped before broadcast, and what does get through is named:

```mermaid
flowchart TB
  A["Bulk execute<br/>2 queued txs"] --> P{"runBatchExecutionPreChecks"}
  P -->|"nonce moved"| Q["Blocked, no gas spent<br/>'Transaction 2 in this batch<br/>no longer matches the queue.'"]
  P -->|"signature invalid"| R["Blocked, no gas spent<br/>'Could not verify a signature<br/>on transaction 2 in this batch.'"]
  P -->|"all clear"| B["MultiSendCallOnly.multiSend"]
  B --> D["Inner tx reverts anyway<br/>revert(0, 0)"]
  D --> F["isOpaqueRevertError"]
  F --> G["OPAQUE_REVERT_MESSAGE<br/>(shared source)"]
  G --> H["Toast"]
  G --> I["Inline alert"]
  F --> J["getErrorReference → undefined<br/>no Details, no payload"]
```

How every revert class now resolves behind Details:

```mermaid
flowchart LR
  E["Error"] --> R{"isRevertError?"}
  R -->|no| M["keep our own message"]
  R -->|yes| G{"GS code?"}
  G -->|yes| C["'Error code GS0xx'"]
  G -->|no| S{"Error(string)<br/>selector?"}
  S -->|yes| D["decoded reason<br/>e.g. 'ERC20: transfer amount<br/>exceeds balance'"]
  S -->|no| N["nothing —<br/>affordance hidden"]
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — *not tested; `packages/utils` type-checks and the parity test passes, but no mobile surface renders the new copy yet*
- [x] I've documented how it affects the analytics (if at all) 📊 — *no analytics change. Pre-check blocks are still tracked as `Errors._804`, matching the single-tx flow; worth revisiting if WA-3005's error-rate KR should exclude prevented failures*
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — *`yarn verify:changed:web` exits 0: 643 suites, 5487 tests. Plus `@safe-global/utils` (110) and the mobile parity test*
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
