### PR TITLE
fix: network name, alignment and backdrop in the Add manually dialog (WA-3438)

### DIFF
--- a/apps/web/src/features/spaces/components/AddAccounts/AddManually.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/AddManually.tsx
@@ -112,7 +112,7 @@ const AddManually = ({
                   >
                     {/* eslint-disable-next-line no-restricted-syntax -- h-full/w-full fill the row cell (layout); skin is variant="ghost" */}
                     <SelectTrigger variant="ghost" className="h-full w-full">
-                      <SelectValue />
+                      <SelectValue>{(value) => <ChainIndicator chainId={value} />}</SelectValue>
                     </SelectTrigger>
                     <SelectContent>
                       {configs.map((chain) => (

--- a/apps/web/src/features/spaces/components/AddAccounts/AddManually.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/AddManually.tsx
@@ -84,6 +84,7 @@ const AddManually = ({
         dialogTitle="Add safe account"
         onClose={onClose}
         hideChainIndicator
+        forceBackdrop
         PaperProps={{ sx: { maxWidth: '760px' } }}
       >
         <FormProvider {...formMethods}>

--- a/apps/web/src/features/spaces/components/AddAccounts/AddManually.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/AddManually.tsx
@@ -94,7 +94,7 @@ const AddManually = ({
             }}
           >
             <div className="px-6 py-4">
-              <div className="flex flex-col gap-4 md:flex-row">
+              <div className="flex flex-col gap-4 md:flex-row md:items-end">
                 <AddressInput
                   data-testid="add-address-input"
                   label="Safe account"

--- a/apps/web/src/features/spaces/components/AddAccounts/__tests__/AddManually.test.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/__tests__/AddManually.test.tsx
@@ -1,9 +1,16 @@
-import { render, screen, fireEvent } from '@/tests/test-utils'
+import { render, screen, fireEvent, waitFor } from '@/tests/test-utils'
+import { chainBuilder } from '@/tests/builders/chains'
+import chains from '@safe-global/utils/config/chains'
 import AddManually from '../AddManually'
+
+const chainConfigs = [
+  chainBuilder().with({ chainId: chains.eth, chainName: 'Ethereum' }).build(),
+  chainBuilder().with({ chainId: '137', chainName: 'Polygon' }).build(),
+]
 
 jest.mock('@/hooks/useChains', () => ({
   __esModule: true,
-  default: () => ({ configs: [] }),
+  default: () => ({ configs: chainConfigs }),
   useHasFeature: () => false,
 }))
 
@@ -18,7 +25,7 @@ jest.mock('@/components/common/AddressInput', () => ({
 
 jest.mock('@/components/common/ChainIndicator', () => ({
   __esModule: true,
-  default: () => <div data-testid="chain-indicator" />,
+  default: ({ chainId }: { chainId: string }) => <span>Chain {chainId}</span>,
 }))
 
 jest.mock('@/components/common/ModalDialog', () => ({
@@ -46,5 +53,15 @@ describe('AddManually', () => {
     fireEvent.click(screen.getByTestId('add-manually-button'))
 
     expect(screen.queryByTestId('modal-dialog')).not.toBeInTheDocument()
+  })
+
+  it('shows the network label on the closed network trigger for the default chain', async () => {
+    render(<AddManually handleAddSafe={jest.fn()} />)
+
+    fireEvent.click(screen.getByTestId('add-manually-button'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('network-selector')).toHaveTextContent(`Chain ${chains.eth}`)
+    })
   })
 })

--- a/apps/web/src/features/spaces/components/AddAccounts/__tests__/AddManually.test.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/__tests__/AddManually.test.tsx
@@ -30,8 +30,20 @@ jest.mock('@/components/common/ChainIndicator', () => ({
 
 jest.mock('@/components/common/ModalDialog', () => ({
   __esModule: true,
-  default: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
-    open ? <div data-testid="modal-dialog">{children}</div> : null,
+  default: ({
+    open,
+    children,
+    forceBackdrop,
+  }: {
+    open: boolean
+    children: React.ReactNode
+    forceBackdrop?: boolean
+  }) =>
+    open ? (
+      <div data-testid="modal-dialog" data-force-backdrop={String(Boolean(forceBackdrop))}>
+        {children}
+      </div>
+    ) : null,
 }))
 
 describe('AddManually', () => {
@@ -53,6 +65,16 @@ describe('AddManually', () => {
     fireEvent.click(screen.getByTestId('add-manually-button'))
 
     expect(screen.queryByTestId('modal-dialog')).not.toBeInTheDocument()
+  })
+
+  // The dialog is nested inside the "My accounts" picker dialog, and Base UI drops the backdrop of a
+  // nested dialog. Without forceBackdrop the two surfaces render with nothing between them.
+  it('forces its own backdrop so it does not merge into the dialog behind it', () => {
+    render(<AddManually handleAddSafe={jest.fn()} />)
+
+    fireEvent.click(screen.getByTestId('add-manually-button'))
+
+    expect(screen.getByTestId('modal-dialog')).toHaveAttribute('data-force-backdrop', 'true')
   })
 
   it('shows the network label on the closed network trigger for the default chain', async () => {


### PR DESCRIPTION
> **This pull request was produced entirely by an automated Claude run.** A human wrote the ticket. The research, plan, code, tests and this description all came from the automated run, with no human in the loop. Please review it like a new colleague's first pull request and assume nothing.

## What it solves

Resolves: [WA-3438](https://linear.app/safe-global/issue/WA-3438/workspace-add-manually-network-picker-shows-a-bare-chain-id-instead-of)

Three things in the Workspace **Add safe account** dialog. One from the ticket, two found by reviewers on this PR. All three are post-migration regressions that were already on `dev`; none were introduced here.

| # | Problem | Commit |
|---|---|---|
| 1 | Network picker showed a bare chain id (`1`) instead of the network name | `529b3c0` |
| 2 | **Safe account** field and the picker did not line up | `6e8e123` |
| 3 | Nested dialog had no backdrop, so it merged into the picker behind it | `99ed87f` |

## How each is fixed

**1. The chain id.** `SelectValue` was self-closing; it now takes a render-function child that receives the selected value and returns a `ChainIndicator`.

The option labels live in `SelectContent`, and Base UI throws that popup away while closed — so a self-closing `SelectValue` has no label to read and prints the raw value. Giving it children removes the dependency on the popup existing. The primitive documents two escapes (`select.tsx:39-41`): an `items` map, or `SelectValue` children. The `items` map is strings-only, so it would show "Ethereum" with no logo — fixing half the bug and regressing the other half. [NetworkInput](https://github.com/safe-global/safe-wallet-monorepo/blob/dev/apps/web/src/components/common/NetworkInput/index.tsx#L60-L66) already uses the children form for this exact problem.

**2. The alignment.** One class: `md:flex-row` becomes `md:flex-row md:items-end`.

Both boxes already set `min-height: 66px` with identical padding, border and radius. `AddressInput` has a label above its box and the selector does not, so the input started 31px lower. Two things make bottom-alignment the safe version: `AddressInput`'s `Field` holds only the label and the box (an invalid address recolors them rather than adding a message), so nothing can move the bottom edge later; and it is scoped to `md` because the row is `flex-col` below that, where `items-end` would right-align both fields.

**3. The backdrop.** One prop: `forceBackdrop`.

This dialog opens from inside the "My accounts" picker dialog, and Base UI drops the backdrop of a nested dialog. `ModalDialog` already has the prop for this case — its comment says *"Renders the backdrop even when nested in another dialog"* — and `AdvancedParamsForm.tsx:72` and `CSVAirdropAppModal` already use it.

## How to test it

```bash
yarn workspace @safe-global/web jest src/features/spaces/components/AddAccounts
yarn verify:changed:web
```

By hand:

1. Open a Workspace you are an **Admin** of → `/spaces/safe-accounts`.
2. **Add accounts** → **Select from my accounts**.
3. Bottom-left, click **Add manually**.
4. The picker behind should be dimmed and blurred, not flush against this dialog.
5. The network selector should show the network name and logo, not a number, and its box should line up with the **Safe account** box.
6. Open the dropdown, pick another network, close it — the trigger should follow.
7. Narrow below 768px: the fields stack, and neither should be right-aligned.

Preview: https://claude-trusting-carson-s0peag--walletweb.review.5afe.dev/

## Affected flows

- Workspace admin adds a Safe account manually, picking its network.

## Blast radius

Two files, +25 / -2 on top of the original one-line fix.

- `AddManually.tsx` has exactly one importer, `AddAccounts/index.tsx`. Nothing else uses it.
- `ui/select.tsx`, `ui/dialog.tsx`, `ModalDialog`, `ChainIndicator` and `AddressInput` are all untouched — so the other 28 `Select` call sites, every other `AddressInput`, and every other dialog are unaffected.
- `forceBackdrop` and `md:items-end` act only within this dialog.
- No API contract, cache, persisted state, or `packages/**` change, so no mobile impact.
- No new imports, so no bundle impact.

## Measured, not eyeballed

| | before | after |
|---|---|---|
| network selector box | top 404, bottom 470 | top 435, bottom 501 |
| address box | top 435, bottom 501 | top 435, bottom 501 |
| backdrops mounted | 1 (the picker's only) | 2, `blur(4px)` on both |

## Risks / not checked

- **Did not fix the shared root cause of #1.** `ui/select.tsx:44` is a bare re-export with no lint rule or dev warning, so any new `Select` whose labels differ from its values hits this again silently. That primitive has 29 consumers and it needs a decision on warn vs. lint vs. type-error. Its own ticket.
- **Did not audit the other 28 `Select` call sites,** nor other nested dialogs for the same missing backdrop. Given `ui/overlay.ts` records that the migration once left *"four hand-copied scrims… two of them had no blur at all"*, a sweep is probably worth its own ticket.
- **Chose bottom-alignment over labelling the selector.** A "Network" label would also align them and would match `NetworkInput`, but adds UI copy nobody asked for. Easy to switch.
- **No test for the alignment.** Asserting a utility class tests the implementation, not the behaviour; the geometry table above covers it. The backdrop *did* get a test, because its failure mode is silent — nothing throws, the scrim just goes missing.
- **The chain logo does not render in my screenshots.** My capture environment, not the app: all five dropdown logos fail too (`naturalWidth: 0`) and the sandbox blocks that host entirely (`curl` → nothing, github.com too). The fixture URL is a correct staging path, so it loads normally for anyone with network access. Separately worth a ticket: Storybook's chain fixtures point at a live staging host, so logos break silently offline, in restricted CI, or during an outage. The fix is vendoring them locally — needs network access I do not have.
- No Playwright or Cypress test covers this dialog and I did not add one; unit tests cover the two silent-failure regressions.
- Not tested on mobile hardware, or with a real wallet. Not verified on the preview, since reaching this dialog needs an Admin Workspace behind wallet auth I do not have.
- Not verified against a Workspace at its Safe limit, where **Add manually** is disabled. Existing behaviour, untouched.

## Visual summary

Same story, same data, one change at a time. The broken-image icon is the unreachable logo host above, not part of any change.

**Chain id** — reads `1`, then `Ethereum`:

| Before | After |
|---|---|
| ![before](https://github.com/safe-global/safe-wallet-monorepo/blob/claude/pr-media/WA-3438/before-network-selector.png?raw=true) | ![after](https://github.com/safe-global/safe-wallet-monorepo/blob/claude/pr-media/WA-3438/after-network-selector.png?raw=true) |

**Alignment** — selector sits 31px high, then lines up:

| Before | After |
|---|---|
| ![before](https://github.com/safe-global/safe-wallet-monorepo/blob/claude/pr-media/WA-3438/before-alignment.png?raw=true) | ![after](https://github.com/safe-global/safe-wallet-monorepo/blob/claude/pr-media/WA-3438/after-alignment.png?raw=true) |

**Backdrop** — picker behind is sharp, then dimmed and blurred:

| Before | After |
|---|---|
| ![before](https://github.com/safe-global/safe-wallet-monorepo/blob/claude/pr-media/WA-3438/before-backdrop.png?raw=true) | ![after](https://github.com/safe-global/safe-wallet-monorepo/blob/claude/pr-media/WA-3438/after-backdrop.png?raw=true) |

Why the chain id fell back to the raw value:

```mermaid
flowchart TB
  subgraph Before
    A1["Select closed"] --> B1["Base UI unmounts the popup"]
    B1 --> C1["ChainIndicator labels go with it"]
    C1 --> D1["self-closing SelectValue has no label"]
    D1 --> E1["falls back to raw value: '1'"]
  end
  subgraph After
    A2["Select closed"] --> B2["Base UI unmounts the popup"]
    B2 --> C2["SelectValue has its own render-function child"]
    C2 --> D2["renders ChainIndicator for current value"]
    D2 --> E2["shows logo plus 'Ethereum'"]
  end
```

## What to review closely

1. **The render function.** Can the value it receives be `null` or `undefined`? I believe not — the form defaults `chainId` to `chains.eth` and `onValueChange` only writes on a truthy value, and `ChainIndicator` falls back to the current chain anyway, so the worst case is a wrong label rather than a crash. Base UI types that argument as `any`, so the compiler will not catch me being wrong.
2. **`md:items-end`.** It rests on nothing ever rendering below `AddressInput`'s box inside its `Field`. True today; if something is added there later, the alignment silently breaks again.
3. **`forceBackdrop`.** Worth confirming two stacked backdrops is what we want here rather than one shared scrim. Both measure `blur(4px)`, and it matches the two existing call sites, but a designer may have a view on the doubled tint.
4. **The `useChains` mock in the test now returns two real chain configs instead of `[]`.** That empty array is why no test caught bug #1: with no configs, `ChainIndicator` renders a skeleton and the trigger is never exercised. Worth checking the other tests still assert what they meant to.

## How I got here

Read the ticket, the files it names, `ui/select.tsx`, then both stylesheets and `ModalDialog`. Grepped all 29 `SelectValue` call sites, which surfaced `NetworkInput` already solving #1 correctly — that settled the approach instead of inventing one. Same for #3: grepping `forceBackdrop` found two precedents and its own doc comment naming the nested case.

Everything visual was measured with Playwright (`boundingBox()`, computed styles, `img.naturalWidth`) rather than eyeballed, rendering the same story with and without each change. That is what showed #2 and #3 predate this PR, and that #1 changes width only.

Evidence sources: **Datadog** RUM `/spaces/*` errors over 30 days — 34, all unrelated (Ledger timeouts, `GS013` reverts), expected since a wrong label throws nothing. **Mixpanel** — could not check, `Get-Business-Context` fails with a missing `business_context` scope, so I have no usage numbers and am not guessing at blast radius. **Notion** — "Staging bugs after the shadcn migration" and "Polishing and bugfixes after Shadcn migration" confirm this is WA-3111 family, matching the ticket. No design doc governs this picker, so I matched pre-migration behaviour and the rest of the app.

Backed out of two things: the `items` map (strings-only, loses the logo) and a permanent Storybook story, because `yarn generate:storybook-tests` regenerates 335 files and the convention is inconsistent (73 tracked, 335 generated). Screenshots come from throwaway stories not in this diff.

## Trade-offs

Fixed three visible problems in one dialog and left the two shared-primitive sweeps alone. Those are higher leverage but touch 29 call sites and every dialog respectively, and both need a design decision — shipping the visible fixes now keeps this reviewable.

Preferred existing patterns over invention throughout: `NetworkInput`'s render function, `ModalDialog`'s own `forceBackdrop`, and the smallest correct alignment fix rather than new UI copy.

## Checklist

- [ ] I've tested the branch on mobile 📱 — not on hardware; the stacked layout below 768px is deliberately unaffected, see step 7
- [x] I've documented how it affects the analytics (if at all) 📊 — no change; `ADD_ACCOUNT_MANUALLY` and its `chainId` param are untouched
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — regression tests for the two silent failures (chain id, backdrop); alignment covered by measurement
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯