### PR TITLE
feat(safe-pro): subscription-activated modal after checkout

### DIFF
--- a/apps/web/src/features/safe-pro-announcement/components/SafeProSubscriptionActivatedModal/SafeProSubscriptionActivatedModal.stories.test.tsx
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProSubscriptionActivatedModal/SafeProSubscriptionActivatedModal.stories.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * Auto-generated snapshot tests for Storybook stories
+ * Run "yarn generate:storybook-tests" to regenerate
+ */
+import '../../../../tests/storybook-setup'
+import { composeStories } from '@storybook/react'
+import { render } from '@testing-library/react'
+import type { ComponentType } from 'react'
+
+import * as stories from './SafeProSubscriptionActivatedModal.stories'
+
+const composedStories = composeStories(stories)
+
+describe('./SafeProSubscriptionActivatedModal.stories', () => {
+  Object.entries(composedStories).forEach(([storyName, Story]) => {
+    test(storyName, () => {
+      const StoryComponent = Story as ComponentType
+      const { container } = render(<StoryComponent />)
+      expect(container.firstChild).toMatchSnapshot()
+    })
+  })
+})

--- a/apps/web/src/features/safe-pro-announcement/components/SafeProSubscriptionActivatedModal/SafeProSubscriptionActivatedModal.stories.tsx
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProSubscriptionActivatedModal/SafeProSubscriptionActivatedModal.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import SafeProSubscriptionActivatedModal from './index'
+
+const meta = {
+  component: SafeProSubscriptionActivatedModal,
+  title: 'Features/SafePro/SafeProSubscriptionActivatedModal',
+  tags: ['autodocs'],
+  args: {
+    open: true,
+    onOpenChange: () => {},
+    planName: 'Business',
+    price: 499,
+    currency: 'eur',
+    billingCycle: 'month',
+    nextBillingAt: Date.UTC(2026, 9, 1),
+  },
+} satisfies Meta<typeof SafeProSubscriptionActivatedModal>
+
+export default meta
+
+export const Default: StoryObj<typeof meta> = {}
+
+export const Yearly: StoryObj<typeof meta> = { args: { price: 5389, billingCycle: 'year' } }

--- a/apps/web/src/features/safe-pro-announcement/components/SafeProSubscriptionActivatedModal/SafeProSubscriptionActivatedModal.stories.tsx
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProSubscriptionActivatedModal/SafeProSubscriptionActivatedModal.stories.tsx
@@ -11,8 +11,7 @@ const meta = {
     planName: 'Business',
     price: 499,
     currency: 'eur',
-    billingCycle: 'month',
-    nextBillingAt: Date.UTC(2026, 9, 1),
+    nextBillingAt: Date.UTC(2026, 10, 1),
   },
 } satisfies Meta<typeof SafeProSubscriptionActivatedModal>
 
@@ -20,4 +19,4 @@ export default meta
 
 export const Default: StoryObj<typeof meta> = {}
 
-export const Yearly: StoryObj<typeof meta> = { args: { price: 5389, billingCycle: 'year' } }
+export const Yearly: StoryObj<typeof meta> = { args: { price: 5389 } }

--- a/apps/web/src/features/safe-pro-announcement/components/SafeProSubscriptionActivatedModal/__snapshots__/SafeProSubscriptionActivatedModal.stories.test.tsx.snap
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProSubscriptionActivatedModal/__snapshots__/SafeProSubscriptionActivatedModal.stories.test.tsx.snap
@@ -84,27 +84,23 @@ exports[`./SafeProSubscriptionActivatedModal.stories Default 1`] = `
                 data-variant="h3"
                 id="base-ui-_r_3_"
               >
-                Your Workspace is now on 
+                Your paid subscription is active, you're on 
                 <span
                   class="highlight"
                 >
-                  Safe Pro
+                  Business
                 </span>
+                !
               </h2>
               <p
                 class="m-0 text-base leading-6 font-normal block w-full text-center text-muted-foreground"
                 data-slot="typography"
                 data-variant="paragraph"
               >
-                Business
-                 plan, 
+                You'll pay 
                 €499
-                 per 
-                month
-                . Your next payment is on
-                 
-                Oct 1, 2026
-                .
+                 on 
+                Nov 1, 2026
               </p>
             </div>
             <button
@@ -246,27 +242,23 @@ exports[`./SafeProSubscriptionActivatedModal.stories Yearly 1`] = `
                 data-variant="h3"
                 id="base-ui-_r_7_"
               >
-                Your Workspace is now on 
+                Your paid subscription is active, you're on 
                 <span
                   class="highlight"
                 >
-                  Safe Pro
+                  Business
                 </span>
+                !
               </h2>
               <p
                 class="m-0 text-base leading-6 font-normal block w-full text-center text-muted-foreground"
                 data-slot="typography"
                 data-variant="paragraph"
               >
-                Business
-                 plan, 
+                You'll pay 
                 €5,389
-                 per 
-                year
-                . Your next payment is on
-                 
-                Oct 1, 2026
-                .
+                 on 
+                Nov 1, 2026
               </p>
             </div>
             <button

--- a/apps/web/src/features/safe-pro-announcement/components/SafeProSubscriptionActivatedModal/__snapshots__/SafeProSubscriptionActivatedModal.stories.test.tsx.snap
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProSubscriptionActivatedModal/__snapshots__/SafeProSubscriptionActivatedModal.stories.test.tsx.snap
@@ -1,0 +1,325 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`./SafeProSubscriptionActivatedModal.stories Default 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+>
+  <div
+    class="shadcn-scope"
+  >
+    <div
+      data-base-ui-portal=""
+      data-slot="dialog-portal"
+      id="_r_2_"
+    >
+      <div
+        aria-hidden="true"
+        data-base-ui-inert=""
+        role="presentation"
+        style="position: fixed; inset: 0; user-select: none;"
+      />
+      <div
+        aria-hidden="true"
+        class="bg-backdrop supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-[var(--z-overlay)] duration-100 data-open:animate-in data-closed:animate-out data-open:fade-in-0 data-closed:fade-out-0 data-starting-style:opacity-0 data-ending-style:opacity-0 data-closed:pointer-events-none"
+        data-base-ui-inert=""
+        data-open=""
+        data-slot="dialog-overlay"
+        role="presentation"
+        style="user-select: none;"
+      />
+      <span
+        data-base-ui-focus-guard=""
+        data-type="inside"
+        role="button"
+        style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: fixed; top: 0px; left: 0px;"
+        tabindex="0"
+      />
+      <div
+        aria-labelledby="base-ui-_r_3_"
+        class="data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-starting-style:opacity-0 data-ending-style:opacity-0 fixed top-[50%] left-[50%] z-[var(--z-overlay)] w-full -translate-x-1/2 -translate-y-1/2 rounded-xl shadow-lg duration-200 max-w-[600px] p-0 bg-card"
+        data-base-ui-focusable=""
+        data-open=""
+        data-slot="dialog-content"
+        id="_r_0_"
+        role="dialog"
+        style="--nested-dialogs: 0;"
+        tabindex="-1"
+      >
+        <div
+          class="p-1 pb-2"
+        >
+          <div
+            class="relative w-full overflow-hidden rounded-t-[calc(var(--radius-xl)-4px)] aspect-[568/369] *:object-left"
+          >
+            <img
+              alt="A Workspace from Safe Pro, with its accounts, members and transactions"
+              class="object-cover dark:hidden"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              sizes="100vw"
+              src="/_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=3840&q=75"
+              srcset="/_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=640&q=75 640w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=750&q=75 750w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=828&q=75 828w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=1080&q=75 1080w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=1200&q=75 1200w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=1920&q=75 1920w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=2048&q=75 2048w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=3840&q=75 3840w"
+              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+            />
+            <img
+              alt="A Workspace from Safe Pro, with its accounts, members and transactions"
+              class="hidden object-cover dark:block"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              src="/images/safe-pro/pro-announcement-hero-dark.svg"
+              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+            />
+          </div>
+          <div
+            class="flex flex-col items-center gap-8 px-8 pt-6 pb-4"
+          >
+            <div
+              class="flex flex-col gap-2"
+            >
+              <h2
+                class="text-foreground m-0 scroll-m-20 text-2xl font-semibold leading-[28.8px] tracking-normal block w-full text-center"
+                data-slot="typography"
+                data-variant="h3"
+                id="base-ui-_r_3_"
+              >
+                Your Workspace is now on 
+                <span
+                  class="highlight"
+                >
+                  Safe Pro
+                </span>
+              </h2>
+              <p
+                class="m-0 text-base leading-6 font-normal block w-full text-center text-muted-foreground"
+                data-slot="typography"
+                data-variant="paragraph"
+              >
+                Business
+                 plan, 
+                €499
+                 per 
+                month
+                . Your next payment is on
+                 
+                Oct 1, 2026
+                .
+              </p>
+            </div>
+            <button
+              class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none bg-primary text-primary-foreground hover:bg-primary/80 disabled:bg-muted disabled:text-muted-foreground aria-disabled:bg-muted aria-disabled:text-muted-foreground disabled:[&_svg]:text-muted-foreground aria-disabled:[&_svg]:text-muted-foreground dark:[&_svg]:text-black dark:disabled:bg-muted dark:disabled:text-muted-foreground dark:aria-disabled:bg-muted dark:aria-disabled:text-muted-foreground dark:disabled:[&_svg]:text-muted-foreground dark:aria-disabled:[&_svg]:text-muted-foreground h-10 gap-1.5 px-4 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3 w-full"
+              data-slot="button"
+              tabindex="0"
+              type="button"
+            >
+              Go to Workspace
+            </button>
+          </div>
+        </div>
+        <button
+          class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground size-8 in-data-[slot=button-group]:rounded-sm absolute top-4 right-4"
+          data-slot="dialog-close"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-x"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M18 6 6 18"
+            />
+            <path
+              d="m6 6 12 12"
+            />
+          </svg>
+          <span
+            class="sr-only"
+          >
+            Close
+          </span>
+        </button>
+      </div>
+      <span
+        data-base-ui-focus-guard=""
+        data-type="inside"
+        role="button"
+        style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: fixed; top: 0px; left: 0px;"
+        tabindex="0"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`./SafeProSubscriptionActivatedModal.stories Yearly 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+>
+  <div
+    class="shadcn-scope"
+  >
+    <div
+      data-base-ui-portal=""
+      data-slot="dialog-portal"
+      id="_r_6_"
+    >
+      <div
+        aria-hidden="true"
+        data-base-ui-inert=""
+        role="presentation"
+        style="position: fixed; inset: 0; user-select: none;"
+      />
+      <div
+        aria-hidden="true"
+        class="bg-backdrop supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-[var(--z-overlay)] duration-100 data-open:animate-in data-closed:animate-out data-open:fade-in-0 data-closed:fade-out-0 data-starting-style:opacity-0 data-ending-style:opacity-0 data-closed:pointer-events-none"
+        data-base-ui-inert=""
+        data-open=""
+        data-slot="dialog-overlay"
+        role="presentation"
+        style="user-select: none;"
+      />
+      <span
+        data-base-ui-focus-guard=""
+        data-type="inside"
+        role="button"
+        style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: fixed; top: 0px; left: 0px;"
+        tabindex="0"
+      />
+      <div
+        aria-labelledby="base-ui-_r_7_"
+        class="data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-starting-style:opacity-0 data-ending-style:opacity-0 fixed top-[50%] left-[50%] z-[var(--z-overlay)] w-full -translate-x-1/2 -translate-y-1/2 rounded-xl shadow-lg duration-200 max-w-[600px] p-0 bg-card"
+        data-base-ui-focusable=""
+        data-open=""
+        data-slot="dialog-content"
+        id="_r_4_"
+        role="dialog"
+        style="--nested-dialogs: 0;"
+        tabindex="-1"
+      >
+        <div
+          class="p-1 pb-2"
+        >
+          <div
+            class="relative w-full overflow-hidden rounded-t-[calc(var(--radius-xl)-4px)] aspect-[568/369] *:object-left"
+          >
+            <img
+              alt="A Workspace from Safe Pro, with its accounts, members and transactions"
+              class="object-cover dark:hidden"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              sizes="100vw"
+              src="/_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=3840&q=75"
+              srcset="/_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=640&q=75 640w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=750&q=75 750w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=828&q=75 828w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=1080&q=75 1080w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=1200&q=75 1200w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=1920&q=75 1920w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=2048&q=75 2048w, /_next/image?url=%2Fimages%2Fsafe-pro%2Fpro-announcement-hero.jpg&w=3840&q=75 3840w"
+              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+            />
+            <img
+              alt="A Workspace from Safe Pro, with its accounts, members and transactions"
+              class="hidden object-cover dark:block"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              src="/images/safe-pro/pro-announcement-hero-dark.svg"
+              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+            />
+          </div>
+          <div
+            class="flex flex-col items-center gap-8 px-8 pt-6 pb-4"
+          >
+            <div
+              class="flex flex-col gap-2"
+            >
+              <h2
+                class="text-foreground m-0 scroll-m-20 text-2xl font-semibold leading-[28.8px] tracking-normal block w-full text-center"
+                data-slot="typography"
+                data-variant="h3"
+                id="base-ui-_r_7_"
+              >
+                Your Workspace is now on 
+                <span
+                  class="highlight"
+                >
+                  Safe Pro
+                </span>
+              </h2>
+              <p
+                class="m-0 text-base leading-6 font-normal block w-full text-center text-muted-foreground"
+                data-slot="typography"
+                data-variant="paragraph"
+              >
+                Business
+                 plan, 
+                €5,389
+                 per 
+                year
+                . Your next payment is on
+                 
+                Oct 1, 2026
+                .
+              </p>
+            </div>
+            <button
+              class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none bg-primary text-primary-foreground hover:bg-primary/80 disabled:bg-muted disabled:text-muted-foreground aria-disabled:bg-muted aria-disabled:text-muted-foreground disabled:[&_svg]:text-muted-foreground aria-disabled:[&_svg]:text-muted-foreground dark:[&_svg]:text-black dark:disabled:bg-muted dark:disabled:text-muted-foreground dark:aria-disabled:bg-muted dark:aria-disabled:text-muted-foreground dark:disabled:[&_svg]:text-muted-foreground dark:aria-disabled:[&_svg]:text-muted-foreground h-10 gap-1.5 px-4 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3 w-full"
+              data-slot="button"
+              tabindex="0"
+              type="button"
+            >
+              Go to Workspace
+            </button>
+          </div>
+        </div>
+        <button
+          class="focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground size-8 in-data-[slot=button-group]:rounded-sm absolute top-4 right-4"
+          data-slot="dialog-close"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-x"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M18 6 6 18"
+            />
+            <path
+              d="m6 6 12 12"
+            />
+          </svg>
+          <span
+            class="sr-only"
+          >
+            Close
+          </span>
+        </button>
+      </div>
+      <span
+        data-base-ui-focus-guard=""
+        data-type="inside"
+        role="button"
+        style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: fixed; top: 0px; left: 0px;"
+        tabindex="0"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/apps/web/src/features/safe-pro-announcement/components/SafeProSubscriptionActivatedModal/__tests__/index.test.tsx
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProSubscriptionActivatedModal/__tests__/index.test.tsx
@@ -11,13 +11,12 @@ describe('SafeProSubscriptionActivatedModal', () => {
         planName="Business"
         price={499}
         currency="eur"
-        billingCycle="month"
-        nextBillingAt={Date.UTC(2026, 9, 1, 12)}
+        nextBillingAt={Date.UTC(2026, 10, 1, 12)}
       />,
     )
 
-    expect(screen.getByRole('heading')).toHaveTextContent('Your Workspace is now on Safe Pro')
-    expect(screen.getByText('Business plan, €499 per month. Your next payment is on Oct 1, 2026.')).toBeInTheDocument()
+    expect(screen.getByRole('heading')).toHaveTextContent("Your paid subscription is active, you're on Business!")
+    expect(screen.getByText("You'll pay €499 on Nov 1, 2026")).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Go to Workspace' }))
     expect(onOpenChange).toHaveBeenCalledWith(false)

--- a/apps/web/src/features/safe-pro-announcement/components/SafeProSubscriptionActivatedModal/__tests__/index.test.tsx
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProSubscriptionActivatedModal/__tests__/index.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent, render, screen } from '@/tests/test-utils'
+import SafeProSubscriptionActivatedModal from '../index'
+
+describe('SafeProSubscriptionActivatedModal', () => {
+  it('shows the plan, price and next billing date, and closes from the CTA', () => {
+    const onOpenChange = jest.fn()
+    render(
+      <SafeProSubscriptionActivatedModal
+        open
+        onOpenChange={onOpenChange}
+        planName="Business"
+        price={499}
+        currency="eur"
+        billingCycle="month"
+        nextBillingAt={Date.UTC(2026, 9, 1, 12)}
+      />,
+    )
+
+    expect(screen.getByRole('heading')).toHaveTextContent('Your Workspace is now on Safe Pro')
+    expect(screen.getByText('Business plan, €499 per month. Your next payment is on Oct 1, 2026.')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go to Workspace' }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/apps/web/src/features/safe-pro-announcement/components/SafeProSubscriptionActivatedModal/index.tsx
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProSubscriptionActivatedModal/index.tsx
@@ -1,0 +1,53 @@
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { Typography } from '@/components/ui/typography'
+import { formatDate } from '@safe-global/utils/utils/date'
+import SafeProHero from '../SafeProHero'
+import css from '../SafeProAnnouncement/styles.module.css'
+
+const formatPrice = (price: number, currency: string) =>
+  new Intl.NumberFormat('en', { style: 'currency', currency, maximumFractionDigits: 0 }).format(price)
+
+const SafeProSubscriptionActivatedModal = ({
+  open,
+  onOpenChange,
+  planName,
+  price,
+  currency,
+  billingCycle,
+  nextBillingAt,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  planName: string
+  price: number
+  currency: string
+  billingCycle: 'month' | 'year'
+  nextBillingAt: number
+}) => (
+  <Dialog open={open} onOpenChange={onOpenChange}>
+    <DialogContent size="sm" surface="card" padding="none">
+      <div className="p-1 pb-2">
+        <SafeProHero variant="tall" />
+
+        <div className="flex flex-col items-center gap-8 px-8 pt-6 pb-4">
+          <div className="flex flex-col gap-2">
+            <Typography variant="h3" align="center" as={DialogTitle}>
+              Your Workspace is now on <span className={css.highlight}>Safe Pro</span>
+            </Typography>
+            <Typography color="muted" align="center">
+              {planName} plan, {formatPrice(price, currency)} per {billingCycle}. Your next payment is on{' '}
+              {formatDate(nextBillingAt)}.
+            </Typography>
+          </div>
+
+          <Button size="lg" className="w-full" onClick={() => onOpenChange(false)}>
+            Go to Workspace
+          </Button>
+        </div>
+      </div>
+    </DialogContent>
+  </Dialog>
+)
+
+export default SafeProSubscriptionActivatedModal

--- a/apps/web/src/features/safe-pro-announcement/components/SafeProSubscriptionActivatedModal/index.tsx
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProSubscriptionActivatedModal/index.tsx
@@ -14,7 +14,6 @@ const SafeProSubscriptionActivatedModal = ({
   planName,
   price,
   currency,
-  billingCycle,
   nextBillingAt,
 }: {
   open: boolean
@@ -22,7 +21,6 @@ const SafeProSubscriptionActivatedModal = ({
   planName: string
   price: number
   currency: string
-  billingCycle: 'month' | 'year'
   nextBillingAt: number
 }) => (
   <Dialog open={open} onOpenChange={onOpenChange}>
@@ -33,11 +31,10 @@ const SafeProSubscriptionActivatedModal = ({
         <div className="flex flex-col items-center gap-8 px-8 pt-6 pb-4">
           <div className="flex flex-col gap-2">
             <Typography variant="h3" align="center" as={DialogTitle}>
-              Your Workspace is now on <span className={css.highlight}>Safe Pro</span>
+              Your paid subscription is active, you&apos;re on <span className={css.highlight}>{planName}</span>!
             </Typography>
             <Typography color="muted" align="center">
-              {planName} plan, {formatPrice(price, currency)} per {billingCycle}. Your next payment is on{' '}
-              {formatDate(nextBillingAt)}.
+              You&apos;ll pay {formatPrice(price, currency)} on {formatDate(nextBillingAt)}
             </Typography>
           </div>
 

--- a/apps/web/src/features/safe-pro-announcement/contract.ts
+++ b/apps/web/src/features/safe-pro-announcement/contract.ts
@@ -2,6 +2,7 @@ import type SafeProAnnouncement from './components/SafeProAnnouncement'
 import type SafeProAnnouncementModal from './components/SafeProAnnouncementModal'
 import type SafeProLockedWorkspace from './components/SafeProLockedWorkspace'
 import type SafeProTrialActivatedModal from './components/SafeProTrialActivatedModal'
+import type SafeProSubscriptionActivatedModal from './components/SafeProSubscriptionActivatedModal'
 import type SafeProBanner from './components/SafeProBanner'
 import type SafeProSidebarBanner from './components/SafeProSidebarBanner'
 import type SafeProWorkspacesBanner from './components/SafeProWorkspacesBanner'
@@ -11,6 +12,7 @@ export interface SafeProContract {
   SafeProAnnouncementModal: typeof SafeProAnnouncementModal
   SafeProLockedWorkspace: typeof SafeProLockedWorkspace
   SafeProTrialActivatedModal: typeof SafeProTrialActivatedModal
+  SafeProSubscriptionActivatedModal: typeof SafeProSubscriptionActivatedModal
   SafeProBanner: typeof SafeProBanner
   SafeProSidebarBanner: typeof SafeProSidebarBanner
   SafeProWorkspacesBanner: typeof SafeProWorkspacesBanner

--- a/apps/web/src/features/safe-pro-announcement/feature.ts
+++ b/apps/web/src/features/safe-pro-announcement/feature.ts
@@ -4,6 +4,7 @@ import SafeProAnnouncement from './components/SafeProAnnouncement'
 import SafeProAnnouncementModal from './components/SafeProAnnouncementModal'
 import SafeProLockedWorkspace from './components/SafeProLockedWorkspace'
 import SafeProTrialActivatedModal from './components/SafeProTrialActivatedModal'
+import SafeProSubscriptionActivatedModal from './components/SafeProSubscriptionActivatedModal'
 import SafeProBanner from './components/SafeProBanner'
 import SafeProSidebarBanner from './components/SafeProSidebarBanner'
 import SafeProWorkspacesBanner from './components/SafeProWorkspacesBanner'
@@ -13,6 +14,7 @@ export default {
   SafeProAnnouncementModal,
   SafeProLockedWorkspace,
   SafeProTrialActivatedModal,
+  SafeProSubscriptionActivatedModal,
   SafeProBanner,
   SafeProSidebarBanner,
   SafeProWorkspacesBanner,

--- a/apps/web/src/features/spaces/components/Dashboard/__tests__/index.test.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/__tests__/index.test.tsx
@@ -25,8 +25,10 @@ jest.mock('@/components/common/CheckWallet', () => ({
   default: ({ children }: { children: (ok: boolean) => unknown }) => children(true),
 }))
 
+const mockReplace = jest.fn()
+let mockQuery: Record<string, string> = {}
 jest.mock('next/router', () => ({
-  useRouter: () => ({ push: jest.fn() }),
+  useRouter: () => ({ push: jest.fn(), replace: mockReplace, pathname: '/spaces', query: mockQuery }),
 }))
 
 jest.mock('@/services/analytics', () => ({
@@ -133,6 +135,13 @@ function setupUseLoadFeature(txEntries: Array<{ safeAddress: string; txId: strin
     SafeProAnnouncementModal: () => <div data-testid="safe-pro-announcement-modal" />,
     SafeProLockedWorkspace: () => <div data-testid="safe-pro-locked-workspace" />,
     SafeProTrialActivatedModal: () => null,
+    SafeProSubscriptionActivatedModal: ({
+      open,
+      onOpenChange,
+    }: {
+      open: boolean
+      onOpenChange: (o: boolean) => void
+    }) => (open ? <button data-testid="checkout-success-modal" onClick={() => onOpenChange(false)} /> : null),
     $isReady: true,
   })
 }
@@ -413,5 +422,34 @@ describe('SpaceDashboard – locked Workspace (SAFE_PRO)', () => {
 
     expect(screen.queryByTestId('safe-pro-locked-workspace')).not.toBeInTheDocument()
     expect(screen.getByTestId(`pending-tx-row-${MOCK_TX_ID}`)).toBeInTheDocument()
+  })
+})
+
+describe('SpaceDashboard – checkout success', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    restoreDefaultMocks()
+    setupUseLoadFeature()
+  })
+
+  afterEach(() => {
+    mockQuery = {}
+  })
+
+  it('opens the subscription modal from ?checkout=success and drops the flag on close', () => {
+    mockQuery = { spaceId: MOCK_SPACE_ID, checkout: 'success' }
+
+    render(<SpaceDashboard />)
+
+    fireEvent.click(screen.getByTestId('checkout-success-modal'))
+    expect(mockReplace).toHaveBeenCalledWith({ pathname: '/spaces', query: { spaceId: MOCK_SPACE_ID } }, undefined, {
+      shallow: true,
+    })
+  })
+
+  it('stays closed without the flag', () => {
+    render(<SpaceDashboard />)
+
+    expect(screen.queryByTestId('checkout-success-modal')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/features/spaces/components/Dashboard/index.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/index.tsx
@@ -29,6 +29,7 @@ import { useSpacesGetOneV1Query } from '@safe-global/store/gateway/AUTO_GENERATE
 import { Typography } from '@/components/ui/typography'
 import { FEATURES } from '@safe-global/utils/utils/chains'
 import TrialFlow from '../Plans/TrialFlow'
+import { TIERS, TRIAL_PLANS } from '../Plans/fixtures'
 
 const EmptyStateAddAction = () => {
   return (
@@ -44,7 +45,8 @@ const PENDING_TX_DISPLAY_LIMIT = 4
 const SpaceDashboard = () => {
   const { AccountsWidget, $isReady } = useLoadFeature(MyAccountsFeature)
   const { PendingTxWidget } = useLoadFeature(SpacesFeature)
-  const { SafeProAnnouncementModal, SafeProLockedWorkspace } = useLoadFeature(SafeProFeature)
+  const { SafeProAnnouncementModal, SafeProLockedWorkspace, SafeProSubscriptionActivatedModal } =
+    useLoadFeature(SafeProFeature)
   const { allSafes: safes, isLoading: isSafesLoading } = useSpaceSafes()
   const safeItems = flattenSafeItems(safes)
   const spaceId = useCurrentSpaceId()
@@ -124,6 +126,25 @@ const SpaceDashboard = () => {
 
   const showSetupWidget = safeItems.length === 0 && !isSafesLoading && !setupDismissed && !isSetupDismissedForSpace
 
+  // Stripe Checkout returns to Home with `?checkout=success`; the flag is dropped once the modal closes.
+  const closeCheckoutSuccess = () => {
+    const query = { ...router.query }
+    delete query.checkout
+    router.replace({ pathname: router.pathname, query }, undefined, { shallow: true })
+  }
+  const paidTier = TIERS.find((tier) => tier.isCurrent)
+  const checkoutSuccessModal = paidTier?.price !== null && paidTier?.billingCycle && (
+    <SafeProSubscriptionActivatedModal
+      open={router.query.checkout === 'success'}
+      onOpenChange={closeCheckoutSuccess}
+      planName={paidTier.name}
+      price={paidTier.price}
+      currency={paidTier.currency}
+      billingCycle={paidTier.billingCycle}
+      nextBillingAt={Date.parse(TRIAL_PLANS.plan?.periodEndsAt ?? '')}
+    />
+  )
+
   if (isLocked) {
     return (
       <div className="pt-6">
@@ -132,6 +153,7 @@ const SpaceDashboard = () => {
         </Typography>
         <SafeProLockedWorkspace onStartTrial={() => setIsTrialOpen(true)} />
         <TrialFlow trialDays={60} open={isTrialOpen} onOpenChange={setIsTrialOpen} />
+        {checkoutSuccessModal}
       </div>
     )
   }
@@ -139,6 +161,7 @@ const SpaceDashboard = () => {
   return (
     <>
       {isSafeProEnabled && <SafeProAnnouncementModal open={isAnnouncementOpen} onOpenChange={setIsAnnouncementOpen} />}
+      {checkoutSuccessModal}
 
       {isInvited && <PreviewInvite />}
 

--- a/apps/web/src/features/spaces/components/Dashboard/index.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/index.tsx
@@ -133,14 +133,13 @@ const SpaceDashboard = () => {
     router.replace({ pathname: router.pathname, query }, undefined, { shallow: true })
   }
   const paidTier = TIERS.find((tier) => tier.isCurrent)
-  const checkoutSuccessModal = paidTier?.price !== null && paidTier?.billingCycle && (
+  const checkoutSuccessModal = paidTier && paidTier.price !== null && (
     <SafeProSubscriptionActivatedModal
       open={router.query.checkout === 'success'}
       onOpenChange={closeCheckoutSuccess}
       planName={paidTier.name}
       price={paidTier.price}
       currency={paidTier.currency}
-      billingCycle={paidTier.billingCycle}
       nextBillingAt={Date.parse(TRIAL_PLANS.plan?.periodEndsAt ?? '')}
     />
   )


### PR DESCRIPTION
## What it solves

Resolves: https://linear.app/safe-global/issue/PLA-1927/safe-pro-active-paid-subscription-ui-upgrade-success-modal

Confirms a paid Safe Pro subscription after checkout, on the Workspace Home.

## How this PR fixes it

New `SafeProSubscriptionActivatedModal`

## How to test it

1. Enable `SAFE_PRO_ANNOUNCEMENT` via Developer > Feature flags in the sidebar (it gates the Safe Pro feature module).
2. Open a Workspace Home with the flag: `/spaces?spaceId=<uuid>&checkout=success`. The modal opens; closing it removes `checkout` from the URL

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [X] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
