### PR TITLE
feat(gtf): Safenet check opt-in and fee line in the fee preview

### DIFF
--- a/apps/web/src/components/tx-flow/SafeTxContext.ts
+++ b/apps/web/src/components/tx-flow/SafeTxContext.ts
@@ -43,6 +43,10 @@ export type SafeTxContextParams = {
   setGtfPaymentMode: (source: GtfPaymentMode) => void
   gtfSelectedGasToken?: string
   setGtfSelectedGasToken: Dispatch<SetStateAction<string | undefined>>
+
+  /** Per-transaction opt-in, gated by chain availability. Off by default. */
+  safenetCheckEnabled: boolean
+  setSafenetCheckEnabled: Dispatch<SetStateAction<boolean>>
 }
 
 export const SafeTxContext = createContext<SafeTxContextParams>({
@@ -58,4 +62,6 @@ export const SafeTxContext = createContext<SafeTxContextParams>({
   gtfPaymentMode: 'safe',
   setGtfPaymentMode: () => {},
   setGtfSelectedGasToken: () => {},
+  safenetCheckEnabled: false,
+  setSafenetCheckEnabled: () => {},
 })

--- a/apps/web/src/components/tx-flow/SafeTxProvider.tsx
+++ b/apps/web/src/components/tx-flow/SafeTxProvider.tsx
@@ -12,6 +12,8 @@ import { useAppDispatch, useAppSelector } from '@/store'
 import { selectGtfPaymentSourcePreference, setGtfPaymentSourcePreference } from '@/features/gtf/store'
 import type { GtfPaymentMode } from '@/features/gtf/types'
 import useWallet from '@/hooks/wallets/useWallet'
+import { useCurrentChain } from '@/hooks/useChains'
+import { isSafenetCheckAvailable } from '@/features/gtf/utils/isSafenetCheckAvailable'
 
 export { SafeTxContext } from './SafeTxContext'
 export type { SafeTxContextParams } from './SafeTxContext'
@@ -38,6 +40,13 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
     [dispatch, signerAddress],
   )
   const [gtfSelectedGasToken, setGtfSelectedGasToken] = useState<string>()
+  const [safenetCheckRequested, setSafenetCheckEnabled] = useState(false)
+
+  // Gate the opt-in here, once, so every consumer reads a value that is already valid for
+  // the current chain. A request carried over from a Safenet chain must never be sent to
+  // one that cannot run the check.
+  const currentChain = useCurrentChain()
+  const safenetCheckEnabled = safenetCheckRequested && isSafenetCheckAvailable(currentChain)
 
   // Signed txs cannot be updated
   const isSigned = Boolean(safeTx && safeTx.signatures.size > 0)
@@ -98,6 +107,8 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
         setGtfPaymentMode,
         gtfSelectedGasToken,
         setGtfSelectedGasToken,
+        safenetCheckEnabled,
+        setSafenetCheckEnabled,
       }}
     >
       {children}

--- a/apps/web/src/components/tx-flow/__tests__/SafeTxProvider.test.tsx
+++ b/apps/web/src/components/tx-flow/__tests__/SafeTxProvider.test.tsx
@@ -4,6 +4,7 @@ import SafeTxProvider, { SafeTxContext } from '../SafeTxProvider'
 import { getTxOrigin } from '@/utils/transactions'
 import { gtfPaymentSourcePreferenceSlice } from '@/features/gtf/store'
 import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
+import { FEATURES } from '@safe-global/utils/utils/chains'
 import { Errors, logError } from '@/services/exceptions'
 
 jest.mock('@/services/exceptions', () => ({
@@ -25,6 +26,13 @@ jest.mock('@/hooks/wallets/useWallet', () => ({
   useSigner: () => null,
   useWalletContext: () => null,
 }))
+
+const mockUseCurrentChain = jest.fn()
+jest.mock('@/hooks/useChains', () => ({
+  useCurrentChain: () => mockUseCurrentChain(),
+}))
+
+const buildChain = (features: string[]) => ({ chainId: '1', features })
 
 const SIGNER_A = '0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa'
 const SIGNER_B = '0xBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBb'
@@ -54,6 +62,7 @@ const FailingFlow = ({ error }: { error: Error }) => {
 describe('SafeTxProvider', () => {
   beforeEach(() => {
     mockUseWallet.mockReturnValue(null)
+    mockUseCurrentChain.mockReturnValue(buildChain([]))
     mockedLogError.mockClear()
   })
 
@@ -243,6 +252,51 @@ describe('SafeTxProvider', () => {
       )
 
       expect(() => screen.getByText('toggle').click()).not.toThrow()
+    })
+  })
+
+  describe('safenetCheckEnabled availability gate', () => {
+    const SafenetReader = () => {
+      const { safenetCheckEnabled, setSafenetCheckEnabled } = useContext(SafeTxContext)
+      return (
+        <>
+          <div data-testid="safenet">{String(safenetCheckEnabled)}</div>
+          <button onClick={() => setSafenetCheckEnabled(true)}>opt in</button>
+        </>
+      )
+    }
+
+    const renderReader = () =>
+      render(
+        <SafeTxProvider>
+          <SafenetReader />
+        </SafeTxProvider>,
+      )
+
+    it('defaults to off — the check is opt-in per transaction', () => {
+      mockUseCurrentChain.mockReturnValue(buildChain([FEATURES.SAFENET_CHECKS]))
+      renderReader()
+
+      expect(screen.getByTestId('safenet')).toHaveTextContent('false')
+    })
+
+    it('reports the opt-in on a chain that supports the check', () => {
+      mockUseCurrentChain.mockReturnValue(buildChain([FEATURES.SAFENET_CHECKS]))
+      renderReader()
+
+      act(() => screen.getByText('opt in').click())
+
+      expect(screen.getByTestId('safenet')).toHaveTextContent('true')
+    })
+
+    it('suppresses an opt-in carried over to a chain without the feature', () => {
+      mockUseCurrentChain.mockReturnValue(buildChain([]))
+      renderReader()
+
+      act(() => screen.getByText('opt in').click())
+
+      // The request must never reach a chain that cannot run the check.
+      expect(screen.getByTestId('safenet')).toHaveTextContent('false')
     })
   })
 })

--- a/apps/web/src/components/tx-flow/actions/__tests__/ProposeSlot.test.tsx
+++ b/apps/web/src/components/tx-flow/actions/__tests__/ProposeSlot.test.tsx
@@ -86,6 +86,8 @@ const safeTxContext: SafeTxContextParams = {
   gtfPaymentMode: 'safe',
   setGtfPaymentMode: jest.fn(),
   setGtfSelectedGasToken: jest.fn(),
+  safenetCheckEnabled: false,
+  setSafenetCheckEnabled: jest.fn(),
 }
 
 describe('Propose slot', () => {

--- a/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.contextSync.test.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.contextSync.test.tsx
@@ -44,6 +44,8 @@ const defaultSafeTxContext: SafeTxContextParams = {
   setGtfPaymentMode: jest.fn(),
   gtfSelectedGasToken: undefined,
   setGtfSelectedGasToken: jest.fn(),
+  safenetCheckEnabled: false,
+  setSafenetCheckEnabled: jest.fn(),
 }
 
 const renderTxNonce = (contextOverrides: Partial<SafeTxContextParams> = {}) => {

--- a/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.test.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.test.tsx
@@ -40,6 +40,8 @@ const defaultSafeTxContext: SafeTxContextParams = {
   setGtfPaymentMode: jest.fn(),
   gtfSelectedGasToken: undefined,
   setGtfSelectedGasToken: jest.fn(),
+  safenetCheckEnabled: false,
+  setSafenetCheckEnabled: jest.fn(),
 }
 
 const renderTxNonce = (

--- a/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.typedValue.test.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.typedValue.test.tsx
@@ -48,6 +48,8 @@ const defaultSafeTxContext: SafeTxContextParams = {
   setGtfPaymentMode: jest.fn(),
   gtfSelectedGasToken: undefined,
   setGtfSelectedGasToken: jest.fn(),
+  safenetCheckEnabled: false,
+  setSafenetCheckEnabled: jest.fn(),
 }
 
 const renderTxNonce = (contextOverrides: Partial<SafeTxContextParams> = {}) =>

--- a/apps/web/src/components/tx-flow/flows/ConfirmTx/ConfirmProposedTx.test.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmTx/ConfirmProposedTx.test.tsx
@@ -34,6 +34,8 @@ const renderWithContexts = (safeTxContext: Partial<SafeTxContextParams>) => {
     gtfPaymentMode: 'safe',
     setGtfPaymentMode: jest.fn(),
     setGtfSelectedGasToken: jest.fn(),
+    safenetCheckEnabled: false,
+    setSafenetCheckEnabled: jest.fn(),
     ...safeTxContext,
   }
 

--- a/apps/web/src/components/tx-flow/flows/SignMessage/SignMessage.test.tsx
+++ b/apps/web/src/components/tx-flow/flows/SignMessage/SignMessage.test.tsx
@@ -760,6 +760,8 @@ describe('SignMessage', () => {
         setGtfPaymentMode: jest.fn(),
         gtfSelectedGasToken: undefined,
         setGtfSelectedGasToken: jest.fn(),
+        safenetCheckEnabled: false,
+        setSafenetCheckEnabled: jest.fn(),
       }
     })
 

--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/__tests__/ReviewTokenTransfer.test.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/__tests__/ReviewTokenTransfer.test.tsx
@@ -82,6 +82,8 @@ describe('ReviewTokenTransfer', () => {
           gtfPaymentMode: 'safe',
           setGtfPaymentMode: jest.fn(),
           setGtfSelectedGasToken: jest.fn(),
+          safenetCheckEnabled: false,
+          setSafenetCheckEnabled: jest.fn(),
         }}
       >
         <ReviewTokenTransfer params={params} onSubmit={jest.fn()} txNonce={txNonce} />

--- a/apps/web/src/components/tx/ConfirmTxDetails/Receipt.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/Receipt.tsx
@@ -49,7 +49,7 @@ const DataStack = ({ children }: { children: ReactNode }) => (
 export const Receipt = ({ safeTxData, txData, txDetails, txInfo, grid, withSignatures = false }: ReceiptProps) => {
   const chain = useCurrentChain()
   const { safe, safeAddress } = useSafeInfo()
-  const { safeTx, gtfPaymentMode, gtfSelectedGasToken } = useContext(SafeTxContext)
+  const { safeTx, gtfPaymentMode, gtfSelectedGasToken, safenetCheckEnabled } = useContext(SafeTxContext)
   const { balances } = useBalances()
   const operation = Number(safeTxData.operation) as Operation
 
@@ -82,6 +82,7 @@ export const Receipt = ({ safeTxData, txData, txDetails, txInfo, grid, withSigna
     safeAddress,
     gasToken: gtfSelectedGasToken,
     numberSignatures: safe.threshold,
+    safenetCheck: safenetCheckEnabled,
   })
 
   const previewTxData = shouldPreviewGtf ? previewData?.txData : undefined

--- a/apps/web/src/components/tx/shared/__tests__/hooks.test.ts
+++ b/apps/web/src/components/tx/shared/__tests__/hooks.test.ts
@@ -804,6 +804,8 @@ describe('SignOrExecute hooks', () => {
         setGtfPaymentMode: jest.fn(),
         gtfSelectedGasToken: GAS_TOKEN,
         setGtfSelectedGasToken: jest.fn(),
+        safenetCheckEnabled: false,
+        setSafenetCheckEnabled: jest.fn(),
         ...overrides,
       }
       const Harness = () => {
@@ -875,6 +877,22 @@ describe('SignOrExecute hooks', () => {
         expect.objectContaining({ gasToken: GAS_TOKEN, numberSignatures: 2 }),
       )
       expect(signSpy).toHaveBeenCalledWith(mergedTx, expect.anything(), undefined)
+    })
+
+    it('carries the Safenet opt-in into the sign-time quote', async () => {
+      setupGtfChain()
+      jest.spyOn(walletHooks, 'isSmartContractWallet').mockReturnValue(Promise.resolve(false))
+
+      const mergedTx = createSafeTx()
+      const resolveFeeParams = jest.fn().mockResolvedValue(mergedTx)
+      mockFeatureResolve(resolveFeeParams)
+
+      jest.spyOn(txSender, 'dispatchTxSigning').mockResolvedValue(mergedTx)
+
+      const ref = captureActions({ safenetCheckEnabled: true })
+      await ref.current!.signTx(createSafeTx())
+
+      expect(resolveFeeParams).toHaveBeenCalledWith(expect.objectContaining({ safenetCheck: true }))
     })
 
     it('skips the merge for confirmers (safeTx already has a signature)', async () => {

--- a/apps/web/src/components/tx/shared/hooks.ts
+++ b/apps/web/src/components/tx/shared/hooks.ts
@@ -65,7 +65,7 @@ export const useTxActions = (): TxActions => {
   const chain = useCurrentChain()
   const dispatch = useAppDispatch()
   const gtfFeature = useLoadFeature(GTFFeature)
-  const { gtfPaymentMode, gtfSelectedGasToken } = useContext(SafeTxContext)
+  const { gtfPaymentMode, gtfSelectedGasToken, safenetCheckEnabled } = useContext(SafeTxContext)
   const currency = useAppSelector(selectCurrency)
 
   return useMemo<TxActions>(() => {
@@ -82,6 +82,7 @@ export const useTxActions = (): TxActions => {
         chainId,
         safeAddress,
         numberSignatures: safe.threshold,
+        safenetCheck: safenetCheckEnabled,
         currency,
         dispatch,
       })
@@ -234,6 +235,7 @@ export const useTxActions = (): TxActions => {
     gtfFeature,
     gtfPaymentMode,
     gtfSelectedGasToken,
+    safenetCheckEnabled,
     currency,
   ])
 }

--- a/apps/web/src/features/gtf/components/FeesPreview/FeesPreview.stories.tsx
+++ b/apps/web/src/features/gtf/components/FeesPreview/FeesPreview.stories.tsx
@@ -8,18 +8,42 @@ import { StoreDecorator } from '@/stories/storeDecorator'
 import { RouterDecorator } from '@/stories/routerDecorator'
 import { createInitialState } from '@/stories/mocks/defaults'
 import { safeFixtures } from '@safe-global/test/msw/fixtures'
+import { http, HttpResponse } from 'msw'
+import { createChainData, createChainsPageDataV2 } from '@/stories/mocks/chains'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+
+// The checkbox is gated on a chain feature the shared fixtures do not carry, and
+// `useCurrentChain` resolves through the v2 chains list. Enable it across that list for the
+// opt-in stories rather than editing the shared fixture.
+const withSafenetChecks = (chain: Chain): Chain => ({
+  ...chain,
+  features: [...chain.features, FEATURES.SAFENET_CHECKS],
+})
+
+const safenetChainsPage = () => {
+  const page = createChainsPageDataV2(withSafenetChecks(createChainData()))
+  return { ...page, results: page.results.map(withSafenetChecks) }
+}
+
+const safenetChainHandlers = [http.get(/\/v2\/chains$/, () => HttpResponse.json(safenetChainsPage()))]
 
 /**
- * The panel reads the chain and the display currency from the store, and the payment mode from
- * SafeTxContext — so the story holds that mode in state, which makes the "Pay fees from" selector
- * actually switch between Safe-pays and signer-pays rather than snapping back.
+ * The panel reads the chain and the display currency from the store, and both the payment mode
+ * and the Safenet opt-in from SafeTxContext — so the story holds those in state, which makes the
+ * "Pay fees from" selector and the Safenet checkbox actually switch rather than snapping back.
  */
-const PaymentModeHarness = (props: FeesPreviewData) => {
+type HarnessProps = FeesPreviewData & { initialSafenetCheck?: boolean }
+
+const PaymentModeHarness = ({ initialSafenetCheck = false, ...props }: HarnessProps) => {
   const defaults = useContext(SafeTxContext)
   const [gtfPaymentMode, setGtfPaymentMode] = useState<GtfPaymentMode>('safe')
+  const [safenetCheckEnabled, setSafenetCheckEnabled] = useState(initialSafenetCheck)
 
   return (
-    <SafeTxContext.Provider value={{ ...defaults, gtfPaymentMode, setGtfPaymentMode }}>
+    <SafeTxContext.Provider
+      value={{ ...defaults, gtfPaymentMode, setGtfPaymentMode, safenetCheckEnabled, setSafenetCheckEnabled }}
+    >
       <div className="w-[420px]">
         <FeesPreview {...props} />
       </div>
@@ -139,4 +163,28 @@ export const FallbackNoGtfAmount: Story = {
     executionFee: { label: 'Execution fee', isFree: true },
     gasFee: { label: 'Gas fee', amount: '3.50', currency: 'ETH', fiatAmount: '$3.50' },
   },
+}
+
+/**
+ * A Safenet chain, check not requested: the checkbox is offered and off, so no fee is quoted
+ * and the card keeps its two rows.
+ */
+export const SafenetCheckAvailable: Story = {
+  args: defaultArgs,
+  parameters: { msw: { handlers: safenetChainHandlers } },
+}
+
+/**
+ * The checked result. The CGW answers on the GTF arm — `feeBreakdown` (USD end-to-end) and no
+ * `relayCost` — so the Safenet fee renders in the primary slot and the gas fiat comes from
+ * `totalUsd`.
+ */
+export const SafenetFee: Story = {
+  args: {
+    ...defaultArgs,
+    initialSafenetCheck: true,
+    safenetFee: { label: 'Safenet fee', amount: '$\u200A1.00' },
+    gasFee: { label: 'Max gas fee', amount: '0.02733', currency: 'ETH', fiatAmount: '$\u200A97.30' },
+  },
+  parameters: { msw: { handlers: safenetChainHandlers } },
 }

--- a/apps/web/src/features/gtf/components/FeesPreview/FeesPreview.test.tsx
+++ b/apps/web/src/features/gtf/components/FeesPreview/FeesPreview.test.tsx
@@ -2,9 +2,18 @@ import { screen, fireEvent } from '@testing-library/react'
 import { render } from '@/tests/test-utils'
 import FeesPreview from './index'
 import type { FeesPreviewData } from '../../hooks/useFeesPreview'
+import { SafeTxContext, type SafeTxContextParams } from '@/components/tx-flow/SafeTxProvider'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import { useContext } from 'react'
+import { TxFlowContext } from '@/components/tx-flow/TxFlowProvider'
 
+// Safenet-check availability is a chain feature, so the suite drives it per test.
+let mockChainFeatures: string[] = []
 jest.mock('@/hooks/useChains', () => ({
-  useCurrentChain: () => ({ nativeCurrency: { symbol: 'ETH', logoUri: 'https://example/eth.svg' } }),
+  useCurrentChain: () => ({
+    nativeCurrency: { symbol: 'ETH', logoUri: 'https://example/eth.svg' },
+    features: mockChainFeatures,
+  }),
 }))
 
 // Keeps the Safe-pays suite below as live-relaying coverage; the last describe flips it off.
@@ -18,6 +27,7 @@ jest.mock('../../constants', () => ({
 
 afterEach(() => {
   mockRelayingLive = true
+  mockChainFeatures = []
 })
 
 const defaultProps: FeesPreviewData = {
@@ -64,6 +74,32 @@ describe('FeesPreview', () => {
 
     expect(screen.getByText('Max gas fee')).toBeInTheDocument()
     expect(screen.getByText('$97.30')).toBeInTheDocument()
+  })
+
+  it('renders the Safenet fee row between Execution fee and Max gas fee with its tooltip', () => {
+    const { container } = render(
+      <FeesPreview {...defaultProps} safenetFee={{ label: 'Safenet fee', amount: '$\u200A1.00' }} />,
+    )
+
+    const rows = Array.from(container.querySelectorAll('.feeRow'))
+    expect(rows).toHaveLength(3)
+    expect(rows[0].textContent).toContain('Execution fee')
+    expect(rows[1].textContent).toContain('Safenet fee')
+    // Exact, not `toContain`: a currency-less amount must not leave a trailing space behind.
+    expect(rows[1].querySelector('.feeAmount')?.textContent).toBe('$\u200A1.00')
+    expect(rows[2].textContent).toContain('Max gas fee')
+
+    // The tooltip trigger renders only when the tooltip prop is wired through.
+    expect(rows[1].querySelector('.tooltipIcon')).toBeInTheDocument()
+  })
+
+  it('renders exactly two fee rows when safenetFee is absent', () => {
+    const { container } = render(<FeesPreview {...defaultProps} />)
+
+    const rows = Array.from(container.querySelectorAll('.feeRow'))
+    expect(rows).toHaveLength(2)
+    expect(rows[0].textContent).toContain('Execution fee')
+    expect(rows[1].textContent).toContain('Max gas fee')
   })
 
   it('renders total outgoing when Safe wallet selected', () => {
@@ -260,6 +296,111 @@ describe('FeesPreview', () => {
       render(<FeesPreview {...defaultProps} isConfirmation totalOutgoing={twoCurrencyOutgoing} />)
 
       expect(screen.getByText('3.50 USDC')).toBeInTheDocument()
+    })
+  })
+
+  describe('Safenet check opt-in', () => {
+    const CHECKBOX_LABEL = 'Run a Safenet check on this transaction'
+
+    // Only the fields the card actually reads; the rest of the flow context is irrelevant here.
+    const renderWithContext = (
+      props: Partial<FeesPreviewData>,
+      { gtfPaymentMode = 'safe', setSafenetCheckEnabled = jest.fn() } = {},
+    ) => {
+      const value = {
+        gtfPaymentMode,
+        setGtfPaymentMode: jest.fn(),
+        safenetCheckEnabled: false,
+        setSafenetCheckEnabled,
+      } as unknown as SafeTxContextParams
+      render(
+        <SafeTxContext.Provider value={value}>
+          <FeesPreview {...defaultProps} {...props} />
+        </SafeTxContext.Provider>,
+      )
+      return setSafenetCheckEnabled
+    }
+
+    it('offers the checkbox, unchecked, on a chain with the feature', () => {
+      mockChainFeatures = [FEATURES.SAFENET_CHECKS]
+      renderWithContext({})
+
+      expect(screen.getByLabelText(CHECKBOX_LABEL)).not.toBeChecked()
+    })
+
+    it('removes the opt-in when an owner flow becomes proposer-only', () => {
+      mockChainFeatures = [FEATURES.SAFENET_CHECKS]
+      const Mode = ({ isProposing }: { isProposing: boolean }) => {
+        const flow = useContext(TxFlowContext)
+        return (
+          <TxFlowContext.Provider value={{ ...flow, isProposing }}>
+            <FeesPreview {...defaultProps} />
+          </TxFlowContext.Provider>
+        )
+      }
+      const { rerender } = render(<Mode isProposing={false} />)
+      expect(screen.getByLabelText(CHECKBOX_LABEL)).toBeInTheDocument()
+
+      rerender(<Mode isProposing />)
+      expect(screen.queryByLabelText(CHECKBOX_LABEL)).not.toBeInTheDocument()
+    })
+
+    it('hides the checkbox on a chain without the feature', () => {
+      renderWithContext({})
+
+      expect(screen.queryByLabelText(CHECKBOX_LABEL)).not.toBeInTheDocument()
+    })
+
+    it('hides the checkbox for confirmers — the choice is pinned at the first signature', () => {
+      mockChainFeatures = [FEATURES.SAFENET_CHECKS]
+      renderWithContext({ isConfirmation: true })
+
+      expect(screen.queryByLabelText(CHECKBOX_LABEL)).not.toBeInTheDocument()
+    })
+
+    it('hides the checkbox on a legacy-signed payload', () => {
+      mockChainFeatures = [FEATURES.SAFENET_CHECKS]
+      renderWithContext({ isLegacySigned: true })
+
+      expect(screen.queryByLabelText(CHECKBOX_LABEL)).not.toBeInTheDocument()
+    })
+
+    it('hides the checkbox while relaying is switched off', () => {
+      mockChainFeatures = [FEATURES.SAFENET_CHECKS]
+      mockRelayingLive = false
+      renderWithContext({})
+
+      expect(screen.queryByLabelText(CHECKBOX_LABEL)).not.toBeInTheDocument()
+    })
+
+    it('hides the checkbox in signer-pays mode — no Safe quote to carry the fee', () => {
+      mockChainFeatures = [FEATURES.SAFENET_CHECKS]
+      renderWithContext({}, { gtfPaymentMode: 'signer' })
+
+      expect(screen.queryByLabelText(CHECKBOX_LABEL)).not.toBeInTheDocument()
+    })
+
+    it('hides the checkbox when the Safe holds no eligible gas token', () => {
+      mockChainFeatures = [FEATURES.SAFENET_CHECKS]
+      renderWithContext({ availableGasTokens: [] })
+
+      expect(screen.queryByLabelText(CHECKBOX_LABEL)).not.toBeInTheDocument()
+    })
+
+    it('hides the checkbox when the Safe cannot cover the fees', () => {
+      mockChainFeatures = [FEATURES.SAFENET_CHECKS]
+      renderWithContext({ canCoverFees: false })
+
+      expect(screen.queryByLabelText(CHECKBOX_LABEL)).not.toBeInTheDocument()
+    })
+
+    it('reports the new value to the context when toggled', () => {
+      mockChainFeatures = [FEATURES.SAFENET_CHECKS]
+      const setSafenetCheckEnabled = renderWithContext({})
+
+      fireEvent.click(screen.getByLabelText(CHECKBOX_LABEL))
+
+      expect(setSafenetCheckEnabled).toHaveBeenCalledWith(true, expect.anything())
     })
   })
 })

--- a/apps/web/src/features/gtf/components/FeesPreview/index.tsx
+++ b/apps/web/src/features/gtf/components/FeesPreview/index.tsx
@@ -6,6 +6,7 @@ import { sameAddress } from '@safe-global/utils/utils/addresses'
 import ArrowUpRightIcon from '@/public/images/common/arrow-up-right.svg'
 import InfoIcon from '@/public/images/notifications/info.svg'
 import { Alert, AlertDescription, AlertSeverityIcon } from '@/components/ui/alert'
+import { Checkbox } from '@/components/ui/checkbox'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { Separator } from '@/components/ui/separator'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -16,11 +17,13 @@ import { useCurrentChain } from '@/hooks/useChains'
 import { useAppSelector } from '@/store'
 import { selectCurrency } from '@/store/settingsSlice'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
+import { TxFlowContext } from '@/components/tx-flow/TxFlowProvider'
 import type { GtfPaymentMode } from '@/features/gtf/types'
 import type { FeesPreviewData, TotalOutgoing } from '../../hooks/useFeesPreview'
 import { FeeBreakdownRow } from '../shared/FeeBreakdownRow'
-import { GAS_FEE_TOOLTIP } from '../shared/tooltips'
+import { GAS_FEE_TOOLTIP, SAFENET_FEE_TOOLTIP } from '../shared/tooltips'
 import { IS_RELAYING_LIVE } from '../../constants'
+import { isSafenetCheckAvailable } from '../../utils/isSafenetCheckAvailable'
 import css from './styles.module.css'
 
 const SIGNER_FEE_TOOLTIP = 'Fees will be paid from the connected signer wallet when executing this transaction.'
@@ -208,13 +211,15 @@ const FeesPreview = (props: FeesPreviewData): ReactElement => {
     isConfirmation,
     isLegacySigned,
     executionFee,
+    safenetFee,
     gasFee,
     totalOutgoing,
     availableGasTokens,
     selectedGasToken,
     safeHasEnoughGas,
   } = props
-  const { gtfPaymentMode, setGtfPaymentMode } = useContext(SafeTxContext)
+  const { gtfPaymentMode, setGtfPaymentMode, safenetCheckEnabled, setSafenetCheckEnabled } = useContext(SafeTxContext)
+  const { isProposing } = useContext(TxFlowContext)
   const chain = useCurrentChain()
   const nativeDisplay = {
     symbol: chain?.nativeCurrency.symbol ?? '',
@@ -233,6 +238,12 @@ const FeesPreview = (props: FeesPreviewData): ReactElement => {
     (IS_RELAYING_LIVE ? gtfPaymentMode === 'safe' : !!isConfirmation && !isLegacySigned && canCoverFees) &&
     !noEligibleGasToken
   const displayedOutgoing = totalOutgoing && !isSafeWallet ? { ...totalOutgoing, fees: undefined } : totalOutgoing
+
+  // The opt-in rides the pay-from-Safe quote, so it is only offered when that quote is the
+  // active fee path. In signer-pays there is no fee vehicle to carry it. The chain feature
+  // gates availability, and the choice is pinned once a signature bakes the fee in.
+  const canOfferSafenetCheck =
+    isSafeWallet && canCoverFees && !isConfirmation && !isLegacySigned && !isProposing && isSafenetCheckAvailable(chain)
 
   const handlePaymentSourceChange = (source: GtfPaymentMode) => {
     setGtfPaymentMode(source)
@@ -311,10 +322,30 @@ const FeesPreview = (props: FeesPreviewData): ReactElement => {
                 <Separator bleed="4" />
               </>
             )}
+
+            {canOfferSafenetCheck && (
+              <>
+                <div className={css.paymentRowGroup}>
+                  <Checkbox id="safenet-check" checked={safenetCheckEnabled} onCheckedChange={setSafenetCheckEnabled} />
+                  <label htmlFor="safenet-check">
+                    <Typography variant="paragraph-small">Run a Safenet check on this transaction</Typography>
+                  </label>
+                  <Tooltip>
+                    <TooltipTrigger render={<span className={css.tooltipIcon} />}>
+                      <InfoIcon className="size-4 text-[var(--color-border-main)]" />
+                    </TooltipTrigger>
+                    <TooltipContent side="top">{SAFENET_FEE_TOOLTIP}</TooltipContent>
+                  </Tooltip>
+                </div>
+
+                <Separator bleed="4" />
+              </>
+            )}
           </>
         )}
 
         <FeeBreakdownRow {...executionFee} loading={props.loading} />
+        {safenetFee && <FeeBreakdownRow {...safenetFee} loading={props.loading} tooltip={SAFENET_FEE_TOOLTIP} />}
         <FeeBreakdownRow {...gasFee} loading={props.loading} error={props.error} tooltip={GAS_FEE_TOOLTIP} />
       </div>
 

--- a/apps/web/src/features/gtf/components/shared/FeeBreakdownRow.tsx
+++ b/apps/web/src/features/gtf/components/shared/FeeBreakdownRow.tsx
@@ -66,11 +66,11 @@ export const FeeBreakdownRow = ({
             {amount &&
               (isFree && strikeAs === 'del' ? (
                 <Typography variant="paragraph-small" as="del" color="muted">
-                  {amount} {currency}
+                  {currency ? `${amount} ${currency}` : amount}
                 </Typography>
               ) : (
                 <Typography variant="paragraph-small" as="span" className={isFree ? css.strikethrough : undefined}>
-                  {amount} {currency}
+                  {currency ? `${amount} ${currency}` : amount}
                 </Typography>
               ))}
           </div>

--- a/apps/web/src/features/gtf/components/shared/tooltips.ts
+++ b/apps/web/src/features/gtf/components/shared/tooltips.ts
@@ -2,3 +2,5 @@ export const EXECUTION_FEE_TOOLTIP =
   'Covers third-party services required to securely execute this transaction. Based on the transaction amount. Currently free while the new model is introduced.'
 
 export const GAS_FEE_TOOLTIP = 'Network cost required to process this transaction on the blockchain.'
+
+export const SAFENET_FEE_TOOLTIP = 'Fee for the Safenet check that screens this transaction before execution.'

--- a/apps/web/src/features/gtf/hooks/__tests__/useFeesPreview.test.tsx
+++ b/apps/web/src/features/gtf/hooks/__tests__/useFeesPreview.test.tsx
@@ -1,7 +1,15 @@
-import { useState, type ReactNode } from 'react'
+import { useContext, useState, type ReactNode } from 'react'
 import { act } from '@testing-library/react'
 import { skipToken } from '@reduxjs/toolkit/query'
-import { renderHook } from '@/tests/test-utils'
+import { render, renderHook, screen, waitFor } from '@/tests/test-utils'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/tests/server'
+import { GATEWAY_URL } from '@/config/gateway'
+import { useAppDispatch } from '@/store'
+import { initialState as defaultSettings } from '@/store/settingsSlice'
+import FeesPreview from '../../components/FeesPreview'
+import { mergeGtfFeeParams } from '../../services/mergeGtfFeeParams'
+import { resolveFeeParams } from '../../services/resolveFeeParams'
 import { useFeesPreview } from '../useFeesPreview'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import * as useGasLimitModule from '@/hooks/useGasLimit'
@@ -135,6 +143,18 @@ const mockSuccessfulPreview = {
   refetch: jest.fn(),
 } as unknown as ReturnType<typeof gatewayApi.useGetGtfFeePreviewQuery>
 
+// GTF-arm response: `feeBreakdown` only, no `relayCost` — the disjoint shape the CGW
+// sends for chains with a GTF relayer. Everything on this arm is USD.
+const gtfArmPreview = (feeBreakdown: {
+  relayCostUsd?: number
+  totalUsd?: number
+  safenetFeeUsd?: number
+}): typeof mockSuccessfulPreview =>
+  ({
+    ...mockSuccessfulPreview,
+    data: mockSuccessfulPreview.data && { txData: mockSuccessfulPreview.data.txData, feeBreakdown },
+  }) as typeof mockSuccessfulPreview
+
 const emptyPreview = {
   data: undefined,
   isLoading: false,
@@ -151,9 +171,13 @@ const loadingPreview = {
   refetch: jest.fn(),
 } as unknown as ReturnType<typeof gatewayApi.useGetGtfFeePreviewQuery>
 
-const withSafeTx = (safeTx: SafeTransaction | undefined, gtfPaymentMode: 'safe' | 'signer' = 'safe') => {
+const withSafeTx = (
+  safeTx: SafeTransaction | undefined,
+  gtfPaymentMode: 'safe' | 'signer' = 'safe',
+  initialGasToken?: string,
+) => {
   const SafeTxWrapper = ({ children }: { children: ReactNode }) => {
-    const [gtfSelectedGasToken, setGtfSelectedGasToken] = useState<string | undefined>(undefined)
+    const [gtfSelectedGasToken, setGtfSelectedGasToken] = useState(initialGasToken)
     return (
       <SafeTxContext.Provider
         value={
@@ -266,6 +290,161 @@ describe('useFeesPreview', () => {
     expect(result.current.gasFee.amount).toMatch(/^0\.00005/)
     expect(result.current.gasFee.fiatAmount).toBeDefined()
   })
+
+  it('itemizes Safenet in USD and prices the encoded gas refund from balances', () => {
+    jest
+      .spyOn(gatewayApi, 'useGetGtfFeePreviewQuery')
+      .mockReturnValue(gtfArmPreview({ relayCostUsd: 0.12, totalUsd: 1.12, safenetFeeUsd: 1 }))
+
+    const { result } = renderHook(() => useFeesPreview(), { wrapper: withSafeTx(nativeSafeTx) })
+
+    // formatCurrencyPrecise separates the symbol with a hair space, not U+0020.
+    expect(result.current.safenetFee).toEqual({ label: 'Safenet fee', amount: '$\u200A1.00' })
+    expect(result.current.gasFee.fiatAmount).toBe('$\u200A0.13')
+    expect(result.current.canCoverFees).toBe(true)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('shows "< $ 0.01" for a sub-cent Safenet fee', () => {
+    jest
+      .spyOn(gatewayApi, 'useGetGtfFeePreviewQuery')
+      .mockReturnValue(gtfArmPreview({ totalUsd: 0.13, safenetFeeUsd: 0.004 }))
+
+    const { result } = renderHook(() => useFeesPreview(), { wrapper: withSafeTx(nativeSafeTx) })
+
+    expect(result.current.safenetFee).toEqual({ label: 'Safenet fee', amount: '< $\u200A0.01' })
+  })
+
+  it('omits safenetFee when the reported Safenet fee is zero (unchecked chain)', () => {
+    jest
+      .spyOn(gatewayApi, 'useGetGtfFeePreviewQuery')
+      .mockReturnValue(gtfArmPreview({ totalUsd: 0.12, safenetFeeUsd: 0 }))
+
+    const { result } = renderHook(() => useFeesPreview(), { wrapper: withSafeTx(nativeSafeTx) })
+
+    expect(result.current.safenetFee).toBeUndefined()
+  })
+
+  it('omits safenetFee on the RELAY_FEE arm (relayCost, no feeBreakdown) and keeps its fiat source', () => {
+    jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockReturnValue(mockSuccessfulPreview)
+
+    const { result } = renderHook(() => useFeesPreview(), { wrapper: withSafeTx(nativeSafeTx) })
+
+    expect(result.current.safenetFee).toBeUndefined()
+    // Relay cost 0.12410833692950203 USD from the existing mock — unchanged behavior.
+    expect(result.current.gasFee.fiatAmount).toBe('$\u200A0.12')
+  })
+
+  it('prices GTF outgoing totals in EUR while keeping the Safenet itemization in USD', async () => {
+    jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockRestore()
+    jest.spyOn(useBalancesModule, 'default').mockReturnValue(
+      buildBalances([
+        { ...nativeBalance, fiatConversion: '2000' },
+        { ...wethBalance, fiatConversion: '2000' },
+      ]),
+    )
+    server.use(
+      http.post(`${GATEWAY_URL}/v1/chains/1/fees/:safeAddress/preview`, () =>
+        HttpResponse.json({
+          txData: {
+            ...mockSuccessfulPreview.data!.txData,
+            safeTxGas: '0',
+            baseGas: '500000000000000',
+            gasPrice: '1',
+          },
+          feeBreakdown: { totalUsd: 1.25, safenetFeeUsd: 1 },
+        }),
+      ),
+    )
+    const { result } = renderHook(() => useFeesPreview(), {
+      wrapper: withSafeTx(erc20SafeTx),
+      initialReduxState: { settings: { ...defaultSettings, currency: 'eur' } },
+    })
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.gasFee.fiatAmount).toBe('€\u200A1.00')
+    expect(result.current.totalOutgoing?.fiatTotal).toBe('€\u200A10.00')
+    expect(result.current.safenetFee?.amount).toBe('$\u200A1.00')
+  })
+
+  it.each([undefined, '0'])('keeps a GTF quote without inventing fiat for price %s', async (price) => {
+    jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockRestore()
+    jest
+      .spyOn(useBalancesModule, 'default')
+      .mockReturnValue(buildBalances(price === undefined ? [] : [{ ...nativeBalance, fiatConversion: price }]))
+    server.use(
+      http.post(`${GATEWAY_URL}/v1/chains/1/fees/:safeAddress/preview`, () =>
+        HttpResponse.json({
+          txData: mockSuccessfulPreview.data!.txData,
+          feeBreakdown: { totalUsd: 1.25, safenetFeeUsd: 1 },
+        }),
+      ),
+    )
+    const { result } = renderHook(
+      () => ({
+        preview: useFeesPreview(),
+        selection: useContext(SafeTxContext).gtfSelectedGasToken,
+      }),
+      { wrapper: withSafeTx(nativeSafeTx, 'safe', ETH_ADDRESS) },
+    )
+
+    await waitFor(() => expect(result.current.preview.loading).toBe(false))
+    expect(result.current.preview.canCoverFees).toBe(true)
+    expect(result.current.preview.gasFee.fiatAmount).toBeUndefined()
+    expect(result.current.preview.totalOutgoing).toBeUndefined()
+    expect(result.current.preview.safenetFee?.amount).toBe('$\u200A1.00')
+    expect(result.current.selection).toBe(ETH_ADDRESS)
+    expect(result.current.preview.safeHasEnoughGas).toBe(price === undefined ? undefined : true)
+  })
+
+  it.each([undefined, null, '1', 1e400])(
+    'rejects unusable GTF total %s before fallback can retain Safe-paid signing',
+    async (totalUsd) => {
+      jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockRestore()
+      let requests = 0
+      server.use(
+        http.post(`${GATEWAY_URL}/v1/chains/1/fees/:safeAddress/preview`, () => {
+          requests += 1
+          const txData = JSON.stringify(mockSuccessfulPreview.data!.txData)
+          const total = totalUsd === Infinity ? '1e400' : JSON.stringify(totalUsd)
+          const breakdown = total === undefined ? '' : `"totalUsd":${total},`
+          return new HttpResponse(`{"txData":${txData},"feeBreakdown":{${breakdown}"safenetFeeUsd":1}}`, {
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }),
+      )
+      const { result } = renderHook(
+        () => ({
+          preview: useFeesPreview(),
+          selection: useContext(SafeTxContext).gtfSelectedGasToken,
+          dispatch: useAppDispatch(),
+        }),
+        { wrapper: withSafeTx(nativeSafeTx, 'safe', ETH_ADDRESS) },
+      )
+      await waitFor(() => expect(result.current.preview.canCoverFees).toBe(false))
+      expect(result.current.selection).toBeUndefined()
+      expect(result.current.preview.previewedSafeTx).toBeUndefined()
+      render(<FeesPreview {...result.current.preview} />)
+      expect(screen.getByText(/Fees will be paid from the signer/)).toBeInTheDocument()
+      expect(screen.queryByText('Safenet fee')).not.toBeInTheDocument()
+
+      const signingTx = await mergeGtfFeeParams({
+        safeTx: nativeSafeTx,
+        chain: mockChain,
+        gtfPaymentMode: 'safe',
+        gtfSelectedGasToken: result.current.selection,
+        gtfFeature: { $isReady: true, resolveFeeParams },
+        chainId: '1',
+        safeAddress: mockSafe.address.value,
+        numberSignatures: 2,
+        safenetCheck: true,
+        dispatch: result.current.dispatch,
+      })
+      expect(signingTx).toBe(nativeSafeTx)
+      expect(signingTx.data.gasPrice).toBe('0')
+      expect(requests).toBe(1)
+    },
+  )
 
   it('computes single-currency totalOutgoing for native transfer (send + gas in ETH)', () => {
     jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockReturnValue(mockSuccessfulPreview)

--- a/apps/web/src/features/gtf/hooks/__tests__/useGtfFeePreview.test.tsx
+++ b/apps/web/src/features/gtf/hooks/__tests__/useGtfFeePreview.test.tsx
@@ -1,0 +1,141 @@
+import { useContext, type ReactNode } from 'react'
+import { TxFlowContext } from '@/components/tx-flow/TxFlowProvider'
+import { skipToken } from '@reduxjs/toolkit/query'
+
+import { renderHook } from '@/tests/test-utils'
+import { useGtfFeePreview } from '../useGtfFeePreview'
+import { resolveFeeParams } from '../../services/resolveFeeParams'
+import * as gatewayApi from '@/store/api/gateway'
+import { chainBuilder } from '@/tests/builders/chains'
+import { createSafeTx } from '@/tests/builders/safeTx'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import type { AppDispatch } from '@/store'
+
+const mockChain = chainBuilder()
+  .with({
+    chainId: '1',
+    features: [FEATURES.GTF],
+    relayer: {
+      type: 'RELAY_FEE',
+      safeCreationSponsored: false,
+      safeTransactionSponsored: false,
+      enableTenderlySimulationBeforeRelay: false,
+    },
+  })
+  .build()
+
+const SAFE_ADDRESS = '0x1234567890123456789012345678901234567890'
+const GAS_TOKEN = '0x0000000000000000000000000000000000000000'
+
+const safeTx = createSafeTx()
+
+const capturePreviewArg = (safenetCheck: boolean) => {
+  const spy = jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isFetching: false,
+    error: undefined,
+    refetch: jest.fn(),
+  } as unknown as ReturnType<typeof gatewayApi.useGetGtfFeePreviewQuery>)
+
+  renderHook(() =>
+    useGtfFeePreview({
+      enabled: true,
+      safeTx,
+      chain: mockChain,
+      safeAddress: SAFE_ADDRESS,
+      gasToken: GAS_TOKEN,
+      numberSignatures: 2,
+      safenetCheck,
+    }),
+  )
+
+  const arg = spy.mock.calls.at(-1)?.[0]
+  if (arg === skipToken || arg === undefined) throw new Error('preview query was skipped')
+  return arg
+}
+
+// The sign-time refetch goes through the imperative `initiate`, not the hook. Reject the
+// thunk so only the arg matters — nothing downstream of the quote is under test here.
+const captureSignTimeArg = async (safenetCheck: boolean) => {
+  const initiate = jest
+    .spyOn(gatewayApi.gatewayApi.endpoints.getGtfFeePreview, 'initiate')
+    .mockReturnValue({ unwrap: () => Promise.reject(new Error('stop')) } as never)
+  const dispatch = jest.fn((thunk) => thunk) as unknown as AppDispatch
+
+  await expect(
+    resolveFeeParams({
+      chainId: '1',
+      safeAddress: SAFE_ADDRESS,
+      safeTx,
+      gasToken: GAS_TOKEN,
+      numberSignatures: 2,
+      currency: 'usd',
+      safenetCheck,
+      dispatch,
+    }),
+  ).rejects.toThrow('stop')
+
+  return initiate.mock.calls.at(-1)?.[0]
+}
+
+describe('useGtfFeePreview', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('omits safenetCheck from the request when the user has not opted in', () => {
+    expect(capturePreviewArg(false).tx).not.toHaveProperty('safenetCheck')
+  })
+
+  it('sends safenetCheck: true when the user opts in', () => {
+    expect(capturePreviewArg(true).tx.safenetCheck).toBe(true)
+  })
+
+  it('suppresses an earlier owner opt-in after switching to proposer-only mode', () => {
+    let isProposing = false
+    const Wrapper = ({ children }: { children: ReactNode }) => {
+      const flow = useContext(TxFlowContext)
+      return <TxFlowContext.Provider value={{ ...flow, isProposing }}>{children}</TxFlowContext.Provider>
+    }
+    const query = jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockReturnValue({
+      isLoading: false,
+      refetch: jest.fn(),
+    } as ReturnType<typeof gatewayApi.useGetGtfFeePreviewQuery>)
+    const { rerender } = renderHook(
+      () =>
+        useGtfFeePreview({
+          enabled: true,
+          safeTx,
+          chain: mockChain,
+          safeAddress: SAFE_ADDRESS,
+          gasToken: GAS_TOKEN,
+          numberSignatures: 2,
+          safenetCheck: true,
+        }),
+      { wrapper: Wrapper },
+    )
+    expect(query.mock.calls.at(-1)?.[0]).toMatchObject({ tx: { safenetCheck: true } })
+
+    isProposing = true
+    rerender()
+    const proposerArg = query.mock.calls.at(-1)?.[0]
+    if (!proposerArg || proposerArg === skipToken) throw new Error('Expected a fee preview')
+    expect(proposerArg.tx).not.toHaveProperty('safenetCheck')
+  })
+
+  it('varies the request payload with the opt-in, so RTK caches the two quotes apart', () => {
+    expect(capturePreviewArg(true).tx).not.toEqual(capturePreviewArg(false).tx)
+  })
+
+  describe('preview/sign-time payload parity', () => {
+    // The quote is folded into the signed fee fields. If these two payloads ever diverge,
+    // the user signs a `safeTxHash` for a fee they never saw.
+    it.each([true, false])('builds an identical payload on both paths (opt-in: %s)', async (safenetCheck) => {
+      const previewArg = capturePreviewArg(safenetCheck)
+      const signTimeArg = await captureSignTimeArg(safenetCheck)
+
+      expect(signTimeArg).toEqual(previewArg)
+    })
+  })
+})

--- a/apps/web/src/features/gtf/hooks/useFeesPreview.ts
+++ b/apps/web/src/features/gtf/hooks/useFeesPreview.ts
@@ -50,6 +50,11 @@ export type FeesPreviewData = {
    */
   isLegacySigned?: boolean
   executionFee: FeeRow
+  /**
+   * USD fee for the Safenet check, itemized only when the gateway reports a non-zero amount.
+   * Absent in every other branch.
+   */
+  safenetFee?: FeeRow
   gasFee: FeeRow
   totalOutgoing?: TotalOutgoing
   availableGasTokens?: Array<{ address: string; symbol: string; logoUri: string; fiatBalance?: string }>
@@ -78,7 +83,8 @@ export type FeesPreviewData = {
 const EXECUTION_FEE: FeeRow = { label: 'Execution fee', isFree: true }
 
 export const useFeesPreview = (): FeesPreviewData => {
-  const { safeTx, gtfPaymentMode, gtfSelectedGasToken, setGtfSelectedGasToken } = useContext(SafeTxContext)
+  const { safeTx, gtfPaymentMode, gtfSelectedGasToken, setGtfSelectedGasToken, safenetCheckEnabled } =
+    useContext(SafeTxContext)
   const { safe, safeAddress } = useSafeInfo()
   const chain = useCurrentChain()
   const { balances } = useBalances()
@@ -169,6 +175,7 @@ export const useFeesPreview = (): FeesPreviewData => {
     safeAddress,
     gasToken: selectedAddress,
     numberSignatures: safe.threshold,
+    safenetCheck: safenetCheckEnabled,
   })
 
   // Sync `gtfSelectedGasToken` with the latest preview state
@@ -364,42 +371,62 @@ export const useFeesPreview = (): FeesPreviewData => {
 
   // Happy path — fresh, error-free response.
   if (preview.data && !preview.error && safeTx) {
-    const { txData, relayCost } = preview.data
-    const relayCostFiat = Number(relayCost.fiatValue)
-    const relayCostFiatCode = relayCost.fiatCode
+    const { txData, relayCost, feeBreakdown } = preview.data
     const gasWei = (BigInt(txData.safeTxGas) + BigInt(txData.baseGas)) * BigInt(txData.gasPrice)
-    const gasAmount = formatVisualAmount(gasWei, gasDecimals)
     const gasTokenBalance = balances.items.find((b) => sameAddress(b.tokenInfo.address, selectedAddress))
-    const safeHasEnoughGas = gasTokenBalance
-      ? BigInt(gasTokenBalance.balance) >= gasWei + getSendInGasToken(safeTx, selectedAddress)
-      : false
-    const totalOutgoing = computeTotalOutgoing({
-      safeTx,
-      gasWei,
-      relayCostFiat,
-      relayCostFiatCode,
-      nativeSymbol,
-      nativeDecimals,
-      gasTokenAddress: selectedAddress,
-      gasSymbol,
-      gasDecimals,
-      balances,
-    })
+    // GTF USD totals cannot be added to balances priced in the display currency.
+    // Price the encoded refund just as confirmers do; keep the legacy relay quote unchanged.
+    const gasTokenPrice = Number(gasTokenBalance?.fiatConversion)
+    const gasFiatValue = relayCost
+      ? Number(relayCost.fiatValue)
+      : gasTokenPrice > 0
+        ? Number(formatUnits(gasWei, gasDecimals)) * gasTokenPrice
+        : undefined
+    const gasFiatCode = relayCost?.fiatCode ?? currency
+    const hasFiatValue = typeof gasFiatValue === 'number' && Number.isFinite(gasFiatValue)
 
-    return {
-      ...base,
-      canCoverFees: true,
-      gasFee: {
-        label: 'Max gas fee',
-        amount: gasAmount,
-        currency: gasSymbol,
-        fiatAmount: formatCurrencyMinimal(relayCostFiat, relayCostFiatCode),
-      },
-      totalOutgoing,
-      safeHasEnoughGas,
-      previewedSafeTx,
-      loading: false,
-      error: false,
+    if (feeBreakdown || hasFiatValue) {
+      const gasAmount = formatVisualAmount(gasWei, gasDecimals)
+      const safeHasEnoughGas = gasTokenBalance
+        ? BigInt(gasTokenBalance.balance) >= gasWei + getSendInGasToken(safeTx, selectedAddress)
+        : undefined
+      const totalOutgoing = hasFiatValue
+        ? computeTotalOutgoing({
+            safeTx,
+            gasWei,
+            relayCostFiat: gasFiatValue,
+            relayCostFiatCode: gasFiatCode,
+            nativeSymbol,
+            nativeDecimals,
+            gasTokenAddress: selectedAddress,
+            gasSymbol,
+            gasDecimals,
+            balances,
+          })
+        : undefined
+
+      // The "Max gas fee" token amount already covers this fee — the gateway encodes it into
+      // `baseGas`. This row only itemizes it in USD, so it must not be added to any total.
+      const safenetFeeUsd = feeBreakdown?.safenetFeeUsd ?? 0
+      const safenetFee: FeeRow | undefined =
+        safenetFeeUsd > 0 ? { label: 'Safenet fee', amount: formatCurrencyMinimal(safenetFeeUsd, 'USD') } : undefined
+
+      return {
+        ...base,
+        canCoverFees: true,
+        safenetFee,
+        gasFee: {
+          label: 'Max gas fee',
+          amount: gasAmount,
+          currency: gasSymbol,
+          fiatAmount: hasFiatValue ? formatCurrencyMinimal(gasFiatValue, gasFiatCode) : undefined,
+        },
+        totalOutgoing,
+        safeHasEnoughGas,
+        previewedSafeTx,
+        loading: false,
+        error: false,
+      }
     }
   }
 

--- a/apps/web/src/features/gtf/hooks/useGtfFeePreview.ts
+++ b/apps/web/src/features/gtf/hooks/useGtfFeePreview.ts
@@ -1,9 +1,11 @@
+import { useContext } from 'react'
+import { TxFlowContext } from '@/components/tx-flow/TxFlowProvider'
 import { skipToken } from '@reduxjs/toolkit/query'
 import type { SafeTransaction } from '@safe-global/types-kit'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 
 import { useGetGtfFeePreviewQuery } from '@/store/api/gateway'
-import { toSupportedFiatCode } from '@/store/api/gateway/gtfFeePreview'
+import { buildFeePreviewTx } from '@/store/api/gateway/gtfFeePreview'
 import { useAppSelector } from '@/store'
 import { selectCurrency } from '@/store/settingsSlice'
 import { isGtfFeePreviewAvailable } from '../utils/isGtfFeePreviewAvailable'
@@ -15,6 +17,7 @@ type Args = {
   safeAddress: string | undefined
   gasToken: string | undefined
   numberSignatures: number
+  safenetCheck: boolean
 }
 
 /**
@@ -25,24 +28,30 @@ type Args = {
  * Skipped entirely on chains without a RELAY_FEE relayer — the CGW rejects every preview
  * there, so no `enabled` flag from a caller can override the capability gate.
  */
-export const useGtfFeePreview = ({ enabled, safeTx, chain, safeAddress, gasToken, numberSignatures }: Args) => {
+export const useGtfFeePreview = ({
+  enabled,
+  safeTx,
+  chain,
+  safeAddress,
+  gasToken,
+  numberSignatures,
+  safenetCheck,
+}: Args) => {
   const currency = useAppSelector(selectCurrency)
+  const { isProposing } = useContext(TxFlowContext)
 
   return useGetGtfFeePreviewQuery(
     enabled && isGtfFeePreviewAvailable(chain) && chain && safeTx && safeAddress && gasToken && numberSignatures > 0
       ? {
           chainId: chain.chainId,
           safeAddress,
-          tx: {
-            to: safeTx.data.to,
-            value: safeTx.data.value,
-            data: safeTx.data.data,
-            operation: safeTx.data.operation,
+          tx: buildFeePreviewTx({
+            safeTx,
             gasToken,
             numberSignatures,
-            nonce: safeTx.data.nonce,
-            fiatCode: toSupportedFiatCode(currency),
-          },
+            currency,
+            safenetCheck: safenetCheck && !isProposing,
+          }),
         }
       : skipToken,
   )

--- a/apps/web/src/features/gtf/services/__tests__/mergeGtfFeeParams.test.ts
+++ b/apps/web/src/features/gtf/services/__tests__/mergeGtfFeeParams.test.ts
@@ -30,6 +30,7 @@ const baseArgs = (safeTx: SafeTransaction) => ({
   chainId: '1',
   safeAddress: '0xsafe',
   numberSignatures: 2,
+  safenetCheck: false,
   dispatch,
 })
 
@@ -126,7 +127,18 @@ describe('mergeGtfFeeParams', () => {
       safeTx,
       gasToken: '0xtoken',
       numberSignatures: 2,
+      safenetCheck: false,
       dispatch,
     })
+  })
+
+  it('forwards the Safenet opt-in so the signed quote matches the previewed one', async () => {
+    const safeTx = createSafeTx()
+    const resolveFeeParams = jest.fn().mockResolvedValue(createSafeTx())
+    const feature = buildFeature({ resolveFeeParams })
+
+    await mergeGtfFeeParams({ ...baseArgs(safeTx), safenetCheck: true, gtfFeature: feature })
+
+    expect(resolveFeeParams).toHaveBeenCalledWith(expect.objectContaining({ safenetCheck: true }))
   })
 })

--- a/apps/web/src/features/gtf/services/__tests__/resolveFeeParams.test.ts
+++ b/apps/web/src/features/gtf/services/__tests__/resolveFeeParams.test.ts
@@ -73,6 +73,7 @@ describe('resolveFeeParams', () => {
       safeTx,
       gasToken: '0xa0b86991000000000000000000000000000000aa',
       numberSignatures: 3,
+      safenetCheck: false,
       dispatch,
     })
 
@@ -119,6 +120,7 @@ describe('resolveFeeParams', () => {
       safeTx,
       gasToken: '0xa0b86991000000000000000000000000000000aa',
       numberSignatures: 3,
+      safenetCheck: false,
       currency: 'eur',
       dispatch: buildDispatch(buildThunk(Promise.resolve(previewResponse))),
     })
@@ -134,6 +136,7 @@ describe('resolveFeeParams', () => {
       safeTx,
       gasToken: '0xa0b86991000000000000000000000000000000aa',
       numberSignatures: 3,
+      safenetCheck: false,
       currency: 'COP',
       dispatch: buildDispatch(buildThunk(Promise.resolve(previewResponse))),
     })
@@ -158,6 +161,7 @@ describe('resolveFeeParams', () => {
         safeTx,
         gasToken: '0xa0b86991000000000000000000000000000000aa',
         numberSignatures: 3,
+        safenetCheck: false,
         dispatch,
       }),
     ).rejects.toThrow(/untrusted refundReceiver/)
@@ -180,6 +184,7 @@ describe('resolveFeeParams', () => {
         safeTx,
         gasToken: '0xa0b86991000000000000000000000000000000aa',
         numberSignatures: 3,
+        safenetCheck: false,
         dispatch,
       }),
     ).rejects.toThrow('CGW 403')

--- a/apps/web/src/features/gtf/services/mergeGtfFeeParams.ts
+++ b/apps/web/src/features/gtf/services/mergeGtfFeeParams.ts
@@ -16,6 +16,7 @@ export type GtfMergeContext = {
   chainId: string
   safeAddress: string
   numberSignatures: number
+  safenetCheck: boolean
   currency?: string
   dispatch: AppDispatch
 }
@@ -33,6 +34,7 @@ export const mergeGtfFeeParams = async ({
   chainId,
   safeAddress,
   numberSignatures,
+  safenetCheck,
   currency,
   dispatch,
 }: GtfMergeContext): Promise<SafeTransaction> => {
@@ -47,6 +49,7 @@ export const mergeGtfFeeParams = async ({
     safeTx,
     gasToken: gtfSelectedGasToken,
     numberSignatures,
+    safenetCheck,
     currency,
     dispatch,
   })

--- a/apps/web/src/features/gtf/services/resolveFeeParams.ts
+++ b/apps/web/src/features/gtf/services/resolveFeeParams.ts
@@ -3,7 +3,7 @@ import { sameAddress } from '@safe-global/utils/utils/addresses'
 
 import { createTx } from '@/services/tx/tx-sender'
 import { gatewayApi } from '@/store/api/gateway'
-import { toSupportedFiatCode } from '@/store/api/gateway/gtfFeePreview'
+import { buildFeePreviewTx } from '@/store/api/gateway/gtfFeePreview'
 import type { AppDispatch } from '@/store'
 import { FEE_COLLECTORS } from '../constants'
 import { trackError, Errors } from '@/services/exceptions'
@@ -15,6 +15,7 @@ export type ResolveFeeParamsArgs = {
   gasToken: string
   numberSignatures: number
   currency?: string
+  safenetCheck: boolean
   dispatch: AppDispatch
 }
 
@@ -30,25 +31,17 @@ export const resolveFeeParams = async ({
   gasToken,
   numberSignatures,
   currency,
+  safenetCheck,
   dispatch,
 }: ResolveFeeParamsArgs): Promise<SafeTransaction> => {
-  const { to, value, data, operation, nonce } = safeTx.data
+  const { nonce } = safeTx.data
 
   const preview = await dispatch(
     gatewayApi.endpoints.getGtfFeePreview.initiate(
       {
         chainId,
         safeAddress,
-        tx: {
-          to,
-          value,
-          data,
-          operation,
-          gasToken,
-          numberSignatures,
-          nonce,
-          fiatCode: toSupportedFiatCode(currency),
-        },
+        tx: buildFeePreviewTx({ safeTx, gasToken, numberSignatures, currency, safenetCheck }),
       },
       { forceRefetch: true },
     ),

--- a/apps/web/src/features/gtf/utils/isSafenetCheckAvailable.ts
+++ b/apps/web/src/features/gtf/utils/isSafenetCheckAvailable.ts
@@ -1,0 +1,9 @@
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import { FEATURES, hasFeature } from '@safe-global/utils/utils/chains'
+
+/**
+ * Whether the user may opt into a Safenet check on this chain. The feature gates
+ * availability only — the check itself is off unless the user asks for it per transaction.
+ */
+export const isSafenetCheckAvailable = (chain: Chain | undefined): boolean =>
+  !!chain && hasFeature(chain, FEATURES.SAFENET_CHECKS)

--- a/apps/web/src/features/safe-shield/SafeShield.stories.tsx
+++ b/apps/web/src/features/safe-shield/SafeShield.stories.tsx
@@ -367,6 +367,8 @@ const overflowSafeTxContextValue: SafeTxContextParams = {
   gtfPaymentMode: 'safe',
   setGtfPaymentMode: () => {},
   setGtfSelectedGasToken: () => {},
+  safenetCheckEnabled: false,
+  setSafenetCheckEnabled: () => {},
 }
 
 const overflowStore = makeStore({

--- a/apps/web/src/features/safe-shield/__tests__/SafeShieldContext.test.tsx
+++ b/apps/web/src/features/safe-shield/__tests__/SafeShieldContext.test.tsx
@@ -55,6 +55,8 @@ const mockSafeTxContextValue = {
   gtfPaymentMode: 'safe' as const,
   setGtfPaymentMode: jest.fn(),
   setGtfSelectedGasToken: jest.fn(),
+  safenetCheckEnabled: false,
+  setSafenetCheckEnabled: jest.fn(),
 }
 
 const mockUseThreatAnalysis = jest.requireMock('../hooks').useThreatAnalysis

--- a/apps/web/src/hooks/__tests__/useValidateTxData.test.tsx
+++ b/apps/web/src/hooks/__tests__/useValidateTxData.test.tsx
@@ -26,6 +26,8 @@ const createWrapper = (safeTx?: SafeTransaction) => {
     gtfPaymentMode: 'safe',
     setGtfPaymentMode: () => {},
     setGtfSelectedGasToken: () => {},
+    safenetCheckEnabled: false,
+    setSafenetCheckEnabled: () => {},
   }
   return function Wrapper({ children }: { children: ReactNode }) {
     return <SafeTxContext.Provider value={value}>{children}</SafeTxContext.Provider>

--- a/apps/web/src/store/api/gateway/gtfFeePreview.ts
+++ b/apps/web/src/store/api/gateway/gtfFeePreview.ts
@@ -1,6 +1,6 @@
 import type { fakeBaseQuery } from '@reduxjs/toolkit/query/react'
 import { type EndpointBuilder } from '@reduxjs/toolkit/query/react'
-import type { OperationType } from '@safe-global/types-kit'
+import type { OperationType, SafeTransaction } from '@safe-global/types-kit'
 
 import { GATEWAY_URL } from '@/config/gateway'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
@@ -35,7 +35,38 @@ export type FeePreviewTransactionDto = {
   nonce: number
   fiatCode?: string
   origin?: string
+  safenetCheck?: boolean
 }
+
+/**
+ * Single source for the preview payload. The live preview and the sign-time refetch MUST
+ * send byte-identical bodies: the quote is folded into the signed fee fields, so any
+ * divergence makes the user sign a different `safeTxHash` than the one previewed.
+ */
+export const buildFeePreviewTx = ({
+  safeTx,
+  gasToken,
+  numberSignatures,
+  currency,
+  safenetCheck,
+}: {
+  safeTx: SafeTransaction
+  gasToken: string
+  numberSignatures: number
+  currency: string | undefined
+  safenetCheck: boolean
+}): FeePreviewTransactionDto => ({
+  to: safeTx.data.to,
+  value: safeTx.data.value,
+  data: safeTx.data.data,
+  operation: safeTx.data.operation,
+  gasToken,
+  numberSignatures,
+  nonce: safeTx.data.nonce,
+  fiatCode: toSupportedFiatCode(currency),
+  // Sent only when on, mirroring the gateway's own convention. Absent means no check.
+  ...(safenetCheck && { safenetCheck: true }),
+})
 
 export type FeePreviewTxData = {
   chainId: string
@@ -53,9 +84,19 @@ export type FeePreviewRelayCost = {
   fiatValue: string
 }
 
+/**
+ * The CGW switches the response shape on `chain.relayer.type`: the RELAY_FEE arm sends
+ * `relayCost`, the GTF arm sends `feeBreakdown` (USD end-to-end) and no `relayCost`.
+ * Only the consumed fields are typed.
+ */
 export type FeePreviewResponse = {
   txData: FeePreviewTxData
-  relayCost: FeePreviewRelayCost
+  relayCost?: FeePreviewRelayCost
+  feeBreakdown?: {
+    relayCostUsd?: number
+    totalUsd?: number
+    safenetFeeUsd?: number
+  }
 }
 
 export type FeePreviewArg = {
@@ -64,8 +105,18 @@ export type FeePreviewArg = {
   tx: FeePreviewTransactionDto
 }
 
-const isFeePreviewResponse = (value: unknown): value is FeePreviewResponse =>
-  typeof value === 'object' && value !== null && 'txData' in value && 'relayCost' in value
+const hasCompleteFeeBreakdown = (value: unknown): boolean =>
+  typeof value === 'object' &&
+  value !== null &&
+  'totalUsd' in value &&
+  typeof value.totalUsd === 'number' &&
+  Number.isFinite(value.totalUsd)
+
+const isFeePreviewResponse = (value: unknown): value is FeePreviewResponse => {
+  if (typeof value !== 'object' || value === null || !('txData' in value)) return false
+  if ('feeBreakdown' in value) return hasCompleteFeeBreakdown(value.feeBreakdown)
+  return 'relayCost' in value
+}
 
 export const gtfFeePreviewEndpoints = (builder: GatewayEndpointBuilder) => ({
   getGtfFeePreview: builder.query<FeePreviewResponse, FeePreviewArg>({


### PR DESCRIPTION
## What it solves

The client gateway's GTF fee preview is gaining a user-charged Safenet check fee:
`feeBreakdown.safenetFeeUsd`, priced by the fee service when a transaction opts into a
Safenet check, included upstream in `totalUsd` and encoded into `txData.baseGas` (so it is
part of the signed `safeTxHash`). The wallet had no way to request the check and no way to
show the charge.

## How this PR fixes it

Two pieces, both dark behind `IS_RELAYING_LIVE` like the rest of the GTF flow:

**1. A per-transaction opt-in checkbox** — "Run a Safenet check on this transaction" — in
the GTF fee card. Default off. Rendered only when all of these hold: the viewed chain has
the `SAFENET_CHECKS` feature, fees are paid from the Safe (`isSafeWallet`), the Safe can
cover fees, and no signatures exist yet. The choice lives in `SafeTxContext`
(`safenetCheckEnabled`), gated once at the provider by chain availability — an opt-in
carried over to a chain without the feature is never sent.

The preview request and the sign-time request (`resolveFeeParams`) build their payload
through one shared `buildFeePreviewTx`, so the flag the user previews is exactly the flag
that prices the payload they sign. Toggling re-quotes to a different `safeTxHash`; once
signatures exist the choice is pinned with the rest of the fee params.

**2. The fee line** — `Safenet fee $ 1.00` between "Execution fee" and "Max gas fee",
rendered only when `safenetFeeUsd > 0` (never on field presence: the paired gateway sends
`0` for unchecked quotes, and an older gateway omits `feeBreakdown` entirely). The amount
is USD-denominated end to end on the GTF arm. The fee is already inside `baseGas`, so the
"Max gas fee" token amount and every total contain it exactly once — the row itemizes, it
is never added to a total.

Also fixed while here: the hand-written `FeePreviewResponse` type modelled only the legacy
relay shape `{txData, relayCost}`. The gateway's GTF arm actually returns
`{txData, feeBreakdown, maxFeeCapUsd}` with no `relayCost`, so the guard rejected every
real GTF preview. The type is now the union, and the gas-fee fiat on the GTF arm derives
from `feeBreakdown.totalUsd` (the fiat equivalent of the on-chain refund the token amount
shows). A breakdown without `totalUsd` falls through to the existing local-estimate
fallback rather than rendering NaN.

## How to test it

```
yarn workspace @safe-global/web jest src/features/gtf
yarn workspace @safe-global/web type-check
```

Storybook: `Features/GTF/FeesPreview` → `SafenetCheckAvailable` (checkbox off, two rows),
`SafenetFee` (checkbox on, fee row). Live: against a gateway serving the GTF arm with the
fee fields, tick the checkbox → the row appears and "Max gas fee" grows by the fee;
untick → both revert. Verified end to end on a local five-service stack: the flag left the
wallet only when opted in, the gateway forwarded it only with the chain feature on, and
the quoted, signed, and stored `safeTxHash` were identical.

## Affected flows

- GTF confirm flow (review step): checkbox + fee row. Signer-pays mode, the confirmation
  step for later signers, and chains without the feature see no checkbox and no row.
- Sign-time fee resolution and the advanced-details tabs (`Receipt`): the previewed flag
  rides along, so displayed and signed payloads stay coherent.
- Legacy relay-arm previews: unchanged (`relayCost` path is preserved by the union type).

## Blast radius

- `FeePreviewResponse` (hand-written type): `relayCost` becomes optional; optional
  `feeBreakdown` added. Only consumer of `relayCost` is `useFeesPreview`; `resolveFeeParams`
  and `mergeGtfFeeParams` read `txData` only.
- `SafeTxContext`: additive `safenetCheckEnabled`/`setSafenetCheckEnabled`.
- `useFeesPreview`: additive `safenetFee` row; gas-fiat source widened to the GTF arm.
- `FeeBreakdownRow`: renders `amount` without a trailing space when `currency` is absent.
- Mobile: no GTF surface consumes any of this.

## Risks / not checked

- The fee row for later signers of an already-signed transaction is not itemized (the
  confirmation branch has no preview data); the amount stays inside the gas totals. Known,
  disclosed, needs a persisted breakdown or a keyed preview to recover — out of scope here.
- The whole surface is behind `IS_RELAYING_LIVE = false`; no production path renders it
  until relaying goes live.
- Non-USD display currencies: the Safenet fee renders in USD (its denomination end to end
  on the GTF arm); the gateway does no conversion for it.
- Not tested on mobile (no consuming surface).

## Visual summary

```mermaid
flowchart TB
  CB["checkbox: Run a Safenet check<br/>(default off)"] -->|off| OFF["request has no safenetCheck key<br/>safenetFeeUsd 0 - no row"]
  CB -->|on| ON["safenetCheck: true -> gateway"]
  ON --> FEE["quote: safenetFeeUsd 1<br/>baseGas grows - different safeTxHash"]
  FEE --> ROW["row: Safenet fee $1.00<br/>Max gas fee +$1.00"]
  ROW --> SIGN["sign-time re-quote carries the same flag<br/>quoted hash == signed hash"]
  GATE["chain feature SAFENET_CHECKS<br/>+ Safe pays + no signatures"] -.->|gates| CB
```

**Checkbox off — light / dark**

<img width="340" alt="Checkbox off, light mode" src="https://gist.githubusercontent.com/Fbartoli/42d353ade65f55cd206edf9b79e1572d/raw/gtf-fee-checkbox-off-light.png"> <img width="340" alt="Checkbox off, dark mode" src="https://gist.githubusercontent.com/Fbartoli/42d353ade65f55cd206edf9b79e1572d/raw/gtf-fee-checkbox-off-dark.png">

**Checkbox on, fee itemized — light / dark**

<img width="340" alt="Checkbox on, light mode" src="https://gist.githubusercontent.com/Fbartoli/42d353ade65f55cd206edf9b79e1572d/raw/gtf-fee-checkbox-on-light.png"> <img width="340" alt="Checkbox on, dark mode" src="https://gist.githubusercontent.com/Fbartoli/42d353ade65f55cd206edf9b79e1572d/raw/gtf-fee-checkbox-on-dark.png">

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics change
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
