### PR TITLE
fix: Native app card leaves empty cell

### DIFF
--- a/apps/web/src/components/safe-apps/NativeSwapsCard/NativeSwapsCardCell.stories.tsx
+++ b/apps/web/src/components/safe-apps/NativeSwapsCard/NativeSwapsCardCell.stories.tsx
@@ -1,0 +1,56 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
+import { mswLoader } from 'msw-storybook-addon'
+import { createMockStory } from '@/stories/mocks'
+import listCss from '@/components/safe-apps/SafeAppList/styles.module.css'
+import NativeSwapsCardCell from './NativeSwapsCardCell'
+
+const PlaceholderApp = ({ name }: { name: string }) => (
+  <li>
+    <div className="flex h-full min-h-[220px] items-center justify-center rounded-lg border border-border bg-card p-4 text-center text-sm text-[var(--color-text-secondary)]">
+      {name}
+    </div>
+  </li>
+)
+
+// The real apps grid, so a hidden cell visibly reflows its neighbours.
+const withAppsGrid: Decorator = (Story) => (
+  <ul className={listCss.safeAppsContainer}>
+    <Story />
+    <PlaceholderApp name="Transaction Builder" />
+    <PlaceholderApp name="WalletConnect" />
+  </ul>
+)
+
+const meta = {
+  title: 'Components/SafeApps/NativeSwapsCardCell',
+  component: NativeSwapsCardCell,
+  loaders: [mswLoader],
+  parameters: {
+    componentSubtitle: 'Gates the native swaps promo card and owns its grid cell',
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof NativeSwapsCardCell>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// "Don't show" dismisses for real — clear the `showSwapsAppCard` localStorage
+// key to bring the card back.
+/** Swaps enabled and not dismissed: the card is the first of three grid items. */
+export const InAppsGrid: Story = (() => {
+  const setup = createMockStory({ scenario: 'efSafe', shadcn: true })
+  return {
+    parameters: { ...setup.parameters },
+    decorators: [withAppsGrid, setup.decorator],
+  }
+})()
+
+/** Swaps disabled on the current chain: no card and no `li`, so the grid holds two items. */
+export const SwapsFeatureDisabled: Story = (() => {
+  const setup = createMockStory({ scenario: 'efSafe', shadcn: true, features: { swaps: false } })
+  return {
+    parameters: { ...setup.parameters },
+    decorators: [withAppsGrid, setup.decorator],
+  }
+})()

--- a/apps/web/src/components/safe-apps/NativeSwapsCard/NativeSwapsCardCell.test.tsx
+++ b/apps/web/src/components/safe-apps/NativeSwapsCard/NativeSwapsCardCell.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@/tests/test-utils'
+import NativeSwapsCardCell from './NativeSwapsCardCell'
+import { useNativeSwapsCard } from './useNativeSwapsCard'
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    query: { safe: 'eth:0x123' },
+  }),
+}))
+
+jest.mock('./useNativeSwapsCard', () => ({
+  useNativeSwapsCard: jest.fn(),
+}))
+
+const mockUseNativeSwapsCard = useNativeSwapsCard as jest.MockedFunction<typeof useNativeSwapsCard>
+
+describe('NativeSwapsCardCell', () => {
+  it('wraps the card in a list item when visible', () => {
+    mockUseNativeSwapsCard.mockReturnValue({ isVisible: true, dismiss: jest.fn() })
+
+    const { container } = render(<NativeSwapsCardCell />)
+
+    expect(screen.getByText('Native swaps are here!')).toBeInTheDocument()
+    expect(container.querySelector('li')).toBeInTheDocument()
+  })
+
+  it('renders no list item at all once dismissed', () => {
+    mockUseNativeSwapsCard.mockReturnValue({ isVisible: false, dismiss: jest.fn() })
+
+    const { container } = render(<NativeSwapsCardCell />)
+
+    expect(screen.queryByText('Native swaps are here!')).not.toBeInTheDocument()
+    expect(container.querySelector('li')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/safe-apps/NativeSwapsCard/NativeSwapsCardCell.tsx
+++ b/apps/web/src/components/safe-apps/NativeSwapsCard/NativeSwapsCardCell.tsx
@@ -1,0 +1,20 @@
+import NativeSwapsCard from './index'
+import { useNativeSwapsCard } from './useNativeSwapsCard'
+
+/**
+ * The promo card as a list item. Owns both the visibility decision and the `li`
+ * wrapper so a dismissed card leaves no empty cell behind in the apps grid.
+ */
+const NativeSwapsCardCell = () => {
+  const { isVisible, dismiss } = useNativeSwapsCard()
+
+  if (!isVisible) return null
+
+  return (
+    <li>
+      <NativeSwapsCard onDismiss={dismiss} />
+    </li>
+  )
+}
+
+export default NativeSwapsCardCell

--- a/apps/web/src/components/safe-apps/NativeSwapsCard/NativeSwapsCardCell.tsx
+++ b/apps/web/src/components/safe-apps/NativeSwapsCard/NativeSwapsCardCell.tsx
@@ -1,10 +1,7 @@
 import NativeSwapsCard from './index'
 import { useNativeSwapsCard } from './useNativeSwapsCard'
 
-/**
- * The promo card as a list item. Owns both the visibility decision and the `li`
- * wrapper so a dismissed card leaves no empty cell behind in the apps grid.
- */
+// Owns the visibility decision and the `li`, so a hidden card leaves no empty grid cell.
 const NativeSwapsCardCell = () => {
   const { isVisible, dismiss } = useNativeSwapsCard()
 

--- a/apps/web/src/components/safe-apps/NativeSwapsCard/index.stories.tsx
+++ b/apps/web/src/components/safe-apps/NativeSwapsCard/index.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import NativeSwapsCard from './index'
-import { StoreDecorator } from '@/stories/storeDecorator'
 
 const meta = {
   title: 'Components/SafeApps/NativeSwapsCard',
@@ -10,15 +9,11 @@ const meta = {
   },
 
   decorators: [
-    (Story) => {
-      return (
-        <StoreDecorator initialState={{ chains: { data: [{ chainId: '11155111', features: ['NATIVE_SWAPS'] }] } }}>
-          <div className="max-w-[500px]">
-            <Story />
-          </div>
-        </StoreDecorator>
-      )
-    },
+    (Story) => (
+      <div className="max-w-[500px]">
+        <Story />
+      </div>
+    ),
   ],
   tags: ['autodocs'],
 } satisfies Meta<typeof NativeSwapsCard>
@@ -27,5 +22,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
-  args: {},
+  args: {
+    onDismiss: () => {},
+  },
 }

--- a/apps/web/src/components/safe-apps/NativeSwapsCard/index.test.tsx
+++ b/apps/web/src/components/safe-apps/NativeSwapsCard/index.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@/tests/test-utils'
+import userEvent from '@testing-library/user-event'
 import NativeSwapsCard from './index'
 
 jest.mock('next/router', () => ({
@@ -7,18 +8,9 @@ jest.mock('next/router', () => ({
   }),
 }))
 
-jest.mock('@/features/swap', () => ({
-  useIsSwapFeatureEnabled: () => true,
-}))
-
-jest.mock('@/services/local-storage/useLocalStorage', () => ({
-  __esModule: true,
-  default: () => [true, jest.fn()],
-}))
-
 describe('NativeSwapsCard', () => {
   it('renders as a shadcn Card with promo content', () => {
-    render(<NativeSwapsCard />)
+    render(<NativeSwapsCard onDismiss={jest.fn()} />)
 
     expect(screen.getByText('Native swaps are here!')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Try now' })).toBeInTheDocument()
@@ -26,5 +18,14 @@ describe('NativeSwapsCard', () => {
 
     const card = screen.getByText('Native swaps are here!').closest('[data-slot="card"]')
     expect(card).toHaveAttribute('data-size', 'none')
+  })
+
+  it('calls onDismiss when the user opts out', async () => {
+    const onDismiss = jest.fn()
+    render(<NativeSwapsCard onDismiss={onDismiss} />)
+
+    await userEvent.click(screen.getByRole('button', { name: "Don't show" }))
+
+    expect(onDismiss).toHaveBeenCalled()
   })
 })

--- a/apps/web/src/components/safe-apps/NativeSwapsCard/index.tsx
+++ b/apps/web/src/components/safe-apps/NativeSwapsCard/index.tsx
@@ -7,20 +7,17 @@ import Track from '@/components/common/Track'
 import Link from 'next/link'
 import { AppRoutes } from '@/config/routes'
 import { useRouter } from 'next/router'
-import useLocalStorage from '@/services/local-storage/useLocalStorage'
-import { useIsSwapFeatureEnabled } from '@/features/swap'
 
-const SWAPS_APP_CARD_STORAGE_KEY = 'showSwapsAppCard'
+type NativeSwapsCardProps = {
+  onDismiss: () => void
+}
 
-const NativeSwapsCard = () => {
+const NativeSwapsCard = ({ onDismiss }: NativeSwapsCardProps) => {
   const router = useRouter()
-  const isSwapFeatureEnabled = useIsSwapFeatureEnabled()
-  const [isSwapsCardVisible = true, setIsSwapsCardVisible] = useLocalStorage<boolean>(SWAPS_APP_CARD_STORAGE_KEY)
-  if (!isSwapFeatureEnabled || !isSwapsCardVisible) return null
 
   return (
     // eslint-disable-next-line no-restricted-syntax -- h-full fills the dashboard grid cell (layout); the hover tint is a bespoke affordance with no variant
-    <Card size="none" className="h-full transition-colors hover:bg-muted">
+    <Card size="none" className="h-full transition-colors">
       <div className="flex items-start justify-between px-4 pt-4 pb-2">
         <div className="rounded-full bg-[var(--color-secondary-light)] p-2">
           <SafeAppIconCard src="/images/common/swap.svg" alt="Swap Icon" width={24} height={24} />
@@ -36,15 +33,15 @@ const NativeSwapsCard = () => {
           Experience seamless trading with better decoding and security in native swaps.
         </Typography>
 
-        <div className="mt-auto flex flex-row flex-wrap gap-2 pt-2">
+        <div className="mt-auto flex flex-row flex-wrap justify-end gap-2 pt-2">
+          <Button onClick={onDismiss} size="sm" variant="ghost" className="mr-auto">
+            Don&apos;t show
+          </Button>
           <Track {...SWAP_EVENTS.OPEN_SWAPS} label={SWAP_LABELS.safeAppsPromoWidget}>
             <Button size="sm" render={<Link href={{ pathname: AppRoutes.swap, query: { safe: router.query.safe } }} />}>
               Try now
             </Button>
           </Track>
-          <Button onClick={() => setIsSwapsCardVisible(false)} size="sm" variant="ghost">
-            Don&apos;t show
-          </Button>
         </div>
       </div>
     </Card>

--- a/apps/web/src/components/safe-apps/NativeSwapsCard/useNativeSwapsCard.test.ts
+++ b/apps/web/src/components/safe-apps/NativeSwapsCard/useNativeSwapsCard.test.ts
@@ -1,0 +1,58 @@
+import { renderHook } from '@/tests/test-utils'
+import { useNativeSwapsCard, SWAPS_APP_CARD_STORAGE_KEY } from './useNativeSwapsCard'
+import useLocalStorage from '@/services/local-storage/useLocalStorage'
+import { useIsSwapFeatureEnabled } from '@/features/swap'
+
+jest.mock('@/features/swap', () => ({
+  useIsSwapFeatureEnabled: jest.fn(),
+}))
+
+jest.mock('@/services/local-storage/useLocalStorage', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+
+const mockUseIsSwapFeatureEnabled = useIsSwapFeatureEnabled as jest.MockedFunction<typeof useIsSwapFeatureEnabled>
+const mockUseLocalStorage = useLocalStorage as jest.MockedFunction<typeof useLocalStorage<boolean>>
+
+describe('useNativeSwapsCard', () => {
+  const setIsCardVisible = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseIsSwapFeatureEnabled.mockReturnValue(true)
+    mockUseLocalStorage.mockReturnValue([undefined, setIsCardVisible])
+  })
+
+  it('is visible by default when the swap feature is enabled', () => {
+    const { result } = renderHook(() => useNativeSwapsCard())
+
+    expect(mockUseLocalStorage).toHaveBeenCalledWith(SWAPS_APP_CARD_STORAGE_KEY)
+    expect(result.current.isVisible).toBe(true)
+  })
+
+  it('is hidden once dismissed', () => {
+    mockUseLocalStorage.mockReturnValue([false, setIsCardVisible])
+
+    const { result } = renderHook(() => useNativeSwapsCard())
+
+    expect(result.current.isVisible).toBe(false)
+  })
+
+  it('is hidden when the swap feature is disabled', () => {
+    mockUseIsSwapFeatureEnabled.mockReturnValue(false)
+    mockUseLocalStorage.mockReturnValue([true, setIsCardVisible])
+
+    const { result } = renderHook(() => useNativeSwapsCard())
+
+    expect(result.current.isVisible).toBe(false)
+  })
+
+  it('persists the dismissal', () => {
+    const { result } = renderHook(() => useNativeSwapsCard())
+
+    result.current.dismiss()
+
+    expect(setIsCardVisible).toHaveBeenCalledWith(false)
+  })
+})

--- a/apps/web/src/components/safe-apps/NativeSwapsCard/useNativeSwapsCard.ts
+++ b/apps/web/src/components/safe-apps/NativeSwapsCard/useNativeSwapsCard.ts
@@ -4,10 +4,7 @@ import { useIsSwapFeatureEnabled } from '@/features/swap'
 
 export const SWAPS_APP_CARD_STORAGE_KEY = 'showSwapsAppCard'
 
-/**
- * Owns the promo card's visibility so a parent can skip its grid cell entirely
- * instead of laying out an empty one around a card that renders `null`.
- */
+/** Visibility and dismissal for the native swaps promo card. */
 export const useNativeSwapsCard = () => {
   const isSwapFeatureEnabled = useIsSwapFeatureEnabled()
   const [isCardVisible = true, setIsCardVisible] = useLocalStorage<boolean>(SWAPS_APP_CARD_STORAGE_KEY)

--- a/apps/web/src/components/safe-apps/NativeSwapsCard/useNativeSwapsCard.ts
+++ b/apps/web/src/components/safe-apps/NativeSwapsCard/useNativeSwapsCard.ts
@@ -1,0 +1,21 @@
+import { useCallback } from 'react'
+import useLocalStorage from '@/services/local-storage/useLocalStorage'
+import { useIsSwapFeatureEnabled } from '@/features/swap'
+
+export const SWAPS_APP_CARD_STORAGE_KEY = 'showSwapsAppCard'
+
+/**
+ * Owns the promo card's visibility so a parent can skip its grid cell entirely
+ * instead of laying out an empty one around a card that renders `null`.
+ */
+export const useNativeSwapsCard = () => {
+  const isSwapFeatureEnabled = useIsSwapFeatureEnabled()
+  const [isCardVisible = true, setIsCardVisible] = useLocalStorage<boolean>(SWAPS_APP_CARD_STORAGE_KEY)
+
+  const dismiss = useCallback(() => setIsCardVisible(false), [setIsCardVisible])
+
+  return {
+    isVisible: isSwapFeatureEnabled && isCardVisible,
+    dismiss,
+  }
+}

--- a/apps/web/src/components/safe-apps/SafeAppList/index.tsx
+++ b/apps/web/src/components/safe-apps/SafeAppList/index.tsx
@@ -10,7 +10,7 @@ import useSafeAppPreviewDrawer from '@/hooks/safe-apps/useSafeAppPreviewDrawer'
 import css from './styles.module.css'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useOpenedSafeApps } from '@/hooks/safe-apps/useOpenedSafeApps'
-import NativeSwapsCard from '@/components/safe-apps/NativeSwapsCard'
+import NativeSwapsCardCell from '@/components/safe-apps/NativeSwapsCard/NativeSwapsCardCell'
 import { SAFE_APPS_EVENTS, SAFE_APPS_LABELS, trackSafeAppEvent, SafeAppLaunchLocation } from '@/services/analytics'
 import { useSafeApps } from '@/hooks/safe-apps/useSafeApps'
 
@@ -83,11 +83,7 @@ const SafeAppList = ({
             </li>
           ))}
 
-        {!isFiltered && showNativeSwapsCard && (
-          <li>
-            <NativeSwapsCard />
-          </li>
-        )}
+        {!isFiltered && showNativeSwapsCard && <NativeSwapsCardCell />}
 
         {/* Flat list filtered by search query */}
         {safeAppsList.map((safeApp) => (


### PR DESCRIPTION
## What it solves

Resolves: [WA-3446](https://linear.app/safe-global/issue/WA-3446/apps-grid-leaves-an-empty-cell-after-dismissing-the-andquotnative)

Two issues on the Apps page native swaps promo card:

1. **Dismissing the card left a blank grid cell.** `NativeSwapsCard` owned its own dismissal state and returned `null` when hidden, but `SafeAppList` rendered the `<li>` wrapper around it unconditionally. The wrapper stayed a grid item, so the remaining app cards never reflowed into the gap.
2. **Button order didn't match the rest of the app.** The primary action sat on the left and the secondary on the right — the inverse of the convention established for dialogs in #8546.

## How this PR fixes it

**Blank cell.** The visibility decision moved out of the card and into a new `useNativeSwapsCard` hook (swap feature flag + the `showSwapsAppCard` localStorage key, unchanged, so existing dismissals still persist). A new `NativeSwapsCardCell` component consumes that hook and owns *both* the decision and the `<li>` wrapper, so a dismissed card renders nothing at all rather than an empty cell. `SafeAppList` drops from a 5-line conditional to `{!isFiltered && showNativeSwapsCard && <NativeSwapsCardCell />}`.

The reflow is immediate without a reload because `useLocalStorage` backs each key with a shared `ExternalStore`, so dismissing re-renders the cell.

`NativeSwapsCard` is now presentational — it takes an `onDismiss` prop and reads no store or storage. This matches the existing `StakingPromoBanner`, which already uses that shape.

**Button order.** The action row is now `justify-end` with the ghost "Don't show" button first in the DOM carrying `mr-auto` — the same mechanism as `DialogActions` in #8546, minus the `sm:` prefix since a grid cell is already narrow and there's no mobile stacking here. `flex-wrap` is retained so the primary wraps below on a very narrow cell instead of overlapping.

Also included: the card's `hover:bg-muted` tint was dropped, so the whole card no longer tints on hover.

## How to test it

1. Go to the Apps page on a chain with `NATIVE_SWAPS` enabled (e.g. Sepolia).
2. Confirm the promo card shows "Don't show" on the left and "Try now" on the right.
3. Click **Don't show** → the card disappears **and** the remaining app cards immediately shift up to close the gap. No blank space, no reload needed.
4. Reload → the card stays hidden.
5. Clear the `showSwapsAppCard` key in localStorage, reload → the card is back.
6. Search/filter the apps list → the card is hidden (unchanged behaviour).

## Affected flows

- Apps page: viewing the native swaps promo card
- Apps page: dismissing the native swaps promo card via "Don't show"
- Apps page: launching swaps from the promo card via "Try now"

## Blast radius

- **`NativeSwapsCard`** — signature changed from no props to a required `onDismiss`. Single consumer, the new `NativeSwapsCardCell`. Storybook story and unit test updated.
- **`SafeAppList`** — three instances on `/apps` plus one on `/apps/custom`. Only the instance passing `showNativeSwapsCard` renders the cell, so the other three no longer subscribe to the localStorage key or the swap feature flag at all (they briefly did in an earlier iteration of this change; they don't now).
- **`showSwapsAppCard` localStorage key** — same key, no migration. Users who already dismissed the card stay dismissed.
- **Feature flag `NATIVE_SWAPS`** — read via `useIsSwapFeatureEnabled`, same as before, just relocated into the hook.
- **Analytics** — `SWAP_EVENTS.OPEN_SWAPS` / `SWAP_LABELS.safeAppsPromoWidget` unchanged; `Track` still wraps the "Try now" button.
- **No shared packages touched** — web only, no mobile impact.

## Risks / not checked

- No browser verification of the reflow or the new button alignment; verified via unit tests and type-check only.
- Cross-tab sync (dismiss in one tab, other tab updates) relies on existing `useLocalStorage` `storage`-event handling and was not exercised.
- Not tested on mobile viewport / mobile app.
- No integration test covers the full chain with the real `useLocalStorage` — each layer is unit-tested with its neighbour mocked, so a future change that breaks the `ExternalStore` reactivity or drifts the storage key would not be caught by these tests.
- The `hover:bg-muted` removal is a deliberate visual change but was not compared against a design reference.

## Visual summary
Before:
<img width="747" height="250" alt="Screenshot 2026-08-27 at 3 26 45 PM" src="https://github.com/user-attachments/assets/5e6bcc73-ec51-4508-a57f-5cf859809ff5" />
<img width="321" height="259" alt="Screenshot 2026-08-27 at 3 40 58 PM" src="https://github.com/user-attachments/assets/839ab63e-54f0-4fd7-9cb1-bd9762ff72e4" />

After:
<img width="380" height="223" alt="Screenshot 2026-08-27 at 3 26 18 PM" src="https://github.com/user-attachments/assets/2935cb58-347f-4b56-b897-1a7d3b701b02" />
<img width="747" height="250" alt="Screenshot 2026-08-27 at 3 30 09 PM" src="https://github.com/user-attachments/assets/1057e974-4083-4e9f-99ed-bf3b2933e774" />

**Rendering path:**

```mermaid
flowchart TB
  subgraph Before
    A1["SafeAppList"] -->|"always renders"| B1["&lt;li&gt; wrapper"]
    B1 --> C1["NativeSwapsCard<br/>(reads localStorage)"]
    C1 -->|"dismissed → null"| D1["empty grid cell 🐛"]
  end
  subgraph After
    A2["SafeAppList"] --> B2["NativeSwapsCardCell"]
    B2 --> H["useNativeSwapsCard<br/>(flag + localStorage)"]
    H --> E{"isVisible?"}
    E -->|"yes"| F["&lt;li&gt; + NativeSwapsCard<br/>onDismiss"]
    E -->|"no"| G["null — no cell, grid reflows ✅"]
  end
```

**Button order — secondary left, primary right, per #8546:**

```
┌──────────────────────────────┐
│  [swap icon]                 │
│                              │
│  Native swaps are here!      │
│  Experience seamless...      │
│                              │
│  Don't show        [Try now] │
└──────────────────────────────┘
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
