### PR TITLE
fix(safenet): reader doc and test follow-ups to the relaunch

### DIFF
--- a/packages/utils/src/features/safenet-checks/abi.ts
+++ b/packages/utils/src/features/safenet-checks/abi.ts
@@ -47,7 +47,6 @@ export const COORDINATOR_READ_ABI = [
   'function groupKey(bytes32 gid) view returns ((uint256 x, uint256 y) key)',
 ] as const
 
-
 export const consensusInterface = new Interface(CONSENSUS_EVENT_FRAGMENTS)
 export const consensusPlainInterface = new Interface(CONSENSUS_PLAIN_EVENT_FRAGMENTS)
 export const sentinelInterface = new Interface(SENTINEL_EVENT_FRAGMENTS)

--- a/packages/utils/src/features/safenet-checks/services/__tests__/safenetReader.integration.test.ts
+++ b/packages/utils/src/features/safenet-checks/services/__tests__/safenetReader.integration.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { SafenetReader } from '../safenetReader'
+import { decodeLogs, type RawLog } from '../../utils/decodeLogs'
 import { AttestationVerificationStatus, CheckEventType, type Hex, type OracleAttestedEvent } from '../../types'
 
 /**
@@ -29,6 +30,7 @@ type Golden = {
   groupKey: { x: string; y: string }
   r: { x: string; y: string }
   z: string
+  logs: RawLog[]
 }
 
 const golden: Golden = JSON.parse(
@@ -38,20 +40,14 @@ const golden: Golden = JSON.parse(
 // `|| undefined` so an empty string (a common way to "unset" in CI) still skips.
 const RPC = process.env.SAFENET_IT_RPC || undefined
 
-const goldenAttested = (): OracleAttestedEvent => ({
-  blockNumber: 0,
-  logIndex: 0,
-  transactionHash: '0x' + '00'.repeat(32),
-  type: CheckEventType.ORACLE_ATTESTED,
-  safeTxHash: golden.safeTxHash,
-  chainId: golden.chainId,
-  safe: golden.oracle,
-  epoch: golden.epoch,
-  oracle: golden.oracle,
-  signatureId: golden.signatureId,
-  attestation: { r: { x: golden.r.x, y: golden.r.y }, z: golden.z },
-  oracleDataHash: golden.oracleDataHash,
-})
+/** The captured `TransactionAttested` log, decoded by the production path. */
+const goldenAttested = (): OracleAttestedEvent => {
+  const attested = decodeLogs(golden.logs).find(
+    (event): event is OracleAttestedEvent => event.type === CheckEventType.ORACLE_ATTESTED,
+  )
+  if (!attested) throw new Error('golden fixture carries no decodable TransactionAttested log')
+  return attested
+}
 
 const makeReader = () =>
   new SafenetReader({

--- a/packages/utils/src/features/safenet-checks/types/events.ts
+++ b/packages/utils/src/features/safenet-checks/types/events.ts
@@ -9,9 +9,9 @@ import type { Hex } from '@safe-global/types-kit'
 export type { Hex }
 
 export enum CheckEventType {
-  /** Consensus `OracleTransactionProposed`. */
+  /** Consensus `TransactionProposed` from the unified oracle pair (`safeId` + oracle). */
   ORACLE_PROPOSED = 'ORACLE_PROPOSED',
-  /** Consensus `OracleTransactionAttested` — carries the FROST signature. */
+  /** Consensus `TransactionAttested` from the oracle pair — carries the FROST signature. */
   ORACLE_ATTESTED = 'ORACLE_ATTESTED',
   /** Consensus `TransactionProposed` — the non-oracle path live beta uses. */
   PLAIN_PROPOSED = 'PLAIN_PROPOSED',
@@ -19,9 +19,9 @@ export enum CheckEventType {
   PLAIN_ATTESTED = 'PLAIN_ATTESTED',
   /** Sentinel `NewRequest` — carries the per-check deadline block. */
   REQUEST_CREATED = 'REQUEST_CREATED',
-  /** Sentinel `Committed` — V1 carries the verdict, V2 is activity-only. */
+  /** Sentinel `Committed` — a blind commitment; the verdict arrives with the reveal. */
   SENTINEL_COMMITTED = 'SENTINEL_COMMITTED',
-  /** Sentinel `Revealed` (V2 only) — carries the per-sentinel verdict. */
+  /** Sentinel `Revealed` — carries the per-sentinel verdict. */
   SENTINEL_REVEALED = 'SENTINEL_REVEALED',
   /** `OracleResult` — the oracle's final approved flag. */
   ORACLE_RESULT = 'ORACLE_RESULT',


### PR DESCRIPTION
> Replaces safe-global/safe-wallet-monorepo#8548, which GitHub closed when its head branch was
> renamed. Same single commit. That PR originally embedded the Safenet check
> fee in the Safe Pays fee breakdown; the display is wrong by design — the
> check fee will be sponsored rather than user-paid, and the planned fee
> adjustment happens in the gateway and the fee service, not in the wallet.
> All fee code is removed. What remains are the small reader follow-ups
> written for safe-global/safe-wallet-monorepo#8547 that did not make its merge.

## What it solves

Resolves: three small defects left in the relaunch reader (safe-global/safe-wallet-monorepo#8547):

- `types/events.ts` documented the oracle consensus pair under their
  pre-relaunch names (`OracleTransactionProposed` /
  `OracleTransactionAttested`) and still described the deleted V1/V2
  sentinel split.
- The opt-in integration spec hand-built its attestation event and passed
  the oracle address as `safe`. It passed only because `verifyAttestation`
  never reads `.safe`.
- A rebase artifact left a double blank line in `abi.ts`.

## How this PR fixes it

- The event enum comments now name the events the contracts emit — both
  consensus pairs are `TransactionProposed` / `TransactionAttested` with
  different signatures, so different topic0s — and describe blind commits
  plus verdict-carrying reveals.
- `goldenAttested()` now decodes the checked-in fixture logs through
  `decodeLogs` and picks the `ORACLE_ATTESTED` entry. The test exercises the
  production decode path, carries the captured Safe and chainId, and cannot
  drift from the capture. No fixture data changed.
- The stray blank line is collapsed.

## How to test it

```
yarn workspace @safe-global/utils jest src/features/safenet-checks   # 177 passed
```

Opt-in live spec against the deployed Sepolia contracts:

```
SAFENET_IT_RPC=https://ethereum-sepolia-rpc.publicnode.com \
  SAFENET_IT_CHAIN_ID=11155111 \
  yarn workspace @safe-global/utils test:integration                 # 3 passed
```

## Affected flows

- None at runtime. Comments, one test helper, and whitespace only.

## Blast radius

- `packages/utils` safenet-checks: doc comments and the integration test.
- No production code path changes; no store or web changes.

## Checklist

- [ ] I've tested the branch on mobile 📱 (no mobile surface)
- [x] I've documented how it affects the analytics (it doesn't) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — covered by
      the existing suites; the integration spec is strengthened

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
