### PR TITLE
fix(UI): give the warning tx accordions one outline token instead of dark-mode coral

### DIFF
--- a/apps/web/src/components/tx/ColorCodedTxAccordion/__snapshots__/index.stories.test.tsx.snap
+++ b/apps/web/src/components/tx/ColorCodedTxAccordion/__snapshots__/index.stories.test.tsx.snap
@@ -406,7 +406,7 @@ exports[`./index.stories SettingsChange 1`] = `
         data-slot="card"
         data-surface="default"
         data-variant="default"
-        style="--accordion-border-active: var(--warning-accent); --accordion-fill-active: var(--warning-subtle);"
+        style="--accordion-border-active: var(--warning-outline); --accordion-fill-active: var(--warning-subtle);"
       >
         <div
           class="flex w-full flex-col"

--- a/apps/web/src/components/tx/ColorCodedTxAccordion/index.test.tsx
+++ b/apps/web/src/components/tx/ColorCodedTxAccordion/index.test.tsx
@@ -38,7 +38,7 @@ describe('ColorCodedTxAccordion', () => {
   // colour and read as no border at all. The values below are the pre-migration ones.
   it.each([
     ['transfer', transferTxInfo, 'var(--color-success-light)', 'var(--color-background-light)'],
-    ['settings change', settingsChangeTxInfo, 'var(--warning-accent)', 'var(--warning-subtle)'],
+    ['settings change', settingsChangeTxInfo, 'var(--warning-outline)', 'var(--warning-subtle)'],
     ['custom', customTxInfo, 'var(--color-info-dark)', 'var(--color-info-background)'],
   ])('gives %s a border token distinct from its fill', (_name, txInfo, expectedBorder, expectedFill) => {
     const { border, fill } = accordionVars(txInfo())

--- a/apps/web/src/components/tx/ColorCodedTxAccordion/index.tsx
+++ b/apps/web/src/components/tx/ColorCodedTxAccordion/index.tsx
@@ -31,8 +31,8 @@ const TX_INFO_LEVEL = {
  */
 const TxInfoColors: Record<ColorLevel, { main: string; mainDark?: string; border: string; background: string }> = {
   [ColorLevel.info]: { main: 'info.dark', border: 'info.dark', background: 'info.background' },
-  // The shadcn warning pair, which light mode pins to the Figma yellows rather than the brand coral.
-  [ColorLevel.warning]: { main: '--warning-strong', border: '--warning-accent', background: '--warning-subtle' },
+  // The shadcn warning trio, which light mode pins to the Figma yellows rather than the brand coral.
+  [ColorLevel.warning]: { main: '--warning-strong', border: '--warning-outline', background: '--warning-subtle' },
   [ColorLevel.success]: {
     main: 'success.main',
     mainDark: 'primary.main',

--- a/apps/web/src/features/gtf/components/HistoryFeesAccordion/HistoryFeesAccordion.test.tsx
+++ b/apps/web/src/features/gtf/components/HistoryFeesAccordion/HistoryFeesAccordion.test.tsx
@@ -1,4 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react'
+import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { transactionDetailsBuilder } from '@/tests/builders/transactionDetails'
 import HistoryFeesAccordion from './index'
 import type { HistoryFeesData } from '../../hooks/useHistoryFeesBreakdown'
 
@@ -8,6 +10,16 @@ const defaultData: HistoryFeesData = {
   gasFee: { label: 'Max gas fee', amount: '0.005', currency: 'ETH', fiatAmount: '$15.12' },
   paidFrom: 'signer',
 }
+
+type TxInfo = TransactionDetails['txInfo']
+
+const transferTxInfo = () => transactionDetailsBuilder().build().txInfo
+
+const settingsChangeTxInfo = (): TxInfo => ({
+  type: 'SettingsChange',
+  dataDecoded: { method: 'changeThreshold', parameters: null },
+  settingsInfo: { type: 'CHANGE_THRESHOLD', threshold: 2 },
+})
 
 describe('HistoryFeesAccordion', () => {
   it('renders collapsed state with total fee', () => {
@@ -100,5 +112,19 @@ describe('HistoryFeesAccordion', () => {
     expect(screen.queryByText('FREE')).not.toBeInTheDocument()
     expect(screen.getByText('0.002730 ETH')).toBeInTheDocument()
     expect(screen.getByText('0.002730 ETH').tagName).not.toBe('DEL')
+  })
+
+  // Must stay in step with ColorCodedTxAccordion's TxInfoColors — the two accordions stack and share
+  // an outline, so a token that drifts here shows up as two different borders on one tx.
+  it.each([
+    ['transfer', transferTxInfo(), 'var(--color-success-light)', 'var(--color-background-light)'],
+    ['settings change', settingsChangeTxInfo(), 'var(--warning-outline)', 'var(--warning-subtle)'],
+    ['unknown type', undefined, 'var(--color-info-dark)', 'var(--color-info-background)'],
+  ])('gives %s its border and fill tokens', (_name, txInfo, expectedBorder, expectedFill) => {
+    const { container } = render(<HistoryFeesAccordion data={defaultData} txInfo={txInfo} />)
+    const root = container.firstElementChild as HTMLElement
+
+    expect(root.style.getPropertyValue('--fees-accordion-border').trim()).toBe(expectedBorder)
+    expect(root.style.getPropertyValue('--fees-accordion-bg').trim()).toBe(expectedFill)
   })
 })

--- a/apps/web/src/features/gtf/components/HistoryFeesAccordion/index.tsx
+++ b/apps/web/src/features/gtf/components/HistoryFeesAccordion/index.tsx
@@ -16,7 +16,7 @@ const TX_PALETTE_BY_TYPE: Record<string, AccordionPalette> = {
   SwapTransfer: { border: 'var(--color-success-light)', bg: 'var(--color-background-light)' },
   TwapOrder: { border: 'var(--color-success-light)', bg: 'var(--color-background-light)' },
   NativeStakingDeposit: { border: 'var(--color-success-light)', bg: 'var(--color-background-light)' },
-  SettingsChange: { border: 'var(--color-warning-light)', bg: 'var(--color-warning-background)' },
+  SettingsChange: { border: 'var(--warning-outline)', bg: 'var(--warning-subtle)' },
 }
 const DEFAULT_PALETTE: AccordionPalette = { border: 'var(--color-info-dark)', bg: 'var(--color-info-background)' }
 

--- a/apps/web/src/styles/shadcn.css
+++ b/apps/web/src/styles/shadcn.css
@@ -70,6 +70,9 @@
   --warning-subtle: #fefce8; /* yellow-50 */
   --warning-strong: #a16207; /* yellow-700 */
   --warning-accent: #eab308; /* yellow-500 */
+  /* Outline on the warning tint. Its own token because dark has to leave `warning-accent`, which
+     falls back to the brand coral there and reads as a different status next to the yellow light. */
+  --warning-outline: var(--warning-accent);
   /* Figma error/background (alert node 1255-183763) — the brand token drifted to #ffe6ea, so the
      Figma hex is pinned here. Dark mode below keeps the brand tint (no dark spec in the file). */
   --error-subtle: #fff4f6;
@@ -138,6 +141,7 @@
   --warning-subtle: var(--color-warning-background);
   --warning-strong: var(--color-warning1-text);
   --warning-accent: var(--color-warning-main);
+  --warning-outline: var(--warning-strong);
   --error-subtle: var(--color-error-background);
   /* Obra DS Badge status colours, dark spec. */
   --badge-warning-subtle: #301d02;
@@ -197,6 +201,7 @@
   /* Icon accent on the warning tint — brighter than the `warning-strong` ink, mirroring how
      `destructive` pairs its icon accent with `error-strong` text. */
   --color-warning-accent: var(--warning-accent);
+  --color-warning-outline: var(--warning-outline);
   --color-badge-warning-subtle: var(--badge-warning-subtle);
   --color-badge-warning-strong: var(--badge-warning-strong);
   --color-badge-dot-success: var(--badge-dot-success);


### PR DESCRIPTION
## What it solves

Resolves:

Settings-change transactions render two stacked accordions — GTF "Fees" on top,
"Transaction details" below — and their outlines disagreed:

- **Fees** used the brand scale (`--color-warning-light`, `#ffbc9f` peach) in both themes.
- **Transaction details** used the shadcn scale (`--warning-accent`), which light mode
  pins to the Figma yellow `#eab308` but dark mode falls back to brand coral `#ff8061`.

So the pair never matched in light, and in dark both read as coral — a different status
next to the yellow the design calls for.

## How this PR fixes it

Adds a `--warning-outline` token to `shadcn.css` and points both accordions at it:

| Theme | Value                              | Was                                |
| ----- | ---------------------------------- | ---------------------------------- |
| light | `--warning-accent` (`#eab308`)     | unchanged for Transaction details  |
| dark  | `--warning-strong` (`#ffe4cb`)     | `--color-warning-main` (`#ff8061`) |

The Fees accordion also moves its summary fill from `--color-warning-background` to
`--warning-subtle`, so the two stacked panels share one tint as well as one outline.

Deliberately a **new** token rather than repointing `--warning-accent` in dark: that
token also inks the warning `Alert` icon and the cookie-banner warning icon, neither of
which is in scope here. Additive means light mode is byte-identical.

This also removes the component-level `borderDark` field and the
`[data-theme='dark']` CSS-module override that an earlier pass added — with the swap
living in the token, neither accordion needs a light/dark branch.

## How to test it

1. Open a settings-change transaction in history (e.g. a threshold change).
2. Hover and expand both the "Fees" and "Transaction details" accordions.
3. Both outlines should be the same colour: yellow `#eab308` in light, cream `#ffe4cb`
   in dark. Neither should be coral.
4. Check a transfer / swap / staking / custom tx — those stay green and blue.
5. Check a warning `Alert` and the cookie banner in dark — their icons should still be
   coral, unchanged.
<img width="479" height="420" alt="Screenshot 2026-08-26 at 6 00 19 PM" src="https://github.com/user-attachments/assets/fe2c3d4d-10ca-423c-ae43-6d2b02d502d9" />

## Affected flows

- Viewing a settings-change transaction in history — hover/open outline and summary tint
  on both stacked accordions, light and dark
- All other transaction types — explicitly unchanged (only the `warning` row of
  `TxInfoColors` moved)

## Blast radius

- **`src/styles/shadcn.css`** — `--warning-outline` is new; `--warning-accent`,
  `--warning-strong` and `--warning-subtle` keep their existing values. Also exposes
  `--color-warning-outline` in `@theme inline`, matching how the file surfaces every
  other token.
- **`ColorCodedTxAccordion`** — consumed by `TxDetails/Summary` for every transaction
  type; `NestedTransaction` imports only its `Divider`.
- **`HistoryFeesAccordion`** — GTF feature, loaded via `useLoadFeature` in the same
  `TxDetails/Summary`.
- **Untouched consumers of `--warning-accent`**: `ui/alert.tsx` (warning variant icon)
  and `CookieAndTermBanner/WarningMessage.tsx`. Guarded by `alert.test.tsx`.
- Other warning-coloured borders in the app (`ApprovalEditor`, `NestedSafesList`,
  `ThirdPartyCookiesWarning`, `TransactionGuards`) use the brand `--color-warning-*`
  scale — a separate visual family, untouched.
- No API contract, Redux slice, feature flag, chain config, route, persistence or
  migration impact. Web-only: a web stylesheet plus two web components, no shared package.

## Risks / not checked

- **Not opened in a browser.** Verified by token values and unit tests only; no visual
  confirmation in either theme.
- **Pre-existing, unchanged, but worth a separate look:** these shadcn tokens are
  declared on `.shadcn-scope`, never `:root`, and I could not find a `.shadcn-scope`
  ancestor on the tx-details render path. If that holds, the outline may not resolve
  in-app in *either* theme. Storybook adds the scope via its decorator, which is why it
  renders correctly there. This has been true of `--warning-accent` in
  `ColorCodedTxAccordion` since cc2b8a6f5 — out of scope for this PR.
- In dark, `--warning-outline` now equals the `ColorCodedTxAccordion` method-chip ink
  (`--warning-strong`). Legible on the `--warning-subtle` chip fill, but not design-reviewed.
- The storybook snapshot suite re-run was still in flight when this was written; the
  snapshot file itself is updated (one line) and the standard jest suites are green.
- Not tested on mobile — no mobile surface is touched.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    F1["Fees accordion"] --> P1["--color-warning-light<br/>#ffbc9f peach"]
    T1["Transaction details"] --> A1["--warning-accent"]
    A1 --> L1["light: #eab308"]
    A1 --> D1["dark: --color-warning-main<br/>#ff8061 coral"]
  end
  subgraph After
    F2["Fees accordion"] --> O["--warning-outline"]
    T2["Transaction details"] --> O
    O --> L2["light: --warning-accent<br/>#eab308"]
    O --> D2["dark: --warning-strong<br/>#ffe4cb"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — n/a, no mobile surface touched
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
