### PR TITLE
fix(mobile): add rel="noreferrer" to the Get Started external links

### DIFF
--- a/apps/mobile/src/features/GetStarted/GetStarted.test.tsx
+++ b/apps/mobile/src/features/GetStarted/GetStarted.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { render } from '@/src/tests/test-utils'
+import { GetStarted } from './GetStarted'
+import { PRIVACY_POLICY_URL, TERMS_OF_USE_URL } from '@/src/config/constants'
+
+type MockLinkProps = {
+  href: string
+  target?: string
+  rel?: string
+  children?: React.ReactNode
+}
+
+jest.mock('expo-router', () => {
+  const ReactLib = require('react')
+  const { View } = require('react-native')
+
+  return {
+    useRouter: () => ({ navigate: jest.fn() }),
+    Link: ({ href, target, rel, children }: MockLinkProps) =>
+      ReactLib.createElement(View, { testID: `link-${href}`, target, rel }, children),
+  }
+})
+
+describe('GetStarted', () => {
+  it.each([
+    ['User Terms', TERMS_OF_USE_URL],
+    ['Privacy Policy', PRIVACY_POLICY_URL],
+  ])('opens the %s link in a new tab without leaking the referrer', (_label, url) => {
+    const { getByTestId } = render(<GetStarted />)
+
+    const link = getByTestId(`link-${url}`)
+
+    expect(link.props.target).toBe('_blank')
+    // Without rel, a _blank link hands the opened page a reference back to this
+    // one via window.opener when the app runs on web.
+    expect(link.props.rel).toBe('noreferrer')
+  })
+})

--- a/apps/mobile/src/features/GetStarted/GetStarted.tsx
+++ b/apps/mobile/src/features/GetStarted/GetStarted.tsx
@@ -106,11 +106,11 @@ export const GetStarted = () => {
           justifyContent="center"
         >
           <StyledText>By continuing, you agree to our </StyledText>
-          <Link href={TERMS_OF_USE_URL} target={'_blank'} asChild>
+          <Link href={TERMS_OF_USE_URL} target={'_blank'} rel="noreferrer" asChild>
             <StyledText textDecorationLine={'underline'}>User Terms</StyledText>
           </Link>
           <StyledText> and </StyledText>
-          <Link href={PRIVACY_POLICY_URL} target={'_blank'} asChild>
+          <Link href={PRIVACY_POLICY_URL} target={'_blank'} rel="noreferrer" asChild>
             <StyledText textDecorationLine={'underline'}>Privacy Policy</StyledText>
           </Link>
           <StyledText>.</StyledText>


### PR DESCRIPTION
## What it solves

Datadog SAST reports 69 open critical/high code findings on this repo. After reading each one, 3 sit in code that actually ships. This PR fixes 2 of them.

The Terms and Privacy links on the mobile Get Started screen open with `target="_blank"` and no `rel`. When the app runs on web, that hands the opened page a live `window.opener` reference back to ours, which is the reverse-tabnabbing pattern the rule flags.

Resolves: n/a (from a Datadog Code Security sweep, no ticket yet)

## How this PR fixes it

Adds `rel="noreferrer"` to both links, plus a test that reads the rendered link props.

Both URLs are our own constants, so this was never exploitable in practice. It's still worth closing: the attribute costs nothing, and the next link someone adds to that screen will be copied from these two.

`expo-router`'s `LinkProps` extends `WebAnchorProps`, which already declares `rel?: string`, so this is a supported prop rather than a passthrough that happens to work.

### The other 67 findings

I went through all of them. Here's where they land:

| Bucket | Count | Why not fixed here |
| --- | --- | --- |
| Test code | 24 | Cypress, Playwright, and Jest files. Building a RegExp from a variable in a test isn't a vulnerability. |
| Build/CI/dev tooling | 28 | `fs.readFile` with a computed path in a build script is the whole point of a build script. |
| Vendored Beamer embed | 5 | `apps/web/public/beamer-embed.js` is Closure-compiled third-party code we self-host. Not ours to patch. |
| Vendored spec-kit shell | 6 | Shell quoting in `.specify/scripts/`, which came in with the spec-kit tooling. |
| Shipping code, false positive | 3 | See below. |
| Shipping code, real | 1 | `apps/mobile/src/utils/uuid.ts` uses md5. Deferred, see below. |

Three findings in shipping code don't hold up once you read the line:

- **The one critical**, "potential SQL injection" at `LedgerAddresses.container.tsx:163`, is a template literal building a UI description string. There is no SQL anywhere in that file.
- `+html.tsx:23` flags `dangerouslySetInnerHTML`, but it's fed a hardcoded static CSS constant with no interpolation. Standard Expo Router boilerplate.
- `useAutoScan.ts:178` flags a sensitive log. It logs a Safe address, which is public on-chain data.

The md5 one is real but not a drive-by. `convertToUuid` feeds the push-notification device ID through `services/notifications/backend.ts`. Swapping md5 for sha256 changes the UUID of every existing install, so the backend would see them all as new devices. That needs a migration plan, so it's a separate ticket.

## How to test it

```bash
node scripts/verify.mjs --changed --workspace=mobile
```

Passes with exit 0. The new test fails if you strip the `rel` attribute, which I checked, so it guards the behaviour rather than just describing it.

## Affected flows

- Mobile onboarding: tapping User Terms or Privacy Policy on the Get Started screen still opens the right URL

## Blast radius

- `apps/mobile/src/features/GetStarted/GetStarted.tsx` only. Two JSX props.
- No shared hooks, components, selectors, slices, or endpoints touched
- No API contracts, feature flags, migrations, or routes
- Web is untouched

## Risks / not checked

- Did not run the app on a physical device or simulator, so I have not watched the links open by hand
- Did not run mobile E2E
- `rel` only does anything when the app runs on web. On native it's inert, which is fine but means the fix is a no-op for the iOS and Android builds.

## Visual summary

```mermaid
flowchart TB
  subgraph Before["Before: opened page can reach back"]
    A["Get Started screen"] -->|"target=_blank"| B["Terms / Privacy tab"]
    B -.->|"window.opener"| A
  end
  subgraph After["After: reference severed"]
    C["Get Started screen"] -->|"target=_blank<br/>rel=noreferrer"| D["Terms / Privacy tab"]
    D -.->|"blocked"| X["✕"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
