### PR TITLE
fix: Restore nonce visibility for bulk and conflicting txn

### DIFF
--- a/apps/web/src/components/safe-apps/AppFrame/TransactionQueueBar/__snapshots__/TransactionQueueBar.stories.test.tsx.snap
+++ b/apps/web/src/components/safe-apps/AppFrame/TransactionQueueBar/__snapshots__/TransactionQueueBar.stories.test.tsx.snap
@@ -186,7 +186,7 @@ exports[`./TransactionQueueBar.stories Collapsed 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -355,7 +355,7 @@ exports[`./TransactionQueueBar.stories Collapsed 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -524,7 +524,7 @@ exports[`./TransactionQueueBar.stories Collapsed 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -872,7 +872,7 @@ exports[`./TransactionQueueBar.stories Expanded 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -1041,7 +1041,7 @@ exports[`./TransactionQueueBar.stories Expanded 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -1210,7 +1210,7 @@ exports[`./TransactionQueueBar.stories Expanded 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -1562,7 +1562,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -1731,7 +1731,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -1900,7 +1900,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -2069,7 +2069,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -2238,7 +2238,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -2407,7 +2407,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -2576,7 +2576,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -2745,7 +2745,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -2914,7 +2914,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -3083,7 +3083,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -3252,7 +3252,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -3421,7 +3421,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -3590,7 +3590,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -3759,7 +3759,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -3928,7 +3928,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -4097,7 +4097,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -4266,7 +4266,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -4435,7 +4435,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -4604,7 +4604,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -4773,7 +4773,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -4942,7 +4942,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -5111,7 +5111,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -5280,7 +5280,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -5449,7 +5449,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -5618,7 +5618,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -5787,7 +5787,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -5956,7 +5956,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -6125,7 +6125,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -6294,7 +6294,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""
@@ -6463,7 +6463,7 @@ exports[`./TransactionQueueBar.stories LongQueue 1`] = `
                             >
                               <div
                                 aria-expanded="false"
-                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+                                class="focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground text-left text-sm font-medium focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50 data-disabled:pointer-events-none data-disabled:opacity-50 @container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3 px-4 sm:px-6"
                                 data-orientation="vertical"
                                 data-slot="accordion-trigger"
                                 data-value=""

--- a/apps/web/src/components/transactions/BulkTxListGroup/index.test.tsx
+++ b/apps/web/src/components/transactions/BulkTxListGroup/index.test.tsx
@@ -1,0 +1,79 @@
+import type { MultisigTransaction, Transaction } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import {
+  ConflictType,
+  DetailedExecutionInfoType,
+  TransactionInfoType,
+  TransactionListItemType,
+  TransactionStatus,
+  TransactionTokenType,
+  TransferDirection,
+} from '@safe-global/store/gateway/types'
+
+import BulkTxListGroup from '@/components/transactions/BulkTxListGroup'
+import { render } from '@/tests/test-utils'
+
+const TX_HASH = '0x0000000000000000000000000000000000000000000000000000000000000abc'
+
+const createTx = (nonce: number, id: string): MultisigTransaction => ({
+  type: TransactionListItemType.TRANSACTION,
+  transaction: {
+    id,
+    txHash: TX_HASH,
+    timestamp: Date.now(),
+    executionInfo: {
+      type: DetailedExecutionInfoType.MULTISIG,
+      nonce,
+      confirmationsRequired: 1,
+      confirmationsSubmitted: 1,
+      missingSigners: [],
+    },
+    txInfo: {
+      type: TransactionInfoType.TRANSFER,
+      direction: TransferDirection.OUTGOING,
+      transferInfo: {
+        value: '1000000',
+        type: TransactionTokenType.NATIVE_COIN,
+      },
+    },
+    txStatus: TransactionStatus.SUCCESS,
+  } as unknown as Transaction,
+  conflictType: ConflictType.NONE,
+})
+
+describe('BulkTxListGroup', () => {
+  it('renders a nonce inside every transaction row of the group', () => {
+    const { getAllByTestId } = render(
+      <BulkTxListGroup groupedListItems={[createTx(11, 'tx-1'), createTx(12, 'tx-2')]} transactionHash={TX_HASH} />,
+    )
+
+    expect(getAllByTestId('nonce').map((el) => el.textContent)).toEqual(['11', '12'])
+  })
+
+  it('renders the nonce within the row, not beside it', () => {
+    const { getAllByTestId, getByTestId } = render(
+      <BulkTxListGroup groupedListItems={[createTx(11, 'tx-1')]} transactionHash={TX_HASH} />,
+    )
+
+    expect(getByTestId('transaction-item')).toContainElement(getAllByTestId('nonce')[0])
+  })
+
+  it('renders no nonce when a transaction has no multisig execution info', () => {
+    const tx = createTx(11, 'tx-1')
+    const withoutExecutionInfo = {
+      ...tx,
+      transaction: { ...tx.transaction, executionInfo: undefined },
+    } as MultisigTransaction
+
+    const { queryByTestId } = render(
+      <BulkTxListGroup groupedListItems={[withoutExecutionInfo]} transactionHash={TX_HASH} />,
+    )
+
+    expect(queryByTestId('nonce')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when the group is empty', () => {
+    const { container } = render(<BulkTxListGroup groupedListItems={[]} transactionHash={TX_HASH} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/apps/web/src/components/transactions/BulkTxListGroup/index.tsx
+++ b/apps/web/src/components/transactions/BulkTxListGroup/index.tsx
@@ -1,10 +1,9 @@
 import type { OrderTransactionInfo } from '@safe-global/store/gateway/types'
 import type { AnyTransactionItem } from '@/utils/tx-list'
 import type { ReactElement } from 'react'
-import { isMultisigExecutionInfo, isSwapTransferOrderTxInfo } from '@/utils/transaction-guards'
+import { isSwapTransferOrderTxInfo } from '@/utils/transaction-guards'
 import { Typography } from '@/components/ui/typography'
 import { Card } from '@/components/ui/card'
-import { cn } from '@/utils/cn'
 import ExpandableTransactionItem from '@/components/transactions/TxListItem/ExpandableTransactionItem'
 import BatchIcon from '@/public/images/common/batch.svg'
 import css from './styles.module.css'
@@ -41,8 +40,7 @@ const GroupedTxListItems = ({
     title = getSettlementOrderTitle(groupedListItems[0].transaction.txInfo as OrderTransactionInfo)
   }
   return (
-    // eslint-disable-next-line no-restricted-syntax -- py-2 tightens the grouped-tx list row; css.container owns the grid layout
-    <Card data-testid="grouped-items" size="none" className={cn(css.container, 'py-2')}>
+    <Card data-testid="grouped-items" size="none" className={css.container}>
       <div style={{ gridArea: 'icon' }}>
         <BatchIcon className="size-6" />
       </div>
@@ -55,17 +53,11 @@ const GroupedTxListItems = ({
       </div>
 
       <div style={{ gridArea: 'items' }} className={css.txItems}>
-        {groupedListItems.map((tx) => {
-          const nonce = isMultisigExecutionInfo(tx.transaction.executionInfo) ? tx.transaction.executionInfo.nonce : ''
-          return (
-            <div className="relative" key={tx.transaction.id}>
-              <div className={css.nonce}>
-                <Typography className={css.nonce}>{nonce}</Typography>
-              </div>
-              <ExpandableTransactionItem item={tx} isBulkGroup={true} />
-            </div>
-          )
-        })}
+        {groupedListItems.map((tx) => (
+          <div key={tx.transaction.id}>
+            <ExpandableTransactionItem item={tx} isBulkGroup={true} />
+          </div>
+        ))}
       </div>
     </Card>
   )

--- a/apps/web/src/components/transactions/BulkTxListGroup/styles.module.css
+++ b/apps/web/src/components/transactions/BulkTxListGroup/styles.module.css
@@ -1,12 +1,16 @@
 .container {
+  /* Same value as the rows' own px-3: the two insets together put the nonce 24px from the card
+     border, level with a standalone transaction row's nonce. */
+  --row-inset: calc(var(--spacing) * 3);
+
   position: relative;
-  padding: var(--space-2);
+  padding: var(--space-2) var(--row-inset) var(--row-inset);
   display: grid;
   align-items: center;
   grid-template-columns: minmax(50px, 0.25fr) minmax(240px, 2fr) minmax(150px, 4fr) minmax(170px, 1fr);
   grid-template-areas:
     'icon info action hash'
-    'nonce items items items';
+    'items items items items';
 }
 
 .action {
@@ -19,12 +23,6 @@
   grid-area: hash;
   display: grid;
   justify-content: flex-end;
-}
-
-.nonce {
-  position: absolute;
-  left: -24px;
-  top: var(--space-1);
 }
 
 .txItems {
@@ -46,10 +44,10 @@
   .container {
     grid-template-columns: minmax(30px, 0.25fr) minmax(230px, 3fr);
     grid-template-areas:
-      'icon info '
-      'nonce action'
-      'nonce hash '
-      'nonce items';
+      'icon  info  '
+      'action action'
+      'hash  hash  '
+      'items items ';
   }
 
   .action {
@@ -57,8 +55,5 @@
   }
   .hash {
     justify-content: flex-start;
-  }
-  .nonce {
-    left: -16px;
   }
 }

--- a/apps/web/src/components/transactions/BulkTxListGroup/styles.module.css
+++ b/apps/web/src/components/transactions/BulkTxListGroup/styles.module.css
@@ -33,11 +33,30 @@
   padding: 0;
   border-radius: var(--radius-lg);
   background-color: var(--surface-sunken);
-  overflow: hidden;
 }
 
 .txItems > div:not(:last-child) {
   border-bottom: 1px solid var(--border);
+  transition: border-color 0.2s ease;
+}
+
+/* A hovered row draws its own ring, so the dividers either side of it would double up. Open rows keep
+   theirs: with no border on the row, the divider is the only thing separating two open rows. */
+.txItems > div:hover,
+.txItems > div:has(+ div:hover) {
+  border-bottom-color: transparent;
+}
+
+/* The outer rows carry the rounding so this block needn't clip — a clipped row would bite the corners
+   off its own hover border. */
+.txItems > div:first-child > [data-slot='accordion'] > [data-slot='accordion-item'] {
+  border-top-left-radius: var(--radius-lg);
+  border-top-right-radius: var(--radius-lg);
+}
+
+.txItems > div:last-child > [data-slot='accordion'] > [data-slot='accordion-item'] {
+  border-bottom-left-radius: var(--radius-lg);
+  border-bottom-right-radius: var(--radius-lg);
 }
 
 @media (max-width: 699px) {

--- a/apps/web/src/components/transactions/GroupedTxListItems/styles.module.css
+++ b/apps/web/src/components/transactions/GroupedTxListItems/styles.module.css
@@ -50,11 +50,20 @@
   padding: 0;
   border-radius: var(--radius-lg);
   background-color: var(--surface-sunken);
-  overflow: hidden;
 }
 
 .txItems > div:not(:last-child) {
   border-bottom: 1px solid var(--border);
+}
+
+.txItems > div:first-child > [data-slot='accordion'] > [data-slot='accordion-item'] {
+  border-top-left-radius: var(--radius-lg);
+  border-top-right-radius: var(--radius-lg);
+}
+
+.txItems > div:last-child > [data-slot='accordion'] > [data-slot='accordion-item'] {
+  border-bottom-left-radius: var(--radius-lg);
+  border-bottom-right-radius: var(--radius-lg);
 }
 
 .txItems [data-slot='accordion-item'] {

--- a/apps/web/src/components/transactions/GroupedTxListItems/styles.module.css
+++ b/apps/web/src/components/transactions/GroupedTxListItems/styles.module.css
@@ -43,6 +43,7 @@
 }
 
 .txItems {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 0;

--- a/apps/web/src/components/transactions/GroupedTxListItems/styles.module.css
+++ b/apps/web/src/components/transactions/GroupedTxListItems/styles.module.css
@@ -54,6 +54,14 @@
 
 .txItems > div:not(:last-child) {
   border-bottom: 1px solid var(--border);
+  transition: border-color 0.2s ease;
+}
+
+/* A hovered row draws its own ring, so the dividers either side of it would double up. Open rows keep
+   theirs: with no border on the row, the divider is the only thing separating two open rows. */
+.txItems > div:hover,
+.txItems > div:has(+ div:hover) {
+  border-bottom-color: transparent;
 }
 
 .txItems > div:first-child > [data-slot='accordion'] > [data-slot='accordion-item'] {
@@ -64,10 +72,6 @@
 .txItems > div:last-child > [data-slot='accordion'] > [data-slot='accordion-item'] {
   border-bottom-left-radius: var(--radius-lg);
   border-bottom-right-radius: var(--radius-lg);
-}
-
-.txItems [data-slot='accordion-item'] {
-  border: none;
 }
 
 .txItems > div {

--- a/apps/web/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
+++ b/apps/web/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
@@ -62,7 +62,9 @@ const ExpandableTransactionItem = ({
           // so viewport-based breakpoints kept the one-line grid past the point it fitted and
           // `overflow-x-auto` turned that into a scrollbar.
           className={classNames(
-            '@container cursor-pointer items-center justify-start overflow-x-auto py-3',
+            // rounded-none: the shadcn trigger's own rounded-md would curve its fill inside the row's
+            // square edges. The row owns the corners — only a group's first and last get any.
+            '@container cursor-pointer items-center justify-start overflow-x-auto rounded-none py-3',
             // A bulk group's card already insets its row block by 12px, so the row halves its own
             // padding to land the nonce 24px in — level with a standalone row's nonce.
             isBulkGroup ? 'px-3' : 'px-4 sm:px-6',

--- a/apps/web/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
+++ b/apps/web/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
@@ -61,7 +61,12 @@ const ExpandableTransactionItem = ({
           // than the viewport's. With the sidebar expanded a 920px viewport leaves the row only 638px,
           // so viewport-based breakpoints kept the one-line grid past the point it fitted and
           // `overflow-x-auto` turned that into a scrollbar.
-          className="@container cursor-pointer items-center justify-start overflow-x-auto px-4 py-3 sm:px-6"
+          className={classNames(
+            '@container cursor-pointer items-center justify-start overflow-x-auto py-3',
+            // A bulk group's card already insets its row block by 12px, so the row halves its own
+            // padding to land the nonce 24px in — level with a standalone row's nonce.
+            isBulkGroup ? 'px-3' : 'px-4 sm:px-6',
+          )}
         >
           <TxSummary item={item} isConflictGroup={isConflictGroup} isBulkGroup={isBulkGroup} />
         </AccordionTrigger>
@@ -72,11 +77,16 @@ const ExpandableTransactionItem = ({
           // Full-bleed panel: the details draw their separators — and the vertical rule beside the
           // audit log — as borders on their own blocks, so any padding here holds those rules off
           // the card's edges. The inset moves onto each block via `--tx-details-edge-inset` (see
-          // TxDetails/styles.module.css), matching the trigger's px-4 / sm:px-6 above so text
+          // TxDetails/styles.module.css), matching the trigger's horizontal padding above so text
           // lands exactly where it did. `pb-0` for the same reason: the blocks bring their own
           // bottom padding, and padding here would cut the vertical rule short of the card's edge.
           className={classNames(
-            'pt-0 pb-0 [--tx-details-edge-inset:var(--space-2)] sm:[--tx-details-edge-inset:var(--space-3)]',
+            'pt-0 pb-0',
+            // Mirrors the trigger's horizontal padding above so the details' text lands on the same
+            // vertical line while their borders still span the card.
+            isBulkGroup
+              ? '[--tx-details-edge-inset:12px]'
+              : '[--tx-details-edge-inset:var(--space-2)] sm:[--tx-details-edge-inset:var(--space-3)]',
             css.accordionContentSurface,
           )}
         >

--- a/apps/web/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
+++ b/apps/web/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
@@ -85,9 +85,10 @@ const ExpandableTransactionItem = ({
           className={classNames(
             'pt-0 pb-0',
             // Mirrors the trigger's horizontal padding above so the details' text lands on the same
-            // vertical line while their borders still span the card.
+            // vertical line while their borders still span the card. `--spacing(3)` is what `px-3`
+            // resolves to, so the two cannot drift if the spacing scale moves.
             isBulkGroup
-              ? '[--tx-details-edge-inset:12px]'
+              ? '[--tx-details-edge-inset:--spacing(3)]'
               : '[--tx-details-edge-inset:var(--space-2)] sm:[--tx-details-edge-inset:var(--space-3)]',
             css.accordionContentSurface,
           )}

--- a/apps/web/src/components/transactions/TxListItem/styles.module.css
+++ b/apps/web/src/components/transactions/TxListItem/styles.module.css
@@ -8,19 +8,6 @@
   overflow: hidden;
 }
 
-.listItemNested {
-  border: none;
-  background-color: transparent;
-  border-radius: 0;
-}
-
-.listItemNested:hover,
-.listItemNested.batched,
-.listItemNested[data-open] {
-  border: none;
-  background-color: transparent;
-}
-
 /* Interior of the card, not a surface of its own — matches ExpandableMsgItem's panel and the
    pre-shadcn behaviour, where the details area simply inherited the card fill. */
 .accordionContentSurface {
@@ -47,7 +34,36 @@
   background-color: var(--color-background-light);
 }
 
-.listItemNested:hover > * > [data-slot='accordion-trigger'],
-.listItemNested[data-open] > * > [data-slot='accordion-trigger'] {
-  background-color: color-mix(in srgb, var(--card) 72%, var(--muted) 28%);
+/* Rows nested in a group sit on the group's own surface: unfilled, square, and borderless so
+   consecutive rows stay flush. They take their hover fill from .listItem above, so these must follow
+   those rules — same specificity. */
+.listItemNested,
+.listItemNested:hover,
+.listItemNested.batched,
+.listItemNested[data-open] {
+  background-color: transparent;
+}
+
+.listItemNested {
+  position: relative;
+  border: none;
+  border-radius: 0;
+}
+
+/* The hover ring is an overlay rather than a border, so a row's edge adds no width that could stack
+   with the neighbouring row's or with the divider between them. It has to be positioned: the trigger
+   is `relative`, and a positioned child paints over its parent's border or outline. */
+.listItemNested::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border: 1px solid transparent;
+  border-radius: inherit;
+  pointer-events: none;
+  transition: border-color 0.2s ease;
+}
+
+.listItemNested:hover::after,
+.listItemNested.batched::after {
+  border-color: var(--color-secondary-light);
 }

--- a/apps/web/src/components/transactions/TxSummary/TxSummary.stories.tsx
+++ b/apps/web/src/components/transactions/TxSummary/TxSummary.stories.tsx
@@ -34,7 +34,7 @@ import {
  */
 const TxCard = ({ children, width }: { children: ReactNode; width?: number }) => (
   <div className="bg-card overflow-hidden rounded-lg border border-transparent" style={{ width, maxWidth: '100%' }}>
-    <div className="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6">
+    <div className="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6">
       {children}
       <ChevronDownIcon className="text-muted-foreground pointer-events-none ml-auto size-4 shrink-0" />
     </div>

--- a/apps/web/src/components/transactions/TxSummary/__snapshots__/TxSummary.stories.test.tsx.snap
+++ b/apps/web/src/components/transactions/TxSummary/__snapshots__/TxSummary.stories.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`./TxSummary.stories AllTypesStacked 1`] = `
             style="max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -183,7 +183,7 @@ exports[`./TxSummary.stories AllTypesStacked 1`] = `
             style="max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -347,7 +347,7 @@ exports[`./TxSummary.stories AllTypesStacked 1`] = `
             style="max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -555,7 +555,7 @@ exports[`./TxSummary.stories AllTypesStacked 1`] = `
             style="max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -763,7 +763,7 @@ exports[`./TxSummary.stories AllTypesStacked 1`] = `
             style="max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -893,7 +893,7 @@ exports[`./TxSummary.stories AllTypesStacked 1`] = `
             style="max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -1023,7 +1023,7 @@ exports[`./TxSummary.stories AllTypesStacked 1`] = `
             style="max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -1153,7 +1153,7 @@ exports[`./TxSummary.stories AllTypesStacked 1`] = `
             style="max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -1382,7 +1382,7 @@ exports[`./TxSummary.stories AllTypesStackedAt360 1`] = `
             style="width: 360px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -1546,7 +1546,7 @@ exports[`./TxSummary.stories AllTypesStackedAt360 1`] = `
             style="width: 360px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -1710,7 +1710,7 @@ exports[`./TxSummary.stories AllTypesStackedAt360 1`] = `
             style="width: 360px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -1918,7 +1918,7 @@ exports[`./TxSummary.stories AllTypesStackedAt360 1`] = `
             style="width: 360px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -2126,7 +2126,7 @@ exports[`./TxSummary.stories AllTypesStackedAt360 1`] = `
             style="width: 360px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -2256,7 +2256,7 @@ exports[`./TxSummary.stories AllTypesStackedAt360 1`] = `
             style="width: 360px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -2386,7 +2386,7 @@ exports[`./TxSummary.stories AllTypesStackedAt360 1`] = `
             style="width: 360px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -2516,7 +2516,7 @@ exports[`./TxSummary.stories AllTypesStackedAt360 1`] = `
             style="width: 360px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -2745,7 +2745,7 @@ exports[`./TxSummary.stories AllTypesStackedAt600 1`] = `
             style="width: 600px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -2909,7 +2909,7 @@ exports[`./TxSummary.stories AllTypesStackedAt600 1`] = `
             style="width: 600px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -3073,7 +3073,7 @@ exports[`./TxSummary.stories AllTypesStackedAt600 1`] = `
             style="width: 600px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -3281,7 +3281,7 @@ exports[`./TxSummary.stories AllTypesStackedAt600 1`] = `
             style="width: 600px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -3489,7 +3489,7 @@ exports[`./TxSummary.stories AllTypesStackedAt600 1`] = `
             style="width: 600px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -3619,7 +3619,7 @@ exports[`./TxSummary.stories AllTypesStackedAt600 1`] = `
             style="width: 600px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -3749,7 +3749,7 @@ exports[`./TxSummary.stories AllTypesStackedAt600 1`] = `
             style="width: 600px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -3879,7 +3879,7 @@ exports[`./TxSummary.stories AllTypesStackedAt600 1`] = `
             style="width: 600px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -4108,7 +4108,7 @@ exports[`./TxSummary.stories AllTypesStackedAt1000 1`] = `
             style="width: 1000px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -4272,7 +4272,7 @@ exports[`./TxSummary.stories AllTypesStackedAt1000 1`] = `
             style="width: 1000px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -4436,7 +4436,7 @@ exports[`./TxSummary.stories AllTypesStackedAt1000 1`] = `
             style="width: 1000px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -4644,7 +4644,7 @@ exports[`./TxSummary.stories AllTypesStackedAt1000 1`] = `
             style="width: 1000px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -4852,7 +4852,7 @@ exports[`./TxSummary.stories AllTypesStackedAt1000 1`] = `
             style="width: 1000px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -4982,7 +4982,7 @@ exports[`./TxSummary.stories AllTypesStackedAt1000 1`] = `
             style="width: 1000px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -5112,7 +5112,7 @@ exports[`./TxSummary.stories AllTypesStackedAt1000 1`] = `
             style="width: 1000px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -5242,7 +5242,7 @@ exports[`./TxSummary.stories AllTypesStackedAt1000 1`] = `
             style="width: 1000px; max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer queue"
@@ -5471,7 +5471,7 @@ exports[`./TxSummary.stories AllTypesStackedHistory 1`] = `
             style="max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer history"
@@ -5603,7 +5603,7 @@ exports[`./TxSummary.stories AllTypesStackedHistory 1`] = `
             style="max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer history"
@@ -5735,7 +5735,7 @@ exports[`./TxSummary.stories AllTypesStackedHistory 1`] = `
             style="max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer history"
@@ -5911,7 +5911,7 @@ exports[`./TxSummary.stories AllTypesStackedHistory 1`] = `
             style="max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer history"
@@ -6009,7 +6009,7 @@ exports[`./TxSummary.stories AllTypesStackedHistory 1`] = `
             style="max-width: 100%;"
           >
             <div
-              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+              class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
             >
               <div
                 class="gridContainer history"
@@ -6125,7 +6125,7 @@ exports[`./TxSummary.stories Batch 1`] = `
           style="max-width: 100%;"
         >
           <div
-            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
           >
             <div
               class="gridContainer queue"
@@ -6272,7 +6272,7 @@ exports[`./TxSummary.stories CustomTransaction 1`] = `
           style="max-width: 100%;"
         >
           <div
-            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
           >
             <div
               class="gridContainer queue"
@@ -6419,7 +6419,7 @@ exports[`./TxSummary.stories HistorySendNativeToken 1`] = `
           style="max-width: 100%;"
         >
           <div
-            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
           >
             <div
               class="gridContainer history"
@@ -6568,7 +6568,7 @@ exports[`./TxSummary.stories HistorySwapOrder 1`] = `
           style="max-width: 100%;"
         >
           <div
-            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
           >
             <div
               class="gridContainer history"
@@ -6761,7 +6761,7 @@ exports[`./TxSummary.stories SendAt360 1`] = `
           style="width: 360px; max-width: 100%;"
         >
           <div
-            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
           >
             <div
               class="gridContainer queue"
@@ -6942,7 +6942,7 @@ exports[`./TxSummary.stories SendAt600 1`] = `
           style="width: 600px; max-width: 100%;"
         >
           <div
-            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
           >
             <div
               class="gridContainer queue"
@@ -7123,7 +7123,7 @@ exports[`./TxSummary.stories SendAt1000 1`] = `
           style="width: 1000px; max-width: 100%;"
         >
           <div
-            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
           >
             <div
               class="gridContainer queue"
@@ -7304,7 +7304,7 @@ exports[`./TxSummary.stories SendErc20 1`] = `
           style="max-width: 100%;"
         >
           <div
-            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
           >
             <div
               class="gridContainer queue"
@@ -7485,7 +7485,7 @@ exports[`./TxSummary.stories SendNativeToken 1`] = `
           style="max-width: 100%;"
         >
           <div
-            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
           >
             <div
               class="gridContainer queue"
@@ -7666,7 +7666,7 @@ exports[`./TxSummary.stories SettingsChange 1`] = `
           style="max-width: 100%;"
         >
           <div
-            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
           >
             <div
               class="gridContainer queue"
@@ -7813,7 +7813,7 @@ exports[`./TxSummary.stories SwapAt360 1`] = `
           style="width: 360px; max-width: 100%;"
         >
           <div
-            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
           >
             <div
               class="gridContainer queue"
@@ -8038,7 +8038,7 @@ exports[`./TxSummary.stories SwapAt600 1`] = `
           style="width: 600px; max-width: 100%;"
         >
           <div
-            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
           >
             <div
               class="gridContainer queue"
@@ -8263,7 +8263,7 @@ exports[`./TxSummary.stories SwapAt1000 1`] = `
           style="width: 1000px; max-width: 100%;"
         >
           <div
-            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
           >
             <div
               class="gridContainer queue"
@@ -8488,7 +8488,7 @@ exports[`./TxSummary.stories SwapBuyOrder 1`] = `
           style="max-width: 100%;"
         >
           <div
-            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
           >
             <div
               class="gridContainer queue"
@@ -8713,7 +8713,7 @@ exports[`./TxSummary.stories SwapOrderWithLongSymbols 1`] = `
           style="max-width: 100%;"
         >
           <div
-            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
           >
             <div
               class="gridContainer queue"
@@ -8938,7 +8938,7 @@ exports[`./TxSummary.stories SwapSellOrder 1`] = `
           style="max-width: 100%;"
         >
           <div
-            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-md border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
+            class="@container relative flex cursor-pointer items-center justify-start overflow-x-auto rounded-none border border-transparent px-4 py-3 text-left text-sm font-medium sm:px-6"
           >
             <div
               class="gridContainer queue"

--- a/apps/web/src/components/transactions/TxSummary/index.test.tsx
+++ b/apps/web/src/components/transactions/TxSummary/index.test.tsx
@@ -89,12 +89,42 @@ describe('TxSummary', () => {
     expect(queryByText('7')).not.toBeInTheDocument()
   })
 
-  it('should not display a nonce for items in bulk execution group', () => {
-    const { queryByText } = render(
+  it('should display a nonce for items in a bulk execution group', () => {
+    const { getByTestId } = render(<TxSummary item={mockTransaction} isBulkGroup={true} isConflictGroup={false} />)
+
+    expect(getByTestId('nonce')).toHaveTextContent('7')
+  })
+
+  it('should not display a nonce for items in a bulk execution group without executionInfo', () => {
+    const { queryByTestId } = render(
       <TxSummary item={mockTransactionWithoutExecutionInfo} isBulkGroup={true} isConflictGroup={false} />,
     )
 
-    expect(queryByText('7')).not.toBeInTheDocument()
+    expect(queryByTestId('nonce')).not.toBeInTheDocument()
+  })
+
+  it('should show the imitation warning instead of the nonce, not on top of it', () => {
+    const imitationTx = {
+      ...mockTransaction,
+      transaction: {
+        ...mockTransaction.transaction,
+        txInfo: {
+          type: TransactionInfoType.TRANSFER,
+          direction: TransferDirection.INCOMING,
+          transferInfo: {
+            type: TransactionTokenType.ERC20,
+            value: '1000000',
+            trusted: false,
+            imitation: true,
+          },
+        },
+      } as unknown as Transaction,
+    }
+
+    const { getByTestId, queryByTestId } = render(<TxSummary item={imitationTx} isConflictGroup={false} />)
+
+    expect(getByTestId('warning')).toBeInTheDocument()
+    expect(queryByTestId('nonce')).not.toBeInTheDocument()
   })
 
   it('should display confirmations if transactions is in queue', () => {

--- a/apps/web/src/components/transactions/TxSummary/index.tsx
+++ b/apps/web/src/components/transactions/TxSummary/index.tsx
@@ -47,6 +47,7 @@ const TxSummary = ({ item, isConflictGroup, isBulkGroup }: TxSummaryProps): Reac
   const nonce = isMultisigExecutionInfo(tx.executionInfo) ? tx.executionInfo.nonce : undefined
   const isTrusted = !hasDefaultTokenlist || isTrustedTx(tx)
   const isImitationTransaction = isImitation(tx)
+  const showWarning = isImitationTransaction || !isTrusted
   const isPending = useIsPending(tx.id)
   const executionInfo = isMultisigExecutionInfo(tx.executionInfo) ? tx.executionInfo : undefined
   const expiredSwap = useIsExpiredSwap(tx.txInfo)
@@ -68,19 +69,20 @@ const TxSummary = ({ item, isConflictGroup, isBulkGroup }: TxSummaryProps): Reac
         [css.history]: !isQueue,
         [css.conflictGroup]: isConflictGroup,
         [css.bulkGroup]: isBulkGroup,
-        [css.untrusted]: !isTrusted || isImitationTransaction,
+        [css.untrusted]: showWarning,
         [css.withAssessment]: showAssessment,
         [css.withSafenet]: showSafenetStatus,
       })}
       id={tx.id}
     >
-      {nonce !== undefined && !isConflictGroup && !isBulkGroup && (
+      {/* The warning claims the same cell, so the nonce yields to it rather than stacking underneath. */}
+      {nonce !== undefined && !isConflictGroup && !showWarning && (
         <div data-testid="nonce" className={css.nonce} style={{ gridArea: 'nonce' }}>
           {nonce}
         </div>
       )}
 
-      {(isImitationTransaction || !isTrusted) && (
+      {showWarning && (
         <div data-testid="warning" style={{ gridArea: 'nonce' }}>
           <MaliciousTxWarning withTooltip={!isImitationTransaction} />
         </div>

--- a/apps/web/src/components/transactions/TxSummary/styles.module.css
+++ b/apps/web/src/components/transactions/TxSummary/styles.module.css
@@ -84,8 +84,8 @@
 }
 
 .gridContainer.bulkGroup {
-  grid-template-columns: var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-status);
-  grid-template-areas: 'type info date status';
+  grid-template-columns: var(--grid-nonce) var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-status);
+  grid-template-areas: 'nonce type info date status';
 }
 
 .gridContainer.bulkGroup .assessment,
@@ -95,7 +95,6 @@
 
 .gridContainer.bulkGroup.untrusted {
   grid-template-columns: var(--grid-nonce) minmax(200px, 2.4fr) var(--grid-info) var(--grid-date) var(--grid-status);
-  grid-template-areas: 'nonce type info date status';
 }
 
 .gridContainer.message {


### PR DESCRIPTION
## What it solves

Resolves: [WA-3405](https://linear.app/safe-global/issue/WA-3405/restore-nonce-visibility-for-bulk-and-conflicting-transactions
)
Three regressions in the new transaction-list design:

1. **Bulk-executed transactions lost their nonce in history** (flagged as critical). The nonce was rendered as an absolutely positioned label hanging outside the group card at `left: -24px`, where it was clipped and effectively invisible.
2. Rows inside bulk and conflicting groups didn't read as separate transactions — no hover feedback of their own, dividers doubling up against row edges, and the group's rounded corners bitten off.
3. The conflicting group's vertical connector rule painted straight across the block of transaction rows instead of stopping at it.

## How this PR fixes it

**Nonce moves inside the row**

- `TxSummary` now renders the nonce for bulk-group rows: `.gridContainer.bulkGroup` gets the `--grid-nonce` column and the `nonce` grid area that every other row variant already had.
- `BulkTxListGroup` drops its hand-rolled absolutely positioned nonce, and the group grid drops the now-empty `nonce` column/area on both desktop and the ≤699px layout.
- Alignment: the group card insets its row block by 12px and the nested trigger halves its own padding to `px-3`, so a bulk row's nonce lands 24px from the card border — level with a standalone row's nonce. `--tx-details-edge-inset` mirrors the same inset so an expanded row's details stay on that vertical line.

**Nonce vs. malicious-tx warning**

The nonce and the untrusted/imitation warning both claim the `nonce` grid area and were stacking on top of each other. The nonce now yields to the warning (`showWarning`). This applies to every row variant, not just bulk.

**Row separation and hover**

- Nested rows draw their hover state as an `::after` overlay ring instead of a border, so a hovered row adds no width and can't stack against its neighbour's edge or the divider between them.
- The dividers immediately above and below a hovered row fade to transparent, so the green ring is the only line there.
- Nested rows no longer override the shared trigger hover fill, so they get the same `--color-background-light` treatment as standalone rows.
- The first and last row carry the group's `--radius-lg` corners, and the row block drops `overflow: hidden` — the clip was cutting the corners off the hover ring and truncating the conflict connector stubs.

**Conflict connector rule**

`.txItems` becomes a positioned element, so it paints above the group's absolutely positioned vertical rule. The rule now stops at the row block instead of running across the top transaction.

## How to test it

1. Open a Safe with bulk-executed transactions in history — e.g. [eth:0x8444…94BB](https://safe-wallet-web.dev.5afe.dev/transactions/history?safe=eth:0x84443F61efc60D10DA9F9a2398980CD5748394BB) (entries from 5 April) or [sep:0x2a73…49b9](https://safe-wallet-web.dev.5afe.dev/transactions/history?safe=sep:0x2a73e61bd15b25B6958b4DA3bfc759ca4db249b9).
   - Every row in a bulk group shows its own nonce, left-aligned with the nonce of standalone rows above/below the group.
2. Hover each row in the group: a single green ring around that row only, no double line against its neighbours, corners intact on the first and last row.
3. Expand a row in a bulk group: details text lines up with the collapsed row's content, separators still span the card.
4. Open the [queue with conflicting transactions](https://safe-wallet-web.dev.5afe.dev/transactions/queue?safe=sep:0x2a73e61bd15b25B6958b4DA3bfc759ca4db249b9).
   - The vertical connector rule stops at the row block instead of crossing the first transaction; rows hover independently.
5. Find an untrusted/imitation transfer in history: the warning icon shows in place of the nonce, not overlapping it.
6. Narrow to <700px and check the bulk group's stacked layout (icon/info, action, hash, items).
7. `yarn workspace @safe-global/web test src/components/transactions/BulkTxListGroup src/components/transactions/TxSummary`

## Affected flows

- History — bulk-executed transaction group (nonce restored, row separation, hover)
- Queue — conflicting transaction group (connector rule, row separation, hover)
- Queue + history — any row with an untrusted or imitation transfer: the warning now replaces the nonce instead of stacking on it
- Batch-execute hover (`.batched`) highlight on rows inside groups

## Blast radius

- **`TxSummary`** — rendered by every transaction row: queue, history, single-tx page, bulk groups, conflict groups. The grid change is scoped to `.bulkGroup`; the nonce/warning precedence change is global.
- **`ExpandableTransactionItem`** — consumed by `TxList`, `SingleTx`, `GroupedTxListItems`, `BulkTxListGroup`. The `px-3` padding and `12px` details inset are gated behind `isBulkGroup`; `rounded-none` on the trigger applies to all rows, but standalone rows still get their corners from `.listItem`'s radius + `overflow: hidden`.
- **`TxListItem/styles.module.css`** — `.listItem` is also used by `ExpandableMsgItem` (safe messages) and the skeleton, and is untouched. All changes are on `.listItemNested`, which only bulk/conflict rows carry.
- **`GroupedTxListItems/styles.module.css`** and **`BulkTxListGroup/styles.module.css`** — module-scoped, no other consumers.
- Recovery groups (`features/recovery/components/GroupedRecoveryListItems`) have their own CSS module and are deliberately left as they were.
- No hooks, selectors, slices, RTK Query endpoints, feature flags, routes, persisted state, or shared packages touched. No mobile impact.

## Risks / not checked

- CSS-only for the grouping/hover work — covered by unit tests for the nonce logic, but there is no visual regression coverage of the ring, dividers, or corners.
- Not verified in dark mode.
- Recovery groups were not re-styled to match; they keep the previous nested-row look.
- `:has()` is used for the divider-fade rule. Supported in all current target browsers; older engines simply keep both lines (cosmetic, no layout break).
- Not exercised on a real mobile device — only at narrow viewport widths.

## Visual summary
Before:
<img width="1253" height="287" alt="Screenshot 2026-08-25 at 2 21 15 PM" src="https://github.com/user-attachments/assets/a7d2f423-6d31-4105-a84f-4cad0c6583a4" />
<img width="1253" height="224" alt="Screenshot 2026-08-25 at 2 21 51 PM" src="https://github.com/user-attachments/assets/34178da2-1eef-4e68-ab67-709b13ded329" />
<img width="1253" height="439" alt="Screenshot 2026-08-25 at 2 21 24 PM" src="https://github.com/user-attachments/assets/da20169f-da47-4b22-b0e4-88d3e1530d49" />

After:
<img width="1424" height="287" alt="Screenshot 2026-08-25 at 2 15 32 PM" src="https://github.com/user-attachments/assets/b0375487-323a-4d70-a69d-8d6fcd648abd" />
<img width="1424" height="287" alt="Screenshot 2026-08-25 at 2 15 27 PM" src="https://github.com/user-attachments/assets/c88bef6c-78df-47a9-8bef-9f6dc686aacc" />
<img width="1424" height="565" alt="Screenshot 2026-08-25 at 2 14 51 PM" src="https://github.com/user-attachments/assets/e6fffc42-cc41-43c9-93ac-83d9317c3305" />
<img width="1424" height="384" alt="Screenshot 2026-08-25 at 2 14 37 PM" src="https://github.com/user-attachments/assets/62bcea4b-6cbd-439e-ab5f-f7adfa340630" />

Screenshots of a bulk group in history and a conflicting group in the queue to be attached.

```mermaid
flowchart TB
  subgraph Before["Before"]
    B1["BulkTxListGroup card"] --> B2["absolute nonce, left: -24px<br/>(outside the card, clipped)"]
    B1 --> B3["row block, overflow: hidden"]
    B3 --> B4["TxSummary — bulkGroup grid<br/>no nonce column"]
    B3 --> B5["nested row: no border,<br/>hover = background fill only"]
    B6["conflict group rule"] -.paints over.-> B3
  end

  subgraph After["After"]
    A1["BulkTxListGroup card<br/>padding: 12px"] --> A2["row block, no clip,<br/>position: relative"]
    A2 --> A3["TxSummary — bulkGroup grid<br/>nonce column restored"]
    A2 --> A4["nested row: ::after overlay ring<br/>+ neighbouring dividers fade"]
    A2 --> A5["first / last row carry<br/>the group's corners"]
    A6["conflict group rule"] -.stops at.-> A2
  end
```

```mermaid
flowchart LR
  N["nonce !== undefined"] --> C{"isConflictGroup?"}
  C -->|yes| H["hidden — group shows the shared nonce"]
  C -->|no| W{"untrusted or imitation?"}
  W -->|yes| M["MaliciousTxWarning takes the nonce cell"]
  W -->|no| S["nonce rendered — including bulk group rows"]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics changes
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
