### PR TITLE
feat(gtf): itemize the Safenet fee for co-signers from the stored quote

### DIFF
--- a/apps/web/src/components/transactions/TxDetails/Summary/SafeTxHashDataRow/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/Summary/SafeTxHashDataRow/index.tsx
@@ -45,7 +45,7 @@ export function useSafeTxHash({
   safeTxData,
   safeTxHash,
 }: {
-  safeTxData: SafeTransactionData
+  safeTxData: SafeTransactionData | undefined
   safeTxHash?: string
 }): string | null {
   const { safe, safeAddress } = useSafeInfo()
@@ -57,7 +57,7 @@ export function useSafeTxHash({
     }
     // Try to get version from SDK first, fall back to safe.version
     const version = safeSDK?.getContractVersion() || safe.version
-    if (!version) {
+    if (!version || !safeTxData) {
       return null
     }
     try {

--- a/apps/web/src/features/gtf/components/FeesPreview/FeesPreview.stories.tsx
+++ b/apps/web/src/features/gtf/components/FeesPreview/FeesPreview.stories.tsx
@@ -188,3 +188,18 @@ export const SafenetFee: Story = {
   },
   parameters: { msw: { handlers: safenetChainHandlers } },
 }
+
+/**
+ * A co-signer on an already-signed payload. The row comes from the stored quote read back by
+ * `safeTxHash`, so it reports what the signers signed; the opt-in checkbox stays hidden.
+ */
+export const ConfirmationWithSafenetFee: Story = {
+  args: {
+    ...defaultArgs,
+    isConfirmation: true,
+    safenetFee: { label: 'Safenet fee', amount: '$\u200A1.00' },
+    gasFee: { label: 'Max gas fee', amount: '0.02733', currency: 'ETH', fiatAmount: '$\u200A97.30' },
+    onGasTokenChange: undefined,
+  },
+  parameters: { msw: { handlers: safenetChainHandlers } },
+}

--- a/apps/web/src/features/gtf/components/FeesPreview/FeesPreview.test.tsx
+++ b/apps/web/src/features/gtf/components/FeesPreview/FeesPreview.test.tsx
@@ -402,5 +402,20 @@ describe('FeesPreview', () => {
 
       expect(setSafenetCheckEnabled).toHaveBeenCalledWith(true, expect.anything())
     })
+
+    it('renders the read-back fee row on the confirmation card, checkbox still hidden', () => {
+      mockChainFeatures = [FEATURES.SAFENET_CHECKS]
+      const { container } = render(
+        <FeesPreview {...defaultProps} isConfirmation safenetFee={{ label: 'Safenet fee', amount: '$\u200A1.00' }} />,
+      )
+
+      const rows = Array.from(container.querySelectorAll('.feeRow'))
+      expect(rows).toHaveLength(3)
+      expect(rows[0].textContent).toContain('Execution fee')
+      expect(rows[1].textContent).toContain('Safenet fee')
+      expect(rows[1].querySelector('.feeAmount')?.textContent).toBe('$\u200A1.00')
+      expect(rows[2].textContent).toContain('Max gas fee')
+      expect(screen.queryByLabelText(CHECKBOX_LABEL)).not.toBeInTheDocument()
+    })
   })
 })

--- a/apps/web/src/features/gtf/hooks/__tests__/useFeesPreview.readback.test.tsx
+++ b/apps/web/src/features/gtf/hooks/__tests__/useFeesPreview.readback.test.tsx
@@ -1,0 +1,372 @@
+/**
+ * Integration cover for the stored-quote read-back: the REAL `getGtfFeeSnapshot` endpoint and the
+ * REAL `useSafeTxHash` run through `useFeesPreview`, with MSW at the network boundary. The sibling
+ * suite mocks the query hook, so only this one can catch a wrong hash input or a wrong URL.
+ */
+import { useContext, useState, type ReactNode } from 'react'
+import { http, HttpResponse, delay } from 'msw'
+import { act, renderHook, waitFor } from '@/tests/test-utils'
+import { useAppSelector } from '@/store'
+import { gatewayApi } from '@/store/api/gateway'
+import { server } from '@/tests/server'
+import { useFeesPreview } from '../useFeesPreview'
+import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
+import * as useGasLimitModule from '@/hooks/useGasLimit'
+import * as useGasPriceModule from '@/hooks/useGasPrice'
+import * as useChainsModule from '@/hooks/useChains'
+import * as useSafeInfoModule from '@/hooks/useSafeInfo'
+import * as useBalancesModule from '@/hooks/useBalances'
+import * as safeCoreSDKModule from '@/hooks/coreSDK/safeCoreSDK'
+import * as useGasTokenCandidatesModule from '../useGasTokenCandidates'
+import { chainBuilder } from '@/tests/builders/chains'
+import { extendedSafeInfoBuilder } from '@/tests/builders/safe'
+import { eip712SafeTxHash } from '@/tests/eip712SafeTx'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import { GATEWAY_URL } from '@/config/gateway'
+import type { SafeTransaction, SafeTransactionData } from '@safe-global/types-kit'
+
+const ETH = '0x0000000000000000000000000000000000000000'
+const SAFE_ADDRESS = '0x1F2504De05f5167650bE5B28c472601Be434b60A'
+const REFUND_RECEIVER = '0xc918e75504D1B0c741Eb4236B72Dae7A52401E95'
+
+const mockChain = chainBuilder()
+  .with({
+    chainId: '1',
+    nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18, logoUri: 'https://eth.logo' },
+    features: [FEATURES.GTF],
+    relayer: {
+      type: 'RELAY_FEE',
+      safeCreationSponsored: false,
+      safeTransactionSponsored: false,
+      enableTenderlySimulationBeforeRelay: false,
+    },
+  })
+  .build()
+
+const mockSafe = extendedSafeInfoBuilder()
+  .with({ threshold: 2, chainId: '1', version: '1.4.1', address: { value: SAFE_ADDRESS } })
+  .build()
+
+// The payload a first signer actually signs on GTF Safe-pays: locked fee fields, non-zero nonce.
+const LOCKED_DATA = {
+  to: '0x38D48FaDa993b749691E93e4E62259c488bCb766',
+  value: '100000000000000',
+  data: '0x',
+  operation: 0,
+  nonce: 7,
+  safeTxGas: '2409',
+  baseGas: '68568',
+  gasPrice: '741064438',
+  gasToken: ETH,
+  refundReceiver: REFUND_RECEIVER,
+} as unknown as SafeTransactionData
+
+const buildSafeTx = (data: Partial<SafeTransactionData>, signatures = new Map<string, unknown>()): SafeTransaction =>
+  ({ data: { ...LOCKED_DATA, ...data }, signatures }) as unknown as SafeTransaction
+
+const signedSafeTx = buildSafeTx({}, new Map([['0xSigner', {}]]))
+
+const withSafeTx = (safeTx: SafeTransaction | undefined, gtfPaymentMode: 'safe' | 'signer' = 'safe') =>
+  function SafeTxWrapper({ children }: { children: ReactNode }) {
+    const [currentSafeTx, setSafeTx] = useState(safeTx)
+    const [gtfSelectedGasToken, setGtfSelectedGasToken] = useState<string | undefined>(undefined)
+    return (
+      <SafeTxContext.Provider
+        value={
+          {
+            safeTx: currentSafeTx,
+            setSafeTx,
+            setSafeMessage: jest.fn(),
+            setSafeMessageHash: jest.fn(),
+            setSafeTxError: jest.fn(),
+            setNonce: jest.fn(),
+            setNonceNeeded: jest.fn(),
+            setSafeTxGas: jest.fn(),
+            setTxOrigin: jest.fn(),
+            gtfPaymentMode,
+            setGtfPaymentMode: jest.fn(),
+            gtfSelectedGasToken,
+            setGtfSelectedGasToken,
+            isReadOnly: false,
+          } as never
+        }
+      >
+        {children}
+      </SafeTxContext.Provider>
+    )
+  }
+
+const nativeBalance = {
+  balance: '1000000000000000000',
+  fiatBalance: '2500',
+  fiatConversion: '2500',
+  tokenInfo: { address: ETH, decimals: 18, logoUri: '', name: 'Ether', symbol: 'ETH', type: 'NATIVE_TOKEN' },
+}
+
+const SNAPSHOT_ROUTE = `${GATEWAY_URL}/v1/chains/:chainId/fees/:safeAddress/preview/:safeTxHash`
+const PREVIEW_ROUTE = `${GATEWAY_URL}/v1/chains/:chainId/fees/:safeAddress/preview`
+
+const snapshotBody = (safenetFeeUsd: number) => ({
+  txData: { chainId: '1', safeAddress: SAFE_ADDRESS, ...LOCKED_DATA, numberSignatures: 2 },
+  feeBreakdown: { totalUsd: 1.12, safenetFeeUsd },
+  maxFeeCapUsd: 2,
+})
+
+let snapshotRequests: string[] = []
+
+// Counting at the network boundary, not at a mock: a negative case can only pass if no request
+// left the app.
+const countSnapshotRequest = ({ request }: { request: Request }) => {
+  if (/\/fees\/[^/]+\/preview\/0x[0-9a-fA-F]{64}$/.test(new URL(request.url).pathname)) {
+    snapshotRequests.push(request.url)
+  }
+}
+
+describe('useFeesPreview — stored-quote read-back (real endpoint)', () => {
+  beforeAll(() => server.events.on('request:start', countSnapshotRequest))
+  afterAll(() => server.events.removeListener('request:start', countSnapshotRequest))
+
+  beforeEach(() => {
+    snapshotRequests = []
+    jest.restoreAllMocks()
+    jest.spyOn(useChainsModule, 'useCurrentChain').mockReturnValue(mockChain)
+    jest.spyOn(useSafeInfoModule, 'default').mockReturnValue({
+      safe: mockSafe,
+      safeAddress: SAFE_ADDRESS,
+      safeLoaded: true,
+      safeLoading: false,
+    })
+    jest.spyOn(useBalancesModule, 'default').mockReturnValue({
+      balances: { fiatTotal: '2500', items: [nativeBalance] as never },
+      loaded: true,
+      loading: false,
+    })
+    jest.spyOn(useGasTokenCandidatesModule, 'useGasTokenCandidates').mockReturnValue({
+      candidates: [{ address: ETH, symbol: 'ETH', logoUri: '', decimals: 18, fiatBalance: '2500' }],
+      defaultAddress: ETH,
+    })
+    jest.spyOn(useGasLimitModule, 'default').mockReturnValue({ gasLimit: BigInt(21000), gasLimitLoading: false })
+    jest
+      .spyOn(useGasPriceModule, 'default')
+      .mockReturnValue([{ maxFeePerGas: BigInt(20000000000), maxPriorityFeePerGas: undefined }, undefined, false])
+    jest.spyOn(safeCoreSDKModule, 'useSafeSDK').mockReturnValue(undefined)
+  })
+
+  it('queries the hash of the SIGNED payload and itemizes the fee', async () => {
+    server.use(http.get(SNAPSHOT_ROUTE, () => HttpResponse.json(snapshotBody(1))))
+
+    const { result } = renderHook(() => useFeesPreview(), { wrapper: withSafeTx(signedSafeTx) })
+
+    await waitFor(() => expect(snapshotRequests).toHaveLength(1))
+
+    const expectedHash = eip712SafeTxHash(signedSafeTx.data, mockSafe.chainId, SAFE_ADDRESS)
+    expect(expectedHash).toMatch(/^0x[0-9a-f]{64}$/)
+    expect(snapshotRequests[0]).toBe(
+      `${GATEWAY_URL}/v1/chains/${mockSafe.chainId}/fees/${SAFE_ADDRESS}/preview/${expectedHash}`,
+    )
+    await waitFor(() => expect(result.current.safenetFee).toEqual({ label: 'Safenet fee', amount: '$\u200A1.00' }))
+  })
+
+  it.each([404, 200])('drops A while B is pending and uses only B after its %s response', async (status) => {
+    const signedB = buildSafeTx({ nonce: 8 }, new Map([['0xSigner', {}]]))
+    const hashA = eip712SafeTxHash(signedSafeTx.data, '1', SAFE_ADDRESS)
+    const hashB = eip712SafeTxHash(signedB.data, '1', SAFE_ADDRESS)
+    const argsB = { chainId: '1', safeAddress: SAFE_ADDRESS, safeTxHash: hashB }
+    let releaseB!: () => void
+    const pendingB = new Promise<void>((resolve) => {
+      releaseB = resolve
+    })
+    server.use(
+      http.get(SNAPSHOT_ROUTE, async ({ params }) => {
+        if (params.safeTxHash === hashA) return HttpResponse.json(snapshotBody(1))
+        await pendingB
+        if (status === 404) return HttpResponse.json({ message: 'no quote' }, { status })
+        return HttpResponse.json({
+          ...snapshotBody(2),
+          txData: { ...snapshotBody(2).txData, ...signedB.data },
+        })
+      }),
+    )
+    const { result } = renderHook(
+      () => ({
+        fees: useFeesPreview(),
+        tx: useContext(SafeTxContext).safeTx,
+        setTx: useContext(SafeTxContext).setSafeTx,
+        snapshotB: useAppSelector(gatewayApi.endpoints.getGtfFeeSnapshot.select(argsB)),
+      }),
+      { wrapper: withSafeTx(signedSafeTx) },
+    )
+    await waitFor(() => expect(result.current.fees.safenetFee?.amount).toBe('$\u200A1.00'))
+
+    act(() => result.current.setTx(signedB))
+    try {
+      await waitFor(() =>
+        expect(snapshotRequests).toContain(`${GATEWAY_URL}/v1/chains/1/fees/${SAFE_ADDRESS}/preview/${hashB}`),
+      )
+      expect(result.current.fees.safenetFee).toBeUndefined()
+      expect(result.current.fees.loading).toBe(false)
+      expect(result.current.fees.error).toBe(false)
+      expect(result.current.tx).toBe(signedB)
+    } finally {
+      await act(async () => releaseB())
+    }
+    await waitFor(() => expect(result.current.snapshotB.status).toBe(status === 404 ? 'rejected' : 'fulfilled'))
+    expect(result.current.fees.safenetFee?.amount).toBe(status === 404 ? undefined : '$\u200A2.00')
+    expect(result.current.fees.loading).toBe(false)
+    expect(result.current.fees.error).toBe(false)
+    expect(result.current.fees.canCoverFees).toBe(true)
+    expect(result.current.fees.previewedSafeTx).toBeUndefined()
+    expect(result.current.tx).toBe(signedB)
+  })
+
+  it('suppresses retained snapshot data when the current query becomes ineligible', async () => {
+    server.use(http.get(SNAPSHOT_ROUTE, () => HttpResponse.json(snapshotBody(1))))
+    const { result } = renderHook(
+      () => ({
+        fees: useFeesPreview(),
+        setTx: useContext(SafeTxContext).setSafeTx,
+      }),
+      { wrapper: withSafeTx(signedSafeTx) },
+    )
+    await waitFor(() => expect(result.current.fees.safenetFee?.amount).toBe('$\u200A1.00'))
+
+    jest.spyOn(useChainsModule, 'useCurrentChain').mockReturnValue({ ...mockChain, relayer: null })
+    act(() => result.current.setTx(buildSafeTx({}, signedSafeTx.signatures)))
+    expect(result.current.fees.safenetFee).toBeUndefined()
+    expect(result.current.fees.canCoverFees).toBe(true)
+    expect(result.current.fees.loading).toBe(false)
+    expect(result.current.fees.error).toBe(false)
+    expect(snapshotRequests).toHaveLength(1)
+  })
+
+  it('computes the same hash when the version comes from the SDK, not safe.version', async () => {
+    jest
+      .spyOn(safeCoreSDKModule, 'useSafeSDK')
+      .mockReturnValue({ getContractVersion: () => '1.4.1' } as unknown as ReturnType<
+        typeof safeCoreSDKModule.useSafeSDK
+      >)
+    server.use(http.get(SNAPSHOT_ROUTE, () => HttpResponse.json(snapshotBody(1))))
+
+    renderHook(() => useFeesPreview(), { wrapper: withSafeTx(signedSafeTx) })
+
+    await waitFor(() => expect(snapshotRequests).toHaveLength(1))
+    expect(snapshotRequests[0]).toContain(eip712SafeTxHash(signedSafeTx.data, mockSafe.chainId, SAFE_ADDRESS))
+  })
+
+  it('leaves the card exactly as today on a 404', async () => {
+    server.use(http.get(SNAPSHOT_ROUTE, () => HttpResponse.json({ message: 'no quote' }, { status: 404 })))
+
+    const { result } = renderHook(() => useFeesPreview(), { wrapper: withSafeTx(signedSafeTx) })
+
+    await waitFor(() => expect(snapshotRequests).toHaveLength(1))
+    expect(result.current.safenetFee).toBeUndefined()
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBe(false)
+    expect(result.current.gasFee.label).toBe('Max gas fee')
+    expect(result.current.gasFee.amount).toBeDefined()
+  })
+
+  it('renders no row for a stored quote with safenetFeeUsd 0', async () => {
+    server.use(http.get(SNAPSHOT_ROUTE, () => HttpResponse.json(snapshotBody(0))))
+
+    const { result } = renderHook(() => useFeesPreview(), { wrapper: withSafeTx(signedSafeTx) })
+
+    await waitFor(() => expect(snapshotRequests).toHaveLength(1))
+    await waitFor(() => expect(result.current.safeHasEnoughGas).toBeDefined())
+    expect(result.current.safenetFee).toBeUndefined()
+  })
+
+  it('never flickers loading or error while the fetch is in flight', async () => {
+    server.use(
+      http.get(SNAPSHOT_ROUTE, async () => {
+        await delay(60)
+        return HttpResponse.json(snapshotBody(1))
+      }),
+    )
+
+    const { result } = renderHook(() => useFeesPreview(), { wrapper: withSafeTx(signedSafeTx) })
+
+    await waitFor(() => expect(snapshotRequests).toHaveLength(1))
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBe(false)
+    expect(result.current.safenetFee).toBeUndefined()
+
+    await waitFor(() => expect(result.current.safenetFee).toBeDefined())
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBe(false)
+  })
+
+  it.each([
+    ['a body carrying neither fee arm', { nonsense: true }],
+    ['a null body', null],
+  ])('renders no row and does not crash on %s', async (_label, body) => {
+    server.use(http.get(SNAPSHOT_ROUTE, () => HttpResponse.json(body)))
+
+    const { result } = renderHook(() => useFeesPreview(), { wrapper: withSafeTx(signedSafeTx) })
+
+    await waitFor(() => expect(snapshotRequests).toHaveLength(1))
+    expect(result.current.safenetFee).toBeUndefined()
+    expect(result.current.error).toBe(false)
+    expect(result.current.loading).toBe(false)
+  })
+
+  describe('the read-back is never issued outside the confirmation branch', () => {
+    const SIGNED = new Map([['0xSigner', {}]])
+    const cases: Array<[string, SafeTransaction, 'safe' | 'signer']> = [
+      ['first signer (no signatures)', buildSafeTx({}), 'safe'],
+      // A signer-pays payload carries zero fee fields, so it is indistinguishable from a
+      // pre-GTF queue item — both land on the legacy-signed branch.
+      [
+        'signer-pays / legacy-signed (zero fee fields)',
+        buildSafeTx({ baseGas: '0', gasPrice: '0', refundReceiver: ETH }, SIGNED),
+        'signer',
+      ],
+      [
+        'legacy-signed with mode=safe',
+        buildSafeTx({ baseGas: '0', gasPrice: '0', refundReceiver: ETH }, SIGNED),
+        'safe',
+      ],
+    ]
+
+    it.each(cases)('%s', async (_label, tx, mode) => {
+      server.use(
+        http.get(SNAPSHOT_ROUTE, () => HttpResponse.json(snapshotBody(1))),
+        http.post(PREVIEW_ROUTE, () => HttpResponse.json(snapshotBody(1))),
+      )
+
+      const { result } = renderHook(() => useFeesPreview(), { wrapper: withSafeTx(tx, mode) })
+
+      await waitFor(() => expect(result.current.executionFee).toBeDefined())
+      await delay(120)
+      expect(snapshotRequests).toEqual([])
+      expect(result.current.safenetFee).toBeUndefined()
+    })
+
+    it('skips a chain without a preview-capable relayer', async () => {
+      jest.spyOn(useChainsModule, 'useCurrentChain').mockReturnValue(
+        chainBuilder()
+          .with({ ...mockChain, relayer: null })
+          .build(),
+      )
+      server.use(http.get(SNAPSHOT_ROUTE, () => HttpResponse.json(snapshotBody(1))))
+
+      const { result } = renderHook(() => useFeesPreview(), { wrapper: withSafeTx(signedSafeTx) })
+
+      await waitFor(() => expect(result.current.executionFee).toBeDefined())
+      await delay(120)
+      expect(snapshotRequests).toEqual([])
+      expect(result.current.safenetFee).toBeUndefined()
+    })
+  })
+
+  // The signed payload is authoritative: a payload carrying live GTF fee params is Safe-pays
+  // regardless of a stale payment-mode flag in context.
+  it('still reads back a GTF-signed payload while context says signer-pays', async () => {
+    server.use(http.get(SNAPSHOT_ROUTE, () => HttpResponse.json(snapshotBody(1))))
+
+    const { result } = renderHook(() => useFeesPreview(), { wrapper: withSafeTx(signedSafeTx, 'signer') })
+
+    await waitFor(() => expect(snapshotRequests).toHaveLength(1))
+    await waitFor(() => expect(result.current.safenetFee).toBeDefined())
+  })
+})

--- a/apps/web/src/features/gtf/hooks/__tests__/useFeesPreview.test.tsx
+++ b/apps/web/src/features/gtf/hooks/__tests__/useFeesPreview.test.tsx
@@ -21,6 +21,7 @@ import * as useGasTokenCandidatesModule from '../useGasTokenCandidates'
 import * as gatewayApi from '@/store/api/gateway'
 import { chainBuilder } from '@/tests/builders/chains'
 import { extendedSafeInfoBuilder } from '@/tests/builders/safe'
+import { eip712SafeTxHash } from '@/tests/eip712SafeTx'
 import { FEATURES } from '@safe-global/utils/utils/chains'
 import type { SafeTransaction, SafeTransactionData } from '@safe-global/types-kit'
 
@@ -171,6 +172,30 @@ const loadingPreview = {
   refetch: jest.fn(),
 } as unknown as ReturnType<typeof gatewayApi.useGetGtfFeePreviewQuery>
 
+// Read-back of the stored quote — confirmation only. `emptySnapshot` is the default so the
+// unrelated confirmation cases below never reach the real RTK endpoint.
+const emptySnapshot = {
+  currentData: undefined,
+  isLoading: false,
+  isFetching: false,
+  error: undefined,
+  refetch: jest.fn(),
+} as unknown as ReturnType<typeof gatewayApi.useGetGtfFeeSnapshotQuery>
+
+const snapshotWith = (safenetFeeUsd: number): typeof emptySnapshot =>
+  ({
+    ...emptySnapshot,
+    currentData: {
+      txData: mockSuccessfulPreview.data?.txData,
+      feeBreakdown: { totalUsd: 1.12, safenetFeeUsd },
+    },
+  }) as typeof emptySnapshot
+
+const notFoundSnapshot = {
+  ...emptySnapshot,
+  error: new Error('Fee snapshot failed with status 404'),
+} as unknown as ReturnType<typeof gatewayApi.useGetGtfFeeSnapshotQuery>
+
 const withSafeTx = (
   safeTx: SafeTransaction | undefined,
   gtfPaymentMode: 'safe' | 'signer' = 'safe',
@@ -244,6 +269,7 @@ describe('useFeesPreview', () => {
     jest
       .spyOn(useGasPriceModule, 'default')
       .mockReturnValue([{ maxFeePerGas: BigInt(20000000000), maxPriorityFeePerGas: undefined }, undefined, false])
+    jest.spyOn(gatewayApi, 'useGetGtfFeeSnapshotQuery').mockReturnValue(emptySnapshot)
   })
 
   it('returns execution fee as FREE with no amount/currency/percentage label', () => {
@@ -846,6 +872,84 @@ describe('useFeesPreview', () => {
       expect(result.current.totalOutgoing).toBeDefined()
       expect(result.current.totalOutgoing?.primary[0].currency).toBe('WETH')
       expect(result.current.totalOutgoing?.fees).toBeUndefined()
+    })
+
+    describe('stored-quote read-back', () => {
+      const signedNativeGasSafeTx = buildSafeTx(
+        { to: mockSafe.address.value, value: '100000000000000', data: '0x', gasToken: ETH_ADDRESS, ...SAFE_PAYS },
+        new Map([['0xSigner', {}]]),
+      )
+
+      it('itemizes the Safenet fee the first signer signed', () => {
+        jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockReturnValue(emptyPreview)
+        const spy = jest.spyOn(gatewayApi, 'useGetGtfFeeSnapshotQuery').mockReturnValue(snapshotWith(1))
+
+        const { result } = renderHook(() => useFeesPreview(), { wrapper: withSafeTx(signedNativeGasSafeTx) })
+
+        expect(result.current.safenetFee).toEqual({ label: 'Safenet fee', amount: '$\u200A1.00' })
+        // The exact hash of the signed payload, computed by an ethers-only oracle so a wrong
+        // hash input cannot pass by agreeing with the implementation's own library.
+        expect(spy.mock.calls.at(-1)?.[0]).toEqual({
+          chainId: mockSafe.chainId,
+          safeAddress: mockSafe.address.value,
+          safeTxHash: eip712SafeTxHash(signedNativeGasSafeTx.data, mockSafe.chainId, mockSafe.address.value),
+        })
+      })
+
+      it('renders exactly today\u2019s card when no quote is stored (404)', () => {
+        jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockReturnValue(emptyPreview)
+        jest.spyOn(gatewayApi, 'useGetGtfFeeSnapshotQuery').mockReturnValue(notFoundSnapshot)
+
+        const { result } = renderHook(() => useFeesPreview(), { wrapper: withSafeTx(signedNativeGasSafeTx) })
+
+        expect(result.current.safenetFee).toBeUndefined()
+        expect(result.current.error).toBe(false)
+        expect(result.current.loading).toBe(false)
+        expect(result.current.gasFee.amount).toMatch(/^0\.00005/)
+      })
+
+      it('omits the row when the stored quote carries no Safenet fee', () => {
+        jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockReturnValue(emptyPreview)
+        jest.spyOn(gatewayApi, 'useGetGtfFeeSnapshotQuery').mockReturnValue(snapshotWith(0))
+
+        const { result } = renderHook(() => useFeesPreview(), { wrapper: withSafeTx(signedNativeGasSafeTx) })
+
+        expect(result.current.safenetFee).toBeUndefined()
+      })
+
+      it('skips the read-back on a chain that cannot quote fees', () => {
+        jest.spyOn(useChainsModule, 'useCurrentChain').mockReturnValue(
+          chainBuilder()
+            .with({ ...mockChain, relayer: null })
+            .build(),
+        )
+        jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockReturnValue(emptyPreview)
+        const spy = jest
+          .spyOn(gatewayApi, 'useGetGtfFeeSnapshotQuery')
+          .mockImplementation((arg) => (arg === skipToken ? emptySnapshot : snapshotWith(1)))
+
+        const { result } = renderHook(() => useFeesPreview(), { wrapper: withSafeTx(signedNativeGasSafeTx) })
+
+        expect(spy.mock.calls.length).toBeGreaterThan(0)
+        spy.mock.calls.forEach(([arg]) => expect(arg).toBe(skipToken))
+        expect(result.current.safenetFee).toBeUndefined()
+      })
+
+      it.each([
+        ['first signer', nativeSafeTx],
+        ['legacy-signed payload', buildSafeTx({ gasToken: ETH_ADDRESS }, new Map([['0xSigner', {}]]))],
+      ])('never subscribes outside the confirmation branch (%s)', (_label, tx) => {
+        jest.spyOn(gatewayApi, 'useGetGtfFeePreviewQuery').mockReturnValue(mockSuccessfulPreview)
+        const spy = jest
+          .spyOn(gatewayApi, 'useGetGtfFeeSnapshotQuery')
+          .mockImplementation((arg) => (arg === skipToken ? emptySnapshot : snapshotWith(1)))
+
+        const { result } = renderHook(() => useFeesPreview(), { wrapper: withSafeTx(tx) })
+
+        expect(spy.mock.calls.length).toBeGreaterThan(0)
+        spy.mock.calls.forEach(([arg]) => expect(arg).toBe(skipToken))
+        expect(result.current.safenetFee).toBeUndefined()
+      })
     })
   })
 

--- a/apps/web/src/features/gtf/hooks/useFeesPreview.ts
+++ b/apps/web/src/features/gtf/hooks/useFeesPreview.ts
@@ -3,6 +3,7 @@ import { formatUnits } from 'ethers'
 import { ZERO_ADDRESS } from '@safe-global/utils/utils/constants'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { formatVisualAmount } from '@safe-global/utils/utils/formatters'
+import { skipToken } from '@reduxjs/toolkit/query'
 
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { useAppSelector } from '@/store'
@@ -12,6 +13,8 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import useBalances from '@/hooks/useBalances'
 import useGasLimit from '@/hooks/useGasLimit'
 import useGasPrice from '@/hooks/useGasPrice'
+import { useSafeTxHash } from '@/components/transactions/TxDetails/Summary/SafeTxHashDataRow'
+import { useGetGtfFeeSnapshotQuery } from '@/store/api/gateway'
 import { useGtfFeePreview } from './useGtfFeePreview'
 import { getTotalFeeFormatted } from '@safe-global/utils/hooks/useDefaultGasPrice'
 import { formatCurrencyMinimal } from '@safe-global/utils/utils/formatNumber'
@@ -178,6 +181,19 @@ export const useFeesPreview = (): FeesPreviewData => {
     safenetCheck: safenetCheckEnabled,
   })
 
+  // Confirmation only: the stored quote is immutable, so reading it back reports exactly what
+  // the first signer signed. Display-only — a 404, an error or a pending fetch must leave the
+  // card exactly as it renders today and must never gate submit.
+  // `safe.chainId`, not `chain.chainId`: the hash is keyed to the same domain, and during a
+  // chain switch the two sources disagree for a render.
+  const signedSafeTxHash = useSafeTxHash({ safeTxData: isConfirmation ? safeTx?.data : undefined })
+  const canReadSnapshot = !!(isConfirmation && feePreviewAvailable && safeAddress && signedSafeTxHash)
+  const snapshot = useGetGtfFeeSnapshotQuery(
+    canReadSnapshot && signedSafeTxHash
+      ? { chainId: safe.chainId, safeAddress, safeTxHash: signedSafeTxHash }
+      : skipToken,
+  )
+
   // Sync `gtfSelectedGasToken` with the latest preview state
   //  - preview unavailable (errored / no eligible token after settling): drop the persisted
   //    selection so `mergeGtfFeeParams` bails and the tx is signed as signer-pays.
@@ -269,9 +285,19 @@ export const useFeesPreview = (): FeesPreviewData => {
       balances,
     })
 
+    // Already inside the signed `baseGas`, so this row itemizes it in USD only — never a total.
+    const snapshotSafenetFeeUsd =
+      canReadSnapshot && !snapshot.isFetching && !snapshot.isLoading && !snapshot.error
+        ? (snapshot.currentData?.feeBreakdown?.safenetFeeUsd ?? 0)
+        : 0
+
     return {
       ...base,
       canCoverFees: true,
+      safenetFee:
+        snapshotSafenetFeeUsd > 0
+          ? { label: 'Safenet fee', amount: formatCurrencyMinimal(snapshotSafenetFeeUsd, 'USD') }
+          : undefined,
       gasFee: {
         label: 'Max gas fee',
         amount: gasAmount,

--- a/apps/web/src/store/api/gateway/gtfFeePreview.test.ts
+++ b/apps/web/src/store/api/gateway/gtfFeePreview.test.ts
@@ -1,0 +1,81 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/tests/server'
+
+import { GATEWAY_URL } from '@/config/gateway'
+import { gatewayApi } from './index'
+
+const SAFE_ADDRESS = '0x1234567890123456789012345678901234567890'
+const SAFE_TX_HASH = `0x${'ab'.repeat(32)}`
+
+const SNAPSHOT_BODY = {
+  txData: {
+    chainId: '1',
+    safeAddress: SAFE_ADDRESS,
+    safeTxGas: '2409',
+    baseGas: '68568',
+    gasPrice: '741064438',
+    gasToken: '0x0000000000000000000000000000000000000000',
+    refundReceiver: '0xc918e75504D1B0c741Eb4236B72Dae7A52401E95',
+    numberSignatures: 2,
+  },
+  feeBreakdown: { relayCostUsd: 0.12, totalUsd: 1.12, safenetFeeUsd: 1 },
+  maxFeeCapUsd: 2,
+}
+
+const SNAPSHOT_ROUTE = `${GATEWAY_URL}/v1/chains/:chainId/fees/:safeAddress/preview/:safeTxHash`
+
+const makeApiStore = () =>
+  configureStore({
+    reducer: { [gatewayApi.reducerPath]: gatewayApi.reducer },
+    // The app store does the same: `fakeBaseQuery<Error>` parks Error instances in state.
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({ serializableCheck: false }).concat(gatewayApi.middleware),
+  })
+
+const fetchSnapshot = () =>
+  makeApiStore().dispatch(
+    gatewayApi.endpoints.getGtfFeeSnapshot.initiate({
+      chainId: '1',
+      safeAddress: SAFE_ADDRESS,
+      safeTxHash: SAFE_TX_HASH,
+    }),
+  )
+
+describe('getGtfFeeSnapshot', () => {
+  it('GETs the stored quote for the signed safeTxHash', async () => {
+    let requestedUrl = ''
+    let method = ''
+    server.use(
+      http.get(SNAPSHOT_ROUTE, ({ request }) => {
+        requestedUrl = request.url
+        method = request.method
+        return HttpResponse.json(SNAPSHOT_BODY)
+      }),
+    )
+
+    const result = await fetchSnapshot()
+
+    expect(method).toBe('GET')
+    expect(requestedUrl).toBe(`${GATEWAY_URL}/v1/chains/1/fees/${SAFE_ADDRESS}/preview/${SAFE_TX_HASH}`)
+    expect(result.data).toEqual(SNAPSHOT_BODY)
+  })
+
+  it('errors when no quote is stored for the hash (404)', async () => {
+    server.use(http.get(SNAPSHOT_ROUTE, () => HttpResponse.json({ message: 'not found' }, { status: 404 })))
+
+    const result = await fetchSnapshot()
+
+    expect(result.data).toBeUndefined()
+    expect((result.error as Error).message).toBe('Fee snapshot failed with status 404')
+  })
+
+  it('errors on a body that carries neither fee arm', async () => {
+    server.use(http.get(SNAPSHOT_ROUTE, () => HttpResponse.json({ txData: SNAPSHOT_BODY.txData })))
+
+    const result = await fetchSnapshot()
+
+    expect(result.data).toBeUndefined()
+    expect((result.error as Error).message).toBe('Fee snapshot response did not match expected shape')
+  })
+})

--- a/apps/web/src/store/api/gateway/gtfFeePreview.ts
+++ b/apps/web/src/store/api/gateway/gtfFeePreview.ts
@@ -105,6 +105,12 @@ export type FeePreviewArg = {
   tx: FeePreviewTransactionDto
 }
 
+export type FeeSnapshotArg = {
+  chainId: string
+  safeAddress: string
+  safeTxHash: string
+}
+
 const hasCompleteFeeBreakdown = (value: unknown): boolean =>
   typeof value === 'object' &&
   value !== null &&
@@ -118,28 +124,49 @@ const isFeePreviewResponse = (value: unknown): value is FeePreviewResponse => {
   return 'relayCost' in value
 }
 
+/**
+ * Both fee routes answer the same envelope and fail the same way, so they share one reader.
+ * `label` prefixes the error message; nothing downstream parses it.
+ */
+const fetchFeePreview = async (
+  label: string,
+  url: string,
+  init?: RequestInit,
+): Promise<{ data: FeePreviewResponse } | { error: Error }> => {
+  try {
+    const response = await fetch(url, init)
+
+    if (!response.ok) {
+      return { error: new Error(`${label} failed with status ${response.status}`) }
+    }
+
+    const body: unknown = await response.json()
+    if (!isFeePreviewResponse(body)) {
+      return { error: new Error(`${label} response did not match expected shape`) }
+    }
+    return { data: body }
+  } catch (error) {
+    return { error: asError(error) }
+  }
+}
+
 export const gtfFeePreviewEndpoints = (builder: GatewayEndpointBuilder) => ({
   getGtfFeePreview: builder.query<FeePreviewResponse, FeePreviewArg>({
-    async queryFn({ chainId, safeAddress, tx }) {
-      try {
-        const response = await fetch(`${GATEWAY_URL}/v1/chains/${chainId}/fees/${safeAddress}/preview`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ ...tx, nonce: String(tx.nonce) }),
-        })
+    queryFn: ({ chainId, safeAddress, tx }) =>
+      fetchFeePreview('Fee preview', `${GATEWAY_URL}/v1/chains/${chainId}/fees/${safeAddress}/preview`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...tx, nonce: String(tx.nonce) }),
+      }),
+  }),
 
-        if (!response.ok) {
-          return { error: new Error(`Fee preview failed with status ${response.status}`) }
-        }
-
-        const body: unknown = await response.json()
-        if (!isFeePreviewResponse(body)) {
-          return { error: new Error('Fee preview response did not match expected shape') }
-        }
-        return { data: body }
-      } catch (error) {
-        return { error: asError(error) }
-      }
-    },
+  /**
+   * Read-back of the immutable quote stored against a signed `safeTxHash`. Co-signers cannot
+   * re-quote, so this is the only way to itemize what the first signer actually signed.
+   * The GTF arm answers with `feeBreakdown` and no `relayCost`; 404 means no stored quote.
+   */
+  getGtfFeeSnapshot: builder.query<FeePreviewResponse, FeeSnapshotArg>({
+    queryFn: ({ chainId, safeAddress, safeTxHash }) =>
+      fetchFeePreview('Fee snapshot', `${GATEWAY_URL}/v1/chains/${chainId}/fees/${safeAddress}/preview/${safeTxHash}`),
   }),
 })

--- a/apps/web/src/store/api/gateway/index.ts
+++ b/apps/web/src/store/api/gateway/index.ts
@@ -37,4 +37,5 @@ export const {
   useGetMultipleSafeOverviewsQuery,
   useGetGtfFeePreviewQuery,
   useGetProposerSafesQuery,
+  useGetGtfFeeSnapshotQuery,
 } = gatewayApi

--- a/apps/web/src/tests/eip712SafeTx.ts
+++ b/apps/web/src/tests/eip712SafeTx.ts
@@ -1,0 +1,36 @@
+import { TypedDataEncoder } from 'ethers'
+import type { SafeTransactionData } from '@safe-global/types-kit'
+
+const SAFE_TX_TYPES = {
+  SafeTx: [
+    { name: 'to', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'data', type: 'bytes' },
+    { name: 'operation', type: 'uint8' },
+    { name: 'safeTxGas', type: 'uint256' },
+    { name: 'baseGas', type: 'uint256' },
+    { name: 'gasPrice', type: 'uint256' },
+    { name: 'gasToken', type: 'address' },
+    { name: 'refundReceiver', type: 'address' },
+    { name: 'nonce', type: 'uint256' },
+  ],
+}
+
+/**
+ * `safeTxHash` computed with ethers alone, for Safe >= 1.3.0. Deliberately independent of
+ * protocol-kit: a test that asserts a hash must not reuse the library that produced it, or a
+ * wrong hash input passes both sides.
+ */
+export const eip712SafeTxHash = (data: SafeTransactionData, chainId: string, safeAddress: string): string =>
+  TypedDataEncoder.hash({ chainId: Number(chainId), verifyingContract: safeAddress }, SAFE_TX_TYPES, {
+    to: data.to,
+    value: data.value,
+    data: data.data,
+    operation: data.operation,
+    safeTxGas: data.safeTxGas,
+    baseGas: data.baseGas,
+    gasPrice: data.gasPrice,
+    gasToken: data.gasToken,
+    refundReceiver: data.refundReceiver,
+    nonce: data.nonce,
+  })


### PR DESCRIPTION

## Stack

Base branch: `Fbartoli/safenet-fee-line`. This PR lands **after** #8588 and will be rebased once
#8588 merges. Do not merge before it.

## Gateway dependency

This PR consumes a gateway route that is still shipping:

```
GET /v1/chains/{chainId}/fees/{safeAddress}/preview/{safeTxHash}
→ 200 FeePreviewResponse, GTF arm ({ txData, feeBreakdown, maxFeeCapUsd }, no relayCost;
      feeBreakdown.safenetFeeUsd present, 0 when the check was not requested)
→ 404 when no quote is stored for the hash
```

Until the route is live every call answers 404, which the consumer treats as "no row". The
confirmation card therefore renders exactly as it does today. Merging ahead of the gateway is safe.

## What it solves

`useFeesPreview`'s confirmation branch does not re-quote — an already-signed GTF Safe-pays
transaction (`signatures.size > 0 && isGtfSafePaid`) has its fees baked into the payload. A later
co-signer therefore could not see the Safenet fee at all: the $1 sat invisibly inside the gas
totals, so a co-signer could not tell whether the first signer had opted into the check.

## How this PR fixes it

The gateway stores the quote against the signed `safeTxHash` and the stored quote is immutable, so
reading it back reports exactly what the signers signed. A new RTK Query endpoint
`getGtfFeeSnapshot` fetches it. `useFeesPreview` subscribes only in the confirmation branch, only
on chains where `isGtfFeePreviewAvailable(chain)` holds, and only once the signed hash resolves
through the existing `useSafeTxHash` util. When the snapshot reports
`feeBreakdown.safenetFeeUsd > 0` the hook builds the same `safenetFee` row the first-signer happy
path builds. Error, 404, zero and in-flight all leave `safenetFee` undefined, which is today's
rendering exactly. The read is display-only: it never gates submit and never toggles the card's
`loading` or `error`.

The opt-in checkbox stays hidden for confirmers — the choice is pinned at the first signature and
this row is history, not a control.

## How to test it

1. On a chain with a GTF/RELAY_FEE relayer and `SAFENET_CHECKS`, create a Safe-pays transaction on
   a 2-of-N Safe with "Run a Safenet check on this transaction" ticked. Sign it.
2. Open the queued transaction as the second signer.
3. The fee card shows `Safenet fee $ 1.00` between `Execution fee` and `Max gas fee`.
4. Repeat with the checkbox unticked: the row is absent and the card is unchanged.
5. Point the app at a gateway without the route: the row is absent, no error is surfaced, and
   signing is not blocked.

Automated:

```
yarn workspace @safe-global/web jest src/features/gtf src/store/api/gateway
yarn workspace @safe-global/web type-check
```

## Affected flows

- Co-signer view of a signed GTF Safe-pays transaction (changed — new row).
- First signer Safe-pays, Signer-pays, legacy-signed confirmer, non-relayer chains (unchanged —
  the query is skipped; asserted by tests).
- Hashes tab and `ConfirmTxDetails/Receipt` (unchanged — `useSafeTxHash`'s widened parameter is a
  no-op for callers that pass a defined value).

## Blast radius

One new endpoint, one new subscription inside a single branch of `useFeesPreview`, and a widened
parameter type on `useSafeTxHash`. No component change: `FeesPreview` already renders `safenetFee`
when the hook supplies it.

## Risks / not checked

- The gateway route is not deployed yet; behaviour against the real service is unverified.
  Pre-deploy behaviour (404 → no row) is covered by tests.
- The read-back is not wired into `HistoryFeesAccordion`; executed transactions still read their
  breakdown from the existing history source.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1[useFeesPreview<br/>confirmation branch] --> B1[gas totals from signed payload]
    B1 --> C1["Safenet fee invisible<br/>(folded into baseGas)"]
  end
  subgraph After
    A2[useFeesPreview<br/>confirmation branch] --> H["useSafeTxHash(safeTx.data)"]
    H --> S["getGtfFeeSnapshot<br/>GET .../preview/{safeTxHash}"]
    S -->|"safenetFeeUsd > 0"| R[Safenet fee row]
    S -->|"404 / error / 0"| N[no row — today's card]
    A2 --> B2[gas totals from signed payload]
  end
```

**Co-signer view with the stored Safenet fee — light / dark**

<img width="340" alt="Confirmation with Safenet fee, light" src="https://gist.githubusercontent.com/Fbartoli/42d353ade65f55cd206edf9b79e1572d/raw/gtf-fee-readback-confirmation-light.png"> <img width="340" alt="Confirmation with Safenet fee, dark" src="https://gist.githubusercontent.com/Fbartoli/42d353ade65f55cd206edf9b79e1572d/raw/gtf-fee-readback-confirmation-dark.png">

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics change
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

