### PR TITLE
feat(policies): build the empty-state policy catalogue with four tiles

### DIFF
--- a/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/PolicyCatalogue.stories.tsx
+++ b/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/PolicyCatalogue.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import PolicyCatalogue from './index'
+
+/**
+ * The empty-state policy catalogue. Mechanisms that have not shipped render as unavailable
+ * rather than being hidden, so the page shows the full range of policies from day one.
+ *
+ * Figma: https://www.figma.com/design/cOOeHQK12YR2SAKYKiNW5S/?node-id=15971-30121
+ */
+const meta = {
+  title: 'Features/Spaces/PolicyCatalogue',
+  component: PolicyCatalogue,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-background p-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof PolicyCatalogue>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/PolicyCatalogueTile.stories.tsx
+++ b/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/PolicyCatalogueTile.stories.tsx
@@ -25,6 +25,7 @@ type Story = StoryObj<typeof meta>
 
 export const Available: Story = {
   args: {
+    id: 'proposer',
     title: 'Proposer',
     description: 'Let teammates without signing rights propose transactions.',
     Icon: UserRoundPen,
@@ -35,6 +36,7 @@ export const Available: Story = {
 
 export const Unavailable: Story = {
   args: {
+    id: 'spending-limit',
     title: 'Spending limit',
     description: 'Let spenders access assets without collecting signatures.',
     Icon: WalletCards,

--- a/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/PolicyCatalogueTile.stories.tsx
+++ b/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/PolicyCatalogueTile.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { UserRoundPen, WalletCards } from 'lucide-react'
+import PolicyCatalogueTile from './PolicyCatalogueTile'
+
+const meta = {
+  title: 'Features/Spaces/PolicyCatalogueTile',
+  component: PolicyCatalogueTile,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-background p-8">
+        <div className="max-w-[560px]">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof PolicyCatalogueTile>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Available: Story = {
+  args: {
+    title: 'Proposer',
+    description: 'Let teammates without signing rights propose transactions.',
+    Icon: UserRoundPen,
+    isAvailable: true,
+    onClick: () => {},
+  },
+}
+
+export const Unavailable: Story = {
+  args: {
+    title: 'Spending limit',
+    description: 'Let spenders access assets without collecting signatures.',
+    Icon: WalletCards,
+    isAvailable: false,
+    onClick: () => {},
+  },
+}

--- a/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/PolicyCatalogueTile.tsx
+++ b/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/PolicyCatalogueTile.tsx
@@ -1,0 +1,51 @@
+import { ArrowRight, type LucideIcon } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Typography } from '@/components/ui/typography'
+import { cn } from '@/utils/cn'
+
+export interface PolicyCatalogueTileProps {
+  title: string
+  description: string
+  Icon: LucideIcon
+  isAvailable: boolean
+  onClick: () => void
+}
+
+const PolicyCatalogueTile = ({ title, description, Icon, isAvailable, onClick }: PolicyCatalogueTileProps) => (
+  <button
+    type="button"
+    data-testid="policy-catalogue-tile"
+    aria-disabled={isAvailable ? undefined : true}
+    onClick={onClick}
+    className={cn(
+      'flex h-full flex-col items-start gap-2 rounded-xl bg-card p-4 text-left transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      isAvailable ? 'cursor-pointer hover:bg-muted' : 'cursor-default',
+    )}
+  >
+    <div className={cn('flex size-10 items-center justify-center rounded-md bg-accent', !isAvailable && 'opacity-60')}>
+      <Icon className="size-4 text-accent-success" />
+    </div>
+
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-1">
+        <Typography variant="paragraph-bold" className={cn(!isAvailable && 'text-muted-foreground')}>
+          {title}
+        </Typography>
+
+        {isAvailable ? (
+          <ArrowRight className="size-4 shrink-0" aria-hidden />
+        ) : (
+          <Badge variant="secondary" size="sm">
+            Soon
+          </Badge>
+        )}
+      </div>
+
+      <Typography variant="paragraph-small" className="text-muted-foreground">
+        {description}
+      </Typography>
+    </div>
+  </button>
+)
+
+export default PolicyCatalogueTile

--- a/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/PolicyCatalogueTile.tsx
+++ b/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/PolicyCatalogueTile.tsx
@@ -20,8 +20,8 @@ const PolicyCatalogueTile = ({ id, title, description, Icon, isAvailable, onClic
     aria-disabled={isAvailable ? undefined : true}
     onClick={onClick}
     className={cn(
-      'flex h-full flex-col items-start gap-2 rounded-xl border border-transparent bg-card p-4 text-left transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-      isAvailable ? 'cursor-pointer hover:border-border' : 'cursor-default',
+      'flex h-full flex-col items-start gap-2 rounded-xl bg-card p-4 text-left transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      isAvailable ? 'cursor-pointer hover:bg-[var(--color-background-secondary)]' : 'cursor-default',
     )}
   >
     <div className={cn('flex size-10 items-center justify-center rounded-md bg-accent', !isAvailable && 'opacity-60')}>

--- a/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/PolicyCatalogueTile.tsx
+++ b/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/PolicyCatalogueTile.tsx
@@ -2,8 +2,10 @@ import { ArrowRight, type LucideIcon } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Typography } from '@/components/ui/typography'
 import { cn } from '@/utils/cn'
+import { type PolicyCatalogueId } from './catalogue'
 
 export interface PolicyCatalogueTileProps {
+  id: PolicyCatalogueId
   title: string
   description: string
   Icon: LucideIcon
@@ -11,10 +13,10 @@ export interface PolicyCatalogueTileProps {
   onClick: () => void
 }
 
-const PolicyCatalogueTile = ({ title, description, Icon, isAvailable, onClick }: PolicyCatalogueTileProps) => (
+const PolicyCatalogueTile = ({ id, title, description, Icon, isAvailable, onClick }: PolicyCatalogueTileProps) => (
   <button
     type="button"
-    data-testid="policy-catalogue-tile"
+    data-testid={`policy-catalogue-tile-${id}`}
     aria-disabled={isAvailable ? undefined : true}
     onClick={onClick}
     className={cn(

--- a/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/PolicyCatalogueTile.tsx
+++ b/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/PolicyCatalogueTile.tsx
@@ -20,8 +20,8 @@ const PolicyCatalogueTile = ({ id, title, description, Icon, isAvailable, onClic
     aria-disabled={isAvailable ? undefined : true}
     onClick={onClick}
     className={cn(
-      'flex h-full flex-col items-start gap-2 rounded-xl bg-card p-4 text-left transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-      isAvailable ? 'cursor-pointer hover:bg-muted' : 'cursor-default',
+      'flex h-full flex-col items-start gap-2 rounded-xl border border-transparent bg-card p-4 text-left transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      isAvailable ? 'cursor-pointer hover:border-border' : 'cursor-default',
     )}
   >
     <div className={cn('flex size-10 items-center justify-center rounded-md bg-accent', !isAvailable && 'opacity-60')}>

--- a/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/__tests__/PolicyCatalogue.test.tsx
+++ b/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/__tests__/PolicyCatalogue.test.tsx
@@ -28,6 +28,15 @@ describe('PolicyCatalogue', () => {
     expect(within(tiles[3]).getByText('Something missing?')).toBeInTheDocument()
   })
 
+  it('gives every tile a test id of its own', () => {
+    render(<PolicyCatalogue />)
+
+    expect(screen.getByTestId('policy-catalogue-tile-spending-limit')).toBeInTheDocument()
+    expect(screen.getByTestId('policy-catalogue-tile-proposer')).toBeInTheDocument()
+    expect(screen.getByTestId('policy-catalogue-tile-account-recovery')).toBeInTheDocument()
+    expect(screen.getByTestId('policy-catalogue-tile-suggestion')).toBeInTheDocument()
+  })
+
   it('describes what each policy does', () => {
     render(<PolicyCatalogue />)
 
@@ -53,10 +62,13 @@ describe('PolicyCatalogue', () => {
 
     await user.click(screen.getByRole('button', { name: /Proposer/ }))
 
-    expect(mockTrackEvent).toHaveBeenCalledWith(POLICY_EVENTS.POLICY_CATALOGUE_TILE_CLICKED, {
-      [MixpanelEventParams.POLICY_TYPE]: 'proposer',
-      [MixpanelEventParams.IS_AVAILABLE]: true,
-    })
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      { ...POLICY_EVENTS.POLICY_CATALOGUE_TILE_CLICKED, label: 'proposer' },
+      {
+        [MixpanelEventParams.POLICY_TYPE]: 'proposer',
+        [MixpanelEventParams.IS_AVAILABLE]: true,
+      },
+    )
   })
 
   it('tracks a click on an unavailable tile', async () => {
@@ -64,10 +76,13 @@ describe('PolicyCatalogue', () => {
 
     await user.click(screen.getByRole('button', { name: /Spending limit/ }))
 
-    expect(mockTrackEvent).toHaveBeenCalledWith(POLICY_EVENTS.POLICY_CATALOGUE_TILE_CLICKED, {
-      [MixpanelEventParams.POLICY_TYPE]: 'spending-limit',
-      [MixpanelEventParams.IS_AVAILABLE]: false,
-    })
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      { ...POLICY_EVENTS.POLICY_CATALOGUE_TILE_CLICKED, label: 'spending-limit' },
+      {
+        [MixpanelEventParams.POLICY_TYPE]: 'spending-limit',
+        [MixpanelEventParams.IS_AVAILABLE]: false,
+      },
+    )
   })
 
   it('opens the flow of an available tile', async () => {

--- a/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/__tests__/PolicyCatalogue.test.tsx
+++ b/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/__tests__/PolicyCatalogue.test.tsx
@@ -1,0 +1,90 @@
+import { render, renderWithUserEvent, screen, within } from '@/tests/test-utils'
+import { trackEvent } from '@/services/analytics'
+import { POLICY_EVENTS } from '@/services/analytics/events/policies'
+import { MixpanelEventParams } from '@/services/analytics/mixpanel-events'
+import PolicyCatalogue from '../index'
+
+jest.mock('@/services/analytics', () => ({
+  ...jest.requireActual('@/services/analytics'),
+  trackEvent: jest.fn(),
+}))
+
+const mockTrackEvent = trackEvent as jest.MockedFunction<typeof trackEvent>
+
+describe('PolicyCatalogue', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders the four tiles in the designed order, Spending limit first', () => {
+    render(<PolicyCatalogue />)
+
+    const tiles = screen.getAllByRole('button')
+
+    expect(tiles).toHaveLength(4)
+    expect(within(tiles[0]).getByText('Spending limit')).toBeInTheDocument()
+    expect(within(tiles[1]).getByText('Proposer')).toBeInTheDocument()
+    expect(within(tiles[2]).getByText('Account recovery')).toBeInTheDocument()
+    expect(within(tiles[3]).getByText('Something missing?')).toBeInTheDocument()
+  })
+
+  it('describes what each policy does', () => {
+    render(<PolicyCatalogue />)
+
+    expect(screen.getByText('Let spenders access assets without collecting signatures.')).toBeInTheDocument()
+    expect(screen.getByText('Let teammates without signing rights propose transactions.')).toBeInTheDocument()
+    expect(
+      screen.getByText('Choose a trusted Recoverer to recover your Safe account if you ever lose access.'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Tell us which rules would help you manage your Safe accounts.')).toBeInTheDocument()
+  })
+
+  it('renders the mechanisms not yet shipped as unavailable rather than absent', () => {
+    render(<PolicyCatalogue />)
+
+    expect(screen.getByRole('button', { name: /Spending limit/ })).toHaveAttribute('aria-disabled', 'true')
+    expect(screen.getByRole('button', { name: /Account recovery/ })).toHaveAttribute('aria-disabled', 'true')
+    expect(screen.getByRole('button', { name: /Proposer/ })).not.toHaveAttribute('aria-disabled')
+    expect(screen.getByRole('button', { name: /Something missing\?/ })).not.toHaveAttribute('aria-disabled')
+  })
+
+  it('tracks a click on an available tile', async () => {
+    const { user } = renderWithUserEvent(<PolicyCatalogue />)
+
+    await user.click(screen.getByRole('button', { name: /Proposer/ }))
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(POLICY_EVENTS.POLICY_CATALOGUE_TILE_CLICKED, {
+      [MixpanelEventParams.POLICY_TYPE]: 'proposer',
+      [MixpanelEventParams.IS_AVAILABLE]: true,
+    })
+  })
+
+  it('tracks a click on an unavailable tile', async () => {
+    const { user } = renderWithUserEvent(<PolicyCatalogue />)
+
+    await user.click(screen.getByRole('button', { name: /Spending limit/ }))
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(POLICY_EVENTS.POLICY_CATALOGUE_TILE_CLICKED, {
+      [MixpanelEventParams.POLICY_TYPE]: 'spending-limit',
+      [MixpanelEventParams.IS_AVAILABLE]: false,
+    })
+  })
+
+  it('opens the flow of an available tile', async () => {
+    const onSelect = jest.fn()
+    const { user } = renderWithUserEvent(<PolicyCatalogue onSelect={onSelect} />)
+
+    await user.click(screen.getByRole('button', { name: /Proposer/ }))
+
+    expect(onSelect).toHaveBeenCalledWith('proposer')
+  })
+
+  it('does not open a flow that has not shipped', async () => {
+    const onSelect = jest.fn()
+    const { user } = renderWithUserEvent(<PolicyCatalogue onSelect={onSelect} />)
+
+    await user.click(screen.getByRole('button', { name: /Account recovery/ }))
+
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/__tests__/PolicyCatalogueTile.test.tsx
+++ b/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/__tests__/PolicyCatalogueTile.test.tsx
@@ -3,6 +3,7 @@ import { render, renderWithUserEvent, screen } from '@/tests/test-utils'
 import PolicyCatalogueTile from '../PolicyCatalogueTile'
 
 const defaultProps = {
+  id: 'spending-limit' as const,
   title: 'Spending limit',
   description: 'Let spenders access assets without collecting signatures.',
   Icon: WalletCards,
@@ -13,6 +14,12 @@ const defaultProps = {
 describe('PolicyCatalogueTile', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+  })
+
+  it('gives each tile a test id of its own so a single tile can be targeted', () => {
+    render(<PolicyCatalogueTile {...defaultProps} />)
+
+    expect(screen.getByTestId('policy-catalogue-tile-spending-limit')).toBeInTheDocument()
   })
 
   it('states the policy name and what it does', () => {

--- a/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/__tests__/PolicyCatalogueTile.test.tsx
+++ b/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/__tests__/PolicyCatalogueTile.test.tsx
@@ -1,0 +1,54 @@
+import { WalletCards } from 'lucide-react'
+import { render, renderWithUserEvent, screen } from '@/tests/test-utils'
+import PolicyCatalogueTile from '../PolicyCatalogueTile'
+
+const defaultProps = {
+  title: 'Spending limit',
+  description: 'Let spenders access assets without collecting signatures.',
+  Icon: WalletCards,
+  isAvailable: true,
+  onClick: jest.fn(),
+}
+
+describe('PolicyCatalogueTile', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('states the policy name and what it does', () => {
+    render(<PolicyCatalogueTile {...defaultProps} />)
+
+    expect(screen.getByRole('button', { name: /Spending limit/ })).toBeInTheDocument()
+    expect(screen.getByText('Let spenders access assets without collecting signatures.')).toBeInTheDocument()
+  })
+
+  it('calls onClick when an available tile is clicked', async () => {
+    const { user } = renderWithUserEvent(<PolicyCatalogueTile {...defaultProps} />)
+
+    await user.click(screen.getByRole('button', { name: /Spending limit/ }))
+
+    expect(defaultProps.onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('marks an unavailable tile as Soon and disabled', () => {
+    render(<PolicyCatalogueTile {...defaultProps} isAvailable={false} />)
+
+    expect(screen.getByText('Soon')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Spending limit/ })).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('does not mark an available tile as Soon', () => {
+    render(<PolicyCatalogueTile {...defaultProps} />)
+
+    expect(screen.queryByText('Soon')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Spending limit/ })).not.toHaveAttribute('aria-disabled')
+  })
+
+  it('still calls onClick for an unavailable tile so the click can be tracked', async () => {
+    const { user } = renderWithUserEvent(<PolicyCatalogueTile {...defaultProps} isAvailable={false} />)
+
+    await user.click(screen.getByRole('button', { name: /Spending limit/ }))
+
+    expect(defaultProps.onClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/catalogue.ts
+++ b/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/catalogue.ts
@@ -1,0 +1,42 @@
+import { LockKeyholeOpen, MessageSquarePlus, UserRoundPen, WalletCards, type LucideIcon } from 'lucide-react'
+
+export type PolicyCatalogueId = 'spending-limit' | 'proposer' | 'account-recovery' | 'suggestion'
+
+export interface PolicyCatalogueEntry {
+  id: PolicyCatalogueId
+  title: string
+  description: string
+  Icon: LucideIcon
+  isAvailable: boolean
+}
+
+export const POLICY_CATALOGUE: PolicyCatalogueEntry[] = [
+  {
+    id: 'spending-limit',
+    title: 'Spending limit',
+    description: 'Let spenders access assets without collecting signatures.',
+    Icon: WalletCards,
+    isAvailable: false,
+  },
+  {
+    id: 'proposer',
+    title: 'Proposer',
+    description: 'Let teammates without signing rights propose transactions.',
+    Icon: UserRoundPen,
+    isAvailable: true,
+  },
+  {
+    id: 'account-recovery',
+    title: 'Account recovery',
+    description: 'Choose a trusted Recoverer to recover your Safe account if you ever lose access.',
+    Icon: LockKeyholeOpen,
+    isAvailable: false,
+  },
+  {
+    id: 'suggestion',
+    title: 'Something missing?',
+    description: 'Tell us which rules would help you manage your Safe accounts.',
+    Icon: MessageSquarePlus,
+    isAvailable: true,
+  },
+]

--- a/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/index.tsx
+++ b/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/index.tsx
@@ -11,10 +11,13 @@ interface PolicyCatalogueProps {
 
 const PolicyCatalogue = ({ onSelect }: PolicyCatalogueProps): ReactElement => {
   const handleClick = ({ id, isAvailable }: PolicyCatalogueEntry) => {
-    trackEvent(POLICY_EVENTS.POLICY_CATALOGUE_TILE_CLICKED, {
-      [MixpanelEventParams.POLICY_TYPE]: id,
-      [MixpanelEventParams.IS_AVAILABLE]: isAvailable,
-    })
+    trackEvent(
+      { ...POLICY_EVENTS.POLICY_CATALOGUE_TILE_CLICKED, label: id },
+      {
+        [MixpanelEventParams.POLICY_TYPE]: id,
+        [MixpanelEventParams.IS_AVAILABLE]: isAvailable,
+      },
+    )
 
     if (isAvailable) onSelect?.(id)
   }

--- a/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/index.tsx
+++ b/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/index.tsx
@@ -1,0 +1,31 @@
+import { type ReactElement } from 'react'
+import { trackEvent } from '@/services/analytics'
+import { POLICY_EVENTS } from '@/services/analytics/events/policies'
+import { MixpanelEventParams } from '@/services/analytics/mixpanel-events'
+import PolicyCatalogueTile from './PolicyCatalogueTile'
+import { POLICY_CATALOGUE, type PolicyCatalogueEntry, type PolicyCatalogueId } from './catalogue'
+
+interface PolicyCatalogueProps {
+  onSelect?: (id: PolicyCatalogueId) => void
+}
+
+const PolicyCatalogue = ({ onSelect }: PolicyCatalogueProps): ReactElement => {
+  const handleClick = ({ id, isAvailable }: PolicyCatalogueEntry) => {
+    trackEvent(POLICY_EVENTS.POLICY_CATALOGUE_TILE_CLICKED, {
+      [MixpanelEventParams.POLICY_TYPE]: id,
+      [MixpanelEventParams.IS_AVAILABLE]: isAvailable,
+    })
+
+    if (isAvailable) onSelect?.(id)
+  }
+
+  return (
+    <div data-testid="policy-catalogue" className="grid gap-4 md:grid-cols-2">
+      {POLICY_CATALOGUE.map((entry) => (
+        <PolicyCatalogueTile key={entry.id} {...entry} onClick={() => handleClick(entry)} />
+      ))}
+    </div>
+  )
+}
+
+export default PolicyCatalogue

--- a/apps/web/src/features/spaces/components/Policies/__tests__/Policies.test.tsx
+++ b/apps/web/src/features/spaces/components/Policies/__tests__/Policies.test.tsx
@@ -40,4 +40,21 @@ describe('Policies', () => {
     expect(link.querySelector('.external-link-icon')).toBeInTheDocument()
     expect(link).toHaveClass('font-bold', 'hover:text-muted-foreground')
   })
+
+  it('renders the policy catalogue', () => {
+    render(<Policies />)
+
+    expect(screen.getByText('Spending limit')).toBeInTheDocument()
+    expect(screen.getByText('Proposer')).toBeInTheDocument()
+    expect(screen.getByText('Account recovery')).toBeInTheDocument()
+    expect(screen.getByText('Something missing?')).toBeInTheDocument()
+  })
+
+  it('renders the catalogue only, with no table, create button or search', () => {
+    render(<Policies />)
+
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Create policy/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument()
+  })
 })

--- a/apps/web/src/features/spaces/components/Policies/index.tsx
+++ b/apps/web/src/features/spaces/components/Policies/index.tsx
@@ -2,6 +2,7 @@ import { type ReactElement } from 'react'
 import { Typography } from '@/components/ui/typography'
 import ExternalLink from '@/components/common/ExternalLink'
 import { HelpCenterArticle } from '@safe-global/utils/config/constants'
+import PolicyCatalogue from './PolicyCatalogue'
 
 const Policies = (): ReactElement => {
   return (
@@ -19,6 +20,9 @@ const Policies = (): ReactElement => {
           </ExternalLink>
         </Typography>
       </div>
+
+      {/* TODO(WA-3138, WA-3160): pass onSelect to open the proposer form and the Suggest a policy dialog */}
+      <PolicyCatalogue />
     </div>
   )
 }

--- a/apps/web/src/services/analytics/events/policies.ts
+++ b/apps/web/src/services/analytics/events/policies.ts
@@ -1,0 +1,8 @@
+const POLICY_CATEGORY = 'policies'
+
+export const POLICY_EVENTS = {
+  POLICY_CATALOGUE_TILE_CLICKED: {
+    action: 'Policy catalogue tile clicked',
+    category: POLICY_CATEGORY,
+  },
+}

--- a/apps/web/src/services/analytics/ga-mixpanel-mapping.ts
+++ b/apps/web/src/services/analytics/ga-mixpanel-mapping.ts
@@ -15,6 +15,7 @@ import { SAFE_SHIELD_EVENTS } from './events/safe-shield'
 import { HYPERNATIVE_EVENTS } from './events/hypernative'
 import { TX_EVENTS } from './events/transactions'
 import { SPACE_EVENTS } from './events/spaces'
+import { POLICY_EVENTS } from './events/policies'
 
 // If an event is mapped here, it will be tracked in Mixpanel
 export const GA_TO_MIXPANEL_MAPPING: Record<string, string> = {
@@ -71,6 +72,7 @@ export const GA_TO_MIXPANEL_MAPPING: Record<string, string> = {
   [TX_EVENTS.EXECUTE_VIA_SPENDING_LIMIT.action]: MixpanelEvent.TRANSACTION_EXECUTED,
   [OVERVIEW_EVENTS.TRUSTED_SAFES_ADDED.action]: MixpanelEvent.TRUSTED_SAFE_ADDED,
   [OVERVIEW_EVENTS.TRUSTED_SAFES_REMOVED.action]: MixpanelEvent.TRUSTED_SAFE_REMOVED,
+  [POLICY_EVENTS.POLICY_CATALOGUE_TILE_CLICKED.action]: MixpanelEvent.POLICY_CATALOGUE_TILE_CLICKED,
   [SPACE_EVENTS.WORKSPACE_CREATED.action]: MixpanelEvent.WORKSPACE_CREATED,
   [SPACE_EVENTS.WORKSPACE_DASHBOARD_VIEWED.action]: MixpanelEvent.WORKSPACE_DASHBOARD_VIEWED,
   [SPACE_EVENTS.AUTH_LOGIN_SUCCEEDED.action]: MixpanelEvent.AUTH_LOGIN_SUCCEEDED,

--- a/apps/web/src/services/analytics/mixpanel-events.ts
+++ b/apps/web/src/services/analytics/mixpanel-events.ts
@@ -85,6 +85,7 @@ export enum MixpanelEvent {
   SECURITY_REPORT_OPENED = 'Security Report Opened',
   ACTIVITY_LOG_VIEWED = 'Activity Log Viewed',
   ACTIVITY_LOG_FILTERED = 'Activity Log Filtered',
+  POLICY_CATALOGUE_TILE_CLICKED = 'Policy Catalogue Tile Clicked',
 }
 
 export enum WorkspaceCreateEntryPoint {
@@ -152,6 +153,8 @@ export enum MixpanelEventParams {
   ACCOUNT_COUNT = 'Account Count',
   ENTRY_COUNT = 'Entry Count',
   MEMBER_ROLE = 'Member Role',
+  POLICY_TYPE = 'Policy Type',
+  IS_AVAILABLE = 'Is Available',
 }
 
 export enum AuthLoginMethod {


### PR DESCRIPTION
## What it solves

Resolves: [WA-3135](https://linear.app/safe-global/issue/WA-3135/build-the-empty-state-policy-catalogue-with-four-tiles)

WA-3134 added the Policies page shell. This fills the body so a Space member with no policies can see what's on offer.

## How this PR fixes it

Four tiles — Spending limit, Proposer, Account recovery, Something missing? — each with a name and one-line description, order and copy in a single `catalogue.ts`.

Unshipped mechanisms render **unavailable, not absent** (AC A10a): muted, `Soon` badge instead of the arrow, `aria-disabled`, still clickable so the click reports. In M1.1 that's Spending limit and Account recovery.

Every click fires `Policy Catalogue Tile Clicked` (GA label + Mixpanel `Policy Type` / `Is Available`).

## How to test it

Enable `POLICIES`, open a Space → **Policies**. Four tiles; Spending limit and Account recovery show `Soon` and don't respond; no table, no `Create policy`, no search. Check dark mode and narrow viewport.

## Affected flows

- Space member opens Policies with no policies configured — the only flow changed.

## Blast radius

- New with no consumers: `Policies/PolicyCatalogue/**`, `analytics/events/policies.ts`.
- `Policies/index.tsx` — renders the catalogue; still stubbed to `null` when the flag is off.
- `mixpanel-events.ts` / `ga-mixpanel-mapping.ts` — one event, two params, one mapping key. Additive; mapping suite passes.
- No route, store, endpoint, persisted state or shared package touched. No mobile impact.

## Risks / not checked

- **AC A7 not met.** No policies data source until WA-3075; WA-3140 / WA-3143 own the empty↔populated switch. A7 should move or carry a note.
- **Unavailable-tile design is invented** — no Figma frame exists for it.
- **Available tiles open nothing yet** (WA-3138 / WA-3160 wire `onSelect`), so `Is Available: true` clicks report no conversion until then.
- `Learn more` still points at the help-centre root — WA-3134's open TODO.
- Not verified: manual browser pass, mobile, Playwright (no flow to drive yet).

## Visual summary

> **TODO:** screenshot of `/spaces/policies` with the flag on. [Figma](https://www.figma.com/design/cOOeHQK12YR2SAKYKiNW5S/Workspaces-%E2%80%93-UX-UI-Review?node-id=15971-30121)

```mermaid
flowchart LR
    A[catalogue.ts] --> B[PolicyCatalogue]
    B --> C[PolicyCatalogueTile ×4]
    C --> D[trackEvent]
    C --> E{isAvailable?}
    E -->|yes| F["onSelect(id) — WA-3138 / WA-3160"]
    E -->|no| G[no-op]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
