### PR TITLE
feat(safe-pro): billing-details reminder modal for active trials

### DIFF
--- a/apps/web/src/features/safe-pro-announcement/components/SafeProBillingReminderModal/SafeProBillingReminderModal.stories.test.tsx
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProBillingReminderModal/SafeProBillingReminderModal.stories.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * Auto-generated snapshot tests for Storybook stories
+ * Run "yarn generate:storybook-tests" to regenerate
+ */
+import '../../../../tests/storybook-setup'
+import { composeStories } from '@storybook/react'
+import { render } from '@testing-library/react'
+import type { ComponentType } from 'react'
+
+import * as stories from './SafeProBillingReminderModal.stories'
+
+const composedStories = composeStories(stories)
+
+describe('./SafeProBillingReminderModal.stories', () => {
+  Object.entries(composedStories).forEach(([storyName, Story]) => {
+    test(storyName, () => {
+      const StoryComponent = Story as ComponentType
+      const { container } = render(<StoryComponent />)
+      expect(container.firstChild).toMatchSnapshot()
+    })
+  })
+})

--- a/apps/web/src/features/safe-pro-announcement/components/SafeProBillingReminderModal/SafeProBillingReminderModal.stories.tsx
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProBillingReminderModal/SafeProBillingReminderModal.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import SafeProBillingReminderModal from './index'
+
+const meta = {
+  component: SafeProBillingReminderModal,
+  title: 'Features/SafePro/SafeProBillingReminderModal',
+  tags: ['autodocs'],
+  args: { open: true, onOpenChange: () => {}, onAddBillingDetails: () => {}, trialEndsAt: Date.UTC(2026, 11, 1) },
+} satisfies Meta<typeof SafeProBillingReminderModal>
+
+export default meta
+
+export const Default: StoryObj<typeof meta> = {}

--- a/apps/web/src/features/safe-pro-announcement/components/SafeProBillingReminderModal/__snapshots__/SafeProBillingReminderModal.stories.test.tsx.snap
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProBillingReminderModal/__snapshots__/SafeProBillingReminderModal.stories.test.tsx.snap
@@ -1,0 +1,169 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`./SafeProBillingReminderModal.stories Default 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+>
+  <div
+    class="shadcn-scope"
+  >
+    <div
+      data-base-ui-portal=""
+      data-slot="dialog-portal"
+      id="_r_2_"
+    >
+      <div
+        aria-hidden="true"
+        data-base-ui-inert=""
+        role="presentation"
+        style="position: fixed; inset: 0; user-select: none;"
+      />
+      <div
+        aria-hidden="true"
+        class="bg-backdrop supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-[var(--z-overlay)] duration-100 data-open:animate-in data-closed:animate-out data-open:fade-in-0 data-closed:fade-out-0 data-starting-style:opacity-0 data-ending-style:opacity-0 data-closed:pointer-events-none"
+        data-base-ui-inert=""
+        data-open=""
+        data-slot="dialog-overlay"
+        role="presentation"
+        style="user-select: none;"
+      />
+      <span
+        data-base-ui-focus-guard=""
+        data-type="inside"
+        role="button"
+        style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: fixed; top: 0px; left: 0px;"
+        tabindex="0"
+      />
+      <div
+        aria-labelledby="base-ui-_r_3_"
+        class="data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-starting-style:opacity-0 data-ending-style:opacity-0 fixed top-[50%] left-[50%] z-[var(--z-overlay)] w-full -translate-x-1/2 -translate-y-1/2 rounded-xl shadow-lg duration-200 max-w-[600px] p-0 bg-card"
+        data-base-ui-focusable=""
+        data-open=""
+        data-slot="dialog-content"
+        id="_r_0_"
+        role="dialog"
+        style="--nested-dialogs: 0;"
+        tabindex="-1"
+      >
+        <div
+          class="p-1 pb-2"
+        >
+          <div
+            class="relative w-full overflow-hidden rounded-t-[calc(var(--radius-xl)-4px)] aspect-[568/369] *:object-left"
+          >
+            <img
+              alt="A Workspace from Safe Pro, with its accounts, members and transactions"
+              class="object-cover dark:hidden"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              sizes="100vw"
+              src="/_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=3840&q=75"
+              srcset="/_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=640&q=75 640w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=750&q=75 750w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=828&q=75 828w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=1080&q=75 1080w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=1200&q=75 1200w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=1920&q=75 1920w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=2048&q=75 2048w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=3840&q=75 3840w"
+              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+            />
+            <img
+              alt="A Workspace from Safe Pro, with its accounts, members and transactions"
+              class="hidden object-cover dark:block"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              src="/images/safe-pro/pro-announcement-hero-dark.svg"
+              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+            />
+          </div>
+          <div
+            class="flex flex-col gap-8 px-7 pt-6 pb-4"
+          >
+            <div
+              class="flex flex-col gap-2"
+            >
+              <h2
+                class="text-foreground m-0 scroll-m-20 text-2xl font-semibold leading-[28.8px] tracking-normal block w-full text-center"
+                data-slot="typography"
+                data-variant="h3"
+                id="base-ui-_r_3_"
+              >
+                Add billing details to continue with 
+                <span
+                  class="highlight"
+                >
+                  Safe Pro
+                </span>
+              </h2>
+              <p
+                class="m-0 text-base leading-6 font-normal block w-full text-center text-muted-foreground"
+                data-slot="typography"
+                data-variant="paragraph"
+              >
+                If you don't add billing details by 
+                Dec 1, 2026
+                , your Workspace will be locked. Your Safe accounts remain available outside the Workspace.
+              </p>
+            </div>
+            <div
+              class="flex gap-4"
+            >
+              <button
+                class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 outline-none group/button select-none bg-secondary text-secondary-foreground hover:bg-secondary-hover aria-expanded:bg-secondary-hover aria-expanded:text-secondary-foreground h-10 gap-1.5 px-4 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3 flex-1"
+                data-slot="button"
+                tabindex="0"
+                type="button"
+              >
+                Not now
+              </button>
+              <button
+                class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 outline-none group/button select-none bg-primary text-primary-foreground hover:bg-primary/80 disabled:bg-muted disabled:text-muted-foreground aria-disabled:bg-muted aria-disabled:text-muted-foreground disabled:[&_svg]:text-muted-foreground aria-disabled:[&_svg]:text-muted-foreground dark:[&_svg]:text-black dark:disabled:bg-muted dark:disabled:text-muted-foreground dark:aria-disabled:bg-muted dark:aria-disabled:text-muted-foreground dark:disabled:[&_svg]:text-muted-foreground dark:aria-disabled:[&_svg]:text-muted-foreground h-10 gap-1.5 px-4 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3 flex-1"
+                data-slot="button"
+                tabindex="0"
+                type="button"
+              >
+                Add billing details
+              </button>
+            </div>
+          </div>
+        </div>
+        <button
+          class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground size-8 in-data-[slot=button-group]:rounded-sm absolute top-4 right-4"
+          data-slot="dialog-close"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-x"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M18 6 6 18"
+            />
+            <path
+              d="m6 6 12 12"
+            />
+          </svg>
+          <span
+            class="sr-only"
+          >
+            Close
+          </span>
+        </button>
+      </div>
+      <span
+        data-base-ui-focus-guard=""
+        data-type="inside"
+        role="button"
+        style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: fixed; top: 0px; left: 0px;"
+        tabindex="0"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/apps/web/src/features/safe-pro-announcement/components/SafeProBillingReminderModal/__tests__/index.test.tsx
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProBillingReminderModal/__tests__/index.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent, render, screen } from '@/tests/test-utils'
+import SafeProBillingReminderModal from '../index'
+
+describe('SafeProBillingReminderModal', () => {
+  it('shows the lock date, dismisses from "Not now" and fires the billing CTA', () => {
+    const onOpenChange = jest.fn()
+    const onAddBillingDetails = jest.fn()
+    render(
+      <SafeProBillingReminderModal
+        open
+        onOpenChange={onOpenChange}
+        onAddBillingDetails={onAddBillingDetails}
+        trialEndsAt={Date.UTC(2026, 11, 1, 12)}
+      />,
+    )
+
+    expect(screen.getByText(/by Dec 1, 2026, your Workspace will be locked/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Not now' }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add billing details' }))
+    expect(onAddBillingDetails).toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/features/safe-pro-announcement/components/SafeProBillingReminderModal/index.tsx
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProBillingReminderModal/index.tsx
@@ -1,0 +1,49 @@
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { Typography } from '@/components/ui/typography'
+import { formatDate } from '@safe-global/utils/utils/date'
+import SafeProHero from '../SafeProHero'
+import css from '../SafeProAnnouncement/styles.module.css'
+
+const SafeProBillingReminderModal = ({
+  open,
+  onOpenChange,
+  trialEndsAt,
+  onAddBillingDetails,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  trialEndsAt: number
+  onAddBillingDetails: () => void
+}) => (
+  <Dialog open={open} onOpenChange={onOpenChange}>
+    <DialogContent size="sm" surface="card" padding="none">
+      <div className="p-1 pb-2">
+        <SafeProHero variant="tall" />
+
+        <div className="flex flex-col gap-8 px-7 pt-6 pb-4">
+          <div className="flex flex-col gap-2">
+            <Typography variant="h3" align="center" as={DialogTitle}>
+              Add billing details to continue with <span className={css.highlight}>Safe Pro</span>
+            </Typography>
+            <Typography color="muted" align="center">
+              If you don&apos;t add billing details by {formatDate(trialEndsAt)}, your Workspace will be locked. Your
+              Safe accounts remain available outside the Workspace.
+            </Typography>
+          </div>
+
+          <div className="flex gap-4">
+            <Button variant="secondary" size="lg" className="flex-1" onClick={() => onOpenChange(false)}>
+              Not now
+            </Button>
+            <Button size="lg" className="flex-1" onClick={onAddBillingDetails}>
+              Add billing details
+            </Button>
+          </div>
+        </div>
+      </div>
+    </DialogContent>
+  </Dialog>
+)
+
+export default SafeProBillingReminderModal

--- a/apps/web/src/features/safe-pro-announcement/contract.ts
+++ b/apps/web/src/features/safe-pro-announcement/contract.ts
@@ -2,6 +2,7 @@ import type SafeProAnnouncement from './components/SafeProAnnouncement'
 import type SafeProAnnouncementModal from './components/SafeProAnnouncementModal'
 import type SafeProLockedWorkspace from './components/SafeProLockedWorkspace'
 import type SafeProTrialActivatedModal from './components/SafeProTrialActivatedModal'
+import type SafeProBillingReminderModal from './components/SafeProBillingReminderModal'
 import type SafeProBanner from './components/SafeProBanner'
 import type SafeProSidebarBanner from './components/SafeProSidebarBanner'
 import type SafeProWorkspacesBanner from './components/SafeProWorkspacesBanner'
@@ -11,6 +12,7 @@ export interface SafeProContract {
   SafeProAnnouncementModal: typeof SafeProAnnouncementModal
   SafeProLockedWorkspace: typeof SafeProLockedWorkspace
   SafeProTrialActivatedModal: typeof SafeProTrialActivatedModal
+  SafeProBillingReminderModal: typeof SafeProBillingReminderModal
   SafeProBanner: typeof SafeProBanner
   SafeProSidebarBanner: typeof SafeProSidebarBanner
   SafeProWorkspacesBanner: typeof SafeProWorkspacesBanner

--- a/apps/web/src/features/safe-pro-announcement/feature.ts
+++ b/apps/web/src/features/safe-pro-announcement/feature.ts
@@ -4,6 +4,7 @@ import SafeProAnnouncement from './components/SafeProAnnouncement'
 import SafeProAnnouncementModal from './components/SafeProAnnouncementModal'
 import SafeProLockedWorkspace from './components/SafeProLockedWorkspace'
 import SafeProTrialActivatedModal from './components/SafeProTrialActivatedModal'
+import SafeProBillingReminderModal from './components/SafeProBillingReminderModal'
 import SafeProBanner from './components/SafeProBanner'
 import SafeProSidebarBanner from './components/SafeProSidebarBanner'
 import SafeProWorkspacesBanner from './components/SafeProWorkspacesBanner'
@@ -13,6 +14,7 @@ export default {
   SafeProAnnouncementModal,
   SafeProLockedWorkspace,
   SafeProTrialActivatedModal,
+  SafeProBillingReminderModal,
   SafeProBanner,
   SafeProSidebarBanner,
   SafeProWorkspacesBanner,

--- a/apps/web/src/features/spaces/components/Plans/Page.tsx
+++ b/apps/web/src/features/spaces/components/Plans/Page.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { Card } from '@/components/ui/card'
 import { Typography } from '@/components/ui/typography'
 import { useDarkMode } from '@/hooks/useDarkMode'
@@ -5,15 +6,29 @@ import { useHasFeature } from '@/hooks/useChains'
 import { cn } from '@/utils/cn'
 import { useLoadFeature } from '@/features/__core__'
 import { SafeProFeature } from '@/features/safe-pro-announcement'
+import { localItem } from '@/services/local-storage/local'
 import { FEATURES } from '@safe-global/utils/utils/chains'
 import AuthState from '../AuthState'
 import Plans from './index'
 import { TRIAL_PLANS } from './fixtures'
 
+const reminderSeen = localItem<boolean>('safeProBillingReminderSeen')
+
 export default function SpacePlansPage({ spaceId }: { spaceId: string }) {
   const isDarkMode = useDarkMode()
   const isSafePro = useHasFeature(FEATURES.SAFE_PRO)
-  const { SafeProAnnouncement } = useLoadFeature(SafeProFeature)
+  const { SafeProAnnouncement, SafeProBillingReminderModal } = useLoadFeature(SafeProFeature)
+  const isTrial = isSafePro && TRIAL_PLANS.plan?.status === 'trialing'
+  const [isReminderOpen, setIsReminderOpen] = useState(false)
+
+  useEffect(() => {
+    if (isTrial && !reminderSeen.get()) setIsReminderOpen(true)
+  }, [isTrial])
+
+  const closeReminder = () => {
+    reminderSeen.set(true)
+    setIsReminderOpen(false)
+  }
 
   return (
     <AuthState spaceId={spaceId}>
@@ -29,6 +44,13 @@ export default function SpacePlansPage({ spaceId }: { spaceId: string }) {
             <SafeProAnnouncement />
           </Card>
         )}
+
+        <SafeProBillingReminderModal
+          open={isReminderOpen}
+          onOpenChange={closeReminder}
+          trialEndsAt={TRIAL_PLANS.plan?.periodEndsAt ? new Date(TRIAL_PLANS.plan.periodEndsAt).getTime() : 0}
+          onAddBillingDetails={closeReminder}
+        />
       </div>
     </AuthState>
   )


### PR DESCRIPTION
## What it solves

Resolves: https://linear.app/safe-global/issue/PLA-1924/active-trial-billing-details-reminder-modal

Adds the billing-details reminder that opens to a Workspace member to add billing details before an active Safe Pro trial locks.

## How this PR fixes it

Adding a new `SafeProBillingReminderModal`

## How to test it

1. Enable `SAFE_PRO` and `SAFE_PRO_ANNOUNCEMENT` via the Developer > Feature flags sidebar entry.
2. Open a Workspace > Plans. The reminder opens once; "Not now" dismisses and it stays dismissed on reload.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [X] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
