### PR TITLE
fix: pin three transitive packages off vulnerable versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,12 @@
     "isows": "1.0.7",
     "webpack": "5.97.1",
     "react-native-quick-base64": "2.2.2",
-    "@tamagui/image@npm:2.0.0-rc.26": "patch:@tamagui/image@npm%3A2.0.0-rc.26#~/.yarn/patches/@tamagui-image-npm-2.0.0-rc.26-04087a216c.patch"
+    "@tamagui/image@npm:2.0.0-rc.26": "patch:@tamagui/image@npm%3A2.0.0-rc.26#~/.yarn/patches/@tamagui-image-npm-2.0.0-rc.26-04087a216c.patch",
+    "lodash": "4.18.1",
+    "glob@^10.2.2": "10.5.0",
+    "glob@^10.3.7": "10.5.0",
+    "glob@^10.3.10": "10.5.0",
+    "minimatch@^10.1.1": "10.2.2"
   },
   "devDependencies": {
     "@storybook/builder-webpack5": "^10.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8874,22 +8874,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@isaacs/balanced-match@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@isaacs/balanced-match@npm:4.0.1"
-  checksum: 10/102fbc6d2c0d5edf8f6dbf2b3feb21695a21bc850f11bc47c4f06aa83bd8884fde3fe9d6d797d619901d96865fdcb4569ac2a54c937992c48885c5e3d9967fe8
-  languageName: node
-  linkType: hard
-
-"@isaacs/brace-expansion@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "@isaacs/brace-expansion@npm:5.0.1"
-  dependencies:
-    "@isaacs/balanced-match": "npm:^4.0.1"
-  checksum: 10/aec226065bc4285436a27379e08cc35bf94ef59f5098ac1c026495c9ba4ab33d851964082d3648d56d63eb90f2642867bd15a3e1b810b98beb1a8c14efce6a94
-  languageName: node
-  linkType: hard
-
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -29591,37 +29575,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:7.1.7":
-  version: 7.1.7
-  resolution: "glob@npm:7.1.7"
-  dependencies:
-    fs.realpath: "npm:^1.0.0"
-    inflight: "npm:^1.0.4"
-    inherits: "npm:2"
-    minimatch: "npm:^3.0.4"
-    once: "npm:^1.3.0"
-    path-is-absolute: "npm:^1.0.0"
-  checksum: 10/ff5aab0386e9cace92b0550d42085b71013c5ea382982dd7fdded998a559635f61413b8ba6fb7294eef289c83b52f4e64136f888300ac8afc4f3e5623182d6c8
-  languageName: node
-  linkType: hard
-
-"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.7":
-  version: 10.4.5
-  resolution: "glob@npm:10.4.5"
-  dependencies:
-    foreground-child: "npm:^3.1.0"
-    jackspeak: "npm:^3.1.2"
-    minimatch: "npm:^9.0.4"
-    minipass: "npm:^7.1.2"
-    package-json-from-dist: "npm:^1.0.0"
-    path-scurry: "npm:^1.11.1"
-  bin:
-    glob: dist/esm/bin.mjs
-  checksum: 10/698dfe11828b7efd0514cd11e573eaed26b2dff611f0400907281ce3eab0c1e56143ef9b35adc7c77ecc71fba74717b510c7c223d34ca8a98ec81777b293d4ac
-  languageName: node
-  linkType: hard
-
-"glob@npm:^10.4.5":
+"glob@npm:10.5.0, glob@npm:^10.4.5":
   version: 10.5.0
   resolution: "glob@npm:10.5.0"
   dependencies:
@@ -29634,6 +29588,20 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 10/ab3bccfefcc0afaedbd1f480cd0c4a2c0e322eb3f0aa7ceaa31b3f00b825069f17cf0f1fc8b6f256795074b903f37c0ade37ddda6a176aa57f1c2bbfe7240653
+  languageName: node
+  linkType: hard
+
+"glob@npm:7.1.7":
+  version: 7.1.7
+  resolution: "glob@npm:7.1.7"
+  dependencies:
+    fs.realpath: "npm:^1.0.0"
+    inflight: "npm:^1.0.4"
+    inherits: "npm:2"
+    minimatch: "npm:^3.0.4"
+    once: "npm:^1.3.0"
+    path-is-absolute: "npm:^1.0.0"
+  checksum: 10/ff5aab0386e9cace92b0550d42085b71013c5ea382982dd7fdded998a559635f61413b8ba6fb7294eef289c83b52f4e64136f888300ac8afc4f3e5623182d6c8
   languageName: node
   linkType: hard
 
@@ -34288,14 +34256,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.7.0":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10/c08619c038846ea6ac754abd6dd29d2568aa705feb69339e836dfa8d8b09abbb2f859371e86863eda41848221f9af43714491467b5b0299122431e202bb0c532
-  languageName: node
-  linkType: hard
-
-"lodash@npm:^4.18.1":
+"lodash@npm:4.18.1":
   version: 4.18.1
   resolution: "lodash@npm:4.18.1"
   checksum: 10/306fea53dfd39dad1f03d45ba654a2405aebd35797b673077f401edb7df2543623dc44b9effbb98f69b32152295fff725a4cec99c684098947430600c6af0c3f
@@ -35987,30 +35948,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:10.2.2, minimatch@npm:^10.2.2":
+  version: 10.2.2
+  resolution: "minimatch@npm:10.2.2"
+  dependencies:
+    brace-expansion: "npm:^5.0.2"
+  checksum: 10/e135be7b502ac97c02bcee42ccc1c55dc26dbac036c0f4acde69e42fe339d7fb53fae711e57b3546cb533426382ea492c73a073c7f78832e0453d120d48dd015
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^10.0.1":
   version: 10.2.4
   resolution: "minimatch@npm:10.2.4"
   dependencies:
     brace-expansion: "npm:^5.0.2"
   checksum: 10/aea4874e521c55bb60744685bbffe3d152e5460f84efac3ea936e6bbe2ceba7deb93345fec3f9bb17f7b6946776073a64d40ae32bf5f298ad690308121068a1f
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^10.1.1":
-  version: 10.1.1
-  resolution: "minimatch@npm:10.1.1"
-  dependencies:
-    "@isaacs/brace-expansion": "npm:^5.0.0"
-  checksum: 10/110f38921ea527022e90f7a5f43721838ac740d0a0c26881c03b57c261354fb9a0430e40b2c56dfcea2ef3c773768f27210d1106f1f2be19cde3eea93f26f45e
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^10.2.2":
-  version: 10.2.2
-  resolution: "minimatch@npm:10.2.2"
-  dependencies:
-    brace-expansion: "npm:^5.0.2"
-  checksum: 10/e135be7b502ac97c02bcee42ccc1c55dc26dbac036c0f4acde69e42fe339d7fb53fae711e57b3546cb533426382ea492c73a073c7f78832e0453d120d48dd015
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What it solves

Datadog SCA reports 23 open critical/high library vulnerabilities on this repo. Every one of them is transitive, so none can be fixed by bumping a direct dependency in a `package.json`. This PR closes 3 of them, picked because they carry the least risk.

Resolves: n/a (from a Datadog Code Security sweep, no ticket yet)

## How this PR fixes it

Three packages already had a safe version resolved somewhere else in the tree. Pinning them collapses a duplicate rather than pulling anything new:

| Package | Was | Now | CVE |
| --- | --- | --- | --- |
| lodash | 4.17.21 | 4.18.1 | CVE-2021-23337 |
| glob | 10.4.5 | 10.5.0 | CVE-2025-64756 |
| minimatch | 10.1.1 | 10.2.2 | CVE-2026-26996 |

Both apps already declare `lodash: ^4.18.1` as a direct dependency, so the global resolution only drags transitive consumers up to the version we ship anyway. The `glob` and `minimatch` entries are scoped by range, so `glob` 7/11/13 and `minimatch` 3/5/9 stay where they are.

`yarn.lock` gets 43 lines shorter, because the pins merge duplicate entries.

### What I deliberately left out

`serialize-javascript` 6.0.2 needs >= 7.0.3, but `terser-webpack-plugin` and `@rollup/plugin-terser` both ask for `^6.x`. Forcing a major bump on the webpack minifier isn't a dedupe, it's a gamble, and it doesn't belong in a low-risk PR. Worth its own change if we want it.

The remaining 18 findings all need a version that isn't in the tree yet:

- `extract-zip` 2.0.1 and `image-size` 2.0.2 have no published fix
- `simple-git` 3.16.0 (both criticals, dev-only) is pinned to an exact version by `@datadog/datadog-ci`, so overriding it risks breaking that CLI
- `crypto-es`, `sharp`, `tmp`, `js-yaml`, `minimatch` 5/9, `image-size` 0.5.5/1.1.1 have fixes but need a real upgrade, not a dedupe

One finding was stale: `js-yaml` 3.15.0 isn't in our lockfile at all, we're already on 3.15.1.

## How to test it

```bash
yarn install --immutable
yarn type-check
yarn workspace @safe-global/web test
```

I ran all three. `--immutable` passes, type-check passes across all 7 packages, and 456 tests over 52 suites covering `lodash` consumers pass. Jest still discovers 854 test files, which is the check that matters for the `glob` bump.

## Affected flows

- Nothing user-facing. This only changes which version of three packages gets resolved.

## Blast radius

- `package.json` resolutions and `yarn.lock`, so every workspace: web, mobile, and `packages/*`
- `glob` feeds `@jest/reporters`, `jest-config`, and `cacache`. A bad pin here breaks test discovery, which is why the 854-file count is in the test plan.
- `minimatch` 10.x is only consumed by `glob@11`
- `lodash` is bundled into shipped web and mobile code
- No API contracts, feature flags, migrations, or routes touched

## Risks / not checked

- Did not run a production `next build`
- Did not run the mobile test suite or any E2E
- The `lodash` resolution is unscoped. Safe here because both versions in the tree are 4.x and our apps already want 4.18.1, but it does reach every consumer.
- Datadog rescans on merge, so the 3 findings should close on their own. I did not force a rescan to confirm.

## Visual summary

```mermaid
flowchart LR
  subgraph Before
    A1["jest-reporters<br/>cacache"] --> B1["glob 10.4.5<br/>CVE-2025-64756"]
    A2["glob 11"] --> B2["minimatch 10.1.1<br/>CVE-2026-26996"]
    A3["transitive deps"] --> B3["lodash 4.17.21<br/>CVE-2021-23337"]
    A4["apps/web, apps/mobile"] --> B4["lodash 4.18.1"]
  end
  subgraph After
    C1["jest-reporters<br/>cacache"] --> D1["glob 10.5.0"]
    C2["glob 11"] --> D2["minimatch 10.2.2"]
    C3["transitive deps"] --> D3["lodash 4.18.1"]
    C4["apps/web, apps/mobile"] --> D3
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — existing suites cover it, no new logic to test
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
