### PR TITLE
fix(safenet): canonical read aim and coverage-gated absent-check claim

### DIFF
--- a/apps/web/src/features/safenet-checks/__tests__/statusPresentation.test.ts
+++ b/apps/web/src/features/safenet-checks/__tests__/statusPresentation.test.ts
@@ -3,14 +3,23 @@ import { CheckStatus, type PublicCheckStatus, type UnavailableReason } from '@sa
 import { resolvePresentation, STATUS_PRESENTATION, UNAVAILABLE_PRESENTATION } from '../statusPresentation'
 
 const VERDICT_STATUSES = Object.keys(STATUS_PRESENTATION) as Exclude<PublicCheckStatus, CheckStatus.UNAVAILABLE>[]
+const UNAVAILABLE_REASONS = Object.keys(UNAVAILABLE_PRESENTATION) as UnavailableReason[]
 
 describe('resolvePresentation', () => {
-  it.each<UnavailableReason>(['NO_CHECK', 'READ_FAILED'])('renders the %s copy with a neutral icon', (reason) => {
+  it.each(UNAVAILABLE_REASONS)('renders the %s copy with a neutral icon', (reason) => {
     expect(resolvePresentation(CheckStatus.UNAVAILABLE, reason, false)).toEqual({
       ...UNAVAILABLE_PRESENTATION[reason],
       severity: Severity.INFO,
       muted: true,
     })
+  })
+
+  it('claims an absent check only for the reason that proves one', () => {
+    // A heuristic window found nothing where it looked. Saying "no check was
+    // requested" there would assert a fact the read cannot support.
+    expect(UNAVAILABLE_PRESENTATION.WINDOW_UNCERTAIN).toEqual(UNAVAILABLE_PRESENTATION.READ_FAILED)
+    expect(UNAVAILABLE_PRESENTATION.WINDOW_UNCERTAIN.copy).not.toContain('No Safenet check was requested')
+    expect(UNAVAILABLE_PRESENTATION.NO_CHECK.copy).toContain('No Safenet check was requested')
   })
 
   it('keeps the neutral icon even when a snapshot says no check was requested', () => {

--- a/apps/web/src/features/safenet-checks/components/SafenetChecksSection.tsx
+++ b/apps/web/src/features/safenet-checks/components/SafenetChecksSection.tsx
@@ -12,8 +12,8 @@ import { resolvePresentation } from '../statusPresentation'
 /**
  * Safenet check state as a section in the Safe Shield widget. Subscribes only
  * for confirm/execute flows of an already-proposed transaction, and only once
- * the submission time is known — the shared cache keys by hash, so a fetch
- * aimed without it would cache a mis-aimed read for every surface.
+ * the submission time is known — `submittedAt` is the transaction's submission
+ * date, the aim the shared read window wants.
  */
 export const SafenetChecksSection = (): ReactElement | null => {
   const { txId, txDetails } = useContext(TxFlowContext)

--- a/apps/web/src/features/safenet-checks/components/SafenetQueueStatus.tsx
+++ b/apps/web/src/features/safenet-checks/components/SafenetQueueStatus.tsx
@@ -9,9 +9,9 @@ import { STATUS_PRESENTATION } from '../statusPresentation'
 export type SafenetQueueStatusProps = {
   safeTxHash: string
   /**
-   * Submission time from the queue summary; aims the reader's block window.
-   * Required: the cache keys by hash and the last fetch's args aim every
-   * later poll, so an unaimed subscription would poison every surface.
+   * The queued transaction's submission date, offered to the shared aim
+   * registry, which aims the read window with the earliest time any surface
+   * knows. The confirm flow offers the same value from `submittedAt`.
    */
   timestampMs: number
 }

--- a/apps/web/src/features/safenet-checks/components/__tests__/SafenetChecksSection.test.tsx
+++ b/apps/web/src/features/safenet-checks/components/__tests__/SafenetChecksSection.test.tsx
@@ -61,7 +61,7 @@ describe('SafenetChecksSection', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('never subscribes before the submission time is known (shared cache aims by the last args)', () => {
+  it('never subscribes before the submission time is known (nothing else aims the shared read)', () => {
     mockUseSafenetCheck.mockReturnValue(buildCheckView())
 
     const { container } = renderInFlow({ txId: TX_ID })

--- a/apps/web/src/features/safenet-checks/components/__tests__/SafenetChecksSection.test.tsx
+++ b/apps/web/src/features/safenet-checks/components/__tests__/SafenetChecksSection.test.tsx
@@ -83,7 +83,11 @@ describe('SafenetChecksSection', () => {
   })
 
   it('renders the no-check copy when no check was requested', () => {
-    const snapshot = buildSnapshot({ safeTxHash: HASH as `0x${string}`, status: CheckStatus.UNAVAILABLE })
+    const snapshot = buildSnapshot({
+      safeTxHash: HASH as `0x${string}`,
+      status: CheckStatus.UNAVAILABLE,
+      windowCoverage: 'proven',
+    })
     mockUseSafenetCheck.mockReturnValue(
       buildCheckView({
         snapshot,
@@ -99,6 +103,30 @@ describe('SafenetChecksSection', () => {
     expect(section).toHaveAttribute('data-reason', 'NO_CHECK')
     expect(section).toHaveTextContent('Not checked')
     expect(section).toHaveTextContent('No Safenet check was requested for this transaction.')
+  })
+
+  it('never claims an absent check when the read window could not cover one', () => {
+    const snapshot = buildSnapshot({
+      safeTxHash: HASH as `0x${string}`,
+      status: CheckStatus.UNAVAILABLE,
+      windowCoverage: 'heuristic',
+    })
+    mockUseSafenetCheck.mockReturnValue(
+      buildCheckView({
+        snapshot,
+        status: CheckStatus.UNAVAILABLE,
+        publicStatus: CheckStatus.UNAVAILABLE,
+        unavailableReason: 'WINDOW_UNCERTAIN',
+      }),
+    )
+
+    renderInFlow({ txId: TX_ID, txDetails })
+
+    const section = screen.getByTestId('safenet-checks-section')
+    expect(section).toHaveAttribute('data-reason', 'WINDOW_UNCERTAIN')
+    expect(section).toHaveTextContent('Status unavailable')
+    expect(section).toHaveTextContent('The Safenet check status could not be read. Retry later.')
+    expect(section).not.toHaveTextContent('No Safenet check was requested')
   })
 
   it('renders the read-failed copy when the status could not be read', () => {

--- a/apps/web/src/features/safenet-checks/statusPresentation.ts
+++ b/apps/web/src/features/safenet-checks/statusPresentation.ts
@@ -45,20 +45,28 @@ export const STATUS_PRESENTATION: Record<
   },
 }
 
+/** The shared "we do not know" state — a failed read and an inconclusive one. */
+const STATUS_UNKNOWN: Pick<SafenetStatusPresentation, 'label' | 'copy'> = {
+  label: 'Status unavailable',
+  copy: 'The Safenet check status could not be read. Retry later.',
+}
+
 /**
- * Neither UNAVAILABLE meaning is a verdict, so both stay neutral: a muted icon
- * and the default text colors, never error or warning ones. No severity field:
- * these states have no verdict to color from.
+ * None of the three UNAVAILABLE meanings is a verdict, so all stay neutral: a
+ * muted icon and the default text colors, never error or warning ones. No
+ * severity field: these states have no verdict to color from.
  */
 export const UNAVAILABLE_PRESENTATION: Record<UnavailableReason, Pick<SafenetStatusPresentation, 'label' | 'copy'>> = {
   NO_CHECK: {
     label: 'Not checked',
     copy: 'No Safenet check was requested for this transaction.',
   },
-  READ_FAILED: {
-    label: 'Status unavailable',
-    copy: 'The Safenet check status could not be read. Retry later.',
-  },
+  READ_FAILED: STATUS_UNKNOWN,
+  // A read over a window that cannot cover the check's lifetime found nothing
+  // where it looked; it did not establish that nothing is there. That is the
+  // same "unknown" a failed read reports, so it gets the same copy — never the
+  // definite "no check was requested", and never an error tone.
+  WINDOW_UNCERTAIN: STATUS_UNKNOWN,
 }
 
 /** Section heading for every verdict: the state itself is in the copy. */

--- a/packages/store/src/safenet/__tests__/safenetAimRegistry.test.ts
+++ b/packages/store/src/safenet/__tests__/safenetAimRegistry.test.ts
@@ -1,0 +1,81 @@
+import { forgetAim, recordAim, resolveAim } from '../safenetAimRegistry'
+
+const HASH = ('0x' + 'ab'.repeat(32)) as `0x${string}`
+const SAFE = '0x0000000000000000000000000000000000000abc'
+const IDENTITY = { safeTxHash: HASH, chainId: '100', safeAddress: SAFE }
+
+/** A transaction's submission date, and a later surrogate a surface might offer. */
+const PROPOSED_AT = 1_700_000_000_000
+const LATER_OFFER = PROPOSED_AT + 3_600_000
+
+beforeEach(() => {
+  forgetAim(IDENTITY)
+  forgetAim({ ...IDENTITY, chainId: '1' })
+})
+
+describe('safenet aim registry', () => {
+  it('has no aim for a check nothing has offered one for', () => {
+    expect(resolveAim(IDENTITY)).toBeNull()
+  })
+
+  it('keeps the earliest offer, whichever order the surfaces offer in', () => {
+    // The read looks for events emitted at or after the submission, so an offer
+    // later than it can only narrow the window past them.
+    expect(recordAim(IDENTITY, LATER_OFFER)).toBe(LATER_OFFER)
+    expect(recordAim(IDENTITY, PROPOSED_AT)).toBe(PROPOSED_AT)
+    expect(resolveAim(IDENTITY)).toBe(PROPOSED_AT)
+
+    forgetAim(IDENTITY)
+
+    expect(recordAim(IDENTITY, PROPOSED_AT)).toBe(PROPOSED_AT)
+    expect(recordAim(IDENTITY, LATER_OFFER)).toBe(PROPOSED_AT)
+    expect(resolveAim(IDENTITY)).toBe(PROPOSED_AT)
+  })
+
+  it('is idempotent — repeating an offer never moves the aim', () => {
+    recordAim(IDENTITY, PROPOSED_AT)
+
+    expect(recordAim(IDENTITY, PROPOSED_AT)).toBe(PROPOSED_AT)
+    expect(resolveAim(IDENTITY)).toBe(PROPOSED_AT)
+  })
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['zero', 0],
+  ])('ignores a %s offer instead of aiming at it', (_label, timestampMs) => {
+    expect(recordAim(IDENTITY, timestampMs)).toBeNull()
+    expect(resolveAim(IDENTITY)).toBeNull()
+  })
+
+  it('keeps an established aim when a later offer is unusable', () => {
+    recordAim(IDENTITY, PROPOSED_AT)
+
+    expect(recordAim(IDENTITY, null)).toBe(PROPOSED_AT)
+    expect(resolveAim(IDENTITY)).toBe(PROPOSED_AT)
+  })
+
+  it('keys the aim by the Safe as well as the hash', () => {
+    // Safe <=1.2.0 leaves the chain id out of its domain, so one hash can name
+    // a check on two chains. They are two checks with two submission times.
+    recordAim(IDENTITY, PROPOSED_AT)
+
+    expect(resolveAim({ ...IDENTITY, chainId: '1' })).toBeNull()
+  })
+
+  it('matches the Safe address case-insensitively', () => {
+    recordAim(IDENTITY, PROPOSED_AT)
+
+    expect(resolveAim({ ...IDENTITY, safeAddress: SAFE.toUpperCase().replace('0X', '0x') })).toBe(PROPOSED_AT)
+  })
+
+  it('forgets an aim so a later mount rebuilds it from its own offer', () => {
+    recordAim(IDENTITY, PROPOSED_AT)
+    forgetAim(IDENTITY)
+
+    expect(resolveAim(IDENTITY)).toBeNull()
+    expect(recordAim(IDENTITY, LATER_OFFER)).toBe(LATER_OFFER)
+  })
+})

--- a/packages/store/src/safenet/__tests__/safenetCheckApi.test.ts
+++ b/packages/store/src/safenet/__tests__/safenetCheckApi.test.ts
@@ -54,6 +54,7 @@ const baseRead = (over: Partial<CheckReadResult> = {}): CheckReadResult => ({
   epoch: null,
   oracle: null,
   deadlineBlock: null,
+  windowCoverage: 'heuristic',
   ...over,
 })
 
@@ -423,6 +424,19 @@ describe('safenetCheckApi.getSafenetCheck', () => {
 
       expect(resolveAim(IDENTITY)).toBeNull()
     })
+
+    it.each(['proven', 'heuristic'] as const)(
+      'carries the read`s %s window coverage onto the snapshot',
+      async (coverage) => {
+        // The snapshot is where the reader's honesty about its window reaches the
+        // presentation layer; dropping it here would restore the false claim.
+        fakeReader.fetchCheckState.mockResolvedValue(baseRead({ windowCoverage: coverage }))
+
+        const result = await runQuery(makeTestStore())
+
+        expect(result.data?.windowCoverage).toBe(coverage)
+      },
+    )
   })
 
   describe('attestation selection', () => {

--- a/packages/store/src/safenet/__tests__/safenetCheckApi.test.ts
+++ b/packages/store/src/safenet/__tests__/safenetCheckApi.test.ts
@@ -16,6 +16,7 @@ import {
   requestCreatedEvent,
 } from '@safe-global/utils/features/safenet-checks/builders'
 import { safenetCheckApi } from '../safenetCheckApi'
+import { forgetAim, recordAim, resolveAim } from '../safenetAimRegistry'
 import {
   pinVerdict,
   safenetCheckSlice,
@@ -40,6 +41,7 @@ const SAFE = '0x0000000000000000000000000000000000000abc'
 const TARGET = { chainId: CHAIN_ID, safeAddress: SAFE }
 /** Attested-event fields that bind an attestation to the Safe under test. */
 const BOUND = { chainId: CHAIN_ID, safe: SAFE }
+const IDENTITY = { safeTxHash: HASH, ...TARGET }
 
 const fakeReader = { fetchCheckState: jest.fn(), verifyAttestation: jest.fn(), blockTimeMs: jest.fn() }
 
@@ -72,12 +74,24 @@ const runQuery = (store: ReturnType<typeof makeTestStore>, over: Partial<CheckTa
     ),
   )
 
+/**
+ * Let a cache-entry lifecycle handler's continuation run. The tick queue drains
+ * ahead of pending microtasks, so this waits on the event loop, not the clock.
+ */
+const flushLifecycle = (): Promise<void> => {
+  const { promise, resolve } = Promise.withResolvers<void>()
+  process.nextTick(resolve)
+  return promise
+}
+
 beforeEach(() => {
   fakeReader.fetchCheckState.mockReset()
   fakeReader.verifyAttestation.mockReset()
   fakeReader.blockTimeMs.mockReset()
   fakeReader.blockTimeMs.mockResolvedValue(null)
   mockedGetReader.mockReturnValue(fakeReader as unknown as ReturnType<typeof getSafenetReader>)
+  forgetAim(IDENTITY)
+  forgetAim({ ...IDENTITY, chainId: '1' })
 })
 
 describe('safenetCheckApi.getSafenetCheck', () => {
@@ -326,32 +340,89 @@ describe('safenetCheckApi.getSafenetCheck', () => {
     expect(pins).toHaveLength(1)
   })
 
-  it('forwards timestampMs so the reader can aim its block window', async () => {
-    fakeReader.fetchCheckState.mockResolvedValue(baseRead())
-    const store = makeTestStore()
+  describe('block window aim', () => {
+    // Every shipped surface offers the transaction's submission date, so the
+    // fold is exercised here with a hypothetical later surrogate: the read looks
+    // for events emitted at or after the submission, so only the earliest may aim it.
+    const PROPOSED_AT = 1_700_000_000_000
+    const LATER_OFFER = PROPOSED_AT + 3_600_000
 
-    await store.dispatch(
-      safenetCheckApi.endpoints.getSafenetCheck.initiate({
-        safeTxHash: HASH,
-        ...TARGET,
-        timestampMs: 1_700_000_000_000,
-      }),
-    )
+    it('aims the read at the registered submission time', async () => {
+      fakeReader.fetchCheckState.mockResolvedValue(baseRead())
+      recordAim(IDENTITY, PROPOSED_AT)
 
-    expect(fakeReader.fetchCheckState).toHaveBeenCalledWith(HASH, { timestampMs: 1_700_000_000_000 })
-  })
+      const result = await runQuery(makeTestStore())
 
-  it('keeps ONE cache entry per check however the timestamp varies (single poll loop)', async () => {
-    fakeReader.fetchCheckState.mockResolvedValue(baseRead())
-    const store = makeTestStore()
+      expect(fakeReader.fetchCheckState).toHaveBeenCalledWith(HASH, { timestampMs: PROPOSED_AT })
+      expect(result.data?.aimedAtMs).toBe(PROPOSED_AT)
+    })
 
-    const args = { safeTxHash: HASH, ...TARGET }
-    await store.dispatch(safenetCheckApi.endpoints.getSafenetCheck.initiate({ ...args, timestampMs: 1_000 }))
-    await store.dispatch(safenetCheckApi.endpoints.getSafenetCheck.initiate({ ...args, timestampMs: 2_000 }))
+    it('scans head-relative when no surface has offered a submission time', async () => {
+      fakeReader.fetchCheckState.mockResolvedValue(baseRead())
 
-    const queries = store.getState()[safenetCheckApi.reducerPath].queries
-    expect(Object.keys(queries)).toHaveLength(1)
-    expect(fakeReader.fetchCheckState).toHaveBeenCalledTimes(1)
+      const result = await runQuery(makeTestStore())
+
+      expect(fakeReader.fetchCheckState).toHaveBeenCalledWith(HASH, { timestampMs: null })
+      expect(result.data?.aimedAtMs).toBeNull()
+    })
+
+    it('keeps ONE cache entry and one read for a check every surface shares', async () => {
+      fakeReader.fetchCheckState.mockResolvedValue(baseRead())
+      const store = makeTestStore()
+
+      recordAim(IDENTITY, LATER_OFFER)
+      await store.dispatch(safenetCheckApi.endpoints.getSafenetCheck.initiate(IDENTITY))
+      recordAim(IDENTITY, PROPOSED_AT)
+      await store.dispatch(safenetCheckApi.endpoints.getSafenetCheck.initiate(IDENTITY))
+
+      expect(Object.keys(store.getState()[safenetCheckApi.reducerPath].queries)).toHaveLength(1)
+      expect(fakeReader.fetchCheckState).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not let the surface that subscribed first aim every later read', async () => {
+      // A worse-aimed surface lands first and a better-aimed one follows. Every
+      // read after the better offer uses it.
+      fakeReader.fetchCheckState.mockResolvedValue(baseRead())
+      const store = makeTestStore()
+
+      recordAim(IDENTITY, LATER_OFFER)
+      await runQuery(store)
+      expect(fakeReader.fetchCheckState).toHaveBeenLastCalledWith(HASH, { timestampMs: LATER_OFFER })
+
+      recordAim(IDENTITY, PROPOSED_AT)
+      const reaimed = await runQuery(store)
+
+      expect(fakeReader.fetchCheckState).toHaveBeenLastCalledWith(HASH, { timestampMs: PROPOSED_AT })
+      expect(reaimed.data?.aimedAtMs).toBe(PROPOSED_AT)
+    })
+
+    it('replays the best aim on every poll, never one read`s own arguments', async () => {
+      fakeReader.fetchCheckState.mockResolvedValue(baseRead())
+      const store = makeTestStore()
+      recordAim(IDENTITY, LATER_OFFER)
+      recordAim(IDENTITY, PROPOSED_AT)
+
+      await runQuery(store)
+      await runQuery(store)
+      await runQuery(store)
+
+      expect(fakeReader.fetchCheckState).toHaveBeenCalledTimes(3)
+      for (const call of fakeReader.fetchCheckState.mock.calls) {
+        expect(call[1]).toEqual({ timestampMs: PROPOSED_AT })
+      }
+    })
+
+    it('forgets the aim once the cache entry is gone', async () => {
+      fakeReader.fetchCheckState.mockResolvedValue(baseRead())
+      const store = makeTestStore()
+      recordAim(IDENTITY, PROPOSED_AT)
+      await store.dispatch(safenetCheckApi.endpoints.getSafenetCheck.initiate(IDENTITY))
+
+      store.dispatch(safenetCheckApi.util.resetApiState())
+      await flushLifecycle()
+
+      expect(resolveAim(IDENTITY)).toBeNull()
+    })
   })
 
   describe('attestation selection', () => {

--- a/packages/store/src/safenet/safenetAimRegistry.ts
+++ b/packages/store/src/safenet/safenetAimRegistry.ts
@@ -1,0 +1,50 @@
+import { checkKey, type CheckIdentity } from './safenetCheckSlice'
+
+/**
+ * The submission time each check's block window is aimed at: the earliest
+ * timestamp any surface has offered for that check.
+ *
+ * Every surface rendering one check shares a single cache entry and a single
+ * poll loop, so exactly one timestamp can aim the read. RTK Query replays the
+ * arguments of the fetch that created the entry, so without a canonical rule
+ * the surface that mounted first would aim every later poll. Every shipped
+ * surface offers the transaction's submission date today, which makes the fold
+ * a no-op; the rule is here so a surface offering a later surrogate cannot pin
+ * a worse aim. Earliest wins because the events the read looks for are emitted
+ * at or after the submission.
+ *
+ * Deliberately not a Redux slice: nothing renders from it, it must never be
+ * persisted, and {@link recordAim} has to answer "what is the aim now" inside a
+ * render pass, which a dispatch cannot. The `getSafenetCheck` endpoint forgets
+ * an aim when its cache entry is evicted; an aim recorded by a render React
+ * discarded before commit has no entry to be forgotten with, so it stays for
+ * the session — one bounded Map entry per check rendered, freed on unload, and
+ * always in the safe direction, since a leaked aim can only be earlier.
+ */
+const aims = new Map<string, number>()
+
+const isUsableAim = (timestampMs: number | null | undefined): timestampMs is number =>
+  timestampMs != null && Number.isFinite(timestampMs) && timestampMs > 0
+
+/**
+ * Offer a submission time for a check and return the aim every read of it now
+ * uses, or null when no surface has offered a usable one. Idempotent: the
+ * registry keeps the minimum, so repeating an offer, or making a later one,
+ * changes nothing.
+ */
+export const recordAim = (identity: CheckIdentity, timestampMs: number | null | undefined): number | null => {
+  const key = checkKey(identity)
+  const current = aims.get(key)
+  if (!isUsableAim(timestampMs)) return current ?? null
+  if (current !== undefined && current <= timestampMs) return current
+  aims.set(key, timestampMs)
+  return timestampMs
+}
+
+/** The aim a read of this check must use, or null when none was ever offered. */
+export const resolveAim = (identity: CheckIdentity): number | null => aims.get(checkKey(identity)) ?? null
+
+/** Drop a check's aim. The next subscriber rebuilds it from its own offer. */
+export const forgetAim = (identity: CheckIdentity): void => {
+  aims.delete(checkKey(identity))
+}

--- a/packages/store/src/safenet/safenetCheckApi.ts
+++ b/packages/store/src/safenet/safenetCheckApi.ts
@@ -115,6 +115,7 @@ export const safenetCheckApi = createApi({
             attestation,
             attestedAtMs,
             aimedAtMs,
+            windowCoverage: read.windowCoverage,
             events,
           }
           return { data: snapshot }

--- a/packages/store/src/safenet/safenetCheckApi.ts
+++ b/packages/store/src/safenet/safenetCheckApi.ts
@@ -9,11 +9,17 @@ import {
   mergeMonotonic,
   type AttestationVerification,
   type AttestedCheckEvent,
-  type CheckTarget,
   type SafenetCheckSnapshot,
   type SafenetReader,
 } from '@safe-global/utils/features/safenet-checks'
-import { checkKey, pinVerdict, selectPinnedVerdict, type SafenetCheckPartialState } from './safenetCheckSlice'
+import {
+  checkKey,
+  pinVerdict,
+  selectPinnedVerdict,
+  type CheckIdentity,
+  type SafenetCheckPartialState,
+} from './safenetCheckSlice'
+import { forgetAim, resolveAim } from './safenetAimRegistry'
 
 /**
  * Standalone chain-reading API for Safenet checks — no HTTP endpoint, the work
@@ -57,27 +63,24 @@ const selectAttestation = async (
 
 /**
  * `chainId` and `safeAddress` are the Safe the check is being viewed for; an
- * attestation that does not name them is not this check's evidence.
- * `timestampMs` is when the Safe transaction was submitted (proposal time, not
- * execution time — checks are proposed around the first signature) and only
- * aims the reader's block window. All callers of one check share a cache entry,
- * so the semantic has to stay canonical. See `serializeQueryArgs` below.
+ * attestation that does not name them is not this check's evidence. There is
+ * deliberately no timestamp here: every surface rendering one check shares this
+ * entry, so the read window is aimed through the aim registry, which keeps the
+ * earliest submission time any surface offered.
  */
-export type SafenetCheckArg = CheckTarget & {
-  safeTxHash: string
-  timestampMs?: number | null
-}
-
 export const safenetCheckApi = createApi({
   reducerPath: 'safenetCheckApi',
   baseQuery: noopBaseQuery,
   endpoints: (builder) => ({
-    getSafenetCheck: builder.query<SafenetCheckSnapshot, SafenetCheckArg>({
-      async queryFn({ safeTxHash, chainId, safeAddress, timestampMs }, { getState, dispatch }) {
-        const identity = { safeTxHash, chainId, safeAddress }
+    getSafenetCheck: builder.query<SafenetCheckSnapshot, CheckIdentity>({
+      async queryFn(identity, { getState, dispatch }) {
+        const { safeTxHash, chainId, safeAddress } = identity
         try {
           const reader = getSafenetReader()
-          const read = await reader.fetchCheckState(safeTxHash, { timestampMs })
+          // Read at execution time, so every poll replays the best aim known
+          // then — never the timestamp of whichever surface subscribed first.
+          const aimedAtMs = resolveAim(identity)
+          const read = await reader.fetchCheckState(safeTxHash, { timestampMs: aimedAtMs })
 
           const { events, candidates } = bindAttestations(read.events, { chainId, safeAddress })
           const selected = await selectAttestation(reader, candidates)
@@ -111,6 +114,7 @@ export const safenetCheckApi = createApi({
             headBlock: read.headBlock,
             attestation,
             attestedAtMs,
+            aimedAtMs,
             events,
           }
           return { data: snapshot }
@@ -119,10 +123,18 @@ export const safenetCheckApi = createApi({
           return { error: { message: error instanceof Error ? error.message : String(error) } }
         }
       },
-      // `timestampMs` only aims the block window — the check's identity is the
-      // Safe plus the hash. Without this, two renderings of the same check with
-      // different timestamps would open a second cache entry and a second poll loop.
+      // The check's identity is the Safe plus the hash, and `checkKey`
+      // normalizes the Safe address case, so two spellings of one Safe cannot
+      // open two entries and two poll loops.
       serializeQueryArgs: ({ endpointName, queryArgs }) => `${endpointName}(${checkKey(queryArgs)})`,
+      // Frees the aim with the entry it aims: once the last subscriber is gone
+      // and the entry is evicted, a later mount rebuilds the aim from its own
+      // offer. Not exact parity — an aim recorded by a discarded render never
+      // opened an entry, so nothing forgets it (see the registry doc).
+      async onCacheEntryAdded(identity, { cacheEntryRemoved }) {
+        await cacheEntryRemoved
+        forgetAim(identity)
+      },
       keepUnusedDataFor: 300,
     }),
   }),

--- a/packages/utils/src/features/safenet-checks/builders/snapshot.ts
+++ b/packages/utils/src/features/safenet-checks/builders/snapshot.ts
@@ -21,6 +21,7 @@ export const buildSnapshot = (over: Partial<SafenetCheckSnapshot> = {}): Safenet
   headBlock: null,
   attestation: UNVERIFIED_ATTESTATION,
   attestedAtMs: null,
+  aimedAtMs: null,
   events: [],
   ...over,
 })

--- a/packages/utils/src/features/safenet-checks/builders/snapshot.ts
+++ b/packages/utils/src/features/safenet-checks/builders/snapshot.ts
@@ -22,6 +22,9 @@ export const buildSnapshot = (over: Partial<SafenetCheckSnapshot> = {}): Safenet
   attestation: UNVERIFIED_ATTESTATION,
   attestedAtMs: null,
   aimedAtMs: null,
+  // The claim-gated default: a test asserting NO_CHECK must state the coverage
+  // that licenses it.
+  windowCoverage: 'heuristic',
   events: [],
   ...over,
 })

--- a/packages/utils/src/features/safenet-checks/hooks/__tests__/useSafenetCheck.test.ts
+++ b/packages/utils/src/features/safenet-checks/hooks/__tests__/useSafenetCheck.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react'
 import { useSelector } from 'react-redux'
 import { useGetSafenetCheckQuery } from '@safe-global/store/safenet/safenetCheckApi'
 import type { PinnedVerdict } from '@safe-global/store/safenet/safenetCheckSlice'
+import { forgetAim, recordAim, resolveAim } from '@safe-global/store/safenet/safenetAimRegistry'
 import { useSafenetCheck } from '../useSafenetCheck'
 import {
   ARBITRATION_POLL_MS,
@@ -24,6 +25,10 @@ const mockSelector = useSelector as unknown as jest.Mock
 
 const HASH = ('0x' + 'ab'.repeat(32)) as `0x${string}`
 const TARGET = { chainId: '100', safeAddress: '0x0000000000000000000000000000000000000abc' }
+const OTHER_HASH = ('0x' + 'cd'.repeat(32)) as `0x${string}`
+/** A transaction's submission date, and a later surrogate a surface might offer. */
+const PROPOSED_AT = 1_700_000_000_000
+const LATER_OFFER = PROPOSED_AT + 3_600_000
 
 /** The slice of the RTK query result the hook consumes, as the mock returns it. */
 type QueryResult = {
@@ -57,6 +62,10 @@ beforeEach(() => {
   mockSelector.mockReset()
   refetchFn.mockReset()
   mockSelector.mockReturnValue(undefined)
+  // The aim registry is module state shared by every surface, so one test's
+  // offer would aim the next test's read.
+  forgetAim({ safeTxHash: HASH, ...TARGET })
+  forgetAim({ safeTxHash: OTHER_HASH, ...TARGET })
 })
 
 describe('useSafenetCheck', () => {
@@ -65,16 +74,105 @@ describe('useSafenetCheck', () => {
 
     renderHook(() => useSafenetCheck(undefined, null, TARGET))
 
-    expect(mockQuery.mock.calls[0][0]).toEqual({ safeTxHash: '', timestampMs: null, ...TARGET })
+    expect(mockQuery.mock.calls[0][0]).toEqual({ safeTxHash: '', ...TARGET })
     expect(mockQuery.mock.calls[0][1]).toMatchObject({ skip: true })
   })
 
-  it('passes the transaction timestamp through so the reader can target its block window', () => {
-    mockQuery.mockReturnValue(queryResult())
+  describe('block window aim', () => {
+    it('offers the submission time to the registry instead of the query arguments', () => {
+      mockQuery.mockReturnValue(queryResult())
 
-    renderHook(() => useSafenetCheck('0xabc', 1_700_000_000_000, TARGET))
+      renderHook(() => useSafenetCheck(HASH, PROPOSED_AT, TARGET))
 
-    expect(mockQuery.mock.calls[0][0]).toEqual({ safeTxHash: '0xabc', timestampMs: 1_700_000_000_000, ...TARGET })
+      // The timestamp is not part of the check's identity, so it must not reach
+      // the arguments the cache entry is keyed from.
+      expect(mockQuery.mock.calls[0][0]).toEqual({ safeTxHash: HASH, ...TARGET })
+      expect(resolveAim({ safeTxHash: HASH, ...TARGET })).toBe(PROPOSED_AT)
+    })
+
+    it('offers nothing while the Safe context is unresolved', () => {
+      mockQuery.mockReturnValue(queryResult())
+
+      renderHook(() => useSafenetCheck(HASH, PROPOSED_AT, { chainId: '', safeAddress: '' }))
+
+      expect(resolveAim({ safeTxHash: HASH, ...TARGET })).toBeNull()
+    })
+
+    it('re-aims the shared read exactly once when a surface knows an earlier time', () => {
+      // One surface mounts first with a later surrogate and its read lands.
+      // A second surface then mounts with the submission date.
+      const aimedWorse = buildSnapshot({ safeTxHash: HASH, aimedAtMs: LATER_OFFER })
+      mockQuery.mockReturnValue(queryResult({ data: aimedWorse }))
+      const queueRow = renderHook(() => useSafenetCheck(HASH, LATER_OFFER, TARGET))
+      expect(refetchFn).not.toHaveBeenCalled()
+
+      const flow = renderHook(() => useSafenetCheck(HASH, PROPOSED_AT, TARGET))
+
+      expect(refetchFn).toHaveBeenCalledTimes(1)
+
+      // The refetch puts the shared entry in flight, and that is what stops the
+      // other surface stacking a second read on the same improved aim.
+      mockQuery.mockReturnValue(queryResult({ data: aimedWorse, isFetching: true }))
+      flow.rerender()
+      queueRow.rerender()
+      expect(refetchFn).toHaveBeenCalledTimes(1)
+
+      // The re-aimed read lands and settles the loop.
+      mockQuery.mockReturnValue(queryResult({ data: buildSnapshot({ safeTxHash: HASH, aimedAtMs: PROPOSED_AT }) }))
+      flow.rerender()
+      queueRow.rerender()
+
+      expect(refetchFn).toHaveBeenCalledTimes(1)
+    })
+
+    it('never re-aims for a surface offering a later time', () => {
+      mockQuery.mockReturnValue(queryResult({ data: buildSnapshot({ safeTxHash: HASH, aimedAtMs: PROPOSED_AT }) }))
+      renderHook(() => useSafenetCheck(HASH, PROPOSED_AT, TARGET))
+
+      renderHook(() => useSafenetCheck(HASH, LATER_OFFER, TARGET))
+
+      expect(refetchFn).not.toHaveBeenCalled()
+      expect(resolveAim({ safeTxHash: HASH, ...TARGET })).toBe(PROPOSED_AT)
+    })
+
+    it('waits for the read in flight instead of stacking a second one', () => {
+      recordAim({ safeTxHash: HASH, ...TARGET }, PROPOSED_AT)
+      mockQuery.mockReturnValue(
+        queryResult({ data: buildSnapshot({ safeTxHash: HASH, aimedAtMs: LATER_OFFER }), isFetching: true }),
+      )
+
+      renderHook(() => useSafenetCheck(HASH, PROPOSED_AT, TARGET))
+
+      expect(refetchFn).not.toHaveBeenCalled()
+    })
+
+    it('does not re-aim before the first read has produced a snapshot', () => {
+      mockQuery.mockReturnValue(queryResult({ isLoading: true, isFetching: true }))
+
+      renderHook(() => useSafenetCheck(HASH, PROPOSED_AT, TARGET))
+
+      expect(refetchFn).not.toHaveBeenCalled()
+    })
+
+    it('anchors the UNAVAILABLE grace window on the earliest offer, not this surface`s', () => {
+      jest.useFakeTimers()
+      // The queue row offers a timestamp one hour later than the proposal. The
+      // grace window is 10 minutes wide, so aiming it at the summary timestamp
+      // would keep polling a check-less transaction an hour past its close.
+      jest.setSystemTime(PROPOSED_AT + UNAVAILABLE_GRACE_MS + 1_000)
+      recordAim({ safeTxHash: HASH, ...TARGET }, PROPOSED_AT)
+      mockQuery.mockReturnValue(
+        queryResult({
+          data: buildSnapshot({ safeTxHash: HASH, status: CheckStatus.UNAVAILABLE, aimedAtMs: PROPOSED_AT }),
+          fulfilledTimeStamp: 1,
+        }),
+      )
+
+      renderHook(() => useSafenetCheck(HASH, LATER_OFFER, TARGET))
+
+      expect(lastOptions().pollingInterval).toBe(0)
+      jest.useRealTimers()
+    })
   })
 
   describe('Safe context gating', () => {

--- a/packages/utils/src/features/safenet-checks/hooks/__tests__/useSafenetCheck.test.ts
+++ b/packages/utils/src/features/safenet-checks/hooks/__tests__/useSafenetCheck.test.ts
@@ -270,7 +270,9 @@ describe('useSafenetCheck', () => {
 
     afterEach(() => jest.useRealTimers())
 
-    const noCheck = () => buildSnapshot({ safeTxHash: HASH, status: CheckStatus.UNAVAILABLE })
+    // A read aimed from the submission time that reached the head: the empty
+    // result is the real "no check yet" the grace window exists for.
+    const noCheck = () => buildSnapshot({ safeTxHash: HASH, status: CheckStatus.UNAVAILABLE, windowCoverage: 'proven' })
 
     it('keeps polling slowly while the check request may still be mining', () => {
       jest.useFakeTimers()
@@ -393,14 +395,25 @@ describe('useSafenetCheck', () => {
   })
 
   describe('unavailable reason', () => {
-    it('reports NO_CHECK when a snapshot says no check was ever requested', () => {
-      mockQuery.mockReturnValue(
-        queryResult({ data: buildSnapshot({ safeTxHash: HASH, status: CheckStatus.UNAVAILABLE }) }),
-      )
+    const emptyRead = (windowCoverage: 'proven' | 'heuristic') =>
+      buildSnapshot({ safeTxHash: HASH, status: CheckStatus.UNAVAILABLE, windowCoverage })
+
+    it('reports NO_CHECK when a window covering the whole lifetime found nothing', () => {
+      mockQuery.mockReturnValue(queryResult({ data: emptyRead('proven') }))
 
       const { result } = renderHook(() => useSafenetCheck(HASH, null, TARGET))
 
       expect(result.current.unavailableReason).toBe('NO_CHECK')
+    })
+
+    it('reports WINDOW_UNCERTAIN when the empty read cannot support the claim', () => {
+      // The window was head-relative, mis-estimated, or ended short of the head.
+      // Nothing found there is not the same statement as nothing existing.
+      mockQuery.mockReturnValue(queryResult({ data: emptyRead('heuristic') }))
+
+      const { result } = renderHook(() => useSafenetCheck(HASH, null, TARGET))
+
+      expect(result.current.unavailableReason).toBe('WINDOW_UNCERTAIN')
     })
 
     it('reports READ_FAILED when the read failed with nothing to show', () => {
@@ -420,18 +433,16 @@ describe('useSafenetCheck', () => {
       expect(result.current.unavailableReason).toBeUndefined()
     })
 
-    it('keeps the retained snapshot as NO_CHECK when a refetch fails over it', () => {
-      mockQuery.mockReturnValue(
-        queryResult({
-          error: FETCH_ERROR,
-          data: buildSnapshot({ safeTxHash: HASH, status: CheckStatus.UNAVAILABLE }),
-        }),
-      )
+    it.each(['proven', 'heuristic'] as const)(
+      'keeps the retained %s-window snapshot`s reason when a refetch fails over it',
+      (coverage) => {
+        mockQuery.mockReturnValue(queryResult({ error: FETCH_ERROR, data: emptyRead(coverage) }))
 
-      const { result } = renderHook(() => useSafenetCheck(HASH, null, TARGET))
+        const { result } = renderHook(() => useSafenetCheck(HASH, null, TARGET))
 
-      expect(result.current.unavailableReason).toBe('NO_CHECK')
-    })
+        expect(result.current.unavailableReason).toBe(coverage === 'proven' ? 'NO_CHECK' : 'WINDOW_UNCERTAIN')
+      },
+    )
 
     it('reports no reason once a check is observed', () => {
       mockQuery.mockReturnValue(queryResult({ data: buildBenignSnapshot({ safeTxHash: HASH }) }))

--- a/packages/utils/src/features/safenet-checks/hooks/useSafenetCheck.ts
+++ b/packages/utils/src/features/safenet-checks/hooks/useSafenetCheck.ts
@@ -17,9 +17,8 @@ export type SafenetCheckView = {
   status: CheckStatus
   publicStatus: PublicCheckStatus
   /**
-   * Set only while the merged status is `UNAVAILABLE`: `NO_CHECK` when a
-   * snapshot says no check was ever requested, `READ_FAILED` when the read
-   * itself failed. `undefined` before the first read resolves.
+   * Set only while the merged status is `UNAVAILABLE` — see
+   * {@link UnavailableReason}. `undefined` before the first read resolves.
    */
   unavailableReason: UnavailableReason | undefined
   isLoading: boolean
@@ -27,6 +26,21 @@ export type SafenetCheckView = {
   /** Showing a retained snapshot because the latest fetch failed. */
   isStale: boolean
   refetch: () => void
+}
+
+/**
+ * Which `UNAVAILABLE` a resolved read means. `NO_CHECK` is a factual claim
+ * about the chain, so only a window that covers the check's whole possible
+ * lifetime licenses it; over any other window the read found nothing where it
+ * looked, which is a weaker statement. A snapshot outranks the error: an error
+ * over retained data is a failed refetch, and the snapshot is still what we know.
+ */
+const resolveUnavailableReason = (
+  snapshot: SafenetCheckSnapshot | undefined,
+  hasError: boolean,
+): UnavailableReason | undefined => {
+  if (snapshot !== undefined) return snapshot.windowCoverage === 'proven' ? 'NO_CHECK' : 'WINDOW_UNCERTAIN'
+  return hasError ? 'READ_FAILED' : undefined
 }
 
 /**
@@ -86,10 +100,8 @@ export const useSafenetCheck = (
   const status = mergeMonotonic(pinned?.status, base)
   const publicStatus = toPublicStatus(status)
 
-  // A snapshot outranks the error: an error over retained data is a failed
-  // refetch (isStale), and the retained snapshot is still what we know.
-  const unavailableReason: UnavailableReason | undefined =
-    status !== CheckStatus.UNAVAILABLE ? undefined : hasData ? 'NO_CHECK' : hasError ? 'READ_FAILED' : undefined
+  const unavailableReason =
+    status !== CheckStatus.UNAVAILABLE ? undefined : resolveUnavailableReason(snapshot, hasError)
 
   // Events are sorted ascending, so [0] substitutes for the deadline on the
   // plain path, which does not emit one.

--- a/packages/utils/src/features/safenet-checks/hooks/useSafenetCheck.ts
+++ b/packages/utils/src/features/safenet-checks/hooks/useSafenetCheck.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useGetSafenetCheckQuery } from '@safe-global/store/safenet/safenetCheckApi'
 import { selectPinnedVerdict, type SafenetCheckPartialState } from '@safe-global/store/safenet/safenetCheckSlice'
+import { recordAim } from '@safe-global/store/safenet/safenetAimRegistry'
 import { POLL_INTERVAL_FAST_MS, POLL_INTERVAL_LATE_MS } from '../constants'
 import { CheckStatus, toPublicStatus, type PublicCheckStatus, type UnavailableReason } from '../types/status'
 import type { SafenetCheckSnapshot } from '../types/snapshot'
@@ -33,10 +34,11 @@ export type SafenetCheckView = {
  * store's `getSafenetCheck` query with the dynamic poll interval, the merge
  * against the session-pinned verdict, and the stale/UNAVAILABLE error mapping.
  * Platform-neutral (no DOM access). `target` is the Safe being viewed, which
- * every attestation must name. `timestampMs` aims the reader's block window and
- * anchors the UNAVAILABLE grace window; pass the submission time when known.
- * Callers sharing one check must agree on supplying it — the cache keys by Safe
- * and hash, and the last fetch's args aim every later poll.
+ * every attestation must name. `timestampMs` is this surface's idea of the
+ * submission time: it is offered to the aim registry, which keeps the earliest
+ * offer and aims every read of this check with it. Surfaces therefore need not
+ * agree — a surface offering an earlier time re-aims the shared read once, and
+ * a later one changes nothing.
  */
 export const useSafenetCheck = (
   safeTxHash: string | undefined,
@@ -48,21 +50,24 @@ export const useSafenetCheck = (
   // block window and, once the real Safe lands, leave a second cache entry and
   // a second poll loop behind.
   const skip = !safeTxHash || !target.chainId || !target.safeAddress
+  const identity = { safeTxHash: safeTxHash ?? '', ...target }
+
+  // Offered during render, so the aim is in place before the query hook's
+  // subscription effect fires the first read. Repeating it is free and a render
+  // React discards costs nothing: the registry keeps the minimum of all offers.
+  const aim = skip ? null : recordAim(identity, timestampMs)
 
   // The interval feeds back into the query below, so the (status → interval →
   // next poll) loop is reconfigured from the query's own output via an effect.
   const [pollingInterval, setPollingInterval] = useState(POLL_INTERVAL_FAST_MS)
 
-  const query = useGetSafenetCheckQuery(
-    { safeTxHash: safeTxHash ?? '', timestampMs: timestampMs ?? null, ...target },
-    {
-      skip,
-      pollingInterval,
-      // No refetchOnFocus: a settled check does not change, and a history page
-      // would cost ~3 chain reads per row on every tab switch back.
-      skipPollingIfUnfocused: true,
-    },
-  )
+  const query = useGetSafenetCheckQuery(identity, {
+    skip,
+    pollingInterval,
+    // No refetchOnFocus: a settled check does not change, and a history page
+    // would cost ~3 chain reads per row on every tab switch back.
+    skipPollingIfUnfocused: true,
+  })
 
   const pinned = useSelector((state: SafenetCheckPartialState) =>
     safeTxHash && !skip ? selectPinnedVerdict(state, { safeTxHash, ...target }) : undefined,
@@ -108,7 +113,7 @@ export const useSafenetCheck = (
         headBlock: snapshot?.headBlock ?? null,
         deadlineBlock: snapshot?.deadlineBlock ?? null,
         firstEventBlock,
-        submittedAtMs: timestampMs ?? null,
+        submittedAtMs: aim,
         attestedAtMs: snapshot?.attestedAtMs ?? null,
         nowMs: Date.now(),
       }),
@@ -121,11 +126,20 @@ export const useSafenetCheck = (
     snapshot?.deadlineBlock,
     snapshot?.attestedAtMs,
     firstEventBlock,
-    timestampMs,
+    aim,
     fulfilledAt,
   ])
 
   const { refetch: queryRefetch } = query
+
+  // This surface offered a better aim than the snapshot was read with, so
+  // re-aim the shared entry. Exactly one refetch: the aim moves only when a
+  // surface offers an earlier time, and the refetch equalises the two.
+  useEffect(() => {
+    if (skip || query.isFetching || snapshot === undefined) return
+    if (snapshot.aimedAtMs !== aim) queryRefetch()
+  }, [skip, query.isFetching, snapshot, aim, queryRefetch])
+
   const refetch = useCallback(() => {
     if (!skip) queryRefetch()
   }, [skip, queryRefetch])

--- a/packages/utils/src/features/safenet-checks/services/__tests__/safenetReader.test.ts
+++ b/packages/utils/src/features/safenet-checks/services/__tests__/safenetReader.test.ts
@@ -2,6 +2,7 @@ import { setupServer, type SetupServerApi } from 'msw/node'
 import { SafenetReader, type SafenetReaderConfig } from '../safenetReader'
 import { CONSENSUS_TOPIC0S } from '../../abi'
 import { transactionProposalHash } from '../../utils/proposalHash'
+import { BLOCK_ESTIMATE_TOLERANCE_SECONDS } from '../../constants'
 import {
   resetLogCounter,
   buildOracleProposedLog,
@@ -618,6 +619,118 @@ describe('SafenetReader block targeting — estimate convergence', () => {
     const result = await makeReader().fetchCheckState(SAFE_TX_HASH, { timestampMs: 900_000 * 1000 })
 
     expect(result.events.map((event) => event.blockNumber)).toEqual([centre, 988_999])
+  })
+})
+
+describe('SafenetReader window coverage', () => {
+  // Head is block 1,000,000 at t=1,000,000s with 5s blocks (see the mock), so
+  // the aimed window spans 10,000 blocks ≈ 13.9h from 1,000 blocks back.
+  const recent = () => makeEndpoint({ url: 'http://rpc.test/1', head: 1_000_000, headTimestamp: 1_000_000, logs: [] })
+
+  it('proves an aimed window that still runs to the chain head', async () => {
+    const endpoint = recent()
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    // 1,000s old: the window starts before the transaction and ends at the head,
+    // so no block the check could live in went unread.
+    const result = await makeReader().fetchCheckState(SAFE_TX_HASH, { timestampMs: 999_000 * 1000 })
+
+    expect(consensusCalls(endpoint.getLogsCalls)[0].toBlock).toBe(1_000_000)
+    expect(result.windowCoverage).toBe('proven')
+  })
+
+  it('cannot prove an aimed window that ends short of the head', async () => {
+    const endpoint = recent()
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    // 100,000s old: the window closes at block 988,999 and the 11,001 blocks up
+    // to the head are never read, so a settlement could sit outside it.
+    const result = await makeReader().fetchCheckState(SAFE_TX_HASH, { timestampMs: 900_000 * 1000 })
+
+    expect(consensusCalls(endpoint.getLogsCalls)[0].toBlock).toBe(988_999)
+    expect(result.windowCoverage).toBe('heuristic')
+  })
+
+  it('cannot prove a head-relative scan — it is not tied to the transaction', async () => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 45_000, logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader().fetchCheckState(SAFE_TX_HASH)
+
+    expect(result.windowCoverage).toBe('heuristic')
+  })
+
+  it('cannot prove a window the block estimate never converged on', async () => {
+    const endpoint = makeEndpoint({
+      url: 'http://rpc.test/1',
+      head: 600_000,
+      timestampAt: (n) => (n <= 500_000 ? n : 10_000_000 + (n - 500_000) * 5),
+      logs: [],
+    })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader().fetchCheckState(SAFE_TX_HASH, { timestampMs: 5_000_000 * 1000 })
+
+    expect(result.windowCoverage).toBe('heuristic')
+  })
+
+  it('cannot prove a window placed without a usable block probe', async () => {
+    const endpoint = makeEndpoint({ url: 'http://rpc.test/1', head: 45_000, failBlockProbes: 'error', logs: [] })
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader().fetchCheckState(SAFE_TX_HASH, { timestampMs: 1_000 * 1000 })
+
+    expect(result.windowCoverage).toBe('heuristic')
+  })
+
+  // The estimate pins to the head for any target at or past it, and its drift is
+  // then the skew. A skew inside BLOCK_ESTIMATE_TOLERANCE_SECONDS therefore
+  // reads as "converged" — the boundary where a lagging head could otherwise
+  // license the confident claim over blocks the endpoint has not served.
+  it.each([
+    ['300s', 300],
+    ['exactly BLOCK_ESTIMATE_TOLERANCE_SECONDS', BLOCK_ESTIMATE_TOLERANCE_SECONDS],
+    ['30,000s', 30_000],
+  ])('cannot prove a window whose submission the head has not reached (%s ahead)', async (_label, lagSeconds) => {
+    const endpoint = recent()
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader().fetchCheckState(SAFE_TX_HASH, {
+      timestampMs: (1_000_000 + lagSeconds) * 1000,
+    })
+
+    // The window is pinned to the head and unchanged by the classification.
+    const calls = consensusCalls(endpoint.getLogsCalls)
+    expect(calls).toHaveLength(1)
+    expect([calls[0].fromBlock, calls[0].toBlock]).toEqual([999_000, 1_000_000])
+    expect(result.windowCoverage).toBe('heuristic')
+  })
+
+  // The mirror of the case above: the same separation between head and target,
+  // the other way round. A submission the chain has seen still proves its window.
+  it.each([
+    ['300s', 300],
+    ['exactly BLOCK_ESTIMATE_TOLERANCE_SECONDS', BLOCK_ESTIMATE_TOLERANCE_SECONDS],
+  ])('still proves a window whose submission the head has passed (%s behind)', async (_label, ageSeconds) => {
+    const endpoint = recent()
+    server = setupServer(endpoint.handler)
+    server.listen()
+
+    const result = await makeReader().fetchCheckState(SAFE_TX_HASH, {
+      timestampMs: (1_000_000 - ageSeconds) * 1000,
+    })
+
+    const calls = consensusCalls(endpoint.getLogsCalls)
+    expect(calls).toHaveLength(1)
+    // centre = head − ageSeconds/5, then 1,000 blocks back, clamped at the head.
+    expect([calls[0].fromBlock, calls[0].toBlock]).toEqual([1_000_000 - ageSeconds / 5 - 1_000, 1_000_000])
+    expect(result.windowCoverage).toBe('proven')
   })
 })
 

--- a/packages/utils/src/features/safenet-checks/services/safenetReader.ts
+++ b/packages/utils/src/features/safenet-checks/services/safenetReader.ts
@@ -23,6 +23,7 @@ import {
   type OracleAttestedEvent,
   type OracleProposedEvent,
   type PlainAttestedEvent,
+  type WindowCoverage,
 } from '../types'
 import { decodeLogs, type RawLog } from '../utils/decodeLogs'
 import { deadlineBlockOf } from '../utils/deriveCheckState'
@@ -49,6 +50,11 @@ export type CheckReadResult = {
   oracle: string | null
   /** Block the check times out at (the request's reveal deadline). */
   deadlineBlock: string | null
+  /**
+   * Whether the block window this read used covers the check's whole possible
+   * lifetime. An empty event set only proves the absence of a check when it does.
+   */
+  windowCoverage: WindowCoverage
 }
 
 export type SafenetReaderConfig = {
@@ -220,31 +226,57 @@ export class SafenetReader {
   /**
    * Choose the block range to read: a narrow window around the block matching
    * the transaction timestamp (constant cost at any age), or the head-relative
-   * scan when no timestamp is given or the estimate did not converge.
+   * scan when no timestamp is given or the estimate did not converge. Reports
+   * how much the chosen window can prove, since a caller that finds no events
+   * needs to know whether the window ever covered them.
    *
-   * Known limit: the targeted window ends ~12.5h after the transaction, so a
-   * later settlement reads TIMED_OUT rather than a BENIGN it cannot support.
+   * A targeted window reaches ~12.5h past the transaction, so it only covers a
+   * check's whole lifetime while it still runs to the chain head. Past that the
+   * read is a sample, and a later settlement can sit outside it.
    */
   private async readRange(
     provider: JsonRpcProvider,
     timestampMs: number | null | undefined,
     head: { number: number; timestamp: number },
-  ): Promise<{ fromBlock: number; toBlock: number }> {
-    const headRelative = { fromBlock: Math.max(0, head.number - MAX_LOOKBACK_BLOCKS + 1), toBlock: head.number }
+  ): Promise<{ fromBlock: number; toBlock: number; coverage: WindowCoverage }> {
+    const headRelative = {
+      fromBlock: Math.max(0, head.number - MAX_LOOKBACK_BLOCKS + 1),
+      toBlock: head.number,
+      // A fixed lookback is not tied to the transaction at all: it may start
+      // well after the submission and never reach it.
+      coverage: 'heuristic' as const,
+    }
     if (timestampMs == null || !Number.isFinite(timestampMs)) return headRelative
 
     const targetSeconds = Math.floor(timestampMs / 1000)
+    // Only a submission the chain has already seen can be located on it. Past
+    // the head the estimate pins to the head and its drift measures the skew,
+    // not the transaction's block, so such a window aims but proves nothing.
+    const seenByChain = targetSeconds < head.timestamp
     const { block: centre, driftSeconds } = await this.estimateBlockAt(provider, targetSeconds, head)
+    const converged = Math.abs(driftSeconds) <= BLOCK_ESTIMATE_TOLERANCE_SECONDS
     // Aim only when the estimate converged — converting leftover drift into a
-    // block budget needs a local cadence nothing here measures. A target at or
-    // past the head is the exception: the estimate is pinned to the head.
-    if (targetSeconds < head.timestamp && Math.abs(driftSeconds) > BLOCK_ESTIMATE_TOLERANCE_SECONDS) {
-      return headRelative
-    }
+    // block budget needs a local cadence nothing here measures. A target past
+    // the head is the exception: the head is still the best aim available.
+    if (seenByChain && !converged) return headRelative
 
     // One chunk wide, so a targeted read is always a single getLogs.
     const fromBlock = Math.max(0, centre - TARGETED_WINDOW_BACK_BLOCKS)
-    return { fromBlock, toBlock: Math.min(head.number, fromBlock + GETLOGS_CHUNK_BLOCKS - 1) }
+    const toBlock = Math.min(head.number, fromBlock + GETLOGS_CHUNK_BLOCKS - 1)
+    // ponytail: `proven` reads the aim as the submission time. Ceiling: the
+    // window only reaches TARGETED_WINDOW_BACK_BLOCKS (~1.4h) behind it, so an
+    // aim later than the real submission by more than that can miss the
+    // proposal and still report `proven`. No shipped surface can trigger it —
+    // every one offers the transaction's submission date (checked against CGW
+    // v1.122.0) — so the trigger is a future surface, or an upstream mapping
+    // change such as the queued summary timestamp becoming the modified date.
+    // Upgrade path: carry the aim's provenance so a surrogate timestamp cannot
+    // license the claim, or widen the backward reach.
+    return {
+      fromBlock,
+      toBlock,
+      coverage: seenByChain && converged && toBlock >= head.number ? 'proven' : 'heuristic',
+    }
   }
 
   /**
@@ -388,6 +420,7 @@ export class SafenetReader {
         epoch: active?.epoch ?? null,
         oracle: active?.oracle ?? null,
         deadlineBlock: deadline === null ? null : deadline.toString(),
+        windowCoverage: range.coverage,
       }
     })
   }

--- a/packages/utils/src/features/safenet-checks/types/snapshot.ts
+++ b/packages/utils/src/features/safenet-checks/types/snapshot.ts
@@ -2,6 +2,17 @@ import type { AttestationVerification, CheckStatus } from './status'
 import type { Hex, NormalizedCheckEvent } from './events'
 
 /**
+ * How much the block window a read used can prove. `proven`: the window was
+ * placed from a real submission timestamp with a converged block estimate AND
+ * still runs to the chain head, so it covers the check's whole possible
+ * lifetime — finding nothing there means nothing is there. `heuristic`: the
+ * window was head-relative, or placed from an estimate that did not converge,
+ * or it ends short of the head, so finding nothing only means the read did not
+ * look everywhere the check could be.
+ */
+export type WindowCoverage = 'proven' | 'heuristic'
+
+/**
  * The full read-layer view of one check at one poll. Everything numeric is a
  * decimal string so the snapshot is safe to hold in Redux. Recomputed from
  * scratch each poll; the monotonic merge is applied on top separately.
@@ -36,6 +47,8 @@ export type SafenetCheckSnapshot = {
    * earlier time compares against this to decide whether to re-aim the read.
    */
   aimedAtMs: number | null
+  /** What an empty event set from this read is allowed to claim. */
+  windowCoverage: WindowCoverage
   /** All decoded lifecycle events, sorted ascending by (block, logIndex). */
   events: NormalizedCheckEvent[]
 }

--- a/packages/utils/src/features/safenet-checks/types/snapshot.ts
+++ b/packages/utils/src/features/safenet-checks/types/snapshot.ts
@@ -29,6 +29,13 @@ export type SafenetCheckSnapshot = {
    * when the header read failed — a missing date never suppresses a verdict.
    */
   attestedAtMs: number | null
+  /**
+   * The submission time this read aimed its block window at, in ms — the
+   * earliest one any surface offered for the check. Null when none was offered
+   * and the read scanned back from the head instead. A subscriber that knows an
+   * earlier time compares against this to decide whether to re-aim the read.
+   */
+  aimedAtMs: number | null
   /** All decoded lifecycle events, sorted ascending by (block, logIndex). */
   events: NormalizedCheckEvent[]
 }

--- a/packages/utils/src/features/safenet-checks/types/status.ts
+++ b/packages/utils/src/features/safenet-checks/types/status.ts
@@ -34,11 +34,18 @@ export type PublicCheckStatus =
   | CheckStatus.UNAVAILABLE
 
 /**
- * Why a check reads as `UNAVAILABLE`: no check was ever requested, or the
- * chain read failed. `undefined` while the first read is still in flight, so
- * an unresolved read never claims a failure.
+ * Why a check reads as `UNAVAILABLE`:
+ *
+ *  - `NO_CHECK`: a read whose window covers the check's whole possible lifetime
+ *    found nothing, so no check was ever requested.
+ *  - `WINDOW_UNCERTAIN`: a read found nothing over a window that cannot support
+ *    that claim (see `WindowCoverage`). The state is unknown, not absent.
+ *  - `READ_FAILED`: the chain read itself failed.
+ *
+ * `undefined` while the first read is still in flight, so an unresolved read
+ * never claims a failure.
  */
-export type UnavailableReason = 'NO_CHECK' | 'READ_FAILED'
+export type UnavailableReason = 'NO_CHECK' | 'WINDOW_UNCERTAIN' | 'READ_FAILED'
 
 /**
  * Map an internal status to its public projection: `AWAITING_VERIFICATION`

--- a/packages/utils/src/features/safenet-checks/utils/computePollingInterval.ts
+++ b/packages/utils/src/features/safenet-checks/utils/computePollingInterval.ts
@@ -72,8 +72,10 @@ export const computePollingInterval = ({
   // requested around the first read still self-heals. Ceiling: past the window
   // a later check is only picked up by a page reload, or by a fresh mount after
   // the five-minute cache retention lapses — there is no re-check control in
-  // the UI. Polling on past the window would put every check-less transaction
-  // on a public RPC forever.
+  // the UI. (Re-aiming the shared read is a third path in principle, but every
+  // shipped surface offers the same submission date, so it cannot fire today.)
+  // Polling on past the window would put every check-less transaction on a
+  // public RPC forever.
   if (status === CheckStatus.UNAVAILABLE) {
     if (submittedAtMs == null || nowMs === undefined) return 0
     // A submission stamped in the future is clock skew, not a young check:


### PR DESCRIPTION
## What it solves

Two gaps in the Safenet check read path, found in a deep review of the aiming and
classification logic after #8577.

- **The read-window aim belonged to whichever surface subscribed first.** All surfaces share
  one cache entry and one poll loop, but RTK Query replays the `originalArgs` of the fetch
  that created the entry — so the first subscriber's timestamp aimed every later poll, and a
  later surface could neither refetch nor re-aim. Today every shipped surface offers the same
  `submissionDate` (verified against CGW v1.122.0: the queue summary `timestamp` and
  `detailedExecutionInfo.submittedAt` both map to it, and the queue chip only renders while
  `executionDate` is null), so the guarantee currently holds **by accident**. This makes it
  hold by construction, so a future surface with a worse timestamp cannot silently mis-aim
  the shared read.
- **"No Safenet check was requested" rendered for any empty read.** An empty snapshot only
  means "no matching logs in the chosen range", and several real paths produce an empty
  snapshot from a window that cannot support the claim: a non-converged block estimate, the
  head-relative fallback, a targeted window whose forward reach has closed behind the head —
  and a chain head lagging the submission stamp, where a lag inside the 600s estimate
  tolerance read as "converged" and asserted the confident copy over blocks the endpoint had
  not served yet.

## How this PR fixes it

One commit per concern:

1. `fix(safenet): make a check's read aim canonical instead of first-subscriber` — a
   module-level aim registry keyed by the same `chainId:safeAddress:safeTxHash` identity as
   the cache entry. Surfaces offer timestamps; the registry keeps the minimum (submission
   time is by definition the earliest any surface can offer); `queryFn` resolves the aim at
   execution time, so every poll replays the best aim known then. `timestampMs` is removed
   from the query args entirely, which makes "the query never aims by its own stale args"
   structural. If a later surface offers an earlier time, the hook refetches exactly once
   (guarded on `isFetching`; terminates because the aim only decreases on external input).
   Registry lifetime is tied to the cache entry via `onCacheEntryAdded`.
2. `fix(safenet): claim an absent check only from a window that covers one` — the reader now
   reports `windowCoverage: 'proven' | 'heuristic'` alongside the snapshot. `proven` requires
   all three: the chain head has actually reached the submission time, the block estimate
   converged on a real past timestamp, and the window still runs to the head (no block the
   check could live in went unread). Only a `proven` empty read renders "No Safenet check was
   requested" (`NO_CHECK`); every other empty read is the new `WINDOW_UNCERTAIN` reason,
   wearing the existing non-committal "Status unavailable" copy — no new product copy, never
   an error tone. Chosen block ranges are byte-identical to before; coverage is a report
   about the window, not a change to it.

## How to test it

- `yarn workspace @safe-global/utils test --testPathPattern safenet-checks` → 223 passing
  (new: aim registry fold/lifetime, one-shot re-aim, window-coverage classification with the
  lagging-head boundary tested on both sides of the tolerance, reason projection).
- `yarn workspace @safe-global/store test src/safenet` → 50 passing (canonical aim replayed
  on every poll, first-subscriber inversion probe, coverage carried onto the snapshot).
- `yarn workspace @safe-global/web test src/features/safenet-checks` → 45 passing
  (`WINDOW_UNCERTAIN` presentation, absent-check copy gated on the proving reason).
- Every behavioral change is mutation-tested: inverting the registry fold (max instead of
  min), ignoring the registry in `queryFn`, dropping the refetch guard, forcing
  `coverage: 'proven'`, collapsing the reason projection, or giving `WINDOW_UNCERTAIN` the
  confident copy each makes named tests fail.
- Verified on a full local stack (config service, transaction service, CGW, chain +
  validators): BENIGN unchanged; a fresh unproposed transaction renders `NO_CHECK` from a
  proven window; a staged 300s-lagging head renders `WINDOW_UNCERTAIN` with the
  non-committal copy where it previously asserted the confident claim; opening a second
  surface over a mounted one produces no extra read burst (no re-aim loop).

## Affected flows

- Confirm/execute flow (Safe Shield section): the only surface that renders the absent-check
  copy — now gated on proven coverage.
- Transaction queue rows and audit log: same shared read; aim now canonical across surfaces.
- Polling: `UNAVAILABLE` cadence and the 10-minute grace window are unchanged; the grace
  anchor now uses the resolved aim (identical in practice — all surfaces offer the same
  date; a surface offering nothing now inherits the shared anchor instead of disabling the
  window).

## Blast radius

- `safenetCheckApi`: endpoint arg type narrowed to the check identity; cache key unchanged;
  single-entry/single-loop property preserved and still probed by tests.
- New `safenetAimRegistry` (store package): render-safe min-fold; not persisted; bounded by
  checks rendered per session.
- `useSafenetCheck`: offers timestamps to the registry instead of passing them as args; new
  one-shot re-aim effect (inert today — all surfaces offer the same value).
- `SafenetReader.readRange`: classification added; ranges untouched (every coverage test
  also asserts the exact `[fromBlock, toBlock]`).
- `statusPresentation`: three-valued `UnavailableReason`; presentation table is exhaustive
  by construction (a fourth reason cannot ship without a presentation).
- Mobile: no mobile surface consumes these modules; shared-package changes covered by the
  package suites.

## Risks / not checked

- `proven` rests on an upstream contract this repo cannot assert: every shipped surface
  offers CGW's `submissionDate`. If an upstream mapping ever offered a later surrogate (for
  example the summary `timestamp` becoming the modification date), a window aimed more than
  ~1.4h past the real submission could miss the proposal and still classify `proven` — the
  ceiling and its upgrade path (carry aim provenance) are documented at the reader.
- An aim recorded during a render React discards before commit has no cache entry to be
  forgotten with and stays for the session — one bounded map entry, always in the safe
  (earlier) direction; documented at the registry.
- The lagging-head fix is verified against the repo's RPC harness with a real
  `ethers.JsonRpcProvider` and live against a staged lagging endpoint, not against a
  naturally degraded public RPC.
- No re-check control exists past the UNAVAILABLE grace window (unchanged); recovery is
  reload or cache eviction, as documented.

## Visual summary

```mermaid
flowchart TD
    S1["queue row"] -- "offer(submittedAt)" --> R["aim registry<br/>min per check identity"]
    S2["confirm flow"] -- "offer(submittedAt)" --> R
    S3["audit log"] -- "offer(submittedAt)" --> R
    R -- "resolve at fetch time" --> Q["queryFn / every poll"]
    Q --> W["read window"]
    W --> C{"coverage"}
    C -- "head reached submission<br/>AND estimate converged<br/>AND window runs to head" --> P["proven"]
    C -- otherwise --> H["heuristic"]
    P -- "empty read" --> NC["'No Safenet check was requested'"]
    H -- "empty read" --> WU["'Status unavailable' (non-committal)"]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
