### PR TITLE
feat(safenet-checks): attestation-latency allowance before TIMED_OUT

### DIFF
--- a/packages/utils/src/features/safenet-checks/constants.ts
+++ b/packages/utils/src/features/safenet-checks/constants.ts
@@ -109,6 +109,22 @@ export const LATE_WINDOW_BLOCKS = 720
 export const PLAIN_DEADLINE_BLOCKS = 240
 
 /**
+ * Attestation-latency allowance: how many blocks past the reveal deadline a
+ * verdict-less check stays pending before it reads as TIMED_OUT. The committee
+ * only attests RESOLVED checks, and resolution itself lands at the reveal
+ * deadline, so a healthy attestation always trails the deadline (5–11 blocks
+ * observed on Sepolia). Without the allowance every checked transaction
+ * flashes "check failed" before its attestation upgrades it to BENIGN.
+ *
+ * ponytail: a fixed BLOCK count standing in for a wall-clock latency, with only
+ * 4 blocks of margin over the worst observed case (deadline+11). This file is
+ * tuned to {@link BLOCK_TIME_SECONDS} (Gnosis, 5s); on a 5s chain 15 blocks is
+ * 75s, below the 60-132s the Sepolia observations imply. Upgrade path: derive
+ * this from {@link BLOCK_TIME_SECONDS}, or express the allowance in seconds.
+ */
+export const ATTESTATION_GRACE_BLOCKS = 15
+
+/**
  * How long after submission an UNAVAILABLE read keeps polling. Covers the race
  * where the first read lands before the check request is mined; Gnosis blocks
  * every ~5s, so a request mines well inside this window.

--- a/packages/utils/src/features/safenet-checks/utils/__tests__/computePollingInterval.test.ts
+++ b/packages/utils/src/features/safenet-checks/utils/__tests__/computePollingInterval.test.ts
@@ -2,6 +2,7 @@ import { computePollingInterval } from '../computePollingInterval'
 import {
   ARBITRATION_POLL_MS,
   ARBITRATION_WINDOW_MS,
+  ATTESTATION_GRACE_BLOCKS,
   LATE_WINDOW_BLOCKS,
   PLAIN_DEADLINE_BLOCKS,
   POLL_INTERVAL_FAST_MS,
@@ -144,11 +145,33 @@ describe('computePollingInterval', () => {
     ).toBe(POLL_INTERVAL_FAST_MS)
   })
 
-  it('drops to the late interval at head == deadline + 1 (first out-of-window block)', () => {
+  it('stays fast one block past the deadline — the attestation trails it by design', () => {
+    expect(
+      computePollingInterval({
+        status: CheckStatus.IN_PROGRESS,
+        headBlock: '151',
+        deadlineBlock: '150',
+        firstEventBlock: '100',
+      }),
+    ).toBe(POLL_INTERVAL_FAST_MS)
+  })
+
+  it('stays fast at head == deadline + ATTESTATION_GRACE_BLOCKS (allowance is inclusive)', () => {
+    expect(
+      computePollingInterval({
+        status: CheckStatus.IN_PROGRESS,
+        headBlock: String(150 + ATTESTATION_GRACE_BLOCKS),
+        deadlineBlock: '150',
+        firstEventBlock: '100',
+      }),
+    ).toBe(POLL_INTERVAL_FAST_MS)
+  })
+
+  it('drops to the late interval one block past the attestation grace', () => {
     expect(
       computePollingInterval({
         status: CheckStatus.TIMED_OUT,
-        headBlock: '151',
+        headBlock: String(150 + ATTESTATION_GRACE_BLOCKS + 1),
         deadlineBlock: '150',
         firstEventBlock: '100',
       }),
@@ -243,11 +266,22 @@ describe('computePollingInterval', () => {
       ).toBe(POLL_INTERVAL_FAST_MS)
     })
 
-    it('drops to the late interval past the substitute deadline', () => {
+    it('stays fast through the attestation grace past the substitute deadline', () => {
       expect(
         computePollingInterval({
           status: CheckStatus.SUBMITTED,
-          headBlock: String(first + PLAIN_DEADLINE_BLOCKS + 1),
+          headBlock: String(first + PLAIN_DEADLINE_BLOCKS + ATTESTATION_GRACE_BLOCKS),
+          deadlineBlock: null,
+          firstEventBlock: String(first),
+        }),
+      ).toBe(POLL_INTERVAL_FAST_MS)
+    })
+
+    it('drops to the late interval past the substitute deadline plus grace', () => {
+      expect(
+        computePollingInterval({
+          status: CheckStatus.SUBMITTED,
+          headBlock: String(first + PLAIN_DEADLINE_BLOCKS + ATTESTATION_GRACE_BLOCKS + 1),
           deadlineBlock: null,
           firstEventBlock: String(first),
         }),

--- a/packages/utils/src/features/safenet-checks/utils/__tests__/deriveCheckState.test.ts
+++ b/packages/utils/src/features/safenet-checks/utils/__tests__/deriveCheckState.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { ATTESTATION_GRACE_BLOCKS } from '../../constants'
 import { deriveCheckState } from '../deriveCheckState'
 import {
   attestedEvent,
@@ -34,8 +35,11 @@ const derive = (
   attestation: AttestationVerification = UNVERIFIED_ATTESTATION,
 ) => deriveCheckState({ events, headBlock, attestation })
 
-// A request that times out at block 150.
+// A request that times out at block 150; with the attestation-latency
+// allowance the wallet declares TIMED_OUT past 150 + ATTESTATION_GRACE_BLOCKS.
 const request = () => requestCreatedEvent({ deadlineBlock: '150', commitDeadlineBlock: '150' })
+const GRACE_END = String(150 + ATTESTATION_GRACE_BLOCKS)
+const PAST_GRACE = String(150 + ATTESTATION_GRACE_BLOCKS + 1)
 
 describe('deriveCheckState — precedence table', () => {
   it('SUBMITTED when only proposed', () => {
@@ -124,23 +128,27 @@ describe('deriveCheckState — precedence table', () => {
     expect(derive(events, '140')).toBe(CheckStatus.MALICIOUS)
   })
 
-  it('TIMED_OUT past the deadline with no verdict', () => {
-    expect(derive([proposedEvent(), request()], '151')).toBe(CheckStatus.TIMED_OUT)
+  it('TIMED_OUT past the deadline plus the attestation grace, with no verdict', () => {
+    expect(derive([proposedEvent(), request()], PAST_GRACE)).toBe(CheckStatus.TIMED_OUT)
   })
 
-  it('TIMED_OUT for a frozen dispute past the deadline', () => {
+  it('TIMED_OUT for a frozen dispute past the deadline plus grace', () => {
     const events = [proposedEvent(), request(), disputeResolvedEvent()]
-    expect(derive(events, '151')).toBe(CheckStatus.TIMED_OUT)
+    expect(derive(events, PAST_GRACE)).toBe(CheckStatus.TIMED_OUT)
   })
 })
 
-describe('deriveCheckState — head == deadline boundary', () => {
+describe('deriveCheckState — deadline and grace boundary', () => {
   it('stays IN_PROGRESS at head == deadline (reveal window is inclusive)', () => {
     expect(derive([proposedEvent(), request()], '150')).toBe(CheckStatus.IN_PROGRESS)
   })
 
-  it('TIMED_OUT one block later', () => {
-    expect(derive([proposedEvent(), request()], '151')).toBe(CheckStatus.TIMED_OUT)
+  it('stays IN_PROGRESS one block past the deadline — the attestation trails it by design', () => {
+    expect(derive([proposedEvent(), request()], '151')).toBe(CheckStatus.IN_PROGRESS)
+  })
+
+  it('stays IN_PROGRESS at head == deadline + grace (allowance is inclusive)', () => {
+    expect(derive([proposedEvent(), request()], GRACE_END)).toBe(CheckStatus.IN_PROGRESS)
   })
 })
 

--- a/packages/utils/src/features/safenet-checks/utils/computePollingInterval.ts
+++ b/packages/utils/src/features/safenet-checks/utils/computePollingInterval.ts
@@ -1,6 +1,7 @@
 import {
   ARBITRATION_POLL_MS,
   ARBITRATION_WINDOW_MS,
+  ATTESTATION_GRACE_BLOCKS,
   LATE_WINDOW_BLOCKS,
   PLAIN_DEADLINE_BLOCKS,
   POLL_INTERVAL_FAST_MS,
@@ -41,10 +42,13 @@ type PollingInput = {
 /**
  * How often to re-poll a check, in ms; `0` = stop (RTK Query's convention).
  * Stops on a rejection; otherwise fast (6s) up to the effective deadline
- * (on-chain, or {@link PLAIN_DEADLINE_BLOCKS} past the first event), slow (30s)
- * through the ~1h late window, then stops. UNAVAILABLE polls slowly inside
- * {@link UNAVAILABLE_GRACE_MS} of submission and BENIGN inside
- * {@link ARBITRATION_WINDOW_MS} of the attestation, then both stop.
+ * (on-chain, or {@link PLAIN_DEADLINE_BLOCKS} past the first event) plus
+ * {@link ATTESTATION_GRACE_BLOCKS}, slow (30s) through the ~1h late window,
+ * then stops. The attestation lands past the deadline by design, so the fast
+ * cadence holds through the allowance instead of a slow poll delaying the
+ * BENIGN flip. UNAVAILABLE polls slowly inside {@link UNAVAILABLE_GRACE_MS} of
+ * submission and BENIGN inside {@link ARBITRATION_WINDOW_MS} of the
+ * attestation, then both stop.
  */
 export const computePollingInterval = ({
   status,
@@ -92,7 +96,9 @@ export const computePollingInterval = ({
         ? BigInt(firstEventBlock) + BigInt(PLAIN_DEADLINE_BLOCKS)
         : null
 
-  if (deadline === null || head === null || head <= deadline) return POLL_INTERVAL_FAST_MS
+  if (deadline === null || head === null || head <= deadline + BigInt(ATTESTATION_GRACE_BLOCKS)) {
+    return POLL_INTERVAL_FAST_MS
+  }
   if (head <= deadline + BigInt(LATE_WINDOW_BLOCKS)) return POLL_INTERVAL_LATE_MS
   return 0
 }

--- a/packages/utils/src/features/safenet-checks/utils/deriveCheckState.ts
+++ b/packages/utils/src/features/safenet-checks/utils/deriveCheckState.ts
@@ -1,3 +1,4 @@
+import { ATTESTATION_GRACE_BLOCKS } from '../constants'
 import {
   AttestationVerificationStatus,
   CheckEventType,
@@ -60,7 +61,10 @@ const hasOracleActivity = (events: ReadonlyArray<NormalizedCheckEvent>): boolean
  *  2. Attested → `BENIGN` only if the FROST signature verified,
  *     `VERIFICATION_FAILED` if it did not, else `AWAITING_VERIFICATION`.
  *     Above the deadline check so a late attestation beats `TIMED_OUT`.
- *  3. Past the deadline block → `TIMED_OUT` (incl. frozen disputes).
+ *  3. Past the deadline block plus {@link ATTESTATION_GRACE_BLOCKS} →
+ *     `TIMED_OUT` (incl. frozen disputes). The allowance covers the protocol's
+ *     structural attestation latency: resolution lands at the reveal deadline
+ *     and the committee attests only resolved checks.
  *  4. Any oracle activity → `IN_PROGRESS` (a positive `OracleResult` alone is
  *     NOT `BENIGN` without a verified attestation).
  *  5. Any proposal event → `SUBMITTED`.
@@ -89,7 +93,7 @@ export const deriveCheckState = ({ events, attestation, headBlock }: DeriveCheck
   }
 
   const deadline = deadlineBlockOf(events)
-  if (deadline !== null && headBlock !== null && BigInt(headBlock) > deadline) {
+  if (deadline !== null && headBlock !== null && BigInt(headBlock) > deadline + BigInt(ATTESTATION_GRACE_BLOCKS)) {
     return CheckStatus.TIMED_OUT
   }
 


### PR DESCRIPTION
## What it solves

Every checked transaction flashes "Safenet check failed" before its attestation lands.
The committee attests only RESOLVED checks, and resolution itself lands at the reveal
deadline, so a healthy attestation always trails the deadline — observed at
deadline+5..+11 blocks on Sepolia. `deriveCheckState` declared `TIMED_OUT` the moment
the head passed the deadline, so structural protocol latency rendered as a failure for
~60s on every healthy checked transaction, then upgraded to BENIGN.

## How this PR fixes it

`ATTESTATION_GRACE_BLOCKS = 15`:

- `deriveCheckState` keeps a verdict-less check `IN_PROGRESS` through
  deadline + grace (inclusive) and declares `TIMED_OUT` only past it.
- `computePollingInterval` keeps the fast (6s) cadence through the allowance, so the
  flip to BENIGN does not wait for a slow poll.
- The late window still closes at deadline + `LATE_WINDOW_BLOCKS`; a check that never
  resolves still reaches `TIMED_OUT`, 15 blocks later than before.

The constant carries a ceiling comment: it is a block count standing in for wall-clock
latency, tuned to this file's Gnosis cadence, with the upgrade path named (derive from
`BLOCK_TIME_SECONDS` or express in seconds).

## How to test it

```
yarn workspace @safe-global/utils jest packages/utils/src/features/safenet-checks
yarn workspace @safe-global/utils type-check
```

The specs pin the boundaries: still `IN_PROGRESS` at the deadline, one block past it,
and at deadline+grace; `TIMED_OUT` at deadline+grace+1; polling stays fast through the
allowance and drops to the late interval one block past it (on-chain and
substitute-deadline variants both covered).

## Affected flows

- Queue chip and Safe Shield status of a checked transaction whose attestation is in
  flight: stays "Simulating"/in-progress through the allowance instead of flashing
  "check failed", then upgrades to BENIGN as before.
- Genuinely dead checks (no sentinel activity): `TIMED_OUT` renders 15 blocks
  (~75s at 5s cadence) later than before. Same terminal state.

## Blast radius

- `packages/utils/src/features/safenet-checks/` only: `constants.ts`,
  `deriveCheckState.ts`, `computePollingInterval.ts` and their specs.
- Known consumers, all verified unaffected beyond the intended timing change:
  `packages/store` `safenetCheckApi` (forwards `headBlock` opaquely),
  `useSafenetCheck` (passes snapshot fields through), and two `apps/web` surfaces
  keying off the `CheckStatus.TIMED_OUT` enum value only
  (`statusPresentation.ts`, `SafenetAuditRow.tsx`).
- No RTK Query contract change, no feature flag, no persistence change. Shared
  package, but mobile consumes no changed behavior surface.

## Risks / not checked

- The magnitude 15 is deliberately not pinned by a test (the specs defend "grace ≥ 1"
  and boundary inclusivity against the symbol); a future retune to a wrong value
  passes CI silently. The ceiling comment names the correct derivation.
- 15 blocks is wall-clock-motivated with 4 blocks of margin over the worst observed
  latency; a chain with a faster cadence gets a shorter wall-clock allowance.
- No live-chain run in this PR. The behavior was proven live twice on Sepolia with
  this exact change (rehearsal + recorded take); this PR ports it to `dev` with its
  spec defense.
- Not tested on mobile (no consuming surface).

## Visual summary

```mermaid
flowchart LR
  A[reveal deadline passes] -->|before| B["TIMED_OUT immediately<br/>'check failed' flash ~60s"]
  B -->|attestation lands| C[BENIGN]
  A -->|after| D["IN_PROGRESS through<br/>deadline + 15 blocks<br/>(fast 6s polling)"]
  D -->|attestation lands| C
  D -->|nothing by deadline+16| E[TIMED_OUT]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics change
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
