### PR TITLE
feat(safenet): split UNAVAILABLE into no-check and read-failed copy

### DIFF
--- a/apps/web/src/features/safenet-checks/__tests__/statusPresentation.test.ts
+++ b/apps/web/src/features/safenet-checks/__tests__/statusPresentation.test.ts
@@ -1,0 +1,42 @@
+import { Severity } from '@safe-global/utils/features/safe-shield/types'
+import { CheckStatus, type PublicCheckStatus, type UnavailableReason } from '@safe-global/utils/features/safenet-checks'
+import { resolvePresentation, STATUS_PRESENTATION, UNAVAILABLE_PRESENTATION } from '../statusPresentation'
+
+const VERDICT_STATUSES = Object.keys(STATUS_PRESENTATION) as Exclude<PublicCheckStatus, CheckStatus.UNAVAILABLE>[]
+
+describe('resolvePresentation', () => {
+  it.each<UnavailableReason>(['NO_CHECK', 'READ_FAILED'])('renders the %s copy with a neutral icon', (reason) => {
+    expect(resolvePresentation(CheckStatus.UNAVAILABLE, reason, false)).toEqual({
+      ...UNAVAILABLE_PRESENTATION[reason],
+      severity: Severity.INFO,
+      muted: true,
+    })
+  })
+
+  it('keeps the neutral icon even when a snapshot says no check was requested', () => {
+    // NO_CHECK arrives with a snapshot; the state is still not a verdict.
+    expect(resolvePresentation(CheckStatus.UNAVAILABLE, 'NO_CHECK', true)).toMatchObject({
+      severity: Severity.INFO,
+      muted: true,
+    })
+  })
+
+  it('renders nothing while the first read has not resolved (no reason yet)', () => {
+    expect(resolvePresentation(CheckStatus.UNAVAILABLE, undefined, false)).toBeUndefined()
+  })
+
+  it.each(VERDICT_STATUSES)('renders %s with its severity and the section heading', (status) => {
+    expect(resolvePresentation(status, undefined, true)).toEqual({
+      severity: STATUS_PRESENTATION[status].severity,
+      copy: STATUS_PRESENTATION[status].copy,
+      label: 'Safenet check',
+      muted: false,
+    })
+  })
+
+  it.each(VERDICT_STATUSES)('renders nothing for a %s pinned without its snapshot', (status) => {
+    // A failed refetch drops the snapshot under a pinned verdict; the next
+    // poll restores it, so the section stays out rather than showing a stub.
+    expect(resolvePresentation(status, undefined, false)).toBeUndefined()
+  })
+})

--- a/apps/web/src/features/safenet-checks/components/SafenetChecksSection.stories.tsx
+++ b/apps/web/src/features/safenet-checks/components/SafenetChecksSection.stories.tsx
@@ -40,7 +40,6 @@ const blockAt = (number: number) => ({
   transactions: [],
 })
 
-/** A healthy Gnosis endpoint holding exactly `logs` for this check. */
 const rpcHolding = (logs: RawLog[]) =>
   http.post(SAFENET_RPC_URLS[0], async ({ request }) => {
     const answer = (req: RpcRequest) => {
@@ -75,7 +74,6 @@ const rpcHolding = (logs: RawLog[]) =>
     return HttpResponse.json(Array.isArray(body) ? body.map(answer) : answer(body))
   })
 
-/** Every endpoint in the rotation is down — the read cannot resolve at all. */
 const unreachableRpc = http.post(SAFENET_RPC_URLS[0], () => new HttpResponse(null, { status: 503 }))
 
 const txDetails = {
@@ -108,7 +106,6 @@ const meta: Meta<typeof SafenetChecksSection> = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-/** RFC W10: the chain answered, and it holds no check for this transaction. */
 export const NoCheckRequested: Story = {
   loaders: [mswLoader],
   parameters: {
@@ -117,7 +114,6 @@ export const NoCheckRequested: Story = {
   },
 }
 
-/** RFC W10: the read itself failed, so the check's state is unknown. */
 export const ReadFailed: Story = {
   loaders: [mswLoader],
   parameters: {
@@ -126,7 +122,6 @@ export const ReadFailed: Story = {
   },
 }
 
-/** A real verdict state, for contrast: the unavailable copy must not look like one. */
 export const Submitted: Story = {
   loaders: [mswLoader],
   parameters: {

--- a/apps/web/src/features/safenet-checks/components/SafenetChecksSection.stories.tsx
+++ b/apps/web/src/features/safenet-checks/components/SafenetChecksSection.stories.tsx
@@ -1,0 +1,142 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { http, HttpResponse } from 'msw'
+import { mswLoader } from 'msw-storybook-addon'
+import { faker } from '@faker-js/faker'
+import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { DetailedExecutionInfoType } from '@safe-global/store/gateway/types'
+import { SAFENET_RPC_URLS } from '@safe-global/utils/features/safenet-checks'
+import { buildPlainProposedLog } from '@safe-global/utils/features/safenet-checks/builders'
+import type { RawLog } from '@safe-global/utils/features/safenet-checks/utils/decodeLogs'
+import { StoreDecorator } from '@/stories/storeDecorator'
+import { TxFlowContext, type TxFlowContextType } from '@/components/tx-flow/TxFlowProvider'
+import { SafenetChecksSection } from './SafenetChecksSection'
+
+faker.seed(456)
+
+const SAFE = '0x0000000000000000000000000000000000000123'
+const SAFE_TX_HASH = `0x${'cd'.repeat(32)}`
+const SUBMITTED_AT = 1_770_000_000_000
+const HEAD_BLOCK = 40_000_000
+const BLOCK_TIME_SECONDS = 5
+// Ten minutes of blocks after the proposal, so the derived read window is real.
+const HEAD_TIMESTAMP = Math.floor(SUBMITTED_AT / 1000) + 600
+
+const toHex = (value: number): string => `0x${value.toString(16)}`
+
+type RpcRequest = { id: number; method: string; params: unknown[] }
+
+const blockAt = (number: number) => ({
+  number: toHex(number),
+  timestamp: toHex(HEAD_TIMESTAMP - (HEAD_BLOCK - number) * BLOCK_TIME_SECONDS),
+  hash: `0x${'22'.repeat(32)}`,
+  parentHash: `0x${'33'.repeat(32)}`,
+  nonce: '0x0000000000000000',
+  difficulty: '0x0',
+  gasLimit: '0x1c9c380',
+  gasUsed: '0x0',
+  miner: `0x${'00'.repeat(20)}`,
+  extraData: '0x',
+  baseFeePerGas: '0x7',
+  transactions: [],
+})
+
+/** A healthy Gnosis endpoint holding exactly `logs` for this check. */
+const rpcHolding = (logs: RawLog[]) =>
+  http.post(SAFENET_RPC_URLS[0], async ({ request }) => {
+    const answer = (req: RpcRequest) => {
+      const ok = (result: unknown) => ({ jsonrpc: '2.0', id: req.id, result })
+      switch (req.method) {
+        case 'eth_chainId':
+          return ok('0x64')
+        case 'eth_getBlockByNumber': {
+          const tag = req.params[0] as string
+          return ok(blockAt(tag === 'latest' ? HEAD_BLOCK : Number(BigInt(tag))))
+        }
+        case 'eth_getLogs':
+          return ok(
+            logs.map((log) => ({
+              address: log.address,
+              topics: log.topics,
+              data: log.data,
+              blockNumber: toHex(log.blockNumber),
+              transactionHash: log.transactionHash,
+              transactionIndex: '0x0',
+              blockHash: `0x${'11'.repeat(32)}`,
+              logIndex: toHex(log.logIndex),
+              removed: false,
+            })),
+          )
+        default:
+          return { jsonrpc: '2.0', id: req.id, error: { code: 3, message: `unhandled ${req.method}` } }
+      }
+    }
+
+    const body = (await request.json()) as RpcRequest | RpcRequest[]
+    return HttpResponse.json(Array.isArray(body) ? body.map(answer) : answer(body))
+  })
+
+/** Every endpoint in the rotation is down — the read cannot resolve at all. */
+const unreachableRpc = http.post(SAFENET_RPC_URLS[0], () => new HttpResponse(null, { status: 503 }))
+
+const txDetails = {
+  detailedExecutionInfo: { type: DetailedExecutionInfoType.MULTISIG, submittedAt: SUBMITTED_AT },
+} as unknown as TransactionDetails
+
+const flow = { txId: `multisig_${SAFE}_${SAFE_TX_HASH}`, txDetails } as TxFlowContextType
+
+const meta: Meta<typeof SafenetChecksSection> = {
+  title: 'Features/SafenetChecks/SafenetChecksSection',
+  component: SafenetChecksSection,
+  // The copy appears only after a chain read and a fade-in, so a pixel baseline
+  // would race the poll loop.
+  parameters: { layout: 'centered', visualTest: { disable: true } },
+  loaders: [mswLoader],
+  decorators: [
+    (Story, context) => (
+      <StoreDecorator initialState={{}} context={context}>
+        <TxFlowContext.Provider value={flow}>
+          <div className="bg-background w-80 rounded-lg">
+            <Story />
+          </div>
+        </TxFlowContext.Provider>
+      </StoreDecorator>
+    ),
+  ],
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** RFC W10: the chain answered, and it holds no check for this transaction. */
+export const NoCheckRequested: Story = {
+  loaders: [mswLoader],
+  parameters: {
+    msw: { handlers: [rpcHolding([])] },
+    docs: { description: { story: 'Normal on beta today: nothing requested a check for this transaction.' } },
+  },
+}
+
+/** RFC W10: the read itself failed, so the check's state is unknown. */
+export const ReadFailed: Story = {
+  loaders: [mswLoader],
+  parameters: {
+    msw: { handlers: [unreachableRpc] },
+    docs: { description: { story: 'A problem: the chain read failed, so no state can be reported.' } },
+  },
+}
+
+/** A real verdict state, for contrast: the unavailable copy must not look like one. */
+export const Submitted: Story = {
+  loaders: [mswLoader],
+  parameters: {
+    msw: {
+      handlers: [
+        rpcHolding([
+          buildPlainProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 32_939n }, { blockNumber: HEAD_BLOCK - 20 }),
+        ]),
+      ],
+    },
+    docs: { description: { story: 'A check was proposed onchain and is inside its deadline.' } },
+  },
+}

--- a/apps/web/src/features/safenet-checks/components/SafenetChecksSection.tsx
+++ b/apps/web/src/features/safenet-checks/components/SafenetChecksSection.tsx
@@ -5,10 +5,8 @@ import { SeverityIcon } from '@/features/safe-shield/components/SeverityIcon'
 import { TxFlowContext } from '@/components/tx-flow/TxFlowProvider'
 import { getSafeTxHashFromTxId } from '@/utils/transactions'
 import { isMultisigDetailedExecutionInfo } from '@/utils/transaction-guards'
-import { CheckStatus } from '@safe-global/utils/features/safenet-checks'
 import { useSafenetCheck } from '@safe-global/utils/features/safenet-checks/hooks'
-import { Severity } from '@safe-global/utils/features/safe-shield/types'
-import { STATUS_PRESENTATION, UNAVAILABLE_PRESENTATION } from '../statusPresentation'
+import { resolvePresentation } from '../statusPresentation'
 
 /**
  * Safenet check state as a section in the Safe Shield widget. Subscribes only
@@ -29,14 +27,7 @@ export const SafenetChecksSection = (): ReactElement | null => {
     submittedAt,
   )
 
-  // A pinned verdict without its snapshot renders nothing — the refetch
-  // restores the snapshot within one poll.
-  const unavailable =
-    publicStatus === CheckStatus.UNAVAILABLE && unavailableReason
-      ? UNAVAILABLE_PRESENTATION[unavailableReason]
-      : undefined
-  const verdict = publicStatus !== CheckStatus.UNAVAILABLE && snapshot ? STATUS_PRESENTATION[publicStatus] : undefined
-  const content = unavailable ?? verdict
+  const content = resolvePresentation(publicStatus, unavailableReason, snapshot !== undefined)
   if (!content) return null
 
   return (
@@ -49,10 +40,10 @@ export const SafenetChecksSection = (): ReactElement | null => {
       className="animate-in fade-in slide-in-from-top-1 p-4 duration-300"
     >
       <div className="flex items-start gap-2">
-        <SeverityIcon severity={verdict?.severity ?? Severity.INFO} muted={verdict === undefined} />
+        <SeverityIcon severity={content.severity} muted={content.muted} />
         <div className="flex flex-1 flex-col gap-1">
           <Typography variant="paragraph-small" className="font-bold leading-4">
-            {unavailable?.title ?? 'Safenet check'}
+            {content.label}
           </Typography>
           <Typography variant="paragraph-small" className="text-muted-foreground">
             {content.copy}

--- a/apps/web/src/features/safenet-checks/components/SafenetChecksSection.tsx
+++ b/apps/web/src/features/safenet-checks/components/SafenetChecksSection.tsx
@@ -5,16 +5,21 @@ import { SeverityIcon } from '@/features/safe-shield/components/SeverityIcon'
 import { TxFlowContext } from '@/components/tx-flow/TxFlowProvider'
 import { getSafeTxHashFromTxId } from '@/utils/transactions'
 import { isMultisigDetailedExecutionInfo } from '@/utils/transaction-guards'
-import { useSafenetDisplayStatus } from '../useSafenetDisplayStatus'
-import { STATUS_PRESENTATION } from '../statusPresentation'
+import { CheckStatus } from '@safe-global/utils/features/safenet-checks'
+import { useSafenetCheck } from '@safe-global/utils/features/safenet-checks/hooks'
+import { Severity } from '@safe-global/utils/features/safe-shield/types'
+import { STATUS_PRESENTATION, UNAVAILABLE_PRESENTATION } from '../statusPresentation'
 
 /**
  * Safenet check state as a section in the Safe Shield widget (PRD display
  * rule: reuse the severity components, no new banner UI). Subscribes only for
  * confirm/execute flows of an already-proposed transaction, and only once the
  * submission time is known — the shared cache keys by hash, so a fetch aimed
- * without it would cache a mis-aimed read for every surface. Renders nothing
- * until a check has been observed.
+ * without it would cache a mis-aimed read for every surface.
+ *
+ * This is the one surface that renders UNAVAILABLE, split per RFC W10 into "no
+ * check was requested" and "the status could not be read"; the queue row and
+ * the audit row stay silent for both.
  */
 export const SafenetChecksSection = (): ReactElement | null => {
   const { txId, txDetails } = useContext(TxFlowContext)
@@ -24,11 +29,20 @@ export const SafenetChecksSection = (): ReactElement | null => {
       ? txDetails.detailedExecutionInfo.submittedAt
       : undefined
 
-  const display = useSafenetDisplayStatus(submittedAt !== undefined ? safeTxHash : undefined, submittedAt)
-  if (!display) return null
+  const { publicStatus, snapshot, unavailableReason } = useSafenetCheck(
+    submittedAt !== undefined ? safeTxHash : undefined,
+    submittedAt,
+  )
 
-  const { publicStatus } = display
-  const { severity, copy } = STATUS_PRESENTATION[publicStatus]
+  // A pinned verdict without its snapshot renders nothing — the refetch
+  // restores the snapshot within one poll.
+  const unavailable =
+    publicStatus === CheckStatus.UNAVAILABLE && unavailableReason
+      ? UNAVAILABLE_PRESENTATION[unavailableReason]
+      : undefined
+  const verdict = publicStatus !== CheckStatus.UNAVAILABLE && snapshot ? STATUS_PRESENTATION[publicStatus] : undefined
+  const content = unavailable ?? verdict
+  if (!content) return null
 
   return (
     // The section appears only once the chain read resolves; the entrance
@@ -36,16 +50,18 @@ export const SafenetChecksSection = (): ReactElement | null => {
     <div
       data-testid="safenet-checks-section"
       data-status={publicStatus}
+      data-reason={unavailableReason}
       className="animate-in fade-in slide-in-from-top-1 p-4 duration-300"
     >
       <div className="flex items-start gap-2">
-        <SeverityIcon severity={severity} />
-        <div>
+        <SeverityIcon severity={verdict?.severity ?? Severity.INFO} muted={verdict === undefined} />
+        {/* paragraph-small renders a span; the flex column is what puts the copy on its own line. */}
+        <div className="flex flex-1 flex-col gap-1">
           <Typography variant="paragraph-small" className="font-bold leading-4">
-            Safenet check
+            {unavailable?.title ?? 'Safenet check'}
           </Typography>
           <Typography variant="paragraph-small" className="text-muted-foreground">
-            {copy}
+            {content.copy}
           </Typography>
         </div>
       </div>

--- a/apps/web/src/features/safenet-checks/components/SafenetChecksSection.tsx
+++ b/apps/web/src/features/safenet-checks/components/SafenetChecksSection.tsx
@@ -11,15 +11,10 @@ import { Severity } from '@safe-global/utils/features/safe-shield/types'
 import { STATUS_PRESENTATION, UNAVAILABLE_PRESENTATION } from '../statusPresentation'
 
 /**
- * Safenet check state as a section in the Safe Shield widget (PRD display
- * rule: reuse the severity components, no new banner UI). Subscribes only for
- * confirm/execute flows of an already-proposed transaction, and only once the
- * submission time is known — the shared cache keys by hash, so a fetch aimed
- * without it would cache a mis-aimed read for every surface.
- *
- * This is the one surface that renders UNAVAILABLE, split per RFC W10 into "no
- * check was requested" and "the status could not be read"; the queue row and
- * the audit row stay silent for both.
+ * Safenet check state as a section in the Safe Shield widget. Subscribes only
+ * for confirm/execute flows of an already-proposed transaction, and only once
+ * the submission time is known — the shared cache keys by hash, so a fetch
+ * aimed without it would cache a mis-aimed read for every surface.
  */
 export const SafenetChecksSection = (): ReactElement | null => {
   const { txId, txDetails } = useContext(TxFlowContext)
@@ -55,7 +50,6 @@ export const SafenetChecksSection = (): ReactElement | null => {
     >
       <div className="flex items-start gap-2">
         <SeverityIcon severity={verdict?.severity ?? Severity.INFO} muted={verdict === undefined} />
-        {/* paragraph-small renders a span; the flex column is what puts the copy on its own line. */}
         <div className="flex flex-1 flex-col gap-1">
           <Typography variant="paragraph-small" className="font-bold leading-4">
             {unavailable?.title ?? 'Safenet check'}

--- a/apps/web/src/features/safenet-checks/components/__tests__/SafenetAuditRow.test.tsx
+++ b/apps/web/src/features/safenet-checks/components/__tests__/SafenetAuditRow.test.tsx
@@ -2,9 +2,10 @@ import { render, screen } from '@/tests/test-utils'
 import { useChain } from '@/hooks/useChains'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { AttestationVerificationStatus, CheckStatus } from '@safe-global/utils/features/safenet-checks'
-import { useSafenetCheck, type SafenetCheckView } from '@safe-global/utils/features/safenet-checks/hooks'
+import { useSafenetCheck } from '@safe-global/utils/features/safenet-checks/hooks'
 import {
   buildBenignSnapshot,
+  buildCheckView,
   buildSnapshot,
   plainAttestedEvent,
 } from '@safe-global/utils/features/safenet-checks/builders'
@@ -24,16 +25,7 @@ const mockUseChain = useChain as jest.MockedFunction<typeof useChain>
 
 const HASH = `0x${'ab'.repeat(32)}`
 
-const view = (over: Partial<SafenetCheckView> = {}): SafenetCheckView => ({
-  snapshot: undefined,
-  status: CheckStatus.UNAVAILABLE,
-  publicStatus: CheckStatus.UNAVAILABLE,
-  isLoading: false,
-  isFetching: false,
-  isStale: false,
-  refetch: jest.fn(),
-  ...over,
-})
+const view = buildCheckView
 
 describe('SafenetAuditRow', () => {
   beforeEach(() => {

--- a/apps/web/src/features/safenet-checks/components/__tests__/SafenetChecksSection.test.tsx
+++ b/apps/web/src/features/safenet-checks/components/__tests__/SafenetChecksSection.test.tsx
@@ -70,7 +70,6 @@ describe('SafenetChecksSection', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  // W10: the two meanings of UNAVAILABLE, split. Neither may read as a verdict.
   it('renders the no-check copy when no check was requested', () => {
     const snapshot = buildSnapshot({ safeTxHash: HASH as `0x${string}`, status: CheckStatus.UNAVAILABLE })
     mockUseSafenetCheck.mockReturnValue(
@@ -113,7 +112,7 @@ describe('SafenetChecksSection', () => {
     [CheckStatus.BENIGN, 'Safenet found no issues'],
     [CheckStatus.MALICIOUS, 'Safenet flagged this address/transaction as malicious'],
     [CheckStatus.TIMED_OUT, 'Safenet check is unavailable. You can still continue.'],
-  ])('renders %s with the PRD copy', (status, copy) => {
+  ])('renders %s copy', (status, copy) => {
     const snapshot = buildSnapshot({ safeTxHash: HASH as `0x${string}`, status })
     mockUseSafenetCheck.mockReturnValue(buildCheckView({ snapshot, status, publicStatus: status }))
 

--- a/apps/web/src/features/safenet-checks/components/__tests__/SafenetChecksSection.test.tsx
+++ b/apps/web/src/features/safenet-checks/components/__tests__/SafenetChecksSection.test.tsx
@@ -62,12 +62,49 @@ describe('SafenetChecksSection', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('renders nothing when no check was observed', () => {
-    mockUseSafenetCheck.mockReturnValue(buildCheckView())
+  it('renders nothing while the first read is still in flight', () => {
+    mockUseSafenetCheck.mockReturnValue(buildCheckView({ isLoading: true, isFetching: true }))
 
     const { container } = renderInFlow({ txId: TX_ID, txDetails })
 
     expect(container).toBeEmptyDOMElement()
+  })
+
+  // W10: the two meanings of UNAVAILABLE, split. Neither may read as a verdict.
+  it('renders the no-check copy when no check was requested', () => {
+    const snapshot = buildSnapshot({ safeTxHash: HASH as `0x${string}`, status: CheckStatus.UNAVAILABLE })
+    mockUseSafenetCheck.mockReturnValue(
+      buildCheckView({
+        snapshot,
+        status: CheckStatus.UNAVAILABLE,
+        publicStatus: CheckStatus.UNAVAILABLE,
+        unavailableReason: 'NO_CHECK',
+      }),
+    )
+
+    renderInFlow({ txId: TX_ID, txDetails })
+
+    const section = screen.getByTestId('safenet-checks-section')
+    expect(section).toHaveAttribute('data-reason', 'NO_CHECK')
+    expect(section).toHaveTextContent('Not checked')
+    expect(section).toHaveTextContent('No Safenet check was requested for this transaction.')
+  })
+
+  it('renders the read-failed copy when the status could not be read', () => {
+    mockUseSafenetCheck.mockReturnValue(
+      buildCheckView({
+        status: CheckStatus.UNAVAILABLE,
+        publicStatus: CheckStatus.UNAVAILABLE,
+        unavailableReason: 'READ_FAILED',
+      }),
+    )
+
+    renderInFlow({ txId: TX_ID, txDetails })
+
+    const section = screen.getByTestId('safenet-checks-section')
+    expect(section).toHaveAttribute('data-reason', 'READ_FAILED')
+    expect(section).toHaveTextContent('Status unavailable')
+    expect(section).toHaveTextContent('The Safenet check status could not be read. Retry later.')
   })
 
   it.each<[Exclude<PublicCheckStatus, CheckStatus.UNAVAILABLE>, string]>([

--- a/apps/web/src/features/safenet-checks/statusPresentation.ts
+++ b/apps/web/src/features/safenet-checks/statusPresentation.ts
@@ -1,5 +1,5 @@
 import { Severity } from '@safe-global/utils/features/safe-shield/types'
-import { CheckStatus, type PublicCheckStatus } from '@safe-global/utils/features/safenet-checks'
+import { CheckStatus, type PublicCheckStatus, type UnavailableReason } from '@safe-global/utils/features/safenet-checks'
 
 type SafenetStatusPresentation = {
   /** Safe Shield severity vocabulary — drives SeverityIcon and its colors. */
@@ -10,7 +10,10 @@ type SafenetStatusPresentation = {
   copy: string
 }
 
-/** The PRD "States & Warnings" table. UNAVAILABLE renders nothing everywhere. */
+/**
+ * The PRD "States & Warnings" table. UNAVAILABLE has no verdict presentation —
+ * see {@link UNAVAILABLE_PRESENTATION}, which only the flow section renders.
+ */
 export const STATUS_PRESENTATION: Record<
   Exclude<PublicCheckStatus, CheckStatus.UNAVAILABLE>,
   SafenetStatusPresentation
@@ -39,5 +42,21 @@ export const STATUS_PRESENTATION: Record<
     severity: Severity.ERROR,
     label: 'Safenet check failed',
     copy: 'Safenet check is unavailable. You can still continue.',
+  },
+}
+
+/**
+ * The two meanings of UNAVAILABLE (RFC W10). Neither is a verdict, so both stay
+ * neutral: a muted icon and the default text colors, never error or warning
+ * ones. Each names itself instead of the shared "Safenet check" heading.
+ */
+export const UNAVAILABLE_PRESENTATION: Record<UnavailableReason, { title: string; copy: string }> = {
+  NO_CHECK: {
+    title: 'Not checked',
+    copy: 'No Safenet check was requested for this transaction.',
+  },
+  READ_FAILED: {
+    title: 'Status unavailable',
+    copy: 'The Safenet check status could not be read. Retry later.',
   },
 }

--- a/apps/web/src/features/safenet-checks/statusPresentation.ts
+++ b/apps/web/src/features/safenet-checks/statusPresentation.ts
@@ -1,7 +1,7 @@
 import { Severity } from '@safe-global/utils/features/safe-shield/types'
 import { CheckStatus, type PublicCheckStatus, type UnavailableReason } from '@safe-global/utils/features/safenet-checks'
 
-type SafenetStatusPresentation = {
+export type SafenetStatusPresentation = {
   /** Safe Shield severity vocabulary — drives SeverityIcon and its colors. */
   severity: Severity
   /** Short state name for compact placements. */
@@ -47,15 +47,44 @@ export const STATUS_PRESENTATION: Record<
 
 /**
  * Neither UNAVAILABLE meaning is a verdict, so both stay neutral: a muted icon
- * and the default text colors, never error or warning ones.
+ * and the default text colors, never error or warning ones. No severity field:
+ * these states have no verdict to color from.
  */
-export const UNAVAILABLE_PRESENTATION: Record<UnavailableReason, { title: string; copy: string }> = {
+export const UNAVAILABLE_PRESENTATION: Record<UnavailableReason, Pick<SafenetStatusPresentation, 'label' | 'copy'>> = {
   NO_CHECK: {
-    title: 'Not checked',
+    label: 'Not checked',
     copy: 'No Safenet check was requested for this transaction.',
   },
   READ_FAILED: {
-    title: 'Status unavailable',
+    label: 'Status unavailable',
     copy: 'The Safenet check status could not be read. Retry later.',
   },
+}
+
+/** Section heading for every verdict: the state itself is in the copy. */
+const VERDICT_LABEL = 'Safenet check'
+
+export type ResolvedPresentation = SafenetStatusPresentation & {
+  /** Render the icon neutral — set for the non-verdict UNAVAILABLE states. */
+  muted: boolean
+}
+
+/**
+ * What the flow section renders, or `undefined` for the states it must skip:
+ * an unresolved first read, and a pinned verdict whose snapshot a failed
+ * refetch dropped (the next poll restores it).
+ */
+export const resolvePresentation = (
+  publicStatus: PublicCheckStatus,
+  unavailableReason: UnavailableReason | undefined,
+  hasSnapshot: boolean,
+): ResolvedPresentation | undefined => {
+  if (publicStatus === CheckStatus.UNAVAILABLE) {
+    if (!unavailableReason) return undefined
+    return { ...UNAVAILABLE_PRESENTATION[unavailableReason], severity: Severity.INFO, muted: true }
+  }
+
+  if (!hasSnapshot) return undefined
+
+  return { ...STATUS_PRESENTATION[publicStatus], label: VERDICT_LABEL, muted: false }
 }

--- a/apps/web/src/features/safenet-checks/statusPresentation.ts
+++ b/apps/web/src/features/safenet-checks/statusPresentation.ts
@@ -4,15 +4,15 @@ import { CheckStatus, type PublicCheckStatus, type UnavailableReason } from '@sa
 type SafenetStatusPresentation = {
   /** Safe Shield severity vocabulary — drives SeverityIcon and its colors. */
   severity: Severity
-  /** Short state name (PRD states table) for compact placements. */
+  /** Short state name for compact placements. */
   label: string
-  /** Full-sentence copy (PRD states table, verbatim) for the flow surface. */
+  /** Full-sentence copy for the flow surface. */
   copy: string
 }
 
 /**
- * The PRD "States & Warnings" table. UNAVAILABLE has no verdict presentation —
- * see {@link UNAVAILABLE_PRESENTATION}, which only the flow section renders.
+ * UNAVAILABLE has no verdict presentation — see {@link UNAVAILABLE_PRESENTATION},
+ * which only the flow section renders.
  */
 export const STATUS_PRESENTATION: Record<
   Exclude<PublicCheckStatus, CheckStatus.UNAVAILABLE>,
@@ -46,9 +46,8 @@ export const STATUS_PRESENTATION: Record<
 }
 
 /**
- * The two meanings of UNAVAILABLE (RFC W10). Neither is a verdict, so both stay
- * neutral: a muted icon and the default text colors, never error or warning
- * ones. Each names itself instead of the shared "Safenet check" heading.
+ * Neither UNAVAILABLE meaning is a verdict, so both stay neutral: a muted icon
+ * and the default text colors, never error or warning ones.
  */
 export const UNAVAILABLE_PRESENTATION: Record<UnavailableReason, { title: string; copy: string }> = {
   NO_CHECK: {

--- a/packages/utils/src/features/safenet-checks/builders/checkView.ts
+++ b/packages/utils/src/features/safenet-checks/builders/checkView.ts
@@ -6,6 +6,7 @@ export const buildCheckView = (over: Partial<SafenetCheckView> = {}): SafenetChe
   snapshot: undefined,
   status: CheckStatus.UNAVAILABLE,
   publicStatus: CheckStatus.UNAVAILABLE,
+  unavailableReason: undefined,
   isLoading: false,
   isFetching: false,
   isStale: false,

--- a/packages/utils/src/features/safenet-checks/constants.ts
+++ b/packages/utils/src/features/safenet-checks/constants.ts
@@ -106,3 +106,13 @@ export const LATE_WINDOW_BLOCKS = 720
  * would poll a public RPC at the fast interval forever.
  */
 export const PLAIN_DEADLINE_BLOCKS = 240
+
+/**
+ * How long after submission an UNAVAILABLE read keeps polling. Covers the race
+ * where the first read lands before the check request is mined; Gnosis blocks
+ * every ~5s, so a request mines well inside this window.
+ */
+export const UNAVAILABLE_GRACE_MS = 10 * 60_000
+
+/** Poll interval inside {@link UNAVAILABLE_GRACE_MS}. */
+export const UNAVAILABLE_GRACE_POLL_MS = 30_000

--- a/packages/utils/src/features/safenet-checks/hooks/__tests__/useSafenetCheck.test.ts
+++ b/packages/utils/src/features/safenet-checks/hooks/__tests__/useSafenetCheck.test.ts
@@ -153,6 +153,58 @@ describe('useSafenetCheck', () => {
     })
   })
 
+  // W10: UNAVAILABLE means either "no check was requested" or "we could not
+  // read". Only the reason tells the two apart.
+  describe('unavailable reason', () => {
+    it('reports NO_CHECK when a snapshot says no check was ever requested', () => {
+      mockQuery.mockReturnValue(
+        queryResult({ data: buildSnapshot({ safeTxHash: HASH, status: CheckStatus.UNAVAILABLE }) }),
+      )
+
+      const { result } = renderHook(() => useSafenetCheck(HASH))
+
+      expect(result.current.unavailableReason).toBe('NO_CHECK')
+    })
+
+    it('reports READ_FAILED when the read failed with nothing to show', () => {
+      mockQuery.mockReturnValue(queryResult({ error: FETCH_ERROR }))
+
+      const { result } = renderHook(() => useSafenetCheck(HASH))
+
+      expect(result.current.unavailableReason).toBe('READ_FAILED')
+    })
+
+    it('never reports READ_FAILED while the first read is in flight', () => {
+      mockQuery.mockReturnValue(queryResult({ isLoading: true, isFetching: true }))
+
+      const { result } = renderHook(() => useSafenetCheck(HASH))
+
+      expect(result.current.status).toBe(CheckStatus.UNAVAILABLE)
+      expect(result.current.unavailableReason).toBeUndefined()
+    })
+
+    it('keeps the retained snapshot as NO_CHECK when a refetch fails over it', () => {
+      mockQuery.mockReturnValue(
+        queryResult({
+          error: FETCH_ERROR,
+          data: buildSnapshot({ safeTxHash: HASH, status: CheckStatus.UNAVAILABLE }),
+        }),
+      )
+
+      const { result } = renderHook(() => useSafenetCheck(HASH))
+
+      expect(result.current.unavailableReason).toBe('NO_CHECK')
+    })
+
+    it('reports no reason once a check is observed', () => {
+      mockQuery.mockReturnValue(queryResult({ data: buildBenignSnapshot({ safeTxHash: HASH }) }))
+
+      const { result } = renderHook(() => useSafenetCheck(HASH))
+
+      expect(result.current.unavailableReason).toBeUndefined()
+    })
+  })
+
   describe('read-path pin merge', () => {
     it('never downgrades below the pinned verdict', () => {
       const pinned: PinnedVerdict = { status: CheckStatus.BENIGN, atBlock: '10', verification: UNVERIFIED_ATTESTATION }

--- a/packages/utils/src/features/safenet-checks/hooks/__tests__/useSafenetCheck.test.ts
+++ b/packages/utils/src/features/safenet-checks/hooks/__tests__/useSafenetCheck.test.ts
@@ -3,7 +3,12 @@ import { useSelector } from 'react-redux'
 import { useGetSafenetCheckQuery } from '@safe-global/store/safenet/safenetCheckApi'
 import type { PinnedVerdict } from '@safe-global/store/safenet/safenetCheckSlice'
 import { useSafenetCheck } from '../useSafenetCheck'
-import { POLL_INTERVAL_FAST_MS, POLL_INTERVAL_LATE_MS } from '../../constants'
+import {
+  POLL_INTERVAL_FAST_MS,
+  POLL_INTERVAL_LATE_MS,
+  UNAVAILABLE_GRACE_MS,
+  UNAVAILABLE_GRACE_POLL_MS,
+} from '../../constants'
 import { CheckStatus, UNVERIFIED_ATTESTATION, type SafenetCheckSnapshot } from '../../types'
 import { buildBenignSnapshot, buildSnapshot, plainProposedEvent } from '../../builders'
 
@@ -24,6 +29,7 @@ type QueryResult = {
   isError?: boolean
   isLoading?: boolean
   isFetching?: boolean
+  fulfilledTimeStamp?: number
   refetch?: jest.Mock
 }
 
@@ -95,6 +101,79 @@ describe('useSafenetCheck', () => {
 
       renderHook(() => useSafenetCheck(HASH))
 
+      expect(lastOptions().pollingInterval).toBe(POLL_INTERVAL_FAST_MS)
+    })
+  })
+
+  describe('unavailable grace window', () => {
+    const SUBMITTED = 1_700_000_000_000
+
+    afterEach(() => jest.useRealTimers())
+
+    const noCheck = () => buildSnapshot({ safeTxHash: HASH, status: CheckStatus.UNAVAILABLE })
+
+    it('keeps polling slowly while the check request may still be mining', () => {
+      jest.useFakeTimers()
+      jest.setSystemTime(SUBMITTED + 1_000)
+      mockQuery.mockReturnValue(queryResult({ data: noCheck(), fulfilledTimeStamp: 1 }))
+
+      renderHook(() => useSafenetCheck(HASH, SUBMITTED))
+
+      expect(lastOptions().pollingInterval).toBe(UNAVAILABLE_GRACE_POLL_MS)
+    })
+
+    it('stops polling once the grace window has closed', () => {
+      jest.useFakeTimers()
+      jest.setSystemTime(SUBMITTED + UNAVAILABLE_GRACE_MS)
+      mockQuery.mockReturnValue(queryResult({ data: noCheck(), fulfilledTimeStamp: 1 }))
+
+      renderHook(() => useSafenetCheck(HASH, SUBMITTED))
+
+      expect(lastOptions().pollingInterval).toBe(0)
+    })
+
+    it('re-evaluates the window against the clock of the latest landed poll', () => {
+      // Without this the interval would keep the value the first read computed
+      // and poll a check-less transaction forever.
+      jest.useFakeTimers()
+      jest.setSystemTime(SUBMITTED + 1_000)
+      const snapshot = noCheck()
+      mockQuery.mockReturnValue(queryResult({ data: snapshot, fulfilledTimeStamp: 1 }))
+      const { rerender } = renderHook(() => useSafenetCheck(HASH, SUBMITTED))
+      expect(lastOptions().pollingInterval).toBe(UNAVAILABLE_GRACE_POLL_MS)
+
+      jest.setSystemTime(SUBMITTED + UNAVAILABLE_GRACE_MS)
+      mockQuery.mockReturnValue(queryResult({ data: snapshot, fulfilledTimeStamp: 2 }))
+      rerender()
+
+      expect(lastOptions().pollingInterval).toBe(0)
+    })
+
+    it('picks the check up at the fast cadence when it lands inside the window', () => {
+      jest.useFakeTimers()
+      jest.setSystemTime(SUBMITTED + 1_000)
+      mockQuery.mockReturnValue(queryResult({ data: noCheck(), fulfilledTimeStamp: 1 }))
+      const { result, rerender } = renderHook(() => useSafenetCheck(HASH, SUBMITTED))
+      expect(result.current.unavailableReason).toBe('NO_CHECK')
+      // The cadence that gets the check picked up at all: without it the read
+      // below never happens and NO_CHECK stays pinned for the session.
+      expect(lastOptions().pollingInterval).toBe(UNAVAILABLE_GRACE_POLL_MS)
+
+      mockQuery.mockReturnValue(
+        queryResult({
+          data: buildSnapshot({
+            safeTxHash: HASH,
+            status: CheckStatus.SUBMITTED,
+            headBlock: '150',
+            deadlineBlock: null,
+            events: [plainProposedEvent({ blockNumber: 100 })],
+          }),
+          fulfilledTimeStamp: 2,
+        }),
+      )
+      rerender()
+
+      expect(result.current.unavailableReason).toBeUndefined()
       expect(lastOptions().pollingInterval).toBe(POLL_INTERVAL_FAST_MS)
     })
   })

--- a/packages/utils/src/features/safenet-checks/hooks/__tests__/useSafenetCheck.test.ts
+++ b/packages/utils/src/features/safenet-checks/hooks/__tests__/useSafenetCheck.test.ts
@@ -153,8 +153,6 @@ describe('useSafenetCheck', () => {
     })
   })
 
-  // W10: UNAVAILABLE means either "no check was requested" or "we could not
-  // read". Only the reason tells the two apart.
   describe('unavailable reason', () => {
     it('reports NO_CHECK when a snapshot says no check was ever requested', () => {
       mockQuery.mockReturnValue(

--- a/packages/utils/src/features/safenet-checks/hooks/useSafenetCheck.ts
+++ b/packages/utils/src/features/safenet-checks/hooks/useSafenetCheck.ts
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux'
 import { useGetSafenetCheckQuery } from '@safe-global/store/safenet/safenetCheckApi'
 import { selectPinnedVerdict, type SafenetCheckPartialState } from '@safe-global/store/safenet/safenetCheckSlice'
 import { POLL_INTERVAL_FAST_MS, POLL_INTERVAL_LATE_MS } from '../constants'
-import { CheckStatus, toPublicStatus, type PublicCheckStatus } from '../types/status'
+import { CheckStatus, toPublicStatus, type PublicCheckStatus, type UnavailableReason } from '../types/status'
 import type { SafenetCheckSnapshot } from '../types/snapshot'
 import { computePollingInterval } from '../utils/computePollingInterval'
 import { mergeMonotonic } from '../utils/mergeMonotonic'
@@ -14,6 +14,12 @@ export type SafenetCheckView = {
   /** Internal merged status. Can be `AWAITING_VERIFICATION` or `VERIFICATION_FAILED`. */
   status: CheckStatus
   publicStatus: PublicCheckStatus
+  /**
+   * Set only while the merged status is `UNAVAILABLE`: `NO_CHECK` when a
+   * snapshot says no check was ever requested, `READ_FAILED` when the read
+   * itself failed. `undefined` before the first read resolves.
+   */
+  unavailableReason: UnavailableReason | undefined
   isLoading: boolean
   isFetching: boolean
   /** Showing a retained snapshot because the latest fetch failed. */
@@ -65,6 +71,11 @@ export const useSafenetCheck = (safeTxHash: string | undefined, timestampMs?: nu
   const status = mergeMonotonic(pinned?.status, base)
   const publicStatus = toPublicStatus(status)
 
+  // A snapshot outranks the error: an error over retained data is a failed
+  // refetch (isStale), and the retained snapshot is still what we know.
+  const unavailableReason: UnavailableReason | undefined =
+    status !== CheckStatus.UNAVAILABLE ? undefined : hasData ? 'NO_CHECK' : hasError ? 'READ_FAILED' : undefined
+
   // Events are sorted ascending, so [0] substitutes for the deadline on the
   // plain path, which does not emit one.
   const firstEventBlock = snapshot?.events[0] !== undefined ? String(snapshot.events[0].blockNumber) : null
@@ -96,6 +107,7 @@ export const useSafenetCheck = (safeTxHash: string | undefined, timestampMs?: nu
     snapshot,
     status,
     publicStatus,
+    unavailableReason,
     isLoading: query.isLoading,
     isFetching: query.isFetching,
     isStale,

--- a/packages/utils/src/features/safenet-checks/hooks/useSafenetCheck.ts
+++ b/packages/utils/src/features/safenet-checks/hooks/useSafenetCheck.ts
@@ -32,9 +32,9 @@ export type SafenetCheckView = {
  * store's `getSafenetCheck` query with the dynamic poll interval, the merge
  * against the session-pinned verdict, and the stale/UNAVAILABLE error mapping.
  * Platform-neutral (no DOM access). `timestampMs` aims the reader's block
- * window; pass the submission time when known. Callers sharing one hash must
- * agree on supplying it — the cache keys by hash, and the last fetch's args
- * aim every later poll.
+ * window and anchors the UNAVAILABLE grace window; pass the submission time
+ * when known. Callers sharing one hash must agree on supplying it — the cache
+ * keys by hash, and the last fetch's args aim every later poll.
  */
 export const useSafenetCheck = (safeTxHash: string | undefined, timestampMs?: number | null): SafenetCheckView => {
   const skip = !safeTxHash
@@ -80,6 +80,10 @@ export const useSafenetCheck = (safeTxHash: string | undefined, timestampMs?: nu
   // plain path, which does not emit one.
   const firstEventBlock = snapshot?.events[0] !== undefined ? String(snapshot.events[0].blockNumber) : null
 
+  // A landed poll re-runs this, so the grace window below is re-evaluated
+  // against a fresh clock instead of the one from the first read.
+  const fulfilledAt = query.fulfilledTimeStamp
+
   useEffect(() => {
     // A failed fetch with nothing to show is a transient endpoint problem, not
     // "no check exists" — keep retrying at the slow cadence. This is the only
@@ -94,9 +98,20 @@ export const useSafenetCheck = (safeTxHash: string | undefined, timestampMs?: nu
         headBlock: snapshot?.headBlock ?? null,
         deadlineBlock: snapshot?.deadlineBlock ?? null,
         firstEventBlock,
+        submittedAtMs: timestampMs ?? null,
+        nowMs: Date.now(),
       }),
     )
-  }, [hasError, hasData, status, snapshot?.headBlock, snapshot?.deadlineBlock, firstEventBlock])
+  }, [
+    hasError,
+    hasData,
+    status,
+    snapshot?.headBlock,
+    snapshot?.deadlineBlock,
+    firstEventBlock,
+    timestampMs,
+    fulfilledAt,
+  ])
 
   const { refetch: queryRefetch } = query
   const refetch = useCallback(() => {

--- a/packages/utils/src/features/safenet-checks/services/__tests__/rpcEndpoint.ts
+++ b/packages/utils/src/features/safenet-checks/services/__tests__/rpcEndpoint.ts
@@ -37,7 +37,6 @@ export type RpcConfig = {
   groupKey?: { x: string; y: string }
   /** `groupKey` calls revert (an epoch the coordinator has not seen). */
   failGroupKey?: boolean
-
 }
 
 const hexToNum = (value: string): number => Number(BigInt(value))

--- a/packages/utils/src/features/safenet-checks/services/__tests__/safenetReader.test.ts
+++ b/packages/utils/src/features/safenet-checks/services/__tests__/safenetReader.test.ts
@@ -607,4 +607,3 @@ describe('SafenetReader chain-id assertion (dev-only, one-shot)', () => {
     spy.mockRestore()
   })
 })
-

--- a/packages/utils/src/features/safenet-checks/types/status.ts
+++ b/packages/utils/src/features/safenet-checks/types/status.ts
@@ -34,6 +34,13 @@ export type PublicCheckStatus =
   | CheckStatus.UNAVAILABLE
 
 /**
+ * Why a check reads as `UNAVAILABLE` (RFC W10): no check was ever requested —
+ * the normal case on beta — or the chain read failed. `undefined` while the
+ * first read is still in flight, so an unresolved read never claims a failure.
+ */
+export type UnavailableReason = 'NO_CHECK' | 'READ_FAILED'
+
+/**
  * Map an internal status to its public projection: `AWAITING_VERIFICATION`
  * reads as still-working, `VERIFICATION_FAILED` as `TIMED_OUT` — an attestation
  * that cannot be trusted is not-completed, never safe.

--- a/packages/utils/src/features/safenet-checks/types/status.ts
+++ b/packages/utils/src/features/safenet-checks/types/status.ts
@@ -34,9 +34,9 @@ export type PublicCheckStatus =
   | CheckStatus.UNAVAILABLE
 
 /**
- * Why a check reads as `UNAVAILABLE` (RFC W10): no check was ever requested —
- * the normal case on beta — or the chain read failed. `undefined` while the
- * first read is still in flight, so an unresolved read never claims a failure.
+ * Why a check reads as `UNAVAILABLE`: no check was ever requested, or the
+ * chain read failed. `undefined` while the first read is still in flight, so
+ * an unresolved read never claims a failure.
  */
 export type UnavailableReason = 'NO_CHECK' | 'READ_FAILED'
 

--- a/packages/utils/src/features/safenet-checks/utils/__tests__/computePollingInterval.test.ts
+++ b/packages/utils/src/features/safenet-checks/utils/__tests__/computePollingInterval.test.ts
@@ -4,6 +4,8 @@ import {
   PLAIN_DEADLINE_BLOCKS,
   POLL_INTERVAL_FAST_MS,
   POLL_INTERVAL_LATE_MS,
+  UNAVAILABLE_GRACE_MS,
+  UNAVAILABLE_GRACE_POLL_MS,
 } from '../../constants'
 import { CheckStatus } from '../../types'
 
@@ -15,15 +17,65 @@ describe('computePollingInterval', () => {
     },
   )
 
-  it('stops polling on UNAVAILABLE (a row with no check must not poll forever)', () => {
-    expect(
-      computePollingInterval({
-        status: CheckStatus.UNAVAILABLE,
-        headBlock: null,
-        deadlineBlock: null,
-        firstEventBlock: null,
-      }),
-    ).toBe(0)
+  describe('UNAVAILABLE — bounded grace window instead of an immediate stop', () => {
+    const SUBMITTED = 1_700_000_000_000
+    const unavailable = { status: CheckStatus.UNAVAILABLE, headBlock: null, deadlineBlock: null, firstEventBlock: null }
+
+    it('polls slowly inside the grace window (the check request may still be mining)', () => {
+      expect(computePollingInterval({ ...unavailable, submittedAtMs: SUBMITTED, nowMs: SUBMITTED + 1_000 })).toBe(
+        UNAVAILABLE_GRACE_POLL_MS,
+      )
+    })
+
+    it('polls slowly right up to the last ms of the grace window', () => {
+      expect(
+        computePollingInterval({
+          ...unavailable,
+          submittedAtMs: SUBMITTED,
+          nowMs: SUBMITTED + UNAVAILABLE_GRACE_MS - 1,
+        }),
+      ).toBe(UNAVAILABLE_GRACE_POLL_MS)
+    })
+
+    it('stops at the grace boundary', () => {
+      expect(
+        computePollingInterval({ ...unavailable, submittedAtMs: SUBMITTED, nowMs: SUBMITTED + UNAVAILABLE_GRACE_MS }),
+      ).toBe(0)
+    })
+
+    it('stops past the grace window (a row with no check must not poll forever)', () => {
+      expect(
+        computePollingInterval({
+          ...unavailable,
+          submittedAtMs: SUBMITTED,
+          nowMs: SUBMITTED + UNAVAILABLE_GRACE_MS + 60_000,
+        }),
+      ).toBe(0)
+    })
+
+    it('stops on a submission stamped in the future (clock skew must not stretch the window)', () => {
+      expect(computePollingInterval({ ...unavailable, submittedAtMs: SUBMITTED + 3_600_000, nowMs: SUBMITTED })).toBe(0)
+    })
+
+    it('stops when the submission time is unknown (nothing anchors the window)', () => {
+      expect(computePollingInterval({ ...unavailable, submittedAtMs: null, nowMs: 1_700_000_000_000 })).toBe(0)
+      expect(computePollingInterval(unavailable)).toBe(0)
+    })
+
+    it('keeps the grace window while a pinned snapshot is present', () => {
+      // NO_CHECK arrives with a snapshot and its head block; the window still
+      // applies, since the missing check is what polling waits for.
+      expect(
+        computePollingInterval({
+          status: CheckStatus.UNAVAILABLE,
+          headBlock: '200',
+          deadlineBlock: '150',
+          firstEventBlock: '100',
+          submittedAtMs: SUBMITTED,
+          nowMs: SUBMITTED + 1_000,
+        }),
+      ).toBe(UNAVAILABLE_GRACE_POLL_MS)
+    })
   })
 
   it('polls fast before the deadline', () => {

--- a/packages/utils/src/features/safenet-checks/utils/computePollingInterval.ts
+++ b/packages/utils/src/features/safenet-checks/utils/computePollingInterval.ts
@@ -52,8 +52,10 @@ export const computePollingInterval = ({
 
   // ponytail: UNAVAILABLE backs off only for the grace window, so a check
   // requested around the first read still self-heals. Ceiling: past the window
-  // a later check is not picked up until a manual re-check. Polling on past
-  // the window would put every check-less transaction on a public RPC forever.
+  // a later check is only picked up by a page reload, or by a fresh mount after
+  // the five-minute cache retention lapses — there is no re-check control in
+  // the UI. Polling on past the window would put every check-less transaction
+  // on a public RPC forever.
   if (status === CheckStatus.UNAVAILABLE) {
     if (submittedAtMs == null || nowMs === undefined) return 0
     // A submission stamped in the future is clock skew, not a young check:

--- a/packages/utils/src/features/safenet-checks/utils/computePollingInterval.ts
+++ b/packages/utils/src/features/safenet-checks/utils/computePollingInterval.ts
@@ -1,4 +1,11 @@
-import { LATE_WINDOW_BLOCKS, PLAIN_DEADLINE_BLOCKS, POLL_INTERVAL_FAST_MS, POLL_INTERVAL_LATE_MS } from '../constants'
+import {
+  LATE_WINDOW_BLOCKS,
+  PLAIN_DEADLINE_BLOCKS,
+  POLL_INTERVAL_FAST_MS,
+  POLL_INTERVAL_LATE_MS,
+  UNAVAILABLE_GRACE_MS,
+  UNAVAILABLE_GRACE_POLL_MS,
+} from '../constants'
 import { CheckStatus } from '../types'
 
 type PollingInput = {
@@ -15,23 +22,45 @@ type PollingInput = {
    * null anchors fail open to the fast interval.
    */
   firstEventBlock: string | null
+  /**
+   * Transaction submission time, the anchor of the UNAVAILABLE grace window.
+   * `null` or absent disables the window.
+   */
+  submittedAtMs?: number | null
+  /** Caller's clock for this computation. Keeps the function pure. */
+  nowMs?: number
 }
 
 /**
  * How often to re-poll a check, in ms; `0` = stop (RTK Query's convention).
  * Stops on a settled verdict; otherwise fast (6s) up to the effective deadline
  * (on-chain, or {@link PLAIN_DEADLINE_BLOCKS} past the first event), slow (30s)
- * through the ~1h late window, then stops.
+ * through the ~1h late window, then stops. UNAVAILABLE polls slowly inside
+ * {@link UNAVAILABLE_GRACE_MS} of submission, then stops.
  */
-export const computePollingInterval = ({ status, headBlock, deadlineBlock, firstEventBlock }: PollingInput): number => {
+export const computePollingInterval = ({
+  status,
+  headBlock,
+  deadlineBlock,
+  firstEventBlock,
+  submittedAtMs,
+  nowMs,
+}: PollingInput): number => {
   if (status === CheckStatus.BENIGN || status === CheckStatus.MALICIOUS || status === CheckStatus.VERIFICATION_FAILED) {
     return 0
   }
 
-  // ponytail: UNAVAILABLE stops immediately instead of backing off. Ceiling: a
-  // check proposed after this read is not picked up until a manual re-check.
-  // Without this, every transaction that never had a check polls forever.
-  if (status === CheckStatus.UNAVAILABLE) return 0
+  // ponytail: UNAVAILABLE backs off only for the grace window, so a check
+  // requested around the first read still self-heals. Ceiling: past the window
+  // a later check is not picked up until a manual re-check. Polling on past
+  // the window would put every check-less transaction on a public RPC forever.
+  if (status === CheckStatus.UNAVAILABLE) {
+    if (submittedAtMs == null || nowMs === undefined) return 0
+    // A submission stamped in the future is clock skew, not a young check:
+    // without the lower bound the window would stretch by the whole skew.
+    const age = nowMs - submittedAtMs
+    return age >= 0 && age < UNAVAILABLE_GRACE_MS ? UNAVAILABLE_GRACE_POLL_MS : 0
+  }
 
   const head = headBlock !== null ? BigInt(headBlock) : null
   const deadline =


### PR DESCRIPTION
## What it solves

Resolves RFC W10. `UNAVAILABLE` carried two meanings: "no check was requested for this
transaction" (normal — every wallet transaction on beta today, since nothing proposes checks yet)
and "we could not read the check status" (a problem). One state, two meanings, so the row was
hidden everywhere.

## How this PR fixes it

The read layer already distinguishes the two cases; only the view did not carry it:

- a `SUCCESSFUL` snapshot whose merged status is `UNAVAILABLE` means the chain answered and holds
  no events for the hash;
- a query error with no snapshot means the read failed.

`useSafenetCheck` now reports which one through a new `unavailableReason: 'NO_CHECK' |
'READ_FAILED' | undefined`. A snapshot outranks the error, so a failed refetch over retained data
still reports `NO_CHECK`. No data and no error stays `undefined`, so the first read in flight never
claims a failure.

`SafenetChecksSection` is the only surface that renders it, with neutral copy:

| reason | title | body |
| --- | --- | --- |
| `NO_CHECK` | Not checked | No Safenet check was requested for this transaction. |
| `READ_FAILED` | Status unavailable | The Safenet check status could not be read. Retry later. |

Neither is a verdict, so both use a muted icon and the default text colors — no error or warning
palette in light mode. `CheckStatus` gains no member; `deriveCheckState`, `mergeMonotonic`, and
`computePollingInterval` are untouched.

Also fixed while here: the section's title and copy are both `paragraph-small`, which renders a
`<span>`, so they ran together on one line for every state (`Safenet checkCheck submitted to
Safenet.`). The inner wrapper is now the flex column that `UntrustedSafeWarning` already uses.

## How to test it

Storybook covers all three states against a mocked Gnosis JSON-RPC (real component, real hook,
real reader):

```
yarn workspace @safe-global/web storybook
# Features/SafenetChecks/SafenetChecksSection -> NoCheckRequested | ReadFailed | Submitted
```

Unit tests:

```
yarn workspace @safe-global/utils jest src/features/safenet-checks
yarn workspace @safe-global/web jest safenet
```

## Affected flows

- Confirm/execute transaction flow, Safe Shield widget: the Safenet section now appears for both
  unavailable reasons instead of rendering nothing.
- Every other Safenet surface is unchanged: the queue row, the audit-log step, and the TxSummary
  indicator still render nothing for both reasons, and the `TxSigners` `showsSafenetRow` gate stays
  mirrored to `SafenetAuditRow`.

## Blast radius

- `useSafenetCheck` (`packages/utils`): additive field on `SafenetCheckView`. Consumers are
  `useSafenetDisplayStatus` (web) and `SafenetChecksSection`. Mobile does not consume it yet.
- `useSafenetDisplayStatus`: unchanged. It still folds `UNAVAILABLE` to `null`, which is what keeps
  the queue row and the audit row silent.
- `statusPresentation.ts`: `STATUS_PRESENTATION` unchanged; new `UNAVAILABLE_PRESENTATION` record.
- `buildCheckView` test builder: new field defaults to `undefined`, so existing builder-based tests
  keep their "renders nothing" behavior.
- No RTK Query endpoint, feature flag, chain config, persistence, or route change.

## Risks / not checked

- No mobile verification: mobile has no Safenet surface consuming this view yet.
- The `BENIGN`, `MALICIOUS`, and `TIMED_OUT` states were not re-screenshotted. They share the
  markup with the `Submitted` story shown below, which covers the same code path.
- Storybook image-snapshot baselines are disabled for these stories (`visualTest.disable`): the copy
  arrives after an async chain read and a fade-in, so a pixel baseline would race the poll loop.

## Visual summary

```mermaid
flowchart TB
  Q["getSafenetCheck query"] --> D{"snapshot present?"}
  D -->|"yes, status UNAVAILABLE"| NC["unavailableReason = NO_CHECK<br/>'Not checked'"]
  D -->|"no, error"| RF["unavailableReason = READ_FAILED<br/>'Status unavailable'"]
  D -->|"no, no error (loading)"| NONE["unavailableReason = undefined<br/>render nothing"]
  D -->|"yes, verdict"| V["STATUS_PRESENTATION<br/>'Safenet check'"]
  NC --> S["SafenetChecksSection only"]
  RF --> S
  V --> S
  NC -.->|"still silent"| Q2["queue row · audit row · TxSummary"]
  RF -.->|"still silent"| Q2
```

**NO_CHECK — light / dark**

<img width="340" alt="Not checked, light mode" src="https://gist.githubusercontent.com/Fbartoli/42d353ade65f55cd206edf9b79e1572d/raw/w10-no-check-light.png"> <img width="340" alt="Not checked, dark mode" src="https://gist.githubusercontent.com/Fbartoli/42d353ade65f55cd206edf9b79e1572d/raw/w10-no-check-dark.png">

**READ_FAILED — light / dark**

<img width="340" alt="Status unavailable, light mode" src="https://gist.githubusercontent.com/Fbartoli/42d353ade65f55cd206edf9b79e1572d/raw/w10-read-failed-light.png"> <img width="340" alt="Status unavailable, dark mode" src="https://gist.githubusercontent.com/Fbartoli/42d353ade65f55cd206edf9b79e1572d/raw/w10-read-failed-dark.png">

**Unchanged verdict state, for contrast (SUBMITTED) — light / dark**

<img width="340" alt="Safenet check submitted, light mode" src="https://gist.githubusercontent.com/Fbartoli/42d353ade65f55cd206edf9b79e1572d/raw/w10-submitted-light.png"> <img width="340" alt="Safenet check submitted, dark mode" src="https://gist.githubusercontent.com/Fbartoli/42d353ade65f55cd206edf9b79e1572d/raw/w10-submitted-dark.png">


## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics change
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

