### PR TITLE
fix: keep the allowance preset listed while typing an amount (WA-3454)

### DIFF
--- a/apps/web/src/components/tx/ApprovalEditor/ApprovalValueField.stories.tsx
+++ b/apps/web/src/components/tx/ApprovalEditor/ApprovalValueField.stories.tsx
@@ -57,9 +57,9 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 /**
- * Editable allowance. The trigger opens a single preset — "Unlimited amount" — which only shows
- * because selection is bound via `value`: Base UI's default single-selection filter otherwise
- * treats the typed amount as a search query and filters the preset out.
+ * Editable allowance. The trigger opens a single preset — "Unlimited amount" — which stays listed
+ * even once an amount is typed, because filtering is disabled. Base UI's default filter would treat
+ * the amount as a search query and leave the popup open around an empty list.
  */
 export const Editable: Story = {
   args: { amount: '420.0' },

--- a/apps/web/src/components/tx/ApprovalEditor/ApprovalValueField.test.tsx
+++ b/apps/web/src/components/tx/ApprovalEditor/ApprovalValueField.test.tsx
@@ -106,4 +106,60 @@ describe('ApprovalValueField', () => {
 
     await waitFor(() => expect(input).toHaveValue(PSEUDO_APPROVAL_VALUES.UNLIMITED))
   })
+
+  // Regression: Base UI's default filter treats the typed amount as a search query. It matches no
+  // preset, so the list empties while the popup stays open — `overflow: hidden` collapses it to
+  // height 0 and only its ring paints, as a hairline under the input, while the input keeps
+  // announcing an expanded listbox with nothing in it.
+  it('keeps the preset listed after typing an amount that matches no preset', async () => {
+    const user = userEvent.setup()
+    render(<Harness approval={buildApproval()} />)
+
+    const input = getAmountInput()
+    await user.click(input)
+    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
+
+    await user.clear(input)
+    await user.type(input, '250')
+    expect(input).toHaveValue('250')
+
+    expect(input).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getAllByRole('option')).toHaveLength(Object.values(PSEUDO_APPROVAL_VALUES).length)
+    expect(screen.getByRole('option', { name: PSEUDO_APPROVAL_VALUES.UNLIMITED })).toBeInTheDocument()
+  })
+
+  it('still applies the preset when it is selected after typing an amount', async () => {
+    const user = userEvent.setup()
+    render(<Harness approval={buildApproval()} />)
+
+    const input = getAmountInput()
+    await user.click(input)
+    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
+
+    await user.clear(input)
+    await user.type(input, '250')
+
+    await user.click(await screen.findByRole('option', { name: PSEUDO_APPROVAL_VALUES.UNLIMITED }))
+
+    await waitFor(() => expect(input).toHaveValue(PSEUDO_APPROVAL_VALUES.UNLIMITED))
+  })
+
+  // The editor is forced read-only for ERC-721 approvals today, so this label is unreachable in the
+  // app. It is pinned so that relaxing that gate cannot silently ship the ERC-20 wording.
+  it('labels an ERC-721 approval as a transfer permission', () => {
+    render(
+      <Harness
+        approval={buildApproval({
+          tokenInfo: {
+            symbol: 'TST',
+            decimals: 0,
+            address: faker.finance.ethereumAddress(),
+            type: TokenType.ERC721,
+          },
+        })}
+      />,
+    )
+
+    expect(screen.getByText('Allow to transfer TST')).toBeInTheDocument()
+  })
 })

--- a/apps/web/src/components/tx/ApprovalEditor/ApprovalValueField.tsx
+++ b/apps/web/src/components/tx/ApprovalEditor/ApprovalValueField.tsx
@@ -37,7 +37,7 @@ export const ApprovalValueField = ({ name, tx, readOnly }: { name: string; tx: A
   const hasError = !!fieldState.error
 
   const symbol = tx.tokenInfo?.symbol ?? ''
-  const labelText = approvalMethodDescription[tx.method](symbol)
+  const labelText = approvalMethodDescription[tx.method](symbol, tx.tokenInfo?.type)
   const showAmountTooltip = tx.tokenInfo?.type === TokenType.ERC20
   const inputId = `${name}-approval-amount`
 
@@ -50,13 +50,15 @@ export const ApprovalValueField = ({ name, tx, readOnly }: { name: string; tx: A
     <Combobox
       items={selectValues}
       // `value` must be bound alongside `inputValue`: Base UI resets the input to the selected
-      // value when the popup closes, so leaving selection uncontrolled wipes a typed amount. It
-      // also feeds the default single-selection filter, which otherwise treats the typed amount as
-      // a search query and hides every preset.
+      // value when the popup closes, so leaving selection uncontrolled wipes a typed amount.
       value={value ?? ''}
       onValueChange={(next) => handleInputChange(typeof next === 'string' ? next : '')}
       inputValue={value ?? ''}
       onInputValueChange={handleInputChange}
+      // Always surface the presets regardless of the typed value. The default filter treats the
+      // amount as a search query, which matches no preset and leaves the popup open around an
+      // empty list — a stray hairline on screen and an expanded listbox with nothing in it.
+      filter={() => true}
       readOnly={readOnly}
       inputRef={ref}
     >


### PR DESCRIPTION
> ### 🤖 This pull request was produced entirely by an automated Claude run
>
> A human wrote the ticket. Everything else — the research, the plan, the code, the tests and this description — came from an automated run with no human in the loop. Please review it the way you would review a new colleague's first pull request: assume nothing, check the reasoning, and push back.

## Ticket

https://linear.app/safe-global/issue/WA-3454/allowance-combobox-stays-expanded-with-an-empty-list-after-typing-an

## What it solves

In the "Allow access to tokens?" block on the transaction review screen, typing an amount into the allowance field left the preset dropdown open with nothing in it. The popup collapsed to zero height and painted its 1px outline as a stray horizontal line just under the input, narrower than the input and offset from it.

The line is the part a person notices. The state behind it is worse: the input kept reporting `aria-expanded="true"` while its list of options was empty, so a screen reader announced an open dropdown with nothing to choose from.

## How this PR fixes it

Turn off filtering on that dropdown, so its one preset — "Unlimited amount" — stays listed while an amount is typed.

The dropdown's list is a fixed set of presets, not search results. Base UI's default filter treats whatever is in the input as a search query, so the first digit you type matches no preset and empties the list. The popup does not close when that happens, and `overflow: hidden` on it means an empty list renders as a zero-height box with a visible outline.

With filtering off the list can never be empty, so there is nothing to collapse. It is also better behaviour: today the preset disappears the instant you type, so someone who enters 250 and then changes their mind has nothing to click.

This is the same one-line configuration the nonce field one directory over already uses, for the same reason.

Two other small things:

- The token type is now passed to the function that builds the field's label, matching the only other place that calls it. This changes nothing a user can see today — the editor is forced read-only whenever an approval is an NFT, so the branch it unlocks is unreachable — but it removes a trap for whoever relaxes that gate later.
- A comment on the field was half wrong once filtering is off, and the story's doc comment said the same wrong thing. Both corrected.

### Why not an empty-state message

The other obvious fix is to render "no presets match" in the popup. Rejected: the preset list has exactly one member, so once filtering is off the list can never be empty and that message would be unreachable from day one. It also reads badly — a dropdown telling you the amount you are deliberately typing is not one of its presets.

## How to test it

Unit tests:

```
yarn workspace @safe-global/web test --testPathPattern=ApprovalEditor
```

Three new tests cover it. All three fail without the production change — I checked by reverting the change and re-running.

By hand, in Storybook:

1. `yarn workspace @safe-global/web storybook`
2. Open **Components / TxFlow / ApprovalValueField** and pick the **Editable** story.
3. Click the input, select all, and type `250`.
4. Look just below the input. You should see the popup with "Unlimited amount" in it — not a thin line.
5. Click "Unlimited amount". The input should switch to it.

In the real app you need a transaction containing an ERC-20 `approve` — a dApp swap that needs an allowance works. Reach the "Allow access to tokens?" block, click the pencil to edit, and type an amount.

## Affected flows

- Editing an allowance amount in the "Allow access to tokens?" block on transaction review, reached from transaction review, sign message, and on-chain sign message.

## Blast radius

- One file changed in production code: `apps/web/src/components/tx/ApprovalEditor/ApprovalValueField.tsx`.
- **No shared surface.** The shared combobox primitive in `components/ui/combobox.tsx` is not modified. The change sets a prop that primitive already forwards.
- No hook, selector, Redux slice, RTK Query endpoint, feature flag, route, or persisted state is touched.
- The import chain is linear and has no other branches: transaction review, sign message and on-chain sign message → `ApprovalEditor/index.tsx` → `ApprovalEditorForm` → `EditableApprovalItem` → `ApprovalValueField`. `ApprovalValueField` has exactly one importer, and so does every link above it.
- **No mobile impact.** Nothing under `packages/` changes; this is a web-only component.
- **No multi-chain impact.** No chain-dependent logic here.
- No Storybook snapshots affected — this story file has no generated snapshot test, and the only story change is a doc comment.

## Risks / not checked

- **A separate known issue on this same field is deliberately not fixed here.** Pressing Escape while the popup is closed clears the typed amount, because the underlying library emits an input-value change in that state. It is tracked separately and needs its own change to the shared primitive, which would affect every combobox in the app. It is unchanged by this PR, in either direction — after typing, the popup is open both before and after the fix, so Escape closes the popup rather than clearing. Details are in the Linear ticket.
- Two lines in this area are load-bearing guardrails, not incidental: `rules.required: true` in `ApprovalValueField` and `disabled={!!fieldErrors || !isDirty}` on the Save button in `EditableApprovalItem`. Together they are the only reason an emptied amount cannot be saved into a transaction. Both are untouched here. **Please do not relax either while tidying this area.**
- **No real approve transaction was exercised.** I have no wallet and no funded Safe, so I could not drive the genuine review screen. Verification is the Storybook story driven with real Chromium clicks and keystrokes, plus unit tests.
- Not checked in dark mode or at narrow viewports. The change adds content to a popup that was previously empty; it introduces no colour or layout rule of its own.
- Keyboard selection of the preset after typing (down-arrow then Enter) is not covered by a test. I did confirm from the library source that Enter alone cannot commit the preset: this combobox leaves auto-highlight off, so nothing is highlighted after typing and Enter only closes the popup.
- I could not check how heavily the approve flow is used, so I cannot put a number on how many people see this.

## Visual summary

Same story, same viewport (1440x900), same data, same scroll position, `250` typed into the field. The only difference is this change.

| Before | After |
| --- | --- |
| ![](https://github.com/safe-global/safe-wallet-monorepo/blob/claude/pr-media/WA-3454/before-allowance-field.png?raw=true) | ![](https://github.com/safe-global/safe-wallet-monorepo/blob/claude/pr-media/WA-3454/after-allowance-field.png?raw=true) |

Measured off the live DOM in the same run that took the screenshots:

| | popup box | options in list | `aria-expanded` |
| --- | --- | --- | --- |
| Before | x 585, y 395.5, w 274, **h 0** | **0** | `true` |
| After | x 585, y 395.5, w 274, **h 40** | **1** | `true` |

Identical position and width; only the height and the contents change.

What actually happens inside the dropdown:

```mermaid
flowchart TB
  subgraph Before
    A1["User types 250"] --> B1["Typed text becomes the filter query"]
    B1 --> C1["No preset matches 250"]
    C1 --> D1["List renders 0 options"]
    D1 --> E1["Popup stays open at height 0"]
    E1 --> F1["Only its outline paints: a stray hairline"]
  end
  subgraph After
    A2["User types 250"] --> B2["Filtering disabled"]
    B2 --> C2["List keeps the Unlimited amount preset"]
    C2 --> D2["Popup has content and a real height"]
    D2 --> E2["Preset still selectable after typing"]
  end
```

## What to review closely

1. **`filter={() => true}` at `ApprovalValueField.tsx:61`** — the whole fix. Worth asking whether keeping "Unlimited amount" permanently on screen next to a typed amount is the behaviour we want on this particular screen. I argued yes, because it matches the nonce field and because a vanishing preset is worse. If product disagrees, the alternative is closing the popup when nothing matches, which is more code and a different feel.
2. **The riskiest thing I could imagine, and how I ruled it out** — could the now-always-visible "Unlimited amount" be committed by accident, turning a typed 250 into an unlimited approval? No. This combobox does not enable auto-highlight, so after typing, nothing in the list is highlighted, and Enter only closes the popup. Selecting the preset takes a deliberate click or an explicit arrow-key move. I traced this through the library's key handler rather than assuming it. **This is the assumption most worth a second pair of eyes**, because it is the one that would matter.
3. **`approvalMethodDescription[tx.method](symbol, tx.tokenInfo?.type)` at `ApprovalValueField.tsx:40`** — confirm you agree the ERC-20 label is byte-identical (the function only branches on the NFT case), so this is inert for every reachable input today.
4. **The path I could not test** — a real dApp approve transaction. If you have a funded test Safe, the manual steps above are the check I could not run.

## Self-review

Ran `safe-engineering-plugin:safe-code-review` — the nine-pass review with paired agents independently proving and attacking each finding.

**Verdict: open it.** One finding across nine passes, a nit, resolved as deferred with a reason.

| Area | Score | Note |
| --- | --- | --- |
| Security | 100 | 0 findings. The accidental-unlimited-approval path was traced through library source and refuted. Both guardrails verified intact. |
| Bugs | 100 | 0 findings. Filter-memo identity, the label argument, and validation interactions all traced. |
| Regression | 100 | 0 findings. Call-site ledger built for both changed symbols; existing tests re-run. |
| Testing | 100 | 0 findings above the floor. The pass rebuilt the pre-fix state itself and confirmed all three new tests fail without the change. |
| Architecture | not applicable | Below the surface threshold: one file, no new file or directory, no new cross-module import. Rules were run anyway; none fired. |
| Performance | 100 | 0 findings. The inline arrow does re-run a memo each render; quantified as one comparison over a one-element array, and the same memo already recomputed every keystroke before this change. Dropped as noise, not downgraded. |
| DRY | 95 | 1 nit — see below. |
| KISS | 100 | 0 findings. Confirmed rejecting the empty-state and close-on-empty alternatives was right. |
| Conventions | 100 | 0 findings. `filter={() => true}` is the repo's only idiom for this — three call sites, zero using the alternative spelling. |

**Findings and resolutions**

- **DRY, nit — `filter={() => true}` now appears at three call sites with no shared name.** Suggested remedy was to export a named constant from the shared combobox file and use it at all three.
  **Deferred.** Two reasons. First, two of the three sites are unrelated to this ticket, so applying it means editing files outside this fix. Second, the refuting agent found the three sites do not actually share one rationale: two disable filtering to keep presets visible, while the third does it because its options are already filtered upstream. One constant would put one name on two different justifications. The validating agent independently confirmed the duplication is real and the severity is right; the refuter weakened the framing rather than killing it. Recorded in the ticket for whoever owns the design system. Not fixed here, on purpose.
- **Testing, below threshold, not filed.** One assertion derives its expected option count from the same constant the component reads. The pass judged it discriminating (it fails without the fix) but redundant with the very next line while the preset list has one member. Left as is.

Nothing else surfaced. Both refuted and deferred items are listed above rather than dropped, so you can see what was checked and ruled out.

## How I got here

1. Read the ticket, all of it, and the two attached screenshots.
2. **Verified the ticket's claims instead of trusting them**, and found two things wrong with it. It points at a story file and a story name as the ready-made verification target; neither exists on `dev`, so I pinned the regression in the unit test file instead. And its first suggested fix, an empty-state element, turns out to be unreachable once filtering is off — so I rejected the suggestion and said why.
3. **Confirmed the root cause in the library's own source** rather than inferring it from the symptom. The filter that runs depends on whether the query has changed since the popup opened; the first keystroke flips that, dropping from a filter that spares the selection to a plain text match. That is why the list is full when the dropdown opens and empty one keystroke later, which is exactly the behaviour reported.
4. **Looked for an existing solution before writing one.** The nonce field is the same shape of control — free-text number, a short preset list, the same controlled-value wiring — and already carries this exact line with a comment giving the same reason. That turned an invention into a convergence.
5. Traced consumers by import to establish the blast radius, and confirmed the NFT read-only gate the ticket describes really is the only way into this component.
6. **Checked the internal sources.** The ticket points at internal research about this same field; I read it in full, and it changed the shape of this PR: it is why the fix is scoped narrowly, why two guardrail lines are called out above and left alone, and why I did not bundle the adjacent Escape problem into this change. It also told me which specific thing to prove was safe. The supporting material and figures stay in the Linear ticket. I also checked our error tracking for this area over the last 30 days and found nothing, which is expected — this defect throws no error — so the ticket's DOM measurements remain the evidence, not telemetry.
7. Wrote the fix, wrote the tests, then **reverted the fix and re-ran to prove each test actually fails without it.** All three did.
8. Ran the repo's own verify pipeline: 661 suites, 5735 tests, plus type-check, lint and formatting. Green.
9. Captured before and after from the same story, driving real clicks and keystrokes, measuring the DOM in the same run so the numbers above are read rather than eyeballed.

## Trade-offs

- **Disable filtering vs. close the popup when nothing matches.** Chose disabling. It is one line, it matches the sibling field, and it leaves the preset reachable after typing. Closing the popup would also remove the hairline but keeps the preset vanishing, and means new open/close logic on a field where the open/close machinery is exactly what is already delicate.
- **Disable filtering vs. render an empty state.** Chose disabling; the empty state would be unreachable code and worse wording. Reasoned above.
- **`filter={() => true}` vs. `filter={null}`.** The library treats `null` as its own stable no-op filter, which is marginally more efficient because it does not create a new function each render. I chose the arrow anyway, for consistency: it is the spelling both existing call sites use, and there are none using `null`. The efficiency difference was measured at one comparison over a one-element array. Switching all three sites to `null` would be a reasonable separate cleanup, not something to do unilaterally inside a bug fix.
- **Configure the primitive from the feature vs. change the primitive's default.** Chose configuring here. Making no-filter the default would silently change every other combobox in the app, including ones that rely on real type-to-filter.
- **Fix the adjacent Escape problem in the same PR vs. leave it.** Left it. It needs a change to the shared primitive that every combobox consumer inherits, on a screen where amounts matter. It deserves its own change and its own review, not a ride along on a one-line fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxAQwfVZHNXtECTfezwD5u)_