### PR TITLE
fix(UI): adjust the address in Safe Shield to make it fully visible

### DIFF
--- a/apps/web/src/features/safe-shield/__snapshots__/SafeShield.stories.test.tsx.snap
+++ b/apps/web/src/features/safe-shield/__snapshots__/SafeShield.stories.test.tsx.snap
@@ -3822,7 +3822,7 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                               id="base-ui-_r_1k_"
                                             >
                                               <span
-                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-words text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
+                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-all text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
                                                 data-slot="typography"
                                                 data-variant="paragraph-mini"
                                               >
@@ -3940,7 +3940,7 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                               id="base-ui-_r_1p_"
                                             >
                                               <span
-                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-words text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
+                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-all text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
                                                 data-slot="typography"
                                                 data-variant="paragraph-mini"
                                               >
@@ -4058,7 +4058,7 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                               id="base-ui-_r_1u_"
                                             >
                                               <span
-                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-words text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
+                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-all text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
                                                 data-slot="typography"
                                                 data-variant="paragraph-mini"
                                               >
@@ -4101,7 +4101,7 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                               id="base-ui-_r_22_"
                                             >
                                               <span
-                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-words text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
+                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-all text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
                                                 data-slot="typography"
                                                 data-variant="paragraph-mini"
                                               >
@@ -4219,7 +4219,7 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                               id="base-ui-_r_27_"
                                             >
                                               <span
-                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-words text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
+                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-all text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
                                                 data-slot="typography"
                                                 data-variant="paragraph-mini"
                                               >
@@ -4262,7 +4262,7 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                               id="base-ui-_r_2b_"
                                             >
                                               <span
-                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-words text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
+                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-all text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
                                                 data-slot="typography"
                                                 data-variant="paragraph-mini"
                                               >
@@ -4487,7 +4487,7 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                               id="base-ui-_r_2h_"
                                             >
                                               <span
-                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-words text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
+                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-all text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
                                                 data-slot="typography"
                                                 data-variant="paragraph-mini"
                                               >
@@ -4535,7 +4535,7 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                               id="base-ui-_r_2l_"
                                             >
                                               <span
-                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-words text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
+                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-all text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
                                                 data-slot="typography"
                                                 data-variant="paragraph-mini"
                                               >
@@ -4679,7 +4679,7 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                               id="base-ui-_r_2q_"
                                             >
                                               <span
-                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-words text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
+                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-all text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
                                                 data-slot="typography"
                                                 data-variant="paragraph-mini"
                                               >
@@ -4734,7 +4734,7 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                               id="base-ui-_r_2u_"
                                             >
                                               <span
-                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-words text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
+                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-all text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
                                                 data-slot="typography"
                                                 data-variant="paragraph-mini"
                                               >
@@ -4864,7 +4864,7 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                               id="base-ui-_r_33_"
                                             >
                                               <span
-                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-words text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
+                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-all text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
                                                 data-slot="typography"
                                                 data-variant="paragraph-mini"
                                               >
@@ -4919,7 +4919,7 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                               id="base-ui-_r_37_"
                                             >
                                               <span
-                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-words text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
+                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-all text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
                                                 data-slot="typography"
                                                 data-variant="paragraph-mini"
                                               >
@@ -5049,7 +5049,7 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                               id="base-ui-_r_3c_"
                                             >
                                               <span
-                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-words text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
+                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-all text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
                                                 data-slot="typography"
                                                 data-variant="paragraph-mini"
                                               >
@@ -5104,7 +5104,7 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                               id="base-ui-_r_3g_"
                                             >
                                               <span
-                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-words text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
+                                                class="m-0 text-xs font-normal flex-1 cursor-pointer leading-5 break-all text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
                                                 data-slot="typography"
                                                 data-variant="paragraph-mini"
                                               >

--- a/apps/web/src/features/safe-shield/components/AnalysisGroupCard/__tests__/ShowAllAddress.test.tsx
+++ b/apps/web/src/features/safe-shield/components/AnalysisGroupCard/__tests__/ShowAllAddress.test.tsx
@@ -177,6 +177,15 @@ describe('ShowAllAddress', () => {
         expect(screen.getByText(item.address)).toBeInTheDocument()
       })
     })
+
+    it('should allow long addresses to break onto multiple lines', async () => {
+      const longAddress = [{ address: '0x1234567890123456789012345678901234567890' }]
+      const { user } = renderWithUserEvent(<ShowAllAddress addresses={longAddress} />)
+
+      await user.click(screen.getByText('Show all'))
+
+      expect(screen.getByText(longAddress[0].address)).toHaveClass('break-all')
+    })
   })
 
   describe('Edge Cases', () => {

--- a/apps/web/src/features/safe-shield/components/ShowAllAddress/ShowAllAddress.tsx
+++ b/apps/web/src/features/safe-shield/components/ShowAllAddress/ShowAllAddress.tsx
@@ -58,7 +58,7 @@ export const ShowAllAddress = ({ addresses, showImage }: ShowAllAddressProps) =>
                     <TooltipTrigger render={<span className="inline-flex" />}>
                       <Typography
                         variant="paragraph-mini"
-                        className="flex-1 cursor-pointer leading-5 break-words text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
+                        className="flex-1 cursor-pointer leading-5 break-all text-[var(--color-primary-light)] transition-colors hover:text-[var(--color-text-primary)] [overflow-wrap:break-word]"
                       >
                         {item.address}
                       </Typography>


### PR DESCRIPTION
## What it solves

Resolves:[ WA-3237](https://linear.app/safe-global/issue/WA-3237/safe-shield-transaction-checks-contract-addresses-are-cut-off-at-the)
Contract/recipient addresses being clipped at the card's right edge in the Safe Shield results panel — no ellipsis, no wrap, tail unreadable. Affects every "Show all" address card (unverified contract, first-time interaction, not-in-address-book, low-activity recipient).

## How this PR fixes it

`ShowAllAddress` rendered the address with `break-words` (`overflow-wrap: break-word`), which doesn't lower the token's min-content width. Its flex ancestors kept `min-width: auto`, expanded to the full 42-char address, and the tail was sliced off by the card's `overflow-hidden`.

Switched to `break-all` — matching the sibling `AnalysisIssuesDisplay` — so the address wraps onto multiple lines and stays fully readable.

## How to test it

1. Open a transaction with a Safe Shield warning (unverified contract / first-time / unknown recipient).
2. Expand a "Show all" address card.
3. The full address wraps across lines instead of clipping at the border.

## Checklist

- [x] Code is tested
- [x] No hardcoded values

## Visual summary

**Before:** `0xC16DbO251654COa72E91B19Od81eAD367d2C…` clipped at card border, no ellipsis:
<img width="313" height="604" alt="image" src="https://github.com/user-attachments/assets/850c4afe-2d31-456e-8c8c-9b889329d6a5" />

</br>
**After:** full address wraps onto multiple lines:
</br>
<img width="311" height="661" alt="image" src="https://github.com/user-attachments/assets/99d90c94-b054-46c0-9282-ec3d1af26eb1" />



## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
