### PR TITLE
fix(UI/UX): minor UI fixes (layouts, icon replacement); Spaces List error state

### DIFF
--- a/apps/web/src/features/actions-tray/components/ActionsTray/ActionsTray.tsx
+++ b/apps/web/src/features/actions-tray/components/ActionsTray/ActionsTray.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement, type ReactNode, Fragment, useCallback, useContext } from 'react'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
-import { ArrowUpRight, ArrowDownLeft, Repeat, SquareDashedBottomCode } from 'lucide-react'
+import { ArrowUpRight, QrCode, Repeat, SquareDashedBottomCode } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Button } from '@/components/ui/button'
 import { ActionBar, ActionButton } from '@/components/common/ActionBar'
@@ -131,13 +131,13 @@ const ActionsTray = ({ noAssets, variant = 'safe' }: ActionsTrayProps): ReactEle
         <Track {...OVERVIEW_EVENTS.SHOW_QR} label="dashboard">
           {isSpace ? (
             <ActionButton variant={secondaryVariant} onClick={handleOnReceive} disabled={noAssets}>
-              <ArrowDownLeft className="size-5" />
+              <QrCode className="size-5" />
               Receive
             </ActionButton>
           ) : (
             <QrCodeButton>
               <ActionButton variant={secondaryVariant}>
-                <ArrowDownLeft className="size-5" />
+                <QrCode className="size-5" />
                 Receive
               </ActionButton>
             </QrCodeButton>

--- a/apps/web/src/features/spaces/components/Dashboard/HeaderActions.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/HeaderActions.tsx
@@ -1,4 +1,4 @@
-import { ArrowDownLeft, Repeat, ArrowUpRight, SquareDashedBottomCode } from 'lucide-react'
+import { QrCode, Repeat, ArrowUpRight, SquareDashedBottomCode } from 'lucide-react'
 
 import { ActionBar, ActionButton } from '@/components/common/ActionBar'
 
@@ -28,7 +28,7 @@ const HeaderActions = ({ onSend, onReceive, onSwap, onBuildTransaction, otherAct
           Send
         </ActionButton>
         <ActionButton variant="outline" onClick={onReceive}>
-          <ArrowDownLeft className="size-5" />
+          <QrCode className="size-5" />
           Receive
         </ActionButton>
         <ActionButton variant="outline" onClick={onSwap}>

--- a/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
@@ -163,6 +163,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
 
     // Sign in card must NOT render in this branch.
     expect(screen.queryByTestId('sign-in-options')).not.toBeInTheDocument()
+    expect(screen.queryByRole('status', { name: /loading/i })).not.toBeInTheDocument()
   })
 
   it('renders the No-spaces empty state Card with size="none" so the default gap does not inflate its height', () => {
@@ -243,6 +244,54 @@ describe('SpacesList — auth/expiry state rendering', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /try again/i }))
     expect(refetch).toHaveBeenCalled()
+  })
+
+  it('keeps showing the cached spaces list, not the error state, when a refetch errors but cached spaces remain', () => {
+    setAuth(true)
+    mockUseSpacesGetV1Query.mockReturnValue({
+      currentData: [{ uuid: 'uuid-1', name: 'Cached Space', memberStatus: 'ACTIVE' }],
+      isFetching: false,
+      isUninitialized: false,
+      error: { status: 500, data: 'boom' },
+    })
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 1 } })
+
+    render(<SpacesList />)
+
+    expect(screen.getByTestId('space-row')).toBeInTheDocument()
+    expect(screen.queryByText(/couldn't load your workspaces/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument()
+  })
+
+  it('shows the error state, not a stale empty state, when the query errors with no cached spaces', () => {
+    setAuth(true)
+    mockUseSpacesGetV1Query.mockReturnValue({
+      currentData: [],
+      isFetching: false,
+      isUninitialized: false,
+      error: { status: 500, data: 'boom' },
+    })
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 1 } })
+
+    render(<SpacesList />)
+
+    expect(screen.getByText(/couldn't load your workspaces/i)).toBeInTheDocument()
+    expect(screen.queryByText(/create your first workspace/i)).not.toBeInTheDocument()
+  })
+
+  it('shows a loading spinner, not the spaces list, when the user is signed in but the store is not yet hydrated', () => {
+    setAuth(true, false)
+    mockUseSpacesGetV1Query.mockReturnValue({
+      currentData: [{ uuid: 'uuid-1', name: 'Space 1', memberStatus: 'ACTIVE' }],
+      isFetching: false,
+      error: undefined,
+    })
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 1 } })
+
+    render(<SpacesList />)
+
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument()
+    expect(screen.queryByTestId('space-row')).not.toBeInTheDocument()
   })
 
   // Regression: on re-login after logout the spaces RTK Query cache entry

--- a/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
@@ -5,6 +5,7 @@ import SpacesList, { WORKSPACE_BENEFITS } from '../index'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { WorkspaceCreateEntryPoint } from '@/services/analytics/mixpanel-events'
+import { isAuthenticated, selectIsStoreHydrated } from '@/store/authSlice'
 
 const mockUseAppSelector = jest.fn()
 const mockUseSpacesGetV1Query = jest.fn()
@@ -17,6 +18,7 @@ jest.mock('@/store', () => ({
 
 jest.mock('@/store/authSlice', () => ({
   isAuthenticated: jest.fn(() => 'isAuthenticated'),
+  selectIsStoreHydrated: jest.fn(() => 'selectIsStoreHydrated'),
 }))
 
 jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
@@ -91,8 +93,20 @@ jest.mock('@/services/analytics', () => ({
 }))
 
 describe('SpacesList — auth/expiry state rendering', () => {
+  // The component reads two auth selectors. Route them through the mocked
+  // selector sentinels so a test can set signed-in and store-hydration
+  // independently; hydration defaults to true (a settled store).
+  const setAuth = (signedIn: boolean, storeHydrated = true) => {
+    mockUseAppSelector.mockImplementation((selector: unknown) => {
+      if (selector === isAuthenticated) return signedIn
+      if (selector === selectIsStoreHydrated) return storeHydrated
+      return undefined
+    })
+  }
+
   beforeEach(() => {
     jest.clearAllMocks()
+    setAuth(true)
     mockUseSpacesGetV1Query.mockReturnValue({ currentData: undefined, isFetching: false, error: undefined })
     mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: undefined })
     mockUseSignInRedirect.mockReturnValue({ setHasSignedIn: jest.fn(), redirectLoading: false })
@@ -100,7 +114,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
 
   it('renders the Sign in card (not Create space) when the user is unauthenticated — i.e. after a session expiry redirect', () => {
     // After sessionExpired() runs, setUnauthenticated clears sessionExpiresAt → isAuthenticated returns false.
-    mockUseAppSelector.mockReturnValue(false)
+    setAuth(false)
 
     render(<SpacesList />)
 
@@ -118,7 +132,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
   // tabs must render regardless of auth state, with the sign-in card offered
   // below the tabs.
   it('renders the AccountsNavigation chrome when signed out', () => {
-    mockUseAppSelector.mockReturnValue(false)
+    setAuth(false)
 
     render(<SpacesList />)
 
@@ -127,7 +141,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
   })
 
   it('renders the AccountsNavigation chrome when the user is signed in', () => {
-    mockUseAppSelector.mockReturnValue(true)
+    setAuth(true)
     mockUseSpacesGetV1Query.mockReturnValue({ currentData: [], isFetching: false, error: undefined })
     mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 1 } })
 
@@ -137,7 +151,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
   })
 
   it('renders the No-spaces empty state with Create space CTA when the user is authenticated and has no spaces', () => {
-    mockUseAppSelector.mockReturnValue(true)
+    setAuth(true)
     mockUseSpacesGetV1Query.mockReturnValue({ currentData: [], isFetching: false, error: undefined })
     mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 1 } })
 
@@ -152,7 +166,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
   })
 
   it('renders the No-spaces empty state Card with size="none" so the default gap does not inflate its height', () => {
-    mockUseAppSelector.mockReturnValue(true)
+    setAuth(true)
     mockUseSpacesGetV1Query.mockReturnValue({ currentData: [], isFetching: false, error: undefined })
     mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 1 } })
 
@@ -163,7 +177,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
   })
 
   it('renders the workspace-benefits bullet list with 12px spacing (gap-3)', () => {
-    mockUseAppSelector.mockReturnValue(true)
+    setAuth(true)
     mockUseSpacesGetV1Query.mockReturnValue({ currentData: [], isFetching: false, error: undefined })
     mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 1 } })
 
@@ -175,6 +189,62 @@ describe('SpacesList — auth/expiry state rendering', () => {
     expect(list).not.toHaveClass('gap-1.5')
   })
 
+  it('shows a loading spinner, not the empty state, while the spaces query is still fetching', () => {
+    setAuth(true)
+    mockUseSpacesGetV1Query.mockReturnValue({ currentData: undefined, isFetching: true, error: undefined })
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 1 } })
+
+    render(<SpacesList />)
+
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument()
+    expect(screen.queryByText(/create your first workspace/i)).not.toBeInTheDocument()
+  })
+
+  it('shows a loading spinner, not the sign-in card or empty state, before the store is hydrated on a hard refresh', () => {
+    setAuth(false, false)
+
+    render(<SpacesList />)
+
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument()
+    expect(screen.queryByTestId('sign-in-options')).not.toBeInTheDocument()
+    expect(screen.queryByText(/create your first workspace/i)).not.toBeInTheDocument()
+  })
+
+  it('shows an error message with a retry button, not the empty state, when the spaces query errors', () => {
+    setAuth(true)
+    mockUseSpacesGetV1Query.mockReturnValue({
+      currentData: undefined,
+      isFetching: false,
+      isUninitialized: false,
+      error: { status: 500, data: 'boom' },
+    })
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 1 } })
+
+    render(<SpacesList />)
+
+    expect(screen.getByText(/couldn't load your workspaces/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument()
+    expect(screen.queryByText(/create your first workspace/i)).not.toBeInTheDocument()
+  })
+
+  it('calls refetch when the retry button is clicked in the error state', async () => {
+    const refetch = jest.fn()
+    setAuth(true)
+    mockUseSpacesGetV1Query.mockReturnValue({
+      currentData: undefined,
+      isFetching: false,
+      isUninitialized: false,
+      error: { status: 500, data: 'boom' },
+      refetch,
+    })
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 1 } })
+
+    render(<SpacesList />)
+
+    await userEvent.click(screen.getByRole('button', { name: /try again/i }))
+    expect(refetch).toHaveBeenCalled()
+  })
+
   // Regression: on re-login after logout the spaces RTK Query cache entry
   // already exists (the post-logout page load fired a request with stale
   // persisted auth that errored, then invalidateTags marked it stale). When
@@ -184,7 +254,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
   // and bounced existing users into /welcome/create-space. SpacesList must
   // pass isSpacesLoading=true whenever currentData and error are both absent.
   it('passes isSpacesLoading=true to useSignInRedirect when spaces data and error are both undefined', () => {
-    mockUseAppSelector.mockReturnValue(true)
+    setAuth(true)
     mockUseSpacesGetV1Query.mockReturnValue({
       currentData: undefined,
       isFetching: false,
@@ -199,7 +269,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
   })
 
   it('passes the space uuid as singleSpaceId to useSignInRedirect when the user has exactly one space', () => {
-    mockUseAppSelector.mockReturnValue(true)
+    setAuth(true)
     mockUseSpacesGetV1Query.mockReturnValue({
       currentData: [{ uuid: 'uuid-1', name: 'Solo Space' }],
       isFetching: false,
@@ -215,7 +285,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
   // A pending invite must not auto-redirect the user into the space — they have
   // no access until they accept, so they stay on the list with the invite banner.
   it('passes singleSpaceId=null and shows the invite banner when the only space is a pending invite', () => {
-    mockUseAppSelector.mockReturnValue(true)
+    setAuth(true)
     mockUseSpacesGetV1Query.mockReturnValue({
       currentData: [{ uuid: 'uuid-1', name: 'Pending Space', memberStatus: 'INVITED' }],
       isFetching: false,
@@ -231,7 +301,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
   })
 
   it('passes singleSpaceId with inviteAmount>0 so useSignInRedirect skips the auto-redirect, rendering both the active space row and the invite banner', () => {
-    mockUseAppSelector.mockReturnValue(true)
+    setAuth(true)
     mockUseSpacesGetV1Query.mockReturnValue({
       currentData: [
         { uuid: 'uuid-active', name: 'Active Space', memberStatus: 'ACTIVE' },
@@ -252,7 +322,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
   })
 
   it('passes singleSpaceId=null to useSignInRedirect when the user has multiple spaces', () => {
-    mockUseAppSelector.mockReturnValue(true)
+    setAuth(true)
     mockUseSpacesGetV1Query.mockReturnValue({
       currentData: [
         { uuid: 'uuid-1', name: 'Space 1' },
@@ -270,7 +340,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
 
   // WA-2486: the sign-in card title (logo + heading) is centered, not left-aligned.
   it('centers the "Sign in to your workspace" heading', () => {
-    mockUseAppSelector.mockReturnValue(false)
+    setAuth(false)
 
     render(<SpacesList />)
 
@@ -281,7 +351,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
   // WA-2486: the "By continuing…" Terms/Privacy text is moved out of the card
   // (below it) to reduce text overload inside the box.
   it('renders the "By continuing" text outside the sign-in card', () => {
-    mockUseAppSelector.mockReturnValue(false)
+    setAuth(false)
 
     const { container } = render(<SpacesList />)
 
@@ -294,7 +364,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
   // The Create button sits right-aligned above the workspaces list when the
   // user is signed in and has spaces.
   it('renders the Create workspace button in the tabbed layout when signed in with active spaces', async () => {
-    mockUseAppSelector.mockReturnValue(true)
+    setAuth(true)
     mockUseSpacesGetV1Query.mockReturnValue({
       currentData: [{ uuid: 'uuid-1', name: 'Space 1' }],
       isFetching: false,
@@ -315,7 +385,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
   })
 
   it('does not render the Create workspace button in the header when the user has no active spaces', () => {
-    mockUseAppSelector.mockReturnValue(true)
+    setAuth(true)
     mockUseSpacesGetV1Query.mockReturnValue({ currentData: [], isFetching: false, error: undefined })
     mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 1 } })
 
@@ -328,7 +398,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
   })
 
   it('disables the Create space button and shows a tooltip when the user has reached the 10-space limit', async () => {
-    mockUseAppSelector.mockReturnValue(true)
+    setAuth(true)
     const tenSpaces = Array.from({ length: 10 }, (_, i) => ({
       id: i + 1,
       uuid: `00000000-0000-0000-0000-0000000000${String(i + 1).padStart(2, '0')}`,

--- a/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
-import SpacesList from '../index'
+import SpacesList, { WORKSPACE_BENEFITS } from '../index'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { WorkspaceCreateEntryPoint } from '@/services/analytics/mixpanel-events'
@@ -149,6 +149,30 @@ describe('SpacesList — auth/expiry state rendering', () => {
 
     // Sign in card must NOT render in this branch.
     expect(screen.queryByTestId('sign-in-options')).not.toBeInTheDocument()
+  })
+
+  it('renders the No-spaces empty state Card with size="none" so the default gap does not inflate its height', () => {
+    mockUseAppSelector.mockReturnValue(true)
+    mockUseSpacesGetV1Query.mockReturnValue({ currentData: [], isFetching: false, error: undefined })
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 1 } })
+
+    const { container } = render(<SpacesList />)
+
+    const card = container.querySelector('[data-slot="card"]')
+    expect(card).toHaveAttribute('data-size', 'none')
+  })
+
+  it('renders the workspace-benefits bullet list with 12px spacing (gap-3)', () => {
+    mockUseAppSelector.mockReturnValue(true)
+    mockUseSpacesGetV1Query.mockReturnValue({ currentData: [], isFetching: false, error: undefined })
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 1 } })
+
+    render(<SpacesList />)
+
+    const firstBullet = screen.getByText(WORKSPACE_BENEFITS[0])
+    const list = firstBullet.closest('.gap-3')
+    expect(list).toBeInTheDocument()
+    expect(list).not.toHaveClass('gap-1.5')
   })
 
   // Regression: on re-login after logout the spaces RTK Query cache entry

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -6,10 +6,11 @@ import WorkspaceBanner from '../WorkspaceBanner'
 import SpacesIcon from '@/public/images/spaces/spaces.svg'
 import SafeMarkIcon from '@/public/images/logo-no-text.svg'
 import { useAppSelector } from '@/store'
-import { isAuthenticated } from '@/store/authSlice'
+import { isAuthenticated, selectIsStoreHydrated } from '@/store/authSlice'
 import { Check } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
+import { Spinner } from '@/components/ui/spinner'
 import { Link } from '@/components/ui/link'
 import { Typography } from '@/components/ui/typography'
 import { type GetSpaceResponse, useSpacesGetV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
@@ -186,12 +187,14 @@ const NoSpacesState = ({ isAtLimit }: { isAtLimit: boolean }) => {
 const SpacesList = () => {
   const { AccountsNavigation } = useLoadFeature(MyAccountsFeature)
   const isUserSignedIn = useAppSelector(isAuthenticated)
+  const isStoreHydrated = useAppSelector(selectIsStoreHydrated)
   const { currentData: currentUser } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
   const {
     currentData: spaces,
     isFetching,
     isUninitialized,
     error,
+    refetch,
   } = useSpacesGetV1Query(undefined, { skip: !isUserSignedIn })
   const pendingInvites = filterSpacesByStatus(currentUser, spaces || [], MemberStatus.INVITED)
   const activeSpaces = filterSpacesByStatus(currentUser, spaces || [], MemberStatus.ACTIVE)
@@ -199,18 +202,20 @@ const SpacesList = () => {
 
   const singleSpaceId = activeSpaces.length === 1 ? activeSpaces[0].uuid : null
 
+  // Treat any state without a definitive answer as still loading. The
+  // skip→unskip transition (re-login after logout) returns isFetching=false
+  // and isUninitialized=false on the render where skip flips — RTK Query
+  // dispatches the refetch in a useEffect, so the loading flags lag one
+  // render behind. Without the `spaces === undefined && !error` clause an
+  // existing user gets bounced into /welcome/create-space because the hook
+  // reads spacesAmount=0 with isSpacesLoading=false. Once spaces or error
+  // resolves, this clause becomes false and the normal redirect logic runs.
+  const isSpacesLoading = isFetching || isUninitialized || (spaces === undefined && !error)
+
   const { setHasSignedIn, redirectLoading } = useSignInRedirect({
     spacesAmount: spaces?.length || 0,
     inviteAmount: pendingInvites.length,
-    // Treat any state without a definitive answer as still loading. The
-    // skip→unskip transition (re-login after logout) returns isFetching=false
-    // and isUninitialized=false on the render where skip flips — RTK Query
-    // dispatches the refetch in a useEffect, so the loading flags lag one
-    // render behind. Without the `spaces === undefined && !error` clause an
-    // existing user gets bounced into /welcome/create-space because the hook
-    // reads spacesAmount=0 with isSpacesLoading=false. Once spaces or error
-    // resolves, this clause becomes false and the normal redirect logic runs.
-    isSpacesLoading: isFetching || isUninitialized || (spaces === undefined && !error),
+    isSpacesLoading,
     error: error || undefined,
     singleSpaceId,
   })
@@ -240,8 +245,19 @@ const SpacesList = () => {
           <AccountsNavigation />
         </div>
 
-        {!isUserSignedIn ? (
+        {!isStoreHydrated || (isUserSignedIn && isSpacesLoading) ? (
+          <div className="flex justify-center py-10">
+            <Spinner className="size-6 text-muted-foreground" />
+          </div>
+        ) : !isUserSignedIn ? (
           <SignedOutState afterSignIn={afterSignIn} redirectLoading={redirectLoading} />
+        ) : error ? (
+          <div className="flex flex-col items-center gap-3 py-10 text-center">
+            <Typography color="muted">Couldn&apos;t load your workspaces. Try again, or contact support.</Typography>
+            <Button variant="outline" onClick={() => refetch()}>
+              Try again
+            </Button>
+          </div>
         ) : activeSpaces.length > 0 ? (
           <WelcomeContentCard className="flex flex-col gap-4">
             <div className="flex justify-end">

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -251,7 +251,7 @@ const SpacesList = () => {
           </div>
         ) : !isUserSignedIn ? (
           <SignedOutState afterSignIn={afterSignIn} redirectLoading={redirectLoading} />
-        ) : error ? (
+        ) : error && !spaces?.length ? (
           <div className="flex flex-col items-center gap-3 py-10 text-center">
             <Typography color="muted">Couldn&apos;t load your workspaces. Try again, or contact support.</Typography>
             <Button variant="outline" onClick={() => refetch()}>

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -202,14 +202,11 @@ const SpacesList = () => {
 
   const singleSpaceId = activeSpaces.length === 1 ? activeSpaces[0].uuid : null
 
-  // Treat any state without a definitive answer as still loading. The
-  // skip→unskip transition (re-login after logout) returns isFetching=false
-  // and isUninitialized=false on the render where skip flips — RTK Query
-  // dispatches the refetch in a useEffect, so the loading flags lag one
-  // render behind. Without the `spaces === undefined && !error` clause an
-  // existing user gets bounced into /welcome/create-space because the hook
-  // reads spacesAmount=0 with isSpacesLoading=false. Once spaces or error
-  // resolves, this clause becomes false and the normal redirect logic runs.
+  // Treat any indefinite state as loading. On the skip→unskip flip (re-login
+  // after logout) RTK Query lags one render — isFetching/isUninitialized are
+  // both false while spaces is still undefined. The `spaces === undefined &&
+  // !error` clause covers that gap so an existing user isn't bounced into
+  // /welcome/create-space on a stale spacesAmount=0.
   const isSpacesLoading = isFetching || isUninitialized || (spaces === undefined && !error)
 
   const { setHasSignedIn, redirectLoading } = useSignInRedirect({

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -129,7 +129,7 @@ const SignedOutState = ({ afterSignIn, redirectLoading }: { afterSignIn: () => v
   )
 }
 
-const WORKSPACE_BENEFITS = [
+export const WORKSPACE_BENEFITS = [
   'Organize multiple Safe accounts in one place',
   'Invite members and manage their roles',
   'Share an address book across your team',
@@ -140,41 +140,42 @@ const NoSpacesState = ({ isAtLimit }: { isAtLimit: boolean }) => {
 
   return (
     <>
-      {/* eslint-disable-next-line no-restricted-syntax -- 40px empty-state padding; no p-10 Card size variant */}
-      <Card className="w-full p-10 text-center">
-        <div className="mb-4 flex justify-center">
-          <SpacesIcon />
-        </div>
+      <Card size="none" className="w-full">
+        <div className="flex flex-col p-10 text-center">
+          <div className="mb-4 flex justify-center">
+            <SpacesIcon />
+          </div>
 
-        <Typography variant="h4" className="mb-2 font-bold">
-          Create your first workspace
-        </Typography>
-        <Typography color="muted" className="mb-3">
-          Collaborate on your Safe accounts with your team.
-        </Typography>
+          <Typography variant="h4" className="mb-2 font-bold">
+            Create your first workspace
+          </Typography>
+          <Typography color="muted" className="mb-3">
+            Collaborate on your Safe accounts with your team.
+          </Typography>
 
-        <div className="mx-auto mb-4 flex max-w-[360px] flex-col gap-1.5 text-left">
-          {WORKSPACE_BENEFITS.map((benefit) => (
-            <div key={benefit} className="flex flex-row items-center gap-1.5">
-              <Check className="size-4 shrink-0 text-primary" />
-              <Typography variant="paragraph-small">{benefit}</Typography>
-            </div>
-          ))}
-        </div>
+          <div className="mx-auto mt-2 mb-6 flex max-w-[360px] flex-col gap-3 text-left">
+            {WORKSPACE_BENEFITS.map((benefit) => (
+              <div key={benefit} className="flex flex-row items-center gap-1.5">
+                <Check className="size-4 shrink-0 text-primary" />
+                <Typography variant="paragraph-small">{benefit}</Typography>
+              </div>
+            ))}
+          </div>
 
-        <div className="h-12">
-          <AddSpaceButton
-            disabled={isAtLimit}
-            onClick={() =>
-              trackEvent(SPACE_EVENTS.WORKSPACE_CREATE_STARTED, { entry_point: WorkspaceCreateEntryPoint.WELCOME })
-            }
-          />
-        </div>
+          <div className="h-12">
+            <AddSpaceButton
+              disabled={isAtLimit}
+              onClick={() =>
+                trackEvent(SPACE_EVENTS.WORKSPACE_CREATE_STARTED, { entry_point: WorkspaceCreateEntryPoint.WELCOME })
+              }
+            />
+          </div>
 
-        <div className="mt-2">
-          <Link onClick={() => setIsInfoOpen(true)} href="#">
-            What are workspaces?
-          </Link>
+          <div className="mt-2">
+            <Link onClick={() => setIsInfoOpen(true)} href="#">
+              What are workspaces?
+            </Link>
+          </div>
         </div>
       </Card>
       {isInfoOpen && <SpaceInfoModal onClose={() => setIsInfoOpen(false)} />}


### PR DESCRIPTION
## What it solves

Resolves: [WA-3443](https://linear.app/safe-global/issue/WA-3443/receive-button-icon-changed-from-qr-code-to-a-generic-down-left-arrow)
Resolves: [WA-3441](https://linear.app/safe-global/issue/WA-3441/workspaces-empty-state-is-taller-than-production-shadcn-cards-default)
Resolves: [WA-3464](https://linear.app/safe-global/issue/WA-3464/do-now-show-create-new-workspace-page-on-be-error)

Minor UI fixes after the shadcn migration:
- **Receive** buttons used a directional arrow (`ArrowDownLeft`) instead of a QR-code icon.
- **Create your first workspace** empty state had inflated height (default `Card` gap) and cramped benefit-list spacing.

UX improvements:
- **SpacesList** had no loading or error UI: a hard refresh flashed the sign-in/empty state before the store hydrated, and a failed spaces query silently fell through to the empty "create your first workspace" state.

## How this PR fixes it

- Swap `ArrowDownLeft` → `QrCode` on the Receive buttons (`ActionsTray`, `HeaderActions`).
- `NoSpacesState`: `Card size="none"` + padding moved to an inner div; benefit list bumped to `gap-3`.
- `SpacesList` render ladder now handles all states in order:
  - **Not hydrated / signed-in + loading** → spinner
  - **Signed out** → sign-in card
  - **Error with no cached spaces** → error message + Try again (calls `refetch`)
  - **Error but cached spaces exist** → keep showing the list (transient refetch failure doesn't blank the page)
  - Otherwise → spaces list / empty state

## How to test it

- Open Safe dashboard and Workspace dashboard — Receive buttons show a QR icon.
- Signed in, no spaces → tidy "Create your first workspace" card, not cut on the bottom on 14' screen.
- Force the spaces query to `500` with no data (empty Spaces list): → Try again page appears; retries on button click.

## Visual summary

**Before:**

- Page layout:
<img width="2984" height="1530" alt="image" src="https://github.com/user-attachments/assets/a514a52a-8696-45a5-a1f1-00e3364e5343" />
</br>
- Receive btn:
<img width="288" height="106" alt="image" src="https://github.com/user-attachments/assets/11747cbf-f75d-4f32-a773-7b7ce1159e15" />
</br>
- User-facing page on Spaces error (even when the user actually has spaces):
<img width="2984" height="1530" alt="image" src="https://github.com/user-attachments/assets/a514a52a-8696-45a5-a1f1-00e3364e5343" />
</br>


**After:**

- Page layout:
<img width="2978" height="1526" alt="image" src="https://github.com/user-attachments/assets/1d5828b8-69c9-47d0-b1f6-797c6c38ad0d" />
</br>
- Receive btn:
<img width="276" height="92" alt="image" src="https://github.com/user-attachments/assets/e9dfce8d-53e3-4d5c-9ff8-02653b60200d" />
</br>
- User-facing page on Spaces fetch error:
<img width="3006" height="1520" alt="image" src="https://github.com/user-attachments/assets/96fb36a8-4d38-4a44-817b-edaa9164f55b" />



```mermaid
flowchart TD
  A[SpacesList] --> B{store hydrated?}
  B -->|no| S[Spinner]
  B -->|yes| C{signed in & loading?}
  C -->|yes| S
  C -->|no| D{signed in?}
  D -->|no| SO[Sign-in card]
  D -->|yes| E{error && no cached spaces?}
  E -->|yes| ER[Error + Try again]
  E -->|no| F{active spaces?}
  F -->|yes| L[Spaces list]
  F -->|no| N[Create-first-workspace empty state]
```

**Affected flows:** welcome/spaces list, empty state, Receive button icon.
**Blast radius:** `SpacesList` render tree; icon-only change in `ActionsTray`/`HeaderActions` (no logic).
**Risks / not checked:** full `verify`/E2E not run locally (Turbo/watchman sandbox-blocked); ran jest + tsc directly instead.


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

