### PR TITLE
fix(ui): invite flow elements alignment

### DIFF
--- a/apps/web/src/components/common/NameInput/index.tsx
+++ b/apps/web/src/components/common/NameInput/index.tsx
@@ -23,6 +23,7 @@ type NameInputProps = {
   maxLength?: number
   inputSize?: ComponentProps<typeof Input>['inputSize']
   variant?: ComponentProps<typeof Input>['variant']
+  errorPlacement?: ComponentProps<typeof Field>['errorPlacement']
   InputProps?: {
     endAdornment?: ReactNode
     startAdornment?: ReactNode
@@ -49,6 +50,7 @@ const NameInput = ({
   maxLength,
   inputSize,
   variant,
+  errorPlacement,
   InputProps,
   InputLabelProps,
   ...props
@@ -128,7 +130,7 @@ const NameInput = ({
         )
 
         return (
-          <Field className={className} data-invalid={Boolean(fieldError) || undefined}>
+          <Field className={className} errorPlacement={errorPlacement} data-invalid={Boolean(fieldError) || undefined}>
             {resolvedLabel != null && resolvedLabel !== '' && (
               <FieldLabel htmlFor={id} className={fieldError ? 'text-destructive' : undefined}>
                 {resolvedLabel}

--- a/apps/web/src/components/ui/field.tsx
+++ b/apps/web/src/components/ui/field.tsx
@@ -27,6 +27,9 @@ import { Separator } from '@/components/ui/separator'
  * @remarks
  * Key Props:
  * - Field: `orientation` ('vertical' | 'horizontal'), `invalid`
+ * - Field: `errorPlacement` ('inline' | 'floating') — `floating` takes the error out of flow so it
+ *   cannot grow the field and re-align neighbouring controls. Only use it where there is clearance
+ *   below: a floating error overlaps whatever follows, and is painted over by any opaque sibling.
  * - FieldLegend: `variant` ('legend' | 'label') — see Base UI
  */
 
@@ -73,6 +76,11 @@ function FieldGroup({ className, ...props }: React.ComponentProps<'div'>) {
 
 const fieldVariants = cva('data-[invalid=true]:text-destructive gap-3 group/field flex w-full', {
   variants: {
+    errorPlacement: {
+      inline: '',
+      floating:
+        'relative [&_[data-slot=field-error]]:absolute [&_[data-slot=field-error]]:inset-x-0 [&_[data-slot=field-error]]:top-full',
+    },
     orientation: {
       vertical: 'flex-col [&>*]:w-full [&>.sr-only]:w-auto',
       horizontal:
@@ -82,6 +90,7 @@ const fieldVariants = cva('data-[invalid=true]:text-destructive gap-3 group/fiel
     },
   },
   defaultVariants: {
+    errorPlacement: 'inline',
     orientation: 'vertical',
   },
 })
@@ -89,6 +98,7 @@ const fieldVariants = cva('data-[invalid=true]:text-destructive gap-3 group/fiel
 function Field({
   className,
   orientation = 'vertical',
+  errorPlacement,
   ...props
 }: React.ComponentProps<'div'> & VariantProps<typeof fieldVariants>) {
   return (
@@ -96,7 +106,7 @@ function Field({
       role="group"
       data-slot="field"
       data-orientation={orientation}
-      className={cn(fieldVariants({ orientation }), className)}
+      className={cn(fieldVariants({ orientation, errorPlacement }), className)}
       {...props}
     />
   )

--- a/apps/web/src/components/ui/input.render.test.tsx
+++ b/apps/web/src/components/ui/input.render.test.tsx
@@ -1,7 +1,22 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 
-import { Input } from './input'
+import { Input, SCRIPT_INJECTION_ERROR } from './input'
 import { Field, FieldLabel } from './field'
+
+// The warning and the validation error share one element, so a regression here silently drops the
+// script-injection warning rather than showing the wrong one.
+describe('Input script-injection guard', () => {
+  it('warns and strips the value when a script is typed in', () => {
+    render(<Input placeholder="Injection" />)
+
+    const input = screen.getByPlaceholderText('Injection')
+    fireEvent.change(input, { target: { value: 'hello<script>alert(1)</script>' } })
+
+    expect(screen.getByRole('alert')).toHaveTextContent(SCRIPT_INJECTION_ERROR)
+    expect(input).toHaveAttribute('aria-invalid', 'true')
+    expect(input).toHaveValue('hello')
+  })
+})
 
 describe('Input invalid state', () => {
   it('marks the field invalid from the error prop', () => {

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -46,6 +46,22 @@ const inputVariants = cva(
 )
 
 /**
+ * The error message rendered under the field. `sm` is the design-system default (matches
+ * `FieldError`); `xs` is for compact rows where a full-size message would crowd the layout.
+ */
+const inputErrorVariants = cva('mt-1 text-destructive', {
+  variants: {
+    errorSize: {
+      sm: 'text-sm',
+      xs: 'text-xs',
+    },
+  },
+  defaultVariants: {
+    errorSize: 'sm',
+  },
+})
+
+/**
  * Input Component
  *
  * Displays a form input field.
@@ -60,6 +76,7 @@ const inputVariants = cva(
  * @remarks
  * Key Props:
  * - `type`, `placeholder`, `disabled`, `className` — extends native input props, see Base UI
+ * - `error`, `errorSize` ('sm' | 'xs') — message rendered under the field
  */
 
 const SCRIPT_TAG_REGEX = /<script[\s>][\s\S]*?(?:<\/script>|$)/gi
@@ -99,13 +116,16 @@ function Input({
   onChange,
   onPaste,
   error,
+  errorSize,
   address,
   // Destructured so the `{...props}` spread below cannot overwrite the computed attribute: a caller
   // passing `aria-invalid={undefined}` (or `false`) alongside `error` would otherwise erase the
   // invalid state the error or the script-injection guard had set.
   'aria-invalid': ariaInvalid,
   ...props
-}: React.ComponentProps<'input'> & VariantProps<typeof inputVariants> & { error?: string; address?: boolean }) {
+}: React.ComponentProps<'input'> &
+  VariantProps<typeof inputVariants> &
+  VariantProps<typeof inputErrorVariants> & { error?: string; address?: boolean }) {
   const [hasScriptInjection, setHasScriptInjection] = React.useState(false)
 
   const handleChange = React.useCallback(
@@ -139,6 +159,8 @@ function Input({
     [address, onPaste],
   )
 
+  const errorMessage = hasScriptInjection ? SCRIPT_INJECTION_ERROR : error
+
   return (
     <div className="w-full">
       <InputPrimitive
@@ -150,13 +172,9 @@ function Input({
         onChange={handleChange}
         onPaste={handlePaste}
       />
-      {hasScriptInjection ? (
-        <p role="alert" data-slot="field-error" className="mt-1 text-sm text-destructive">
-          {SCRIPT_INJECTION_ERROR}
-        </p>
-      ) : error ? (
-        <p role="alert" data-slot="field-error" className="mt-1 text-sm text-destructive">
-          {error}
+      {errorMessage ? (
+        <p role="alert" data-slot="field-error" className={inputErrorVariants({ errorSize })}>
+          {errorMessage}
         </p>
       ) : null}
     </div>

--- a/apps/web/src/features/spaces/components/AddMemberModal/AddMemberModal.stories.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/AddMemberModal.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { mswLoader } from 'msw-storybook-addon'
+import { userEvent, within } from 'storybook/test'
+import { NAME_MIN_LENGTH } from '@safe-global/utils/validation/names'
 import AddMemberModal from '.'
 import { createMockStory } from '@/stories/mocks'
 
@@ -31,3 +33,13 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
+
+export const NameValidationError: Story = {
+  play: async () => {
+    // The modal renders through a portal, so query the document rather than the canvas.
+    const screen = within(document.body)
+
+    await userEvent.type(await screen.findByTestId('member-name-input'), 'Jo')
+    await screen.findByText(`Names must be at least ${NAME_MIN_LENGTH} character(s) long`)
+  },
+}

--- a/apps/web/src/features/spaces/components/AddMemberModal/MemberInfoForm.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/MemberInfoForm.tsx
@@ -32,8 +32,8 @@ const MemberInfoForm = ({
         minLength={NAME_MIN_LENGTH}
         maxLength={nameMaxLength}
         InputProps={{ className: 'min-h-[66px]' }}
-        // Float the error so it doesn't grow the field's height and shift the form.
-        className="gap-1.5 relative [&_[data-slot=field-error]]:absolute [&_[data-slot=field-error]]:top-full"
+        errorPlacement="floating"
+        className="gap-1.5"
       />
 
       <div className="flex flex-col gap-1.5">

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/InviteMembersOnboarding.stories.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/InviteMembersOnboarding.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { mswLoader } from 'msw-storybook-addon'
+import { userEvent, within } from 'storybook/test'
 import { createMockStory } from '@/stories/mocks'
+import { INVALID_IDENTIFIER_ERROR } from '../AddMemberModal/utils'
 import InviteMembersOnboarding from '.'
 
 const defaultSetup = createMockStory({
@@ -27,3 +29,15 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
+
+export const ValidationError: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await userEvent.click(canvas.getByTestId('add-another-member'))
+    await userEvent.type(canvas.getByTestId('invite-identifier-input-0'), 'not-an-email')
+
+    // The error is debounced by ERROR_DEBOUNCE_MS before it renders.
+    await canvas.findByText(INVALID_IDENTIFIER_ERROR, {}, { timeout: 3000 })
+  },
+}

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/components/MemberInviteRow.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/components/MemberInviteRow.tsx
@@ -94,9 +94,9 @@ const MemberInviteRow = ({
   }, [resolvedAddress, handleAddressResolved])
 
   return (
-    // items-center so the fixed-height remove button centres against the 44px field/select pair
-    // instead of top-aligning under the default `stretch`.
-    <div className="flex items-center gap-2">
+    // items-start so a validation error grows the field column downwards instead of re-centring the
+    // row; the controls sit in their own 44px band and stay level with the field.
+    <div className="flex items-start gap-2">
       <div className="flex flex-1 flex-col gap-1">
         <div className="relative">
           <Input
@@ -151,6 +151,7 @@ const MemberInviteRow = ({
             // eslint-disable-next-line no-restricted-syntax -- bespoke 44px invite field (h-11, rounded-lg, px-4); between the lg/xl tiers, no size fits
             className={cn('h-11 rounded-lg px-4', resolving && 'pr-10')}
             error={displayError}
+            errorSize="xs"
             data-testid={`invite-identifier-input-${index}`}
           />
           {resolving && (
@@ -160,37 +161,39 @@ const MemberInviteRow = ({
           )}
         </div>
 
-        {resolverError && <p className="pl-1 text-xs text-destructive">Failed to resolve ENS name</p>}
+        {resolverError && <p className="text-xs text-destructive">Failed to resolve ENS name</p>}
       </div>
 
-      <Controller
-        control={control}
-        name={`members.${index}.role`}
-        render={({ field }) => (
-          <Select value={field.value} onValueChange={field.onChange}>
-            <SelectTrigger className="min-w-[120px] cursor-pointer data-[size=default]:h-11">
-              <SelectValue placeholder="Role">{ROLE_LABELS[field.value]}</SelectValue>
-            </SelectTrigger>
-            <SelectContent alignItemWithTrigger={false} align="start">
-              <SelectItem value={MemberRole.ADMIN}>{ROLE_LABELS[MemberRole.ADMIN]}</SelectItem>
-              <SelectItem value={MemberRole.MEMBER}>{ROLE_LABELS[MemberRole.MEMBER]}</SelectItem>
-            </SelectContent>
-          </Select>
-        )}
-      />
+      <div className="flex h-11 items-center gap-2">
+        <Controller
+          control={control}
+          name={`members.${index}.role`}
+          render={({ field }) => (
+            <Select value={field.value} onValueChange={field.onChange}>
+              <SelectTrigger className="min-w-[120px] cursor-pointer data-[size=default]:h-11">
+                <SelectValue placeholder="Role">{ROLE_LABELS[field.value]}</SelectValue>
+              </SelectTrigger>
+              <SelectContent alignItemWithTrigger={false} align="start">
+                <SelectItem value={MemberRole.ADMIN}>{ROLE_LABELS[MemberRole.ADMIN]}</SelectItem>
+                <SelectItem value={MemberRole.MEMBER}>{ROLE_LABELS[MemberRole.MEMBER]}</SelectItem>
+              </SelectContent>
+            </Select>
+          )}
+        />
 
-      {canRemove && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          onClick={onRemove}
-          aria-label="Remove member"
-          data-testid={`remove-member-${index}`}
-        >
-          <X className="size-4" />
-        </Button>
-      )}
+        {canRemove && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={onRemove}
+            aria-label="Remove member"
+            data-testid={`remove-member-${index}`}
+          >
+            <X className="size-4" />
+          </Button>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## What it solves

Resolves: [WA-3442](https://linear.app/safe-global/issue/WA-3442/invite-your-team-onboarding-step-34-a-validation-error-pushes-the-role)

On **Workspace onboarding → "Invite your team"**, entering an invalid identifier shows the inline
error *"Enter a valid email, wallet address, or ENS."* — and the Role dropdown and the ✕ remove
button for that row drop by roughly half the error's height, so they no longer line up with the
input.

Root cause (shadcn migration regression): `Input` renders its error message **in flow**, inside its
wrapper `div`. The invite row is `flex items-center`, so the error grows the field column → grows
the row → both siblings re-centre in the taller row.

A second, related problem: `MemberInfoForm` already solved this class of bug with a hand-typed
Tailwind incantation (`relative [&_[data-slot=field-error]]:absolute …`). It lived at exactly one
call site, was undocumented, and — because `Input` and `Field` route `className` to *different
elements* — could not be copied to the new call site without silently doing nothing.

## How this PR fixes it

**1. Row layout** — `MemberInviteRow` switches to `items-start`, and the Role select + ✕ move into
their own `flex h-11 items-center` band. The error grows the field column downward; the controls
stay pinned to the 44px band and never move.

**2. Promotes the pattern to a real prop** — `Field` gains an `errorPlacement: 'inline' | 'floating'`
variant (default `inline`, i.e. unchanged). `NameInput` forwards it, and `MemberInfoForm` drops the
class string for `errorPlacement="floating"`. The JSDoc now carries the constraint that made the
original bug possible: *floating only works where there is clearance below.*

**3. Error size** — `Input` gains `errorSize: 'sm' | 'xs'` (default `sm`, unchanged). The invite row
uses `xs` so the validation error matches the ENS resolver error directly beneath it. A variant
rather than an `errorClassName` escape hatch because `eslint.config.mjs`'s `dsInputClassnameRule`
already flags `text-(xs|sm|base|lg)` on `Input`'s `className` — font size is component-owned by
policy, and a free-form class prop would be a hole through that guard.

**4. Cleanups** — `Input`'s two byte-identical error `<p>` branches (script-injection and validation)
collapse into one; `resolverError` loses a stray `pl-1` so both messages align flush left.

## How to test it

1. `yarn workspace @safe-global/web dev`
2. Create a Workspace → proceed to step 3, **"Invite your team"**.
3. Type an invalid identifier (e.g. `not-an-email`) in the first row and wait ~500ms for the
   debounced error.
   - ✅ The Role dropdown and ✕ stay vertically aligned with the input.
   - ✅ The error renders at `text-xs`, matching the ENS resolver error.
4. Click **Add another** so there are two rows, then trigger an error on the first row.
   - ✅ The error is fully visible and pushes row 2 down — it is not overlapped or hidden.
5. Enter an unresolvable ENS name (e.g. `definitely-not-registered-xyz.eth`) → the "Failed to resolve
   ENS name" message aligns flush with the input's left edge.
6. Regression check: **Space members → Add member** (and **Edit member**). Submit an invalid name →
   the error still floats and the Role select does not shift.

## Affected flows

- Workspace onboarding → "Invite your team" — invalid identifier, duplicate email/address,
  ENS resolution failure, single-row vs multi-row
- Space members → Add member — name validation error
- Space members → Edit member — name validation error

## Blast radius

| Surface | Consumers | Risk |
| --- | --- | --- |
| `components/ui/field.tsx` — `Field` | ~25 files render `<Field>` | Additive cva variant, `errorPlacement` defaults to `inline` (no classes emitted) |
| `components/ui/input.tsx` — `Input` | 6 call sites pass `error`; `<Input>` used in 39 files | Additive cva variant, `errorSize` defaults to `sm`. The two error `<p>` branches were collapsed — same markup, same `data-slot`, same `role="alert"` |
| `components/common/NameInput` | 15 consumers (Safe creation, Add/Edit owner, address book, proposers, space settings) | Pass-through prop only; omitted everywhere except `MemberInfoForm` |
| `MemberInfoForm` | Add member + Edit member dialogs | Behaviour-equivalent migration, except the floating error now uses `inset-x-0` so long messages wrap to the field width instead of overflowing right |

- No RTK Query endpoints, feature flags, chain configs, routes, or persisted state touched.
- **No mobile impact** — nothing under `packages/` changed; all files are `apps/web`.

## Risks / not checked

- **No visual/pixel regression run.** Every assertion here is structural; alignment was not verified
  against a rendered screenshot in CI.
- Did not manually exercise the Add/Edit member dialogs after the `errorPlacement` migration — only
  their unit tests.
- `inset-x-0` in the floating variant is a real behaviour difference from the original class string
  (wrapping vs. shrink-to-fit). It's an improvement, but it is a change.
- Did not test on mobile viewport/device — the invite row is a horizontal flex layout and its
  narrow-screen behaviour is unchanged by this PR, but also unverified.
- Rendered class order in `Input`'s error changed (`mt-1 text-destructive text-sm` vs
  `mt-1 text-sm text-destructive`). No CSS effect — Tailwind precedence comes from stylesheet order,
  not attribute order — and no snapshot captures the string.

## Visual summary
<img width="889" height="276" alt="Screenshot 2026-08-27 at 12 21 40 PM" src="https://github.com/user-attachments/assets/ddf344bf-d0cf-4cbc-965c-3af86d8819c7" />

**Row layout — why the controls moved, and why they no longer do**

```mermaid
flowchart TB
  subgraph Before["❌ Before - flex items-center"]
    B1["row"] --> B2["field column<br/>44px → 68px once error shows"]
    B1 --> B3["Role select"]
    B1 --> B4["✕ button"]
    B2 --> B5["row height grows to 68px"]
    B3 --> B5
    B4 --> B5
    B5 --> B6["items-center re-centres both<br/>→ each drops ~12px out of alignment"]
  end

  subgraph After["✅ After - flex items-start"]
    A1["row"] --> A2["field column"]
    A1 --> A3["control band · h-11"]
    A2 --> A4["input h-11"]
    A2 --> A5["error text-xs<br/>in flow, grows downward"]
    A3 --> A6["Role select + ✕<br/>pinned to the 44px band"]
    A5 --> A7["row 2 shifts down<br/>error stays visible"]
    A6 --> A8["never moves"]
  end
```

**Prop promotion — why the class string could not simply be copied**

```mermaid
flowchart LR
  subgraph Was["Was: one hand-typed class string"]
    W1["MemberInfoForm"] -->|"className=<br/>'relative [&_…field-error]:absolute'"| W2["NameInput"]
    W2 --> W3["Field root<br/>✅ ancestor of the error"]
    W4["MemberInviteRow"] -.->|"same string, if copied"| W5["Input"]
    W5 --> W6["input element<br/>❌ void tag, error is a sibling<br/>→ selector never matches"]
  end

  subgraph Now["Now: typed variants"]
    N1["MemberInfoForm"] -->|"errorPlacement='floating'"| N2["NameInput"] --> N3["Field cva variant"]
    N4["MemberInviteRow"] -->|"errorSize='xs'"| N5["Input cva variant"]
  end
```

> **📸 Screenshots to attach before merging:** before/after of the "Invite your team" step with a
> validation error on row 1 of 2, and an after-shot of the Add member dialog confirming the migrated
> floating error is unchanged.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
