### PR TITLE
fix: remove underline from headers

### DIFF
--- a/apps/web/src/components/safe-apps/AppFrame/TransactionQueueBar/__snapshots__/TransactionQueueBar.stories.test.tsx.snap
+++ b/apps/web/src/components/safe-apps/AppFrame/TransactionQueueBar/__snapshots__/TransactionQueueBar.stories.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`./TransactionQueueBar.stories Collapsed 1`] = `
                     aria-disabled="false"
                     aria-expanded="false"
                     aria-label="expand transaction queue bar"
-                    class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground cursor-pointer rounded-md py-4 text-left text-sm font-medium hover:underline focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 items-center pl-4 pr-12 **:data-[slot=accordion-trigger-icon]:rotate-180"
+                    class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground cursor-pointer rounded-md py-4 text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 items-center pl-4 pr-12 **:data-[slot=accordion-trigger-icon]:rotate-180"
                     data-orientation="vertical"
                     data-slot="accordion-trigger"
                     data-value=""
@@ -186,7 +186,7 @@ exports[`./TransactionQueueBar.stories Collapsed 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -355,7 +355,7 @@ exports[`./TransactionQueueBar.stories Collapsed 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -524,7 +524,7 @@ exports[`./TransactionQueueBar.stories Collapsed 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -727,7 +727,7 @@ exports[`./TransactionQueueBar.stories Expanded 1`] = `
                     aria-disabled="false"
                     aria-expanded="true"
                     aria-label="expand transaction queue bar"
-                    class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground cursor-pointer rounded-md py-4 text-left text-sm font-medium hover:underline focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 items-center pl-4 pr-12 **:data-[slot=accordion-trigger-icon]:rotate-180"
+                    class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground cursor-pointer rounded-md py-4 text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 items-center pl-4 pr-12 **:data-[slot=accordion-trigger-icon]:rotate-180"
                     data-orientation="vertical"
                     data-panel-open=""
                     data-slot="accordion-trigger"
@@ -872,7 +872,7 @@ exports[`./TransactionQueueBar.stories Expanded 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -1041,7 +1041,7 @@ exports[`./TransactionQueueBar.stories Expanded 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -1210,7 +1210,7 @@ exports[`./TransactionQueueBar.stories Expanded 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -1417,7 +1417,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                     aria-disabled="false"
                     aria-expanded="true"
                     aria-label="expand transaction queue bar"
-                    class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground cursor-pointer rounded-md py-4 text-left text-sm font-medium hover:underline focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 items-center pl-4 pr-12 **:data-[slot=accordion-trigger-icon]:rotate-180"
+                    class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground cursor-pointer rounded-md py-4 text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 items-center pl-4 pr-12 **:data-[slot=accordion-trigger-icon]:rotate-180"
                     data-orientation="vertical"
                     data-panel-open=""
                     data-slot="accordion-trigger"
@@ -1562,7 +1562,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -1731,7 +1731,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -1900,7 +1900,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -2069,7 +2069,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -2238,7 +2238,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -2407,7 +2407,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -2576,7 +2576,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -2745,7 +2745,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -2914,7 +2914,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -3083,7 +3083,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -3252,7 +3252,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -3421,7 +3421,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -3590,7 +3590,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -3759,7 +3759,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -3928,7 +3928,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -4097,7 +4097,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -4266,7 +4266,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -4435,7 +4435,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -4604,7 +4604,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -4773,7 +4773,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -4942,7 +4942,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -5111,7 +5111,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -5280,7 +5280,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -5449,7 +5449,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -5618,7 +5618,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -5787,7 +5787,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -5956,7 +5956,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -6125,7 +6125,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -6294,7 +6294,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -6463,7 +6463,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""

--- a/apps/web/src/components/safe-messages/MsgListItem/ExpandableMsgItem.tsx
+++ b/apps/web/src/components/safe-messages/MsgListItem/ExpandableMsgItem.tsx
@@ -18,7 +18,7 @@ const ExpandableMsgItem = ({ msg, expanded = false }: { msg: MessageItem; expand
           nativeButton={false}
           render={<div role="button" tabIndex={0} />}
           data-testid="message-item"
-          className="cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+          className="cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
         >
           <MsgSummary msg={msg} />
         </AccordionTrigger>

--- a/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
@@ -85,7 +85,7 @@ const SingleTxDecoded = ({
         nativeButton={false}
         render={<div />}
         className={cn(
-          'flex min-h-12 items-center px-4 py-3 hover:no-underline',
+          'flex min-h-12 items-center px-4 py-3',
           isGrouped ? css.groupedTrigger : css.elevationTrigger,
           isGrouped && expanded && css.groupedTriggerOpen,
         )}

--- a/apps/web/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
+++ b/apps/web/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
@@ -61,7 +61,7 @@ const ExpandableTransactionItem = ({
           // than the viewport's. With the sidebar expanded a 920px viewport leaves the row only 638px,
           // so viewport-based breakpoints kept the one-line grid past the point it fitted and
           // `overflow-x-auto` turned that into a scrollbar.
-          className="@container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+          className="@container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
         >
           <TxSummary item={item} isConflictGroup={isConflictGroup} isBulkGroup={isBulkGroup} />
         </AccordionTrigger>
@@ -104,7 +104,7 @@ export const TransactionSkeleton = () => (
           // than the viewport's. With the sidebar expanded a 920px viewport leaves the row only 638px,
           // so viewport-based breakpoints kept the one-line grid past the point it fitted and
           // `overflow-x-auto` turned that into a scrollbar.
-          className="@container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 hover:no-underline sm:px-6"
+          className="@container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
         >
           <Skeleton className="h-5 w-full rounded-none bg-[var(--color-background-skeleton)]" />
         </AccordionTrigger>

--- a/apps/web/src/components/tx/ColorCodedTxAccordion/index.tsx
+++ b/apps/web/src/components/tx/ColorCodedTxAccordion/index.tsx
@@ -84,10 +84,7 @@ const ColorCodedTxAccordion = ({ txInfo, txData, children, defaultExpanded }: De
     <Card style={accordionVars} className={css.item}>
       <Accordion defaultValue={defaultExpanded ? ['tx-details'] : []} onValueChange={onValueChange}>
         <AccordionItem value="tx-details" className="border-0">
-          <AccordionTrigger
-            data-testid="decoded-tx-summary"
-            className={cn(css.trigger, 'items-center px-4 hover:no-underline')}
-          >
+          <AccordionTrigger data-testid="decoded-tx-summary" className={cn(css.trigger, 'items-center px-4')}>
             <div className="flex w-full flex-row items-center justify-between">
               <Typography variant="paragraph-small-bold" data-testid="tx-advanced-details">
                 Transaction details

--- a/apps/web/src/components/tx/GasParams/index.tsx
+++ b/apps/web/src/components/tx/GasParams/index.tsx
@@ -98,7 +98,7 @@ export const _GasParams = ({
           value="gas-params"
           className={classnames('border-b-0', { [css.withExecutionMethod]: isExecution })}
         >
-          <AccordionTrigger className={classnames(accordionCss.accordion, 'items-center px-4 hover:no-underline')}>
+          <AccordionTrigger className={classnames(accordionCss.accordion, 'items-center px-4')}>
             {isExecution ? (
               <span className="flex w-full items-center">
                 <span className="flex-1">Estimated fee </span>

--- a/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                 <button
                   aria-disabled="false"
                   aria-expanded="false"
-                  class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground cursor-pointer rounded-md py-4 text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 trigger items-center px-4 hover:no-underline"
+                  class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground cursor-pointer rounded-md py-4 text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 trigger items-center px-4"
                   data-orientation="vertical"
                   data-slot="accordion-trigger"
                   data-testid="decoded-tx-summary"

--- a/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
+++ b/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`BatchTransactions should render a list of batch transactions 1`] = `
               >
                 <div
                   aria-expanded="false"
-                  class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground cursor-pointer rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex-1 justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 flex min-h-12 items-center px-4 py-3 hover:no-underline elevationTrigger"
+                  class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground cursor-pointer rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex-1 justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 flex min-h-12 items-center px-4 py-3 elevationTrigger"
                   data-orientation="vertical"
                   data-slot="accordion-trigger"
                   data-testid="action-item"

--- a/apps/web/src/components/ui/accordion.tsx
+++ b/apps/web/src/components/ui/accordion.tsx
@@ -47,7 +47,7 @@ function AccordionTrigger({ className, children, ...props }: AccordionPrimitive.
           // rather than being remembered per call site (several were missing it, so a collapsed
           // section gave no hint it could be opened). `pointer-events-none` when disabled means the
           // disabled case needs no counterpart.
-          'focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground cursor-pointer rounded-md py-4 text-left text-sm font-medium hover:underline focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 items-start justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50',
+          'focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground cursor-pointer rounded-md py-4 text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 items-start justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50',
           className,
         )}
         {...props}

--- a/apps/web/src/features/gtf/components/HistoryFeesAccordion/index.tsx
+++ b/apps/web/src/features/gtf/components/HistoryFeesAccordion/index.tsx
@@ -47,7 +47,7 @@ const HistoryFeesAccordion = ({
       >
         <AccordionTrigger
           data-testid="history-fees-summary"
-          className="min-h-[56px] items-center rounded-none border-none px-4 hover:no-underline data-panel-open:bg-[var(--fees-accordion-bg)]"
+          className="min-h-[56px] items-center rounded-none border-none px-4 data-panel-open:bg-[var(--fees-accordion-bg)]"
         >
           <div className={css.summaryContent}>
             <div className={css.summaryLeftColumn}>

--- a/apps/web/src/features/positions/components/PositionsSkeleton/__snapshots__/PositionsSkeleton.stories.test.tsx.snap
+++ b/apps/web/src/features/positions/components/PositionsSkeleton/__snapshots__/PositionsSkeleton.stories.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`./PositionsSkeleton.stories Default 1`] = `
                   aria-controls="base-ui-_r_1_"
                   aria-disabled="false"
                   aria-expanded="true"
-                  class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground cursor-pointer rounded-md text-left text-sm font-medium hover:underline focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 items-center overflow-x-auto px-6 py-4"
+                  class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground cursor-pointer rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 items-center overflow-x-auto px-6 py-4"
                   data-orientation="vertical"
                   data-panel-open=""
                   data-slot="accordion-trigger"

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/AllNetworksSection.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/AllNetworksSection.tsx
@@ -86,7 +86,7 @@ function AllNetworksSection({ safeAddress, deployedChainIds, onAddNetwork }: All
       <AccordionItem value="all-networks" className="border-0">
         <AccordionTrigger
           data-testid="all-networks-accordion-trigger"
-          className="rounded-lg pl-4 pr-2 py-2 hover:no-underline hover:bg-muted/30 text-muted-foreground cursor-pointer"
+          className="rounded-lg pl-4 pr-2 py-2 hover:bg-muted/30 text-muted-foreground cursor-pointer"
         >
           <Typography variant="paragraph-small-medium" className="text-muted-foreground">
             All networks


### PR DESCRIPTION
## What it solves

Hovering an accordion header underlined its entire contents. Most visible on **Assets → Positions**, where hovering a protocol row underlined the protocol name *and* the fiat total, but it affected every accordion in the app that didn't explicitly opt out.

This was a migration regression. `hover:underline` is shadcn's upstream default for `AccordionTrigger` and came in with the design system in #7227. The MUI `AccordionSummary` it replaced had no hover underline at all — it only tinted the background, and in Positions even that was disabled via `backgroundColor: 'transparent !important'`. When #8040 migrated MUI → Tailwind, call sites that didn't pass `hover:no-underline` silently inherited the underline.

The result was an inconsistent baseline: 8 trigger call sites cancelled the underline with `hover:no-underline`, while the rest (Positions, PositionsWidget, PositionsSkeleton, proposers, recovery, safe messages, InfoWidget, WcHints, …) kept it. None of them had it before the migration.

## How this PR fixes it

Removed `hover:underline` from the shared `AccordionTrigger` base in `apps/web/src/components/ui/accordion.tsx`, then deleted the 8 `hover:no-underline` overrides that existed only to cancel it:

| Call site | Occurrences |
| --- | --- |
| `components/tx/GasParams/index.tsx` | 1 |
| `components/tx/ColorCodedTxAccordion/index.tsx` | 1 |
| `features/gtf/components/HistoryFeesAccordion/index.tsx` | 1 |
| `components/transactions/TxListItem/ExpandableTransactionItem.tsx` | 2 |
| `components/transactions/TxDetails/.../SingleTxDecoded/index.tsx` | 1 |
| `components/safe-messages/MsgListItem/ExpandableMsgItem.tsx` | 1 |
| `features/spaces/.../SafeSelectorDropdown/components/AllNetworksSection.tsx` | 1 |

Net effect: one consistent rule instead of an opt-out that half the call sites had to remember. A word-level diff against `dev` shows only underline tokens removed (42 × `hover:no-underline`, 5 × `hover:underline`) and nothing added — the remaining diff noise is the ColorCodedTxAccordion trigger collapsing from multi-line to single-line JSX once its class string got shorter.

Deliberately **not** touched: `hover:no-underline` on `Link`/anchor elements (hypernative rows, safe-shield report link, SafeAppsPermissions, dashboard styled links, disclaimers) — those cancel link underlines, not accordion ones. Links nested inside `AccordionContent` keep their own `[&_a]:underline`.

## How to test it

Hover each of these headers and confirm no text underline appears; the pointer cursor, focus ring, chevron rotation, and background hover states should all be unchanged.

1. **Assets → Positions** — hover a protocol header (the original report). Protocol name and fiat total stay un-underlined.
2. **Transactions → Queue / History** — hover a transaction row.
3. **Transaction details** — expand a tx, hover "Transaction details" and any decoded action row.
4. **Tx flow** — hover "Estimated fee" / "Signing method" in the gas params accordion.
5. **History → fees accordion** — hover the "Fees" summary.
6. **Safe messages** — hover a message row in the list, and the details accordion.
7. **Safe selector dropdown** — hover "All networks"; its `hover:bg-muted/30` background must still apply.
8. **Keyboard** — Tab to any trigger; the focus ring still renders, and Enter/Space still toggles.

## Affected flows

- Assets → Positions: hovering a protocol header
- Transactions queue/history: hovering a transaction row to expand it
- Transaction details: expanding decoded actions and multi-send/batch rows
- Tx flow review: expanding gas params / estimated fee
- History: expanding the fees accordion
- Safe messages: expanding a message in the list and in details
- Safe selector dropdown: expanding "All networks"
- Safe Apps: transaction queue bar
- New Safe creation: InfoWidget accordion
- Recovery list item, proposers pending delegations, WalletConnect hints

## Blast radius

- **Shared UI primitive:** `AccordionTrigger` in `components/ui/accordion.tsx` — ~25 call sites across web. Every accordion in the app changes hover appearance; this is the intended scope, since none of them had a hover underline before the shadcn migration.
- **Class resolution:** the base previously conflicted with call-site `hover:no-underline` and was stripped by `tailwind-merge`. Removing both sides leaves the merged output identical for those 8 sites — verified via snapshots.
- **Snapshots updated (4):** `TransactionQueueBar.stories`, `PositionsSkeleton.stories`, `BatchTransactions`, `ReviewTransactionV2`. All changes are class-attribute-only.
- **Not touched:** no Redux slices, RTK Query endpoints, hooks, selectors, feature flags, chain configs, routes, or persisted state.
- **Mobile:** none. Change is confined to `apps/web`; no `packages/**` files touched, so the Expo app is unaffected.
- **Cypress/Playwright:** no selectors depend on `hover:underline` / `hover:no-underline`.

## Risks / not checked

- **No visual regression run.** Jest snapshots record class strings, not rendered hover state, so "the underline is gone" is verified by class absence, not pixels. No Chromatic/visual diff was executed.
- **Per-call-site design intent not audited.** Any trigger that relied on the underline as its *only* hover affordance now signals interactivity with `cursor-pointer` alone. Most also have a background or border hover (`AllNetworksSection`, `HistoryFeesAccordion`, `WcHints`, `SingleTxDecoded`'s CSS module), but this wasn't reviewed accordion-by-accordion with design.
- **Not manually clicked through in a browser** — verification is type-check + unit/snapshot suites only.
- **Mobile/touch not tested** — hover is a pointer-only state, so there should be nothing to see, but the responsive layouts weren't exercised.
- **Dark mode not separately checked** (no color tokens changed).

## Visual summary
Before:
<img width="1245" height="206" alt="Screenshot 2026-08-24 at 11 03 08 AM" src="https://github.com/user-attachments/assets/a3560f88-37f3-404a-9e5e-480623dd4da4" />

After:
<img width="1245" height="206" alt="Screenshot 2026-08-24 at 10 53 21 AM" src="https://github.com/user-attachments/assets/076858bb-bce1-48bb-ac1b-3d34332b65ff" />

Before/after of how the trigger's text-decoration is resolved:

```mermaid
flowchart TB
  subgraph Before["Before — opt-out that call sites had to remember"]
    B1["AccordionTrigger base<br/>hover:underline"]
    B1 -->|"8 sites pass hover:no-underline"| B2["No underline<br/>(GasParams, tx rows, msg rows, …)"]
    B1 -->|"~17 sites pass nothing"| B3["Underlines whole header on hover<br/>(Positions, recovery, proposers, …)"]
  end

  subgraph After["After — one consistent rule"]
    A1["AccordionTrigger base<br/>(no text-decoration)"]
    A1 --> A2["No underline anywhere<br/>cursor-pointer + focus ring unchanged"]
  end

  Before --> After
```

Why the whole row underlined rather than just a label — `text-decoration` inherits to every child of the trigger:

```mermaid
flowchart LR
  T["AccordionTrigger<br/>hover:underline"] --> H["PositionsHeader"]
  H --> N["Protocol name<br/>(underlined)"]
  H --> F["Fiat total<br/>(underlined)"]
```

<!-- Screenshot: run `yarn workspace @safe-global/web dev`, open Assets → Positions, hover a protocol header, and attach a before/after pair. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — covered by existing snapshot suites; 4 snapshots updated
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
