### PR TITLE
[WA-3252] Show CGW errors clearly: map known response states to agreed UI copy

### DIFF
--- a/apps/web/src/components/transactions/SingleTx/SingleTx.test.tsx
+++ b/apps/web/src/components/transactions/SingleTx/SingleTx.test.tsx
@@ -91,10 +91,12 @@ describe('SingleTx', () => {
       expect(screen.getByText('Failed to load transaction')).toBeInTheDocument()
     })
 
-    await waitFor(() => {
-      fireEvent.click(screen.getByText('Details'))
-      expect(screen.getByText('Server error')).toBeInTheDocument()
-    })
+    // A known CGW response state shows the code-only support reference instead
+    // of a Details toggle revealing the raw response (WA-3252).
+    expect(screen.getByTestId('error-details')).toBeInTheDocument()
+    expect(screen.getByText('CGW-500')).toBeInTheDocument()
+    expect(screen.queryByText('Details')).not.toBeInTheDocument()
+    expect(screen.queryByText('Server error')).not.toBeInTheDocument()
   })
 
   it('shows an error when transaction is not from the opened Safe', async () => {

--- a/apps/web/src/components/tx/ErrorMessage/index.tsx
+++ b/apps/web/src/components/tx/ErrorMessage/index.tsx
@@ -1,6 +1,7 @@
 import { type ReactElement, type ReactNode, type SyntheticEvent, useState } from 'react'
 import { getGsCodeFromError } from '@safe-global/utils/services/exceptions/contractErrors'
 import { getGuardErrorInfo, isRevertError } from '@/utils/transaction-errors'
+import { getCgwSupportCode } from '@/utils/cgw-errors'
 import { decodeCustomError } from '@/utils/customErrorRegistry'
 import { getBlockExplorerLink } from '@/utils/chains'
 import useSafeInfo from '@/hooks/useSafeInfo'
@@ -52,6 +53,11 @@ const ErrorMessage = ({
     error && (gsCode === 'GS013' || (!gsCode && isRevertError(error))) ? decodeCustomError(error) : undefined
   const effectiveGsCode = gsCode ?? (customError ? 'GS013' : undefined)
 
+  // A known CGW response state (429/422/451/5xx) gets the same code-only
+  // support reference, so the raw response body — which can be a gateway's HTML
+  // error page — is never rendered in Details (WA-3252).
+  const supportCode = effectiveGsCode ?? (error ? getCgwSupportCode(error) : undefined)
+
   // Check if this is a Guard error that should get special treatment
   const guardErrorName = error && context ? getGuardErrorInfo(error) : undefined
   const guardExplorerLink =
@@ -92,7 +98,7 @@ const ErrorMessage = ({
             </span>
           )}
 
-          {error && !effectiveGsCode && (
+          {error && !supportCode && (
             <Link
               render={<button type="button" />}
               onClick={onDetailsToggle}
@@ -103,8 +109,8 @@ const ErrorMessage = ({
           )}
         </span>
 
-        {effectiveGsCode ? (
-          <ErrorDetails code={effectiveGsCode} customError={customError} />
+        {supportCode ? (
+          <ErrorDetails code={supportCode} customError={customError} />
         ) : (
           error &&
           showDetails && (

--- a/apps/web/src/components/tx/TxSubmitError/__tests__/TxSubmitError.test.tsx
+++ b/apps/web/src/components/tx/TxSubmitError/__tests__/TxSubmitError.test.tsx
@@ -2,7 +2,11 @@ import { render } from '@/tests/test-utils'
 import type { EthersError } from '@/utils/ethers-utils'
 import type { TransactionReceipt } from 'ethers'
 import { Gs026PreCheckError } from '@/services/tx/executionPreChecks'
+import { asError } from '@safe-global/utils/services/exceptions/utils'
 import TxSubmitError from '..'
+
+const HTML_502 =
+  '<html><head><title>502 Bad Gateway</title></head><body><center><h1>502 Bad Gateway</h1></center><hr><center>nginx</center></body></html>'
 
 describe('TxSubmitError', () => {
   it('shows the cause-specific message for a failed GS026 pre-check', () => {
@@ -65,5 +69,64 @@ describe('TxSubmitError', () => {
     const { getByText } = render(<TxSubmitError error={error} />)
 
     expect(getByText('Could not submit the transaction. Try again.')).toBeInTheDocument()
+  })
+
+  describe('CGW response states (WA-3252)', () => {
+    it.each([429, 502, 500, 503, 422])('renders the agreed copy for a %s from CGW', (status) => {
+      const error = asError({ status, data: {} })
+
+      const { getByText } = render(<TxSubmitError error={error} />)
+
+      expect(getByText('Something went wrong on our end. Try again.')).toBeInTheDocument()
+    })
+
+    it('renders the agreed copy — not the raw HTML — for the original 502 defect', () => {
+      const error = asError({
+        status: 'PARSING_ERROR',
+        originalStatus: 502,
+        data: HTML_502,
+        error: "SyntaxError: Unexpected token '<'",
+      })
+
+      const { getByText, queryByText, container } = render(<TxSubmitError error={error} />)
+
+      expect(getByText('Something went wrong on our end. Try again.')).toBeInTheDocument()
+      expect(container.textContent).not.toContain('Bad Gateway')
+      expect(container.textContent).not.toContain('nginx')
+      expect(container.textContent).not.toContain('<')
+      expect(queryByText(/Could not submit/)).not.toBeInTheDocument()
+    })
+
+    it('renders the banned-Safe copy for a 451', () => {
+      const error = asError({ status: 451, data: {} })
+
+      const { getByText } = render(<TxSubmitError error={error} />)
+
+      expect(getByText('This Safe Account is not available.')).toBeInTheDocument()
+    })
+
+    it('shows a code-only support reference instead of a raw Details payload', () => {
+      const error = asError({
+        status: 'PARSING_ERROR',
+        originalStatus: 502,
+        data: HTML_502,
+        error: "SyntaxError: Unexpected token '<'",
+      })
+
+      const { getByTestId, getByText, queryByText } = render(<TxSubmitError error={error} />)
+
+      expect(getByTestId('error-details')).toBeInTheDocument()
+      expect(getByText('CGW-502')).toBeInTheDocument()
+      expect(queryByText('Details')).not.toBeInTheDocument()
+    })
+
+    it('leaves a 404 alone — out of scope for this mapping', () => {
+      const error = asError({ status: 404, data: {} })
+
+      const { getByText, queryByText } = render(<TxSubmitError error={error} />)
+
+      expect(getByText('Could not submit the transaction. Try again.')).toBeInTheDocument()
+      expect(queryByText(/on our end/)).not.toBeInTheDocument()
+    })
   })
 })

--- a/apps/web/src/components/tx/TxSubmitError/__tests__/TxSubmitError.test.tsx
+++ b/apps/web/src/components/tx/TxSubmitError/__tests__/TxSubmitError.test.tsx
@@ -2,7 +2,9 @@ import { render } from '@/tests/test-utils'
 import type { EthersError } from '@/utils/ethers-utils'
 import type { TransactionReceipt } from 'ethers'
 import { Gs026PreCheckError } from '@/services/tx/executionPreChecks'
+import { BaseError } from 'viem'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
+import { RATE_LIMIT_USER_MESSAGE } from '@/utils/transaction-errors'
 import TxSubmitError from '..'
 
 const HTML_502 =
@@ -126,6 +128,18 @@ describe('TxSubmitError', () => {
       const { getByText, queryByText } = render(<TxSubmitError error={error} />)
 
       expect(getByText('Could not submit the transaction. Try again.')).toBeInTheDocument()
+      expect(queryByText(/on our end/)).not.toBeInTheDocument()
+    })
+
+    it('prefers the rate-limit copy over the CGW copy for a 429-carrying error, as the toast does', () => {
+      // Counterpart of the same-named test in `useTxNotifications`: a throttled
+      // request matches both classifiers, and both surfaces must resolve it the
+      // same way (WA-3252).
+      const error = Object.assign(new BaseError('HTTP request failed.'), { status: 429 })
+
+      const { getByText, queryByText } = render(<TxSubmitError error={error} />)
+
+      expect(getByText(RATE_LIMIT_USER_MESSAGE)).toBeInTheDocument()
       expect(queryByText(/on our end/)).not.toBeInTheDocument()
     })
   })

--- a/apps/web/src/components/tx/TxSubmitError/index.tsx
+++ b/apps/web/src/components/tx/TxSubmitError/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/utils/transaction-errors'
 import { didRevert, type EthersError } from '@/utils/ethers-utils'
 import { isGs026PreCheckError } from '@/services/tx/executionPreChecks'
+import { getCgwErrorInfo } from '@/utils/cgw-errors'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 
 export const COULD_NOT_SUBMIT_MESSAGE = 'Could not submit the transaction.'
@@ -61,6 +62,18 @@ const TxSubmitError = ({
     return (
       <ErrorMessage error={error} level="warning" context={context}>
         {RATE_LIMIT_USER_MESSAGE}
+      </ErrorMessage>
+    )
+  }
+
+  // The Safe Client Gateway answered with a known response state. Show the
+  // agreed copy — never the response body, which can be an HTML error page —
+  // and let ErrorMessage render the code-only support reference (WA-3252).
+  const cgwError = getCgwErrorInfo(error)
+  if (cgwError) {
+    return (
+      <ErrorMessage error={error} level="error" context={context}>
+        {cgwError.message}
       </ErrorMessage>
     )
   }

--- a/apps/web/src/hooks/__tests__/useTxNotifications.test.ts
+++ b/apps/web/src/hooks/__tests__/useTxNotifications.test.ts
@@ -1,6 +1,9 @@
 import { act } from 'react'
 import { renderHook, waitFor } from '@/tests/test-utils'
+import { BaseError } from 'viem'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
+import { RATE_LIMIT_USER_MESSAGE } from '@/utils/transaction-errors'
+import { CGW_ERROR_FALLBACK } from '@safe-global/utils/services/exceptions/gatewayErrors'
 import useTxNotifications from '../useTxNotifications'
 import { showNotification } from '@/store/notificationsSlice'
 import { TxEvent, txDispatch } from '@/services/tx/txEvents'
@@ -84,14 +87,14 @@ describe('useTxNotifications — CGW response states (WA-3252)', () => {
     expect(JSON.stringify(notification)).not.toContain('<html')
   })
 
-  it('shows a 422 once and does not loop', async () => {
-    // A 422 is our bug, not a transient failure: it is surfaced a single time.
-    // Nothing retries CGW requests today, so this pins the AC against the
-    // baseline rather than against a fix.
+  it('surfaces exactly one toast per 422, carrying the agreed copy', async () => {
+    // A 422 is our bug, not a transient failure. This pins one dispatch to one
+    // toast with the agreed copy; it does not — and cannot — observe whether a
+    // caller re-issues the request, so it says nothing about looping.
     await dispatchProposeFailure(asError({ status: 422, data: {} }))
 
     expect(showNotification).toHaveBeenCalledTimes(1)
-    expect(lastNotification().message).toBe('Something went wrong on our end. Try again.')
+    expect(lastNotification().message).toBe(CGW_ERROR_FALLBACK)
   })
 
   it('shows the banned-Safe copy for a 451', async () => {
@@ -106,5 +109,21 @@ describe('useTxNotifications — CGW response states (WA-3252)', () => {
     const notification = lastNotification()
     expect(notification.message).toContain('Failed to add to queue')
     expect(notification.detailedMessage).toBe('Not found')
+  })
+
+  it('prefers the rate-limit copy over the CGW copy for a 429-carrying error, as the inline alert does', async () => {
+    // A throttled request matches both classifiers: it is a viem rate-limit
+    // error AND an HTTP 429 the CGW map covers. `TxSubmitError` answers with
+    // the rate-limit copy, so the toast must too — otherwise one failure reads
+    // two different ways depending on where the user sees it (WA-3252).
+    // Swapping these two branches back breaks this test.
+    await dispatchProposeFailure(Object.assign(new BaseError('HTTP request failed.'), { status: 429 }))
+
+    const notification = lastNotification()
+    expect(notification.message).toBe(RATE_LIMIT_USER_MESSAGE)
+    expect(notification.message).not.toBe(CGW_ERROR_FALLBACK)
+    // The support reference still carries the status, exactly as the inline
+    // alert's code-only reference does.
+    expect(notification.detailedMessage).toBe('Error code CGW-429')
   })
 })

--- a/apps/web/src/hooks/__tests__/useTxNotifications.test.ts
+++ b/apps/web/src/hooks/__tests__/useTxNotifications.test.ts
@@ -1,0 +1,110 @@
+import { act } from 'react'
+import { renderHook, waitFor } from '@/tests/test-utils'
+import { asError } from '@safe-global/utils/services/exceptions/utils'
+import useTxNotifications from '../useTxNotifications'
+import { showNotification } from '@/store/notificationsSlice'
+import { TxEvent, txDispatch } from '@/services/tx/txEvents'
+import { chainBuilder } from '@/tests/builders/chains'
+
+const chain = chainBuilder().with({ chainId: '11155111', chainName: 'Sepolia' }).build()
+
+jest.mock('@/store/notificationsSlice', () => {
+  const original = jest.requireActual('@/store/notificationsSlice')
+  return {
+    ...original,
+    showNotification: jest.fn(original.showNotification),
+  }
+})
+
+jest.mock('../useChains', () => ({
+  __esModule: true,
+  useCurrentChain: jest.fn(() => chain),
+  default: jest.fn(),
+}))
+
+jest.mock('../useTxQueue', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ page: undefined })),
+}))
+
+jest.mock('../useIsSafeOwner', () => ({
+  __esModule: true,
+  default: jest.fn(() => false),
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/transactions', () => ({
+  ...jest.requireActual('@safe-global/store/gateway/AUTO_GENERATED/transactions'),
+  useLazyTransactionsGetTransactionByIdV1Query: jest.fn(() => [jest.fn(() => Promise.resolve({ data: undefined }))]),
+}))
+
+const HTML_502 =
+  '<html><head><title>502 Bad Gateway</title></head><body><center><h1>502 Bad Gateway</h1></center><hr><center>nginx</center></body></html>'
+
+const lastNotification = () => {
+  const calls = (showNotification as unknown as jest.Mock).mock.calls
+  return calls[calls.length - 1][0]
+}
+
+describe('useTxNotifications — CGW response states (WA-3252)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const dispatchProposeFailure = async (error: Error) => {
+    renderHook(() => useTxNotifications())
+
+    act(() => {
+      txDispatch(TxEvent.PROPOSE_FAILED, { error })
+    })
+
+    await waitFor(() => expect(showNotification).toHaveBeenCalled())
+  }
+
+  it.each([429, 502, 500, 503, 422])('shows the agreed copy for a %s from CGW', async (status) => {
+    await dispatchProposeFailure(asError({ status, data: {} }))
+
+    expect(lastNotification().message).toBe('Something went wrong on our end. Try again.')
+  })
+
+  it('never leaks the raw HTML body of a 502 into the toast (the original defect)', async () => {
+    await dispatchProposeFailure(
+      asError({
+        status: 'PARSING_ERROR',
+        originalStatus: 502,
+        data: HTML_502,
+        error: "SyntaxError: Unexpected token '<'",
+      }),
+    )
+
+    const notification = lastNotification()
+    expect(notification.message).toBe('Something went wrong on our end. Try again.')
+    expect(notification.detailedMessage).toBe('Error code CGW-502')
+    expect(JSON.stringify(notification)).not.toContain('nginx')
+    expect(JSON.stringify(notification)).not.toContain('Bad Gateway')
+    expect(JSON.stringify(notification)).not.toContain('<html')
+  })
+
+  it('shows a 422 once and does not loop', async () => {
+    // A 422 is our bug, not a transient failure: it is surfaced a single time.
+    // Nothing retries CGW requests today, so this pins the AC against the
+    // baseline rather than against a fix.
+    await dispatchProposeFailure(asError({ status: 422, data: {} }))
+
+    expect(showNotification).toHaveBeenCalledTimes(1)
+    expect(lastNotification().message).toBe('Something went wrong on our end. Try again.')
+  })
+
+  it('shows the banned-Safe copy for a 451', async () => {
+    await dispatchProposeFailure(asError({ status: 451, data: {} }))
+
+    expect(lastNotification().message).toBe('This Safe Account is not available.')
+  })
+
+  it('leaves an unmapped failure (404) on the existing copy', async () => {
+    await dispatchProposeFailure(asError({ status: 404, data: { message: 'Not found' } }))
+
+    const notification = lastNotification()
+    expect(notification.message).toContain('Failed to add to queue')
+    expect(notification.detailedMessage).toBe('Not found')
+  })
+})

--- a/apps/web/src/hooks/messages/__tests__/useSafeMessageNotifications.test.ts
+++ b/apps/web/src/hooks/messages/__tests__/useSafeMessageNotifications.test.ts
@@ -6,6 +6,7 @@ import { showNotification } from '@/store/notificationsSlice'
 import { renderHook } from '@/tests/test-utils'
 import useSafeMessageNotifications, { _getSafeMessagesAwaitingConfirmations } from '../useSafeMessageNotifications'
 import type { PendingSafeMessagesState } from '@/store/pendingSafeMessagesSlice'
+import { asError } from '@safe-global/utils/services/exceptions/utils'
 
 jest.mock('@/store/notificationsSlice', () => {
   const original = jest.requireActual('@/store/notificationsSlice')
@@ -166,6 +167,48 @@ describe('useSafeMessageNotifications', () => {
       message: 'The message was successfully confirmed.',
       groupKey: '0x012',
       variant: 'success',
+    })
+  })
+
+  describe('CGW response states (WA-3252)', () => {
+    const HTML_502 =
+      '<html><head><title>502 Bad Gateway</title></head><body><center><h1>502 Bad Gateway</h1></center><hr><center>nginx</center></body></html>'
+
+    it('shows the agreed copy and no raw HTML for a 502 from CGW', () => {
+      renderHook(() => useSafeMessageNotifications())
+
+      safeMsgDispatch(SafeMsgEvent.PROPOSE_FAILED, {
+        messageHash: '0x345',
+        error: asError({
+          status: 'PARSING_ERROR',
+          originalStatus: 502,
+          data: HTML_502,
+          error: "SyntaxError: Unexpected token '<'",
+        }),
+      })
+
+      expect(showNotification).toHaveBeenCalledWith({
+        message: 'Something went wrong on our end. Try again.',
+        detailedMessage: 'Error code CGW-502',
+        groupKey: '0x345',
+        variant: 'error',
+      })
+    })
+
+    it('shows the banned-Safe copy for a 451', () => {
+      renderHook(() => useSafeMessageNotifications())
+
+      safeMsgDispatch(SafeMsgEvent.PROPOSE_FAILED, {
+        messageHash: '0x346',
+        error: asError({ status: 451, data: {} }),
+      })
+
+      expect(showNotification).toHaveBeenCalledWith({
+        message: 'This Safe Account is not available.',
+        detailedMessage: 'Error code CGW-451',
+        groupKey: '0x346',
+        variant: 'error',
+      })
     })
   })
 })

--- a/apps/web/src/hooks/messages/useSafeMessageNotifications.ts
+++ b/apps/web/src/hooks/messages/useSafeMessageNotifications.ts
@@ -15,6 +15,7 @@ import { useCurrentChain } from '@/hooks/useChains'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import type { PendingSafeMessagesState } from '@/store/pendingSafeMessagesSlice'
 import { isWalletRejection } from '@/utils/wallets'
+import { getCgwErrorInfo } from '@/utils/cgw-errors'
 
 const SafeMessageNotifications: Partial<Record<SafeMsgEvent, string>> = {
   [SafeMsgEvent.PROPOSE]: 'You successfully signed the message.',
@@ -52,12 +53,19 @@ const useSafeMessageNotifications = () => {
         const isError = 'error' in detail
         if (isError && isWalletRejection(detail.error)) return
         const isSuccess = event === SafeMsgEvent.PROPOSE || event === SafeMsgEvent.SIGNATURE_PREPARED
-        const message = isError ? `${baseMessage}${formatError(detail.error)}` : baseMessage
+        // A known CGW response state replaces both the copy and the details:
+        // the response body can be a gateway HTML error page (WA-3252).
+        const cgwError = isError ? getCgwErrorInfo(detail.error) : undefined
+        const message = cgwError
+          ? cgwError.message
+          : isError
+            ? `${baseMessage}${formatError(detail.error)}`
+            : baseMessage
 
         dispatch(
           showNotification({
             message,
-            detailedMessage: isError ? detail.error.message : undefined,
+            detailedMessage: cgwError ? `Error code ${cgwError.code}` : isError ? detail.error.message : undefined,
             groupKey: detail.messageHash,
             variant: isError ? 'error' : isSuccess ? 'success' : 'info',
           }),

--- a/apps/web/src/hooks/useTxNotifications.ts
+++ b/apps/web/src/hooks/useTxNotifications.ts
@@ -22,6 +22,7 @@ import {
   RATE_LIMIT_USER_MESSAGE,
 } from '@/utils/transaction-errors'
 import { getGs026Message } from '@safe-global/utils/services/exceptions/contractErrors'
+import { getCgwErrorInfo } from '@/utils/cgw-errors'
 
 const TxNotifications = {
   [TxEvent.SIGN_FAILED]: 'Failed to sign. Please try again.',
@@ -72,6 +73,9 @@ const useTxNotifications = (): void => {
 
         // Check if this is a Guard error
         const guardErrorName = isError ? getGuardErrorInfo(detail.error) : undefined
+        // A known CGW response state replaces both the copy and the details:
+        // the response body can be a gateway HTML error page (WA-3252).
+        const cgwError = isError ? getCgwErrorInfo(detail.error) : undefined
         let message = isError ? `${baseMessage} ${formatError(detail.error)}` : baseMessage
 
         // Override message for Guard errors
@@ -85,6 +89,8 @@ const useTxNotifications = (): void => {
           // RPC rejected it pre-mining (no gas spent). Same user story as a
           // stale Safe nonce, so show the same message.
           message = getGs026Message('STALE_NONCE')
+        } else if (cgwError) {
+          message = cgwError.message
         } else if (isError && isRateLimitError(detail.error)) {
           // Translate transient RPC rate-limit failures into friendly copy.
           // The raw error from viem looks like a contract revert ("Request is
@@ -110,7 +116,7 @@ const useTxNotifications = (): void => {
           showNotification({
             title: humanDescription,
             message,
-            detailedMessage: isError ? detail.error.message : undefined,
+            detailedMessage: cgwError ? `Error code ${cgwError.code}` : isError ? detail.error.message : undefined,
             groupKey,
             variant: isError ? Variant.ERROR : isSuccess ? Variant.SUCCESS : Variant.INFO,
             link: txId

--- a/apps/web/src/hooks/useTxNotifications.ts
+++ b/apps/web/src/hooks/useTxNotifications.ts
@@ -89,14 +89,16 @@ const useTxNotifications = (): void => {
           // RPC rejected it pre-mining (no gas spent). Same user story as a
           // stale Safe nonce, so show the same message.
           message = getGs026Message('STALE_NONCE')
-        } else if (cgwError) {
-          message = cgwError.message
         } else if (isError && isRateLimitError(detail.error)) {
           // Translate transient RPC rate-limit failures into friendly copy.
           // The raw error from viem looks like a contract revert ("Request is
           // being rate limited"); we replace the message but keep the original
           // in detailedMessage for debugging.
+          // Checked before the CGW classification so a 429-carrying error reads
+          // the same here as it does inline in `TxSubmitError` (WA-3252).
           message = RATE_LIMIT_USER_MESSAGE
+        } else if (cgwError) {
+          message = cgwError.message
         }
 
         const txId = 'txId' in detail ? detail.txId : undefined

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -37,6 +37,7 @@ import { GATEWAY_URL } from '@/config/gateway'
 import { setupListeners } from '@reduxjs/toolkit/query'
 import { migrateBatchTxs } from '@/services/ls-migration/batch'
 import { apiSliceWithChainsConfig } from '@safe-global/store/gateway'
+import { cgwErrorAlert } from './middleware/cgwErrorAlert'
 
 const rootReducer = combineReducers({
   [slices.safeInfoSlice.name]: slices.safeInfoSlice.reducer,
@@ -107,6 +108,7 @@ export const getPersistedState = () => {
 export const listenerMiddlewareInstance = createListenerMiddleware<RootState>()
 
 const middleware: Middleware<{}, RootState>[] = [
+  cgwErrorAlert,
   persistState(persistedSlices),
   broadcastState(persistedSlices),
   listenerMiddlewareInstance.middleware,

--- a/apps/web/src/store/middleware/__tests__/cgwErrorAlert.test.ts
+++ b/apps/web/src/store/middleware/__tests__/cgwErrorAlert.test.ts
@@ -1,6 +1,6 @@
 import type { MiddlewareAPI, UnknownAction } from '@reduxjs/toolkit'
 import { cgwErrorAlert } from '../cgwErrorAlert'
-import { Errors, logError } from '@/services/exceptions'
+import { CodedException, Errors, logError } from '@/services/exceptions'
 
 jest.mock('@/services/exceptions', () => ({
   ...jest.requireActual('@/services/exceptions'),
@@ -66,7 +66,15 @@ describe('cgwErrorAlert', () => {
     run(rejected({ status: 'PARSING_ERROR', originalStatus: 422, data: HTML_502, error: 'SyntaxError' }))
 
     expect(logError).toHaveBeenCalledTimes(1)
-    const [code] = (logError as jest.Mock).mock.calls[0]
+    const [code, thrown] = (logError as jest.Mock).mock.calls[0]
     expect(code).toBe(Errors._622)
+
+    // What actually reaches Datadog is the `CodedException` message, which
+    // interpolates `asError(thrown).message`. Assert on that: asserting the
+    // code alone would still pass if the HTML body leaked into the message.
+    const { message } = new CodedException(code, thrown)
+    expect(message).toContain('Request failed with status 422')
+    expect(message).not.toContain('<html')
+    expect(message).not.toContain('Bad Gateway')
   })
 })

--- a/apps/web/src/store/middleware/__tests__/cgwErrorAlert.test.ts
+++ b/apps/web/src/store/middleware/__tests__/cgwErrorAlert.test.ts
@@ -1,0 +1,72 @@
+import type { MiddlewareAPI, UnknownAction } from '@reduxjs/toolkit'
+import { cgwErrorAlert } from '../cgwErrorAlert'
+import { Errors, logError } from '@/services/exceptions'
+
+jest.mock('@/services/exceptions', () => ({
+  ...jest.requireActual('@/services/exceptions'),
+  logError: jest.fn(),
+}))
+
+const HTML_502 =
+  '<html><head><title>502 Bad Gateway</title></head><body><center><h1>502 Bad Gateway</h1></center></body></html>'
+
+const rejected = (payload: unknown, type = 'api/executeQuery/rejected'): UnknownAction => ({
+  type,
+  payload,
+  meta: { rejectedWithValue: true, requestStatus: 'rejected', arg: {}, requestId: '1', aborted: false },
+  error: { message: 'Rejected' },
+})
+
+const storeApi = { getState: jest.fn(), dispatch: jest.fn() } as unknown as MiddlewareAPI
+
+const run = (action: UnknownAction) => {
+  const next = jest.fn((a: unknown) => a)
+  cgwErrorAlert(storeApi)(next)(action)
+  return next
+}
+
+describe('cgwErrorAlert', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('logs an internal alert when CGW rejects our request as unprocessable', () => {
+    run(rejected({ status: 422, data: { message: 'Validation failed' } }))
+
+    expect(logError).toHaveBeenCalledWith(Errors._622, { status: 422, data: { message: 'Validation failed' } })
+  })
+
+  it.each([429, 502, 500, 451, 404, 400])('does not alert on a %s', (status) => {
+    run(rejected({ status, data: {} }))
+
+    expect(logError).not.toHaveBeenCalled()
+  })
+
+  it('ignores rejections from other APIs', () => {
+    run(rejected({ status: 422, data: {} }, 'safePass/executeQuery/rejected'))
+
+    expect(logError).not.toHaveBeenCalled()
+  })
+
+  it('ignores actions that are not rejectedWithValue', () => {
+    const next = run({ type: 'api/executeQuery/fulfilled', payload: {} })
+
+    expect(logError).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('always forwards the action', () => {
+    const action = rejected({ status: 422, data: {} })
+    const next = run(action)
+
+    expect(next).toHaveBeenCalledWith(action)
+  })
+
+  it('never passes a raw response body to the alert as a message', () => {
+    run(rejected({ status: 'PARSING_ERROR', originalStatus: 422, data: HTML_502, error: 'SyntaxError' }))
+
+    expect(logError).toHaveBeenCalledTimes(1)
+    const [code] = (logError as jest.Mock).mock.calls[0]
+    expect(code).toBe(Errors._622)
+  })
+})

--- a/apps/web/src/store/middleware/cgwErrorAlert.ts
+++ b/apps/web/src/store/middleware/cgwErrorAlert.ts
@@ -1,0 +1,28 @@
+import { isRejectedWithValue, type Middleware } from '@reduxjs/toolkit'
+import { cgwClient } from '@safe-global/store/gateway/cgwClient'
+import { shouldAlertOnCgwStatus } from '@safe-global/utils/services/exceptions/gatewayErrors'
+import { getHttpStatusFromError } from '@safe-global/utils/services/exceptions/utils'
+import { Errors, logError } from '@/services/exceptions'
+
+const CGW_ACTION_PREFIX = `${cgwClient.reducerPath}/`
+
+/**
+ * Raises an internal alert when CGW rejects one of our requests as
+ * unprocessable (422). That state is never the user's fault — it means we sent
+ * a malformed request — so it is logged as our bug, once per rejected request.
+ *
+ * The user still only sees the agreed generic copy; nothing extra is surfaced.
+ * Only the numeric HTTP status reaches analytics (via `CodedException`), never
+ * the response body.
+ */
+export const cgwErrorAlert: Middleware = () => (next) => (action) => {
+  if (isRejectedWithValue(action) && action.type.startsWith(CGW_ACTION_PREFIX)) {
+    const status = getHttpStatusFromError(action.payload)
+
+    if (shouldAlertOnCgwStatus(status)) {
+      logError(Errors._622, action.payload)
+    }
+  }
+
+  return next(action)
+}

--- a/apps/web/src/utils/cgw-errors.test.ts
+++ b/apps/web/src/utils/cgw-errors.test.ts
@@ -1,0 +1,54 @@
+import { asError } from '@safe-global/utils/services/exceptions/utils'
+import { getCgwErrorInfo, getCgwSupportCode } from './cgw-errors'
+
+const HTML_502 =
+  '<html><head><title>502 Bad Gateway</title></head><body><center><h1>502 Bad Gateway</h1></center><hr><center>nginx</center></body></html>'
+
+describe('getCgwErrorInfo', () => {
+  it.each([429, 502, 500, 503, 422])('classifies a %s with the shared generic copy', (status) => {
+    const info = getCgwErrorInfo(Object.assign(new Error('boom'), { status }))
+
+    expect(info?.message).toBe('Something went wrong on our end. Try again.')
+    expect(info?.code).toBe(`CGW-${status}`)
+  })
+
+  it('classifies a 451 as an unavailable Safe Account', () => {
+    const info = getCgwErrorInfo(Object.assign(new Error('boom'), { status: 451 }))
+
+    expect(info?.message).toBe('This Safe Account is not available.')
+    expect(info?.code).toBe('CGW-451')
+  })
+
+  it('classifies the original 502 defect: an HTML body from a failed CGW request', () => {
+    // What RTK Query hands back when a gateway answers a POST with an HTML page.
+    const error = asError({
+      status: 'PARSING_ERROR',
+      originalStatus: 502,
+      data: HTML_502,
+      error: "SyntaxError: Unexpected token '<'",
+    })
+
+    const info = getCgwErrorInfo(error)
+
+    expect(info?.status).toBe(502)
+    expect(info?.message).toBe('Something went wrong on our end. Try again.')
+    expect(info?.message).not.toContain('<')
+    expect(info?.message).not.toContain('nginx')
+  })
+
+  it('returns undefined for a 404 — deliberately out of scope', () => {
+    expect(getCgwErrorInfo(Object.assign(new Error('boom'), { status: 404 }))).toBeUndefined()
+  })
+
+  it('returns undefined for an error with no HTTP status', () => {
+    expect(getCgwErrorInfo(new Error('execution reverted'))).toBeUndefined()
+    expect(getCgwErrorInfo(undefined)).toBeUndefined()
+  })
+})
+
+describe('getCgwSupportCode', () => {
+  it('returns the support reference for a known state and nothing otherwise', () => {
+    expect(getCgwSupportCode(Object.assign(new Error('boom'), { status: 502 }))).toBe('CGW-502')
+    expect(getCgwSupportCode(new Error('boom'))).toBeUndefined()
+  })
+})

--- a/apps/web/src/utils/cgw-errors.ts
+++ b/apps/web/src/utils/cgw-errors.ts
@@ -1,0 +1,33 @@
+/**
+ * Classifies a failed CGW request against the shared response-state contract
+ * (`@safe-global/utils/services/exceptions/gatewayErrors`) so every surface —
+ * inline submit errors, notification toasts — renders the same copy and the
+ * same code-only support reference.
+ */
+import {
+  getCgwErrorCode,
+  getCgwErrorMeta,
+  type CgwErrorMeta,
+} from '@safe-global/utils/services/exceptions/gatewayErrors'
+import { getHttpStatusFromError } from '@safe-global/utils/services/exceptions/utils'
+
+export interface CgwErrorInfo extends CgwErrorMeta {
+  status: number
+  /** Support reference for the Details panel — never part of the message. */
+  code: string
+}
+
+/**
+ * Returns the agreed copy and support reference for a known CGW response
+ * state, or `undefined` when the error is not one we have agreed copy for (the
+ * caller then keeps its existing behaviour).
+ */
+export const getCgwErrorInfo = (error: unknown): CgwErrorInfo | undefined => {
+  const status = getHttpStatusFromError(error)
+  const meta = getCgwErrorMeta(status)
+
+  return status === undefined || !meta ? undefined : { ...meta, status, code: getCgwErrorCode(status) }
+}
+
+/** Support reference code for a known CGW response state. */
+export const getCgwSupportCode = (error: unknown): string | undefined => getCgwErrorInfo(error)?.code

--- a/packages/store/src/gateway/__tests__/cgwClient-no-retry.test.ts
+++ b/packages/store/src/gateway/__tests__/cgwClient-no-retry.test.ts
@@ -1,0 +1,38 @@
+import type { BaseQueryApi } from '@reduxjs/toolkit/query/react'
+import * as cgwClient from '../cgwClient'
+
+/**
+ * The CGW client issues each request exactly once: nothing wraps its base query
+ * in `retry`. A 422 means we sent a malformed request, so re-sending it cannot
+ * change the outcome — this pins that it is never re-sent (WA-3252).
+ *
+ * A retry policy for the transient states (429 / 5xx) is deliberately deferred
+ * to its own ticket. Whoever adds it must keep 422 excluded, and this test is
+ * what fails if they do not.
+ */
+describe('cgwClient request attempts', () => {
+  const api: BaseQueryApi = {
+    dispatch: jest.fn(),
+    getState: jest.fn(),
+    abort: jest.fn(),
+    signal: new AbortController().signal,
+    extra: {},
+    endpoint: 'testEndpoint',
+    type: 'query',
+  }
+
+  const mockRawBaseQuery = jest.spyOn(cgwClient, 'rawBaseQuery')
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    cgwClient.setBaseUrl('http://example.com')
+  })
+
+  it.each([422, 451, 404, 429, 502])('sends a request that fails with %s exactly once', async (status) => {
+    mockRawBaseQuery.mockResolvedValue({ error: { status, data: {} } } as never)
+
+    await cgwClient.dynamicBaseQuery('/test', api, {})
+
+    expect(mockRawBaseQuery).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/store/src/gateway/__tests__/cgwClient-no-retry.test.ts
+++ b/packages/store/src/gateway/__tests__/cgwClient-no-retry.test.ts
@@ -2,13 +2,22 @@ import type { BaseQueryApi } from '@reduxjs/toolkit/query/react'
 import * as cgwClient from '../cgwClient'
 
 /**
- * The CGW client issues each request exactly once: nothing wraps its base query
- * in `retry`. A 422 means we sent a malformed request, so re-sending it cannot
- * change the outcome — this pins that it is never re-sent (WA-3252).
+ * Pins that `dynamicBaseQuery` itself issues each request exactly once: it does
+ * not retry internally. A 422 means we sent a malformed request, so re-sending
+ * it cannot change the outcome (WA-3252).
  *
- * A retry policy for the transient states (429 / 5xx) is deliberately deferred
- * to its own ticket. Whoever adds it must keep 422 excluded, and this test is
- * what fails if they do not.
+ * Scope — what this does NOT cover. It calls `dynamicBaseQuery` directly, so it
+ * says nothing about retries layered *above* it:
+ *  - `gateway/chains/index.ts` already wraps it in `retry(…, { maxRetries: 5 })`
+ *    with no `retryCondition`, so chain-config requests DO retry, 422 included.
+ *  - A `retry()` added at `createApi`/endpoint level would likewise be invisible
+ *    here.
+ *
+ * So "CGW requests are never retried" is not a repo-wide property; it holds for
+ * this base query, which is the propose/submission path. A retry policy for the
+ * transient states (429 / 5xx) is deferred to its own ticket; whoever adds one
+ * must keep 422 excluded and must extend this pin to the wrapper they touch,
+ * because this test alone will not catch them.
  */
 describe('cgwClient request attempts', () => {
   const api: BaseQueryApi = {

--- a/packages/utils/src/services/exceptions/ErrorCodes.ts
+++ b/packages/utils/src/services/exceptions/ErrorCodes.ts
@@ -40,6 +40,7 @@ enum ErrorCodes {
   _619 = '619: Error fetching data from master-copies',
   _620 = '620: Error loading chains',
   _621 = '621: Error checking modules for known vulnerabilities',
+  _622 = '622: CGW rejected our request as unprocessable',
   _630 = '630: Error fetching remaining daily relays',
   _631 = '631: Transaction failed to be relayed',
   _632 = '632: Error fetching relay task status',

--- a/packages/utils/src/services/exceptions/__tests__/gatewayErrors.test.ts
+++ b/packages/utils/src/services/exceptions/__tests__/gatewayErrors.test.ts
@@ -1,0 +1,77 @@
+import {
+  CGW_ERROR_FALLBACK,
+  CGW_SAFE_UNAVAILABLE,
+  CGW_TOO_MANY_REQUESTS,
+  CGW_UNAVAILABLE_FOR_LEGAL_REASONS,
+  CGW_UNPROCESSABLE_ENTITY,
+  getCgwErrorCode,
+  getCgwErrorMeta,
+  shouldAlertOnCgwStatus,
+} from '../gatewayErrors'
+
+const ALL_USER_FACING_STRINGS = [CGW_ERROR_FALLBACK, CGW_SAFE_UNAVAILABLE]
+
+describe('gatewayErrors', () => {
+  describe('message mapping', () => {
+    it.each([429, 502, 500, 503, 504, 599, 422])('maps %s to the generic gateway message', (status) => {
+      expect(getCgwErrorMeta(status)?.message).toBe('Something went wrong on our end. Try again.')
+    })
+
+    it('maps 451 (banned Safe Account) to its own message', () => {
+      expect(getCgwErrorMeta(CGW_UNAVAILABLE_FOR_LEGAL_REASONS)?.message).toBe('This Safe Account is not available.')
+    })
+
+    it('covers the whole 5xx range and nothing outside it', () => {
+      expect(getCgwErrorMeta(500)).toBeDefined()
+      expect(getCgwErrorMeta(599)).toBeDefined()
+      expect(getCgwErrorMeta(499)).toBeUndefined()
+      expect(getCgwErrorMeta(600)).toBeUndefined()
+    })
+
+    it('leaves 404 unmapped — deliberately out of scope', () => {
+      expect(getCgwErrorMeta(404)).toBeUndefined()
+    })
+
+    it('leaves other client errors and an absent status unmapped', () => {
+      expect(getCgwErrorMeta(400)).toBeUndefined()
+      expect(getCgwErrorMeta(403)).toBeUndefined()
+      expect(getCgwErrorMeta(undefined)).toBeUndefined()
+    })
+  })
+
+  describe('internal alerting', () => {
+    it('alerts on 422 only — it means we sent a malformed request', () => {
+      expect(shouldAlertOnCgwStatus(CGW_UNPROCESSABLE_ENTITY)).toBe(true)
+      expect(shouldAlertOnCgwStatus(CGW_TOO_MANY_REQUESTS)).toBe(false)
+      expect(shouldAlertOnCgwStatus(502)).toBe(false)
+      expect(shouldAlertOnCgwStatus(CGW_UNAVAILABLE_FOR_LEGAL_REASONS)).toBe(false)
+      expect(shouldAlertOnCgwStatus(404)).toBe(false)
+      expect(shouldAlertOnCgwStatus(undefined)).toBe(false)
+    })
+  })
+
+  describe('getCgwErrorCode', () => {
+    it('builds a support reference that carries the status', () => {
+      expect(getCgwErrorCode(502)).toBe('CGW-502')
+    })
+  })
+
+  describe('content rules (no technical strings, copy rules)', () => {
+    it.each(ALL_USER_FACING_STRINGS)('"%s" contains no forbidden content', (message) => {
+      expect(message).not.toMatch(/https?:\/\//i) // no provider URL
+      expect(message).not.toMatch(/</) // no markup from a response body
+      expect(message).not.toMatch(/request body/i) // no request body
+      expect(message).not.toMatch(/@\d+\.\d+\.\d+/) // no library version
+      expect(message).not.toMatch(/\b(viem|ethers|sdk|nginx|cloudflare)\b/i) // no library / provider names
+      expect(message).not.toMatch(/\b[1-5]\d{2}\b/) // no HTTP status line
+      expect(message).not.toMatch(/\bplease\b/i) // no "please"
+      expect(message).not.toContain('!') // no exclamation mark
+    })
+
+    it('starts every message with a capital and ends it with a full stop (sentence case)', () => {
+      for (const message of ALL_USER_FACING_STRINGS) {
+        expect(message).toMatch(/^[A-Z][^.]*\./)
+      }
+    })
+  })
+})

--- a/packages/utils/src/services/exceptions/__tests__/utils.test.ts
+++ b/packages/utils/src/services/exceptions/__tests__/utils.test.ts
@@ -82,6 +82,53 @@ describe('utils', () => {
       expect(result.status).toBe('FETCH_ERROR')
     })
 
+    it('never surfaces an unparsable response body as the message (WA-3252)', () => {
+      // RTK Query cannot JSON-parse a gateway's HTML 502 page: it reports
+      // PARSING_ERROR and parks the real status in `originalStatus`.
+      const thrown = {
+        status: 'PARSING_ERROR',
+        originalStatus: 502,
+        data: '<html><head><title>502 Bad Gateway</title></head><body><center><h1>502 Bad Gateway</h1></center><hr><center>nginx</center></body></html>',
+        error: "SyntaxError: Unexpected token '<'",
+      } as FetchBaseQueryError
+
+      const result = asError(thrown)
+
+      expect(result.message).not.toContain('<')
+      expect(result.message).not.toContain('nginx')
+      expect(result.message).not.toContain('Bad Gateway')
+      expect(result.status).toBe(502)
+      expect(getHttpStatusFromError(result)).toBe(502)
+    })
+
+    it('never surfaces a markup body as the message for a plain HTTP error', () => {
+      const thrown: FetchBaseQueryError = { status: 502, data: '<html><body>502 Bad Gateway</body></html>' }
+
+      const result = asError(thrown)
+
+      expect(result.message).not.toContain('<')
+      expect(result.status).toBe(502)
+    })
+
+    it('still surfaces a plain-text body that is not markup', () => {
+      const thrown: FetchBaseQueryError = { status: 429, data: 'Rate limit reached' }
+
+      expect(asError(thrown).message).toBe('Rate limit reached')
+    })
+
+    it('keeps the string status when a parsing error carries no original status', () => {
+      const thrown: FetchBaseQueryError = {
+        status: 'PARSING_ERROR',
+        originalStatus: 0,
+        data: 'plain body',
+        error: 'oops',
+      }
+
+      const result = asError(thrown)
+      expect(result.status).toBe('PARSING_ERROR')
+      expect(result.message).toBe('plain body')
+    })
+
     it('should handle FetchBaseQueryError with missing data.message', () => {
       const thrown: FetchBaseQueryError = {
         status: 500,
@@ -115,6 +162,7 @@ describe('utils', () => {
     it('ignores non-HTTP numbers (CGW internal codes, string statuses)', () => {
       expect(getHttpStatusFromError(new Error('CGW error - 1337: Some internal code'))).toBeUndefined()
       expect(getHttpStatusFromError({ status: 'FETCH_ERROR' })).toBeUndefined()
+      expect(getHttpStatusFromError({ status: 'PARSING_ERROR', originalStatus: 502 })).toBe(502)
       expect(getHttpStatusFromError({ status: 42 })).toBeUndefined()
     })
 

--- a/packages/utils/src/services/exceptions/errorTaxonomy.ts
+++ b/packages/utils/src/services/exceptions/errorTaxonomy.ts
@@ -113,6 +113,7 @@ export const ERROR_CODE_MAP: Record<number, ErrorClassification> = {
   616: { domain: ErrorDomain.API, type: ErrorType.API_ERROR, layer: ErrorLayer.OFF_CHAIN },
   619: { domain: ErrorDomain.DATA_LOADING, type: ErrorType.FETCH_FAILED, layer: ErrorLayer.OFF_CHAIN },
   621: { domain: ErrorDomain.DATA_LOADING, type: ErrorType.FETCH_FAILED, layer: ErrorLayer.OFF_CHAIN },
+  622: { domain: ErrorDomain.API, type: ErrorType.API_ERROR, layer: ErrorLayer.OFF_CHAIN },
   633: { domain: ErrorDomain.DATA_LOADING, type: ErrorType.NOTIFICATION_ERROR, layer: ErrorLayer.OFF_CHAIN },
   640: { domain: ErrorDomain.AUTH, type: ErrorType.AUTH_FAILED, layer: ErrorLayer.OFF_CHAIN },
   650: { domain: ErrorDomain.DATA_LOADING, type: ErrorType.FETCH_FAILED, layer: ErrorLayer.OFF_CHAIN },

--- a/packages/utils/src/services/exceptions/gatewayErrors.ts
+++ b/packages/utils/src/services/exceptions/gatewayErrors.ts
@@ -1,0 +1,64 @@
+/**
+ * Single source of truth for user-facing copy on known CGW (Safe Client
+ * Gateway) HTTP response states — the HTTP-status counterpart to
+ * `contractErrors.ts`. Web and mobile both read from here, so the same gateway
+ * failure renders the exact same text on every platform.
+ *
+ * The raw response body is never part of the copy: a gateway can answer with an
+ * HTML error page, and rendering that verbatim is what this module exists to
+ * prevent. The status is a support reference only (see `getCgwErrorCode`).
+ */
+
+/** Shown for every response state we cannot act on: transient, or our own bug. */
+export const CGW_ERROR_FALLBACK = 'Something went wrong on our end. Try again.'
+
+/** A Safe Account the gateway refuses to serve for legal reasons. */
+export const CGW_SAFE_UNAVAILABLE = 'This Safe Account is not available.'
+
+export interface CgwErrorMeta {
+  /** User-facing copy. */
+  message: string
+  /**
+   * Whether reaching this state means *we* sent a bad request and an internal
+   * alert is warranted. Never implies anything extra is shown to the user.
+   */
+  alertsInternally: boolean
+}
+
+export const CGW_UNPROCESSABLE_ENTITY = 422
+export const CGW_TOO_MANY_REQUESTS = 429
+export const CGW_UNAVAILABLE_FOR_LEGAL_REASONS = 451
+
+/**
+ * Explicitly mapped states. Statuses absent from here and outside the 5xx range
+ * (notably 404) are deliberately unmapped: callers keep their current
+ * behaviour rather than inheriting a generic message.
+ */
+const CGW_ERRORS: Record<number, CgwErrorMeta> = {
+  // We sent CGW a malformed request. Same generic copy — the user cannot fix
+  // it — but it is our bug, so it alerts internally.
+  [CGW_UNPROCESSABLE_ENTITY]: { message: CGW_ERROR_FALLBACK, alertsInternally: true },
+  [CGW_TOO_MANY_REQUESTS]: { message: CGW_ERROR_FALLBACK, alertsInternally: false },
+  [CGW_UNAVAILABLE_FOR_LEGAL_REASONS]: { message: CGW_SAFE_UNAVAILABLE, alertsInternally: false },
+}
+
+/** Any 5xx (502 included) is a gateway-side failure the user cannot act on. */
+const CGW_SERVER_ERROR: CgwErrorMeta = { message: CGW_ERROR_FALLBACK, alertsInternally: false }
+
+const isServerErrorStatus = (status: number): boolean => status >= 500 && status <= 599
+
+/** Resolve an HTTP status to its copy contract, or `undefined` if unmapped. */
+export const getCgwErrorMeta = (status: number | undefined): CgwErrorMeta | undefined => {
+  if (status === undefined) return undefined
+  return CGW_ERRORS[status] ?? (isServerErrorStatus(status) ? CGW_SERVER_ERROR : undefined)
+}
+
+/**
+ * Support reference for the Details panel. Carries the status so support can
+ * correlate the report with gateway logs — it never appears in the message.
+ */
+export const getCgwErrorCode = (status: number): string => `CGW-${status}`
+
+/** Whether this state should raise an internal alert (a bug on our side). */
+export const shouldAlertOnCgwStatus = (status: number | undefined): boolean =>
+  getCgwErrorMeta(status)?.alertsInternally === true

--- a/packages/utils/src/services/exceptions/utils.ts
+++ b/packages/utils/src/services/exceptions/utils.ts
@@ -20,6 +20,9 @@ const isFetchBaseQueryError = (error: unknown): error is FetchBaseQueryError => 
   )
 }
 
+/** A response body that is an error page (HTML/XML) rather than a message. */
+const isMarkup = (body: string): boolean => /^\s*</.test(body)
+
 export const asError = (thrown: unknown): ErrorWithStatus => {
   if (thrown instanceof Error) {
     return thrown as ErrorWithStatus
@@ -30,11 +33,26 @@ export const asError = (thrown: unknown): ErrorWithStatus => {
   if (isFetchBaseQueryError(thrown)) {
     let errorMessage: string
 
+    // An unparsable body means RTK Query could not read the response as JSON —
+    // typically a gateway answering a 5xx with an HTML error page. That body
+    // must never become the error message: it is rendered verbatim in error
+    // details. Keep the real HTTP status (RTK Query parks it in
+    // `originalStatus`) so the UI can map it to agreed copy instead.
+    const originalStatus = (thrown as { originalStatus?: unknown }).originalStatus
+    if (thrown.status === 'PARSING_ERROR' && isHttpStatus(originalStatus)) {
+      const parsingError = new Error(`Request failed with status ${originalStatus}`) as ErrorWithStatus
+      parsingError.status = originalStatus
+      return parsingError
+    }
+
     // Extract message from the error
     if (typeof thrown.data === 'object' && thrown.data !== null && 'message' in thrown.data) {
       errorMessage = String((thrown.data as Record<string, unknown>).message)
-    } else if (typeof thrown.data === 'string') {
+    } else if (typeof thrown.data === 'string' && !isMarkup(thrown.data)) {
       errorMessage = thrown.data
+    } else if (typeof thrown.data === 'string') {
+      // Markup body (an error page) — same reasoning as above.
+      errorMessage = `Request failed with status ${String(thrown.status)}`
     } else if (typeof thrown.status === 'string') {
       // For string error codes like 'FETCH_ERROR', 'PARSING_ERROR', use the status as message
       errorMessage = thrown.status
@@ -73,15 +91,21 @@ const isHttpStatus = (value: unknown): value is number => typeof value === 'numb
 /**
  * Extracts the HTTP status of a failed request from an unknown thrown value,
  * checking structural fields first (RTK Query / `asError` set `status`, the
- * CGW SDK's `ErrorResponse` uses `statusCode`) and falling back to the CGW SDK
- * message format. Returns `undefined` when no plausible HTTP status is found,
- * so non-HTTP numbers (e.g. CGW internal codes) are never misreported.
+ * CGW SDK's `ErrorResponse` uses `statusCode`, RTK Query parks the real status
+ * of an unparsable response in `originalStatus`) and falling back to the CGW
+ * SDK message format. Returns `undefined` when no plausible HTTP status is
+ * found, so non-HTTP numbers (e.g. CGW internal codes) are never misreported.
  */
 export const getHttpStatusFromError = (thrown: unknown): number | undefined => {
   if (typeof thrown === 'object' && thrown !== null) {
-    const { status, statusCode } = thrown as { status?: unknown; statusCode?: unknown }
+    const { status, statusCode, originalStatus } = thrown as {
+      status?: unknown
+      statusCode?: unknown
+      originalStatus?: unknown
+    }
     if (isHttpStatus(status)) return status
     if (isHttpStatus(statusCode)) return statusCode
+    if (isHttpStatus(originalStatus)) return originalStatus
   }
 
   if (thrown instanceof Error) {


### PR DESCRIPTION
## What it solves

Resolves: [WA-3252](https://linear.app/safe-global/issue/WA-3252/show-cgw-errors-clearly-map-known-response-states-to-ui-copy)

A 502 from CGW rendered to users as **raw HTML** while submitting a transaction (reported by Liliya). The underlying problem is bigger than one status code: there was no agreed contract for what the UI shows on known CGW responses, so codes were handled ad hoc or not at all.

### Where the HTML actually escaped

Not at the render layer — two layers earlier, in shared code.

RTK Query cannot JSON-parse a gateway's HTML error page, so `fetchBaseQuery` returns `{ status: 'PARSING_ERROR', originalStatus: 502, data: '<html>…502 Bad Gateway…nginx…' }`. In `packages/utils/src/services/exceptions/utils.ts`, `asError`'s branch order hit `typeof thrown.data === 'string'` **first** and hoisted the entire HTML body into `error.message`, while `error.status` became the string `'PARSING_ERROR'` — so the real 502 was **discarded** and `getHttpStatusFromError` returned `undefined`.

From there it surfaced verbatim in two places: `proposeTransaction` → `TxEvent.PROPOSE_FAILED` → `useTxNotifications` → `detailedMessage` rendered inside a `<pre>`; and the same error object into `TxSubmitError` → `ErrorMessage` details.

Fixing it in `asError` closes the leak for every consumer at once — including mobile, which shares that function.

## How this PR fixes it

**Shared (`packages/`)**
- **`exceptions/gatewayErrors.ts`** (new) — the code-keyed copy source, sitting beside `contractErrors.ts` and shaped like it. 422 / 429 / 451 explicit plus a 5xx range rule.
- **`exceptions/utils.ts`** — `asError` no longer surfaces an unparsable or markup body as the message, and preserves `originalStatus` as a numeric `status`; `getHttpStatusFromError` now also reads `originalStatus`.
- **`exceptions/ErrorCodes.ts` / `errorTaxonomy.ts`** — one line each (`_622`), so `logError` has a code to take and the WA-2775 facets don't degrade to `type: unknown`.

**Web (`apps/web/`)**
- **`utils/cgw-errors.ts`** (new) — `getCgwErrorInfo` / `getCgwSupportCode`; every component edit calls into it rather than spreading conditionals.
- **`ErrorMessage`** — a known CGW state shows `Error code CGW-502` with a copy button instead of a Details toggle over the payload.
- **`TxSubmitError`** — one self-contained branch after the rate-limit branch.
- **`useTxNotifications` / `useSafeMessageNotifications`** — the mapped sentence, and `detailedMessage: undefined` for CGW errors.
- **`store/middleware/cgwErrorAlert.ts`** (new) — the 422 internal alert.

### The agreed contract

| CGW response | Message |
| --- | --- |
| 429, 502, 422, any other 5xx | Something went wrong on our end. Try again. |
| 451 — banned Safe | This Safe Account is not available. |

A 422 means we sent CGW a malformed request — our bug, not the user's — so it emits an internal alert via `logError(Errors._622, …)` → `logger.warn` + `captureError({ isUserFacing: false })`, i.e. the **Datadog** debugging sink.

### On analytics

`trackErrorSurfaced` and `normalizeError` are untouched. What reaches Mixpanel is only what it already sent: normalized enums plus `http_status`, a number already whitelisted in `mapContext`. No response body, no message text, no new property. The WA-2775 privacy invariant ("the sanitized message stays out of Mixpanel") is intact.

## Deliberately out of scope

Three scope decisions, all deliberate:

- **All 404 handling.** The ticket asks for a genuine-404 message *and* a benign-404 silent empty state, but never defines how to tell them apart — and both are literally `404` with the same response shape. Guessing would either suppress real errors or pollute normal empty states, so it is deferred to a follow-up. `gatewayErrors.ts` leaves 404 unmapped, with tests pinning that, and existing 404 suppression (`useLoadSafeInfo`'s `isCgw404`) is untouched.
- **Retry with backoff.** Putting `retry()` on the shared `cgwClient` base query cannot satisfy both platforms without changing mobile's test harness (`jest.setup.tsx` calls `jest.useFakeTimers()` globally, so a backoff `setTimeout` never fires). A web-only retry would ship a silently asymmetric AC, so retry moves to its own ticket.
- **Toast-vs-inline placement.** The ACs specify *which* message, not *where*. The open design question in the ticket thread is left for design; this PR keeps the existing placement.

### Correction on the retry claim

An earlier revision of this description said "nothing retries CGW requests today". **That is accurate for the submission flow this ticket fixes, but not repo-wide:** `packages/store/src/gateway/chains/index.ts:16` wraps `dynamicBaseQuery` in `retry(…, { maxRetries: 5 })` with no `retryCondition`, so failures on the chains endpoints are re-sent. The propose/submission path genuinely has no retry, which is why AC4 ("422 does not retry-loop") holds for the defect flow. `cgwClient-no-retry.test.ts` pins the base query directly and therefore covers neither the chains wrapper nor a `retry()` added at `createApi` level — its comment has been corrected to say so rather than overclaim.

## How to test it

```bash
yarn workspace @safe-global/web test --testPathPattern "(cgw-errors|cgwErrorAlert|TxSubmitError|ErrorMessage|useTxNotifications|useSafeMessageNotifications)"
yarn workspace @safe-global/utils test --testPathPattern "(gatewayErrors|exceptions/__tests__/utils)"
```

Manual — intercept the CGW request (Requestly, as QA does) and return each status while submitting a transaction:
1. 502 → "Something went wrong on our end. Try again." and **no HTML**, no `nginx`, no status line.
2. 422 → same message, shown once, plus an internal alert in Datadog.
3. 451 → "This Safe Account is not available."
4. 404 → unchanged from today (out of scope).

## Affected flows

- Submitting a transaction when CGW answers with a known error state (the original defect)
- Signing an off-chain message on the same paths
- Any surface rendering a CGW failure through `ErrorMessage`, `TxSubmitError`, or the tx/message notification toasts

## Blast radius

| Surface | Consumers | Change |
| --- | --- | --- |
| `packages/utils/.../exceptions/utils.ts` (`asError`) | **web + mobile** | Highest-reach change here. An unparsable or markup body no longer becomes `error.message`; the real HTTP status is preserved. Mobile's full suite was run and passes. |
| `packages/utils/.../gatewayErrors.ts` | new | New shared copy source; currently read by web only (see follow-ups) |
| `ErrorCodes.ts` / `errorTaxonomy.ts` | web + mobile | One line each; additive |
| `components/tx/ErrorMessage`, `TxSubmitError` | broad — many tx surfaces | New branch; non-CGW errors take the identical path they did before |
| `hooks/useTxNotifications`, `useSafeMessageNotifications` | global toasts | `detailedMessage` withheld for CGW errors only |
| `store/index.ts` | web store | One middleware registration |

Not touched: `contractErrors.ts`, `trackErrorSurfaced`, `normalizeError`, the Mixpanel payload, mobile source, CI, dependencies. `apps/tx-builder` does not depend on `@safe-global/utils` and is unaffected despite its preview job running.

## Risks / not checked

- **No live CGW 502.** The defect path is reproduced from RTK Query's actual `PARSING_ERROR` shape, not an end-to-end request against a failing gateway.
- **`asError` is shared with mobile.** Its full suite passes (353 suites / 2930 tests) and mobile source is untouched, but the mobile app was not run.
- `isMarkup` is `/^\s*</`. A plain-text error body that legitimately starts with `<` would be treated as markup and replaced with "Request failed with status N" — informative, but not the original text.
- The 422 alert only fires for CGW calls that go through the RTK Query store, and has no dedup (see follow-ups).
- This PR overlaps #8568 (WA-3243) in four files, including an add/add on `hooks/__tests__/useTxNotifications.test.ts`. The two are semantically independent — Ledger errors carry no HTTP status, so the CGW classifier cannot false-positive on them — but whichever merges second needs a mechanical conflict resolution.

## Known gaps, tracked as follow-ups rather than widened into this PR

- **Mobile does not read `gatewayErrors.ts`.** Mobile surfaces `asError`'s output directly, so a CGW 502 there shows "Request failed with status 502" — no HTML leak, but a status line rather than the agreed copy.
- **"Is a CGW error" is inferred from "carries an HTTP status".** Nothing checks the error actually originated at CGW, so an unwrapped transport error carrying `status: 429` could be labelled `CGW-429`. The proper fix is branding the error at the throw site.
- **`apps/web/src/utils/rtkQuery.ts`** remains a parallel generic-copy mechanism ("Something went wrong (502). Please try again…") used by chains and spaces flows. Pre-existing; worth consolidating onto this copy source.
- **The 422 alert has no dedup**, so a persistently-422 polled endpoint could emit one Datadog event per poll tick.

## Visual summary

```mermaid
flowchart TB
  G["CGW answers 502 with an HTML error page"]

  subgraph Before
    B1["fetchBaseQuery: JSON.parse fails"] --> B2["{ status: 'PARSING_ERROR',<br/>originalStatus: 502,<br/>data: '&lt;html&gt;…nginx…' }"]
    B2 --> B3["asError: data-is-string branch wins<br/>message = the whole HTML<br/>status = 'PARSING_ERROR'"]
    B3 --> B4["getHttpStatusFromError → undefined<br/>the real 502 is lost"]
    B3 --> B5["&lt;pre&gt; in the toast Details<br/>renders raw HTML"]
  end

  subgraph After
    A1["asError: PARSING_ERROR branch first"] --> A2["message = 'Request failed with status 502'<br/>status = 502 (numeric)"]
    A2 --> A3["getCgwErrorInfo"]
    A3 -->|"429 / 5xx / 422"| A4["'Something went wrong on our end. Try again.'"]
    A3 -->|"451"| A5["'This Safe Account is not available.'"]
    A3 -->|"404"| A6["unmapped — unchanged, deferred"]
    A4 --> A7["screen: sentence + Error code CGW-502"]
    A5 --> A7
    A4 --> A8["422 only: internal alert → Datadog"]
  end

  G --> B1
  G --> A1
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — *mobile source untouched; its full suite passes because `asError` is shared*
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯