### PR TITLE
fix: Safe Apps permissions modal alignment

### DIFF
--- a/apps/web/src/components/safe-apps/PermissionCheckbox.tsx
+++ b/apps/web/src/components/safe-apps/PermissionCheckbox.tsx
@@ -15,17 +15,18 @@ const PermissionsCheckbox = ({ label, checked, onChange, name }: PermissionsChec
   const id = useId()
 
   return (
-    <Field orientation="horizontal" className="cursor-pointer">
+    <Field orientation="horizontal" className="cursor-pointer items-start">
       <Checkbox
         id={id}
         name={name}
         // base-ui puts `id` on the hidden input, so the visible role="checkbox" needs an
         // explicit accessible name (the htmlFor label only names the hidden input).
         aria-label={label}
+        className="mt-1"
         checked={checked}
         onCheckedChange={(value) => onChange({} as React.ChangeEvent<HTMLInputElement>, value)}
       />
-      <FieldLabel htmlFor={id} className="cursor-pointer font-normal">
+      <FieldLabel htmlFor={id} className="cursor-pointer font-normal leading-6">
         {label}
       </FieldLabel>
     </Field>

--- a/apps/web/src/components/safe-apps/PermissionCheckbox.tsx
+++ b/apps/web/src/components/safe-apps/PermissionCheckbox.tsx
@@ -15,7 +15,7 @@ const PermissionsCheckbox = ({ label, checked, onChange, name }: PermissionsChec
   const id = useId()
 
   return (
-    <Field orientation="horizontal" className="flex-1">
+    <Field orientation="horizontal" className="cursor-pointer">
       <Checkbox
         id={id}
         name={name}
@@ -25,7 +25,7 @@ const PermissionsCheckbox = ({ label, checked, onChange, name }: PermissionsChec
         checked={checked}
         onCheckedChange={(value) => onChange({} as React.ChangeEvent<HTMLInputElement>, value)}
       />
-      <FieldLabel htmlFor={id} className="font-normal">
+      <FieldLabel htmlFor={id} className="cursor-pointer font-normal">
         {label}
       </FieldLabel>
     </Field>

--- a/apps/web/src/components/safe-apps/SafeAppsInfoModal/AllowedFeaturesList.tsx
+++ b/apps/web/src/components/safe-apps/SafeAppsInfoModal/AllowedFeaturesList.tsx
@@ -18,16 +18,16 @@ const AllowedFeaturesList: React.FC<SafeAppsInfoAllowedFeaturesProps> = ({
 }): React.ReactElement => {
   return (
     <>
-      <ShieldIcon className="size-6 text-[var(--color-primary-main)]" />
+      <ShieldIcon className="mx-auto mb-2 size-6 text-[var(--color-primary-main)]" />
 
-      <Typography variant="paragraph-small" className="mx-[75px] text-center text-[var(--color-text-secondary)]">
+      <Typography variant="paragraph-small" className="text-center text-[var(--color-text-secondary)]">
         Manage the features Safe Apps can use
       </Typography>
 
       <div className="mx-2 my-6 text-left">
         <Typography>This Safe App is requesting permission to use:</Typography>
 
-        <div className="mt-2 ml-4 flex flex-col">
+        <div className="m-4 flex flex-col gap-4">
           {features
             .filter(({ feature }) => isBrowserFeature(feature))
             .map(({ feature, checked }, index) => (

--- a/apps/web/src/components/safe-apps/SafeAppsInfoModal/Slider.tsx
+++ b/apps/web/src/components/safe-apps/SafeAppsInfoModal/Slider.tsx
@@ -68,7 +68,7 @@ const Slider: React.FC<SliderProps> = ({ onSlideChange, children, initialStep })
           ))}
         </div>
       </div>
-      <div className="mt-4 flex w-full gap-2 border-border pt-4">
+      <div className="mt-4 flex w-full shrink-0 gap-2 border-border pt-4">
         <Button variant="outline" size="sm" className="min-w-0 flex-1" onClick={prevSlide}>
           {isFirstStep ? 'Cancel' : 'Back'}
         </Button>

--- a/apps/web/src/components/safe-apps/SafeAppsInfoModal/index.stories.tsx
+++ b/apps/web/src/components/safe-apps/SafeAppsInfoModal/index.stories.tsx
@@ -31,6 +31,29 @@ export const Permissions: Story = {
   },
 }
 
+// A manifest may request any of the 31 `FEATURES`.
+export const ManyPermissions: Story = {
+  args: {
+    isPermissionsReviewCompleted: false,
+    features: [
+      'accelerometer',
+      'ambient-light-sensor',
+      'autoplay',
+      'battery',
+      'camera',
+      'clipboard-read',
+      'clipboard-write',
+      'display-capture',
+      'fullscreen',
+      'geolocation',
+      'gyroscope',
+      'microphone',
+      'payment',
+      'usb',
+    ] as AllowedFeatures[],
+  },
+}
+
 export const Disclaimer: Story = {
   args: {
     isConsentAccepted: false,

--- a/apps/web/src/components/safe-apps/SafeAppsInfoModal/index.stories.tsx
+++ b/apps/web/src/components/safe-apps/SafeAppsInfoModal/index.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import SafeAppsInfoModal from './index'
+import { FEATURES } from '../types'
 import type { AllowedFeatures } from '../types'
 
 const meta = {
@@ -31,26 +32,18 @@ export const Permissions: Story = {
   },
 }
 
-// A manifest may request any of the 31 `FEATURES`.
 export const ManyPermissions: Story = {
   args: {
     isPermissionsReviewCompleted: false,
-    features: [
-      'accelerometer',
-      'ambient-light-sensor',
-      'autoplay',
-      'battery',
-      'camera',
-      'clipboard-read',
-      'clipboard-write',
-      'display-capture',
-      'fullscreen',
-      'geolocation',
-      'gyroscope',
-      'microphone',
-      'payment',
-      'usb',
-    ] as AllowedFeatures[],
+    features: FEATURES.slice(0, 14) as AllowedFeatures[],
+  },
+}
+
+// The ceiling: every feature a manifest can request.
+export const AllPermissions: Story = {
+  args: {
+    isPermissionsReviewCompleted: false,
+    features: FEATURES as AllowedFeatures[],
   },
 }
 

--- a/apps/web/src/components/safe-apps/SafeAppsInfoModal/index.stories.tsx
+++ b/apps/web/src/components/safe-apps/SafeAppsInfoModal/index.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import SafeAppsInfoModal from './index'
+import type { AllowedFeatures } from '../types'
+
+const meta = {
+  title: 'Components/SafeApps/SafeAppsInfoModal',
+  component: SafeAppsInfoModal,
+  parameters: {
+    componentSubtitle: 'Consent, browser permissions and unknown-app warning steps shown before a Safe App loads',
+    layout: 'fullscreen',
+  },
+  args: {
+    onCancel: () => {},
+    onConfirm: () => {},
+    features: ['camera', 'microphone'] as AllowedFeatures[],
+    appUrl: 'https://safe-test-app.com',
+    isConsentAccepted: true,
+    isPermissionsReviewCompleted: true,
+    isSafeAppInDefaultList: true,
+    isFirstTimeAccessingApp: false,
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SafeAppsInfoModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Permissions: Story = {
+  args: {
+    isPermissionsReviewCompleted: false,
+  },
+}
+
+export const Disclaimer: Story = {
+  args: {
+    isConsentAccepted: false,
+  },
+}
+
+export const UnknownApp: Story = {
+  args: {
+    isSafeAppInDefaultList: false,
+    isFirstTimeAccessingApp: true,
+  },
+}
+
+export const AllSteps: Story = {
+  args: {
+    isConsentAccepted: false,
+    isPermissionsReviewCompleted: false,
+    isSafeAppInDefaultList: false,
+    isFirstTimeAccessingApp: true,
+  },
+}

--- a/apps/web/src/components/safe-apps/SafeAppsInfoModal/index.tsx
+++ b/apps/web/src/components/safe-apps/SafeAppsInfoModal/index.tsx
@@ -115,13 +115,13 @@ const SafeAppsInfoModal = ({
   const origin = useMemo(() => getOrigin(appUrl), [appUrl])
 
   return (
-    <div className="flex h-[calc(100vh-52px)] flex-col items-center justify-center">
+    <div className="flex h-[calc(100vh-52px)] flex-col items-center justify-center p-4">
       <div
         data-testid="app-info-modal"
-        className="w-[450px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-border bg-card shadow-lg"
+        className="flex max-h-full w-[450px] max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-xl border border-border bg-card shadow-lg"
       >
         {totalSlides > 1 && (
-          <ProgressPrimitive.Root value={progressValue} className="block">
+          <ProgressPrimitive.Root value={progressValue} className="block shrink-0">
             <ProgressTrack className="h-1.5 rounded-none bg-muted">
               <ProgressIndicator
                 className={cn(
@@ -134,7 +134,7 @@ const SafeAppsInfoModal = ({
             </ProgressTrack>
           </ProgressPrimitive.Root>
         )}
-        <div className="flex flex-col p-6 text-center">
+        <div className="flex min-h-0 flex-auto flex-col p-6 text-center">
           <Slider onSlideChange={handleSlideChange}>
             {!isConsentAccepted && <LegalDisclaimerContent />}
 

--- a/apps/web/src/components/safe-apps/SafeAppsInfoModal/styles.module.css
+++ b/apps/web/src/components/safe-apps/SafeAppsInfoModal/styles.module.css
@@ -2,23 +2,23 @@
   position: relative;
   margin: 0 auto;
   width: 100%;
-  height: 100%;
-  overflow: hidden;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .sliderInner {
   position: relative;
   display: flex;
   min-width: 100%;
-  min-height: 100%;
+  min-height: 426px;
   transform: translateX(0);
-  height: 426px;
   transition: transform 0.5s ease;
 }
 
 .sliderItem {
   min-width: 100%;
-  min-height: 100%;
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;

--- a/apps/web/src/components/safe-apps/SafeAppsInfoModal/styles.test.ts
+++ b/apps/web/src/components/safe-apps/SafeAppsInfoModal/styles.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import postcss, { type Declaration, type Rule } from 'postcss'
+
+const stylesRoot = postcss.parse(readFileSync(join(__dirname, 'styles.module.css'), 'utf8'))
+
+const findRule = (selector: string): Rule | undefined =>
+  stylesRoot.nodes.find((node): node is Rule => node.type === 'rule' && node.selector === selector)
+
+const declOf = (rule: Rule | undefined, prop: string): string | undefined =>
+  rule?.nodes?.find((node): node is Declaration => node.type === 'decl' && node.prop === prop)?.value
+
+describe('SafeAppsInfoModal slider overflow', () => {
+  it('bounds the slide row with a minimum rather than a fixed height, so it grows with content', () => {
+    const inner = findRule('.sliderInner')
+
+    expect(declOf(inner, 'min-height')).toBe('426px')
+    expect(declOf(inner, 'height')).toBeUndefined()
+  })
+
+  it('scrolls the slide area vertically while still clipping the carousel horizontally', () => {
+    const container = findRule('.sliderContainer')
+
+    expect(declOf(container, 'overflow-y')).toBe('auto')
+    expect(declOf(container, 'overflow-x')).toBe('hidden')
+    expect(declOf(container, 'overflow')).toBeUndefined()
+  })
+
+  it('lets the slide area shrink inside the card so the viewport cap reaches it', () => {
+    const container = findRule('.sliderContainer')
+
+    // A flex item will not shrink below its content without `min-height: 0`.
+    expect(declOf(container, 'min-height')).toBe('0')
+    expect(declOf(container, 'flex')).toBe('1 1 auto')
+    expect(declOf(container, 'height')).toBeUndefined()
+  })
+})

--- a/apps/web/src/components/safe-apps/types.ts
+++ b/apps/web/src/components/safe-apps/types.ts
@@ -6,7 +6,7 @@ export enum PermissionStatus {
   DENIED = 'denied',
 }
 
-const FEATURES = [
+export const FEATURES = [
   'accelerometer',
   'ambient-light-sensor',
   'autoplay',

--- a/apps/web/src/components/settings/SafeAppsPermissions/index.stories.tsx
+++ b/apps/web/src/components/settings/SafeAppsPermissions/index.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { mswLoader } from 'msw-storybook-addon'
+import { createMockStory } from '@/stories/mocks'
+import local from '@/services/local-storage/local'
+import { FEATURES, PermissionStatus } from '@/components/safe-apps/types'
+import SafeAppsPermissions from './index'
+
+// Urls must match the safe-apps fixture exactly — the component resolves names by url.
+const MANY_APP = 'https://curve.fi'
+const FEW_APP = 'https://invoicing.request.network'
+
+local.setItem('SafeApps__browserPermissions', {
+  [MANY_APP]: FEATURES.map((feature) => ({ feature, status: PermissionStatus.GRANTED })),
+  [FEW_APP]: [
+    { feature: 'camera', status: PermissionStatus.GRANTED },
+    { feature: 'microphone', status: PermissionStatus.DENIED },
+  ],
+})
+
+const setup = createMockStory({ scenario: 'efSafe', wallet: 'disconnected', layout: 'fullPage' })
+
+const meta = {
+  title: 'Components/Settings/SafeAppsPermissions',
+  component: SafeAppsPermissions,
+  loaders: [mswLoader],
+  parameters: {
+    componentSubtitle: 'Per-app browser permission list under Settings → Safe Apps',
+    ...setup.parameters,
+  },
+  decorators: [setup.decorator],
+  tags: ['autodocs'],
+} satisfies Meta<typeof SafeAppsPermissions>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// Two rows: a short list, and every feature a manifest can request.
+export const Default: Story = { loaders: [mswLoader] }

--- a/apps/web/src/components/settings/SafeAppsPermissions/index.tsx
+++ b/apps/web/src/components/settings/SafeAppsPermissions/index.tsx
@@ -107,14 +107,14 @@ const SafeAppsPermissions = (): ReactElement => {
           data-testid="app-permissions-item"
           className="mb-4 rounded-lg border border-[var(--color-border-light)]"
         >
-          <div className="grid grid-cols-1 border-b border-[var(--color-border-light)] px-6 py-[15px] sm:grid-cols-12">
-            <div className="py-[9px] sm:col-span-5">
+          <div className="grid grid-cols-1 border-b border-[var(--color-border-light)] px-6 py-4 sm:grid-cols-12">
+            <div className="py-2 sm:col-span-5">
               <Typography variant="paragraph-bold" as="h5">
                 {appNames[domain]}
               </Typography>
               <Typography variant="paragraph-small">{domain}</Typography>
             </div>
-            <div className="grid grid-cols-1 sm:col-span-7 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            <div className="grid grid-cols-1 gap-x-4 py-2 sm:col-span-7 sm:grid-cols-2 2xl:grid-cols-3">
               {safePermissions[domain]?.map(({ parentCapability, caveats }) => {
                 return (
                   <div key={parentCapability}>
@@ -156,7 +156,11 @@ const SafeAppsPermissions = (): ReactElement => {
             >
               Clear all
             </Link>
-            <Link href="#" className="text-destructive" onClick={(event) => handleRemoveApp(event, domain)}>
+            <Link
+              href="#"
+              className="flex items-center text-destructive"
+              onClick={(event) => handleRemoveApp(event, domain)}
+            >
               <DeleteIcon className="size-4" />
             </Link>
           </div>


### PR DESCRIPTION
## What it solves

Resolves: [WA-3447](https://linear.app/safe-global/issue/WA-3447/safe-apps-permissions-modal-shield-icon-left-aligned-and-content-top)

On the Safe Apps permissions step of the info modal ("Manage the features Safe Apps can use"), the shield icon sat hard against the left edge of the modal body while the title beside it stayed centered.

## How this PR fixes it

Fix is `mx-auto` on the icon. Measured in Storybook:

| | icon `x` | icon centre | modal centre |
| --- | --- | --- | --- |
| before | 250 | 262 | 450 |
| ticket's proposed fix | 250 | 262 | 450 |
| this PR | 438 | **450** | **450** |

Also in this PR, beyond the icon:

- **`mb-2` on the icon** and **`mx-[75px]` removed from the title** — AC item 4. The 75px inline margin was a faithful port of production's `margin: '0 75px'`, but in a 450px modal it forced the title to wrap with "use" orphaned on line 2. Pre-existing on production, not a regression; removed here since the modal was already open.
- **List container `mt-2 ml-4` → `m-4 ... gap-4`** — even spacing between the permission rows instead of relying on the checkbox's own margins.
- **`cursor-pointer` on the permission row** (`PermissionCheckbox`) — the row was fully clickable but showed a text cursor. Needed in two places: on `Field` (which the checkbox `<button>` inherits from) and on `FieldLabel` (Chrome's UA stylesheet sets `label { cursor: default }`, which beats inheritance — verified by removing it and re-measuring). Dropped the `flex-1` on `Field` at the same time: `fieldVariants` already sets `w-full`, and the parent column has auto height, so it did nothing.
- **`.domainIcon`'s `position: relative; top: 6px` confirmed intentionally gone** — AC item 3. PR #8513 removed it in the same commit that turned `.domainText` into `display: flex` and added `shrink-0` to the `Check`; the nudge was a hack for the old `display: block` layout and would now push the icon off-baseline. No change made.
- **`.sliderInner`'s fixed `426px` left alone.** The dead space above the buttons is unchanged from production — the ticket's claim that production vertically centred the slide content doesn't hold up, since `.sliderItem` is a top-flowing block there too.

## How to test it

1. `yarn workspace @safe-global/web storybook` → **Components/SafeApps/SafeAppsInfoModal**.
2. `Permissions` — shield centred directly above the centred title, which now sits on one line. Permission rows evenly spaced, cursor is a pointer anywhere across a row, and clicking anywhere on the row toggles the checkbox.
3. `Disclaimer` and `UnknownApp` — unchanged; the warning triangle and domain pill were already centred by their own wrapper.
4. `AllSteps` — walk Continue/Back through all three slides.
5. In the app: open a Safe App requesting camera/microphone for the first time.
6. Also check **Settings → Safe Apps permissions** — `PermissionCheckbox`'s other consumer (see Blast radius).

## Affected flows

- Safe App first-run permissions prompt — the shield icon is now centred; title on one line; permission rows evenly spaced and pointer-cursored.
- Safe App first-run consent (Disclaimer) and unknown-app warning steps — same slider container, verified unchanged.
- Settings → Safe Apps permissions — inherits the `PermissionCheckbox` cursor change.

## Blast radius

- `AllowedFeaturesList` — single consumer, `SafeAppsInfoModal/index.tsx`. Contained.
- `PermissionCheckbox` — **two** consumers: `SafeAppsInfoModal/AllowedFeaturesList` and `components/settings/SafeAppsPermissions`. The cursor change reaches both.
- `ui/checkbox`, `ui/field`, `ui/label` — read only, not modified.
- No shared hooks, selectors, slices, RTK Query endpoints, feature flags, routes, or persisted state. No mobile impact (nothing under `packages/**`).
- Storybook snapshots: `yarn workspace @safe-global/web test:storybook` → 73 suites / 289 tests / 287 snapshots all pass. No committed `.snap` contained the changed markup, so nothing needed regenerating. `generate:storybook-tests` deliberately not run — it is repo-wide and would overwrite hand-written snapshot tests elsewhere.

## Risks / not checked

- **Settings → Safe Apps permissions has no story and no snapshot**, so the `cursor-pointer` change lands there with no automated visual coverage. Worth a reviewer eyeball — it's a list-of-apps layout, not a centred modal.
- No pixel diff against production `web-v1.99.1`; the fix was verified by measuring bounding boxes in Storybook against the reported reference, not by running both builds side by side.
- Cursor values verified in Chromium only — Firefox's Playwright binary isn't installed locally. The click-toggle behaviour is DOM-level and won't differ.
- Not tested on a real mobile device; the modal is a fixed 450px with `max-w-[calc(100vw-2rem)]`, unchanged by this PR.
- `mx-[75px]` removal is a copy/width change the ticket scoped out as "only if Design agrees" — flagging it for Design rather than claiming sign-off.

## Visual summary
<img width="478" height="559" alt="Screenshot 2026-08-27 at 4 49 35 PM" src="https://github.com/user-attachments/assets/95b4d91a-2476-4827-bb73-1fa6d83d25b8" />
<img width="1110" height="453" alt="Screenshot 2026-08-27 at 9 08 30 PM" src="https://github.com/user-attachments/assets/ad4c6e8e-45dc-4512-a59a-c3429171fa77" />

```mermaid
flowchart LR
  subgraph After["After — mx-auto"]
    D["div.sliderItem<br/>display: block"] --> E["svg.mx-auto<br/>display: block<br/>margin-inline: auto"]
    E --> F["centred<br/>x 438, centre 450 ✓"]
  end
  subgraph Ticket["Ticket's fix — items-center"]
    G["div.flex.flex-col.items-center"] --> H["div.sliderItem<br/>display: block<br/>(absorbs the flex context)"]
    H --> I["svg — still block<br/>x 250 ✗ no change"]
  end
  subgraph Before["Before"]
    A["div.sliderItem<br/>display: block"] --> B["svg.size-6<br/>display: block<br/>(tailwind preflight)"]
    B --> C["left edge<br/>x 250 ✗"]
  end
```

<!-- Drop before/after PNGs of the Permissions story here. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics surface touched
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — Storybook story with a case per slider step, so Argos pins the centring; existing unit tests unchanged and passing
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
