### PR TITLE
Validate spending limit form before submission

### DIFF
--- a/apps/web/src/components/tx-flow/flows/NewSpendingLimit/__tests__/SpendingLimitForm.test.ts
+++ b/apps/web/src/components/tx-flow/flows/NewSpendingLimit/__tests__/SpendingLimitForm.test.ts
@@ -1,5 +1,8 @@
 // eslint-disable-next-line no-restricted-imports -- test-only export; re-exporting it from the barrel would eagerly pull the heavy CreateSpendingLimit component graph into all barrel consumers
-import { _validateSpendingLimit } from '@/features/spending-limits/components/CreateSpendingLimit'
+import {
+  _validateSpendingLimit,
+  NO_TOKEN_SELECTED_ERROR,
+} from '@/features/spending-limits/components/CreateSpendingLimit'
 
 describe('CreateSpendingLimit', () => {
   describe('validateSpendingLimit', () => {
@@ -23,9 +26,9 @@ describe('CreateSpendingLimit', () => {
       expect(result).toEqual('Amount is too small')
     })
 
-    it('should return no error when the token decimals are unknown', () => {
-      expect(_validateSpendingLimit('1')).toBeUndefined()
-      expect(_validateSpendingLimit('1.1')).toBeUndefined()
+    it('should return an error when the token decimals are unknown', () => {
+      expect(_validateSpendingLimit('1')).toEqual(NO_TOKEN_SELECTED_ERROR)
+      expect(_validateSpendingLimit('1.1', null)).toEqual(NO_TOKEN_SELECTED_ERROR)
     })
   })
 })

--- a/apps/web/src/features/spending-limits/components/CreateSpendingLimit/CreateSpendingLimit.test.tsx
+++ b/apps/web/src/features/spending-limits/components/CreateSpendingLimit/CreateSpendingLimit.test.tsx
@@ -1,11 +1,13 @@
-import { render, screen } from '@/tests/test-utils'
+import { fireEvent, render, screen, waitFor } from '@/tests/test-utils'
+import userEvent from '@testing-library/user-event'
+import { useFormContext } from 'react-hook-form'
 import { ZERO_ADDRESS } from '@safe-global/utils/utils/constants'
 import { TokenType } from '@safe-global/store/gateway/types'
 import type { Balances } from '@safe-global/store/gateway/AUTO_GENERATED/balances'
 import type { PortfolioBalances } from '@/hooks/loadables/useLoadBalances'
 import { TxFlowContext, initialContext, type TxFlowContextType } from '@/components/tx-flow/TxFlowProvider'
 import { SpendingLimitFields, type NewSpendingLimitFlowProps } from '../../types'
-import CreateSpendingLimit from './index'
+import CreateSpendingLimit, { NO_TOKEN_SELECTED_ERROR } from './index'
 import * as useVisibleBalancesHook from '@/hooks/useVisibleBalances'
 import * as useIsSpendingLimitSupportedHook from '../../hooks/useIsSpendingLimitSupported'
 
@@ -17,6 +19,18 @@ jest.mock('@/hooks/useChainId', () => ({
   __esModule: true,
   default: () => '1',
 }))
+
+// The beneficiary field is not under test; a plain required input keeps the form's validity
+// dependent only on the amount/token logic exercised here.
+jest.mock('@/components/common/AddressBookInput', () => {
+  const MockAddressBookInput = ({ name }: { name: string }) => {
+    const { register } = useFormContext()
+    return <input data-testid="beneficiary-input" {...register(name, { required: true })} />
+  }
+  return { __esModule: true, default: MockAddressBookInput }
+})
+
+const BENEFICIARY = '0x1234567890123456789012345678901234567890'
 
 const nativeBalance: Balances['items'][number] = {
   balance: '1000000000000000000',
@@ -40,7 +54,8 @@ const mockBalances = (items: Balances['items']) => {
   })
 }
 
-const renderForm = (data?: Partial<NewSpendingLimitFlowProps>) => {
+const buildForm = (data?: Partial<NewSpendingLimitFlowProps>) => {
+  const onNext = jest.fn()
   const context: TxFlowContextType<NewSpendingLimitFlowProps> = {
     ...initialContext,
     data: {
@@ -50,14 +65,27 @@ const renderForm = (data?: Partial<NewSpendingLimitFlowProps>) => {
       [SpendingLimitFields.resetTime]: '0',
       ...data,
     },
-    onNext: jest.fn(),
+    onNext,
   }
 
-  return render(
+  // A fresh element per render call, so `rerender` cannot bail out on an identical element.
+  const buildUi = () => (
     <TxFlowContext.Provider value={context as TxFlowContextType}>
       <CreateSpendingLimit />
-    </TxFlowContext.Provider>,
+    </TxFlowContext.Provider>
   )
+
+  return { buildUi, onNext }
+}
+
+const renderForm = (data?: Partial<NewSpendingLimitFlowProps>) => {
+  const { buildUi, onNext } = buildForm(data)
+  return { ...render(buildUi()), buildUi, onNext }
+}
+
+const fillForm = async (amount: string) => {
+  await userEvent.type(screen.getByTestId('beneficiary-input'), BENEFICIARY)
+  await userEvent.type(screen.getByTestId('token-amount-field'), amount)
 }
 
 describe('CreateSpendingLimit', () => {
@@ -81,5 +109,79 @@ describe('CreateSpendingLimit', () => {
     renderForm()
 
     expect(screen.getByTestId('token-selector')).toHaveTextContent('ETH')
+  })
+
+  describe('Next button', () => {
+    it('is disabled while the form is empty', () => {
+      mockBalances([nativeBalance])
+
+      renderForm()
+
+      expect(screen.getByTestId('next-btn')).toBeDisabled()
+    })
+
+    it('stays disabled and flags the missing token when an amount is entered without a selectable token', async () => {
+      mockBalances([])
+
+      const { onNext } = renderForm()
+      await fillForm('1')
+
+      expect(await screen.findByText(NO_TOKEN_SELECTED_ERROR)).toBeInTheDocument()
+      expect(screen.getByTestId('next-btn')).toBeDisabled()
+
+      fireEvent.submit(screen.getByTestId('next-btn'))
+      await waitFor(() => expect(screen.getByTestId('next-btn')).toBeDisabled())
+      expect(onNext).not.toHaveBeenCalled()
+    })
+
+    it('stays disabled when the amount exceeds the allowance range of the selected token', async () => {
+      mockBalances([nativeBalance])
+
+      renderForm()
+      await fillForm('100000000000000000000')
+
+      expect(await screen.findByText('Amount is too big')).toBeInTheDocument()
+      expect(screen.getByTestId('next-btn')).toBeDisabled()
+    })
+
+    it('is enabled and submits once beneficiary, token and amount are valid', async () => {
+      mockBalances([nativeBalance])
+
+      const { onNext } = renderForm()
+      await fillForm('1')
+
+      await waitFor(() => expect(screen.getByTestId('next-btn')).toBeEnabled())
+
+      await userEvent.click(screen.getByTestId('next-btn'))
+
+      await waitFor(() =>
+        expect(onNext).toHaveBeenCalledWith(
+          expect.objectContaining({
+            [SpendingLimitFields.beneficiary]: BENEFICIARY,
+            [SpendingLimitFields.tokenAddress]: ZERO_ADDRESS,
+            [SpendingLimitFields.amount]: '1',
+          }),
+          expect.anything(),
+        ),
+      )
+    })
+
+    it('re-validates a prefilled amount once the selected token becomes available', async () => {
+      mockBalances([])
+
+      const { rerender, buildUi } = renderForm({
+        [SpendingLimitFields.beneficiary]: BENEFICIARY,
+        [SpendingLimitFields.amount]: '1.5',
+      })
+
+      expect(await screen.findByText(NO_TOKEN_SELECTED_ERROR)).toBeInTheDocument()
+      expect(screen.getByTestId('next-btn')).toBeDisabled()
+
+      mockBalances([nativeBalance])
+      rerender(buildUi())
+
+      await waitFor(() => expect(screen.getByTestId('next-btn')).toBeEnabled())
+      expect(screen.queryByText(NO_TOKEN_SELECTED_ERROR)).not.toBeInTheDocument()
+    })
   })
 })

--- a/apps/web/src/features/spending-limits/components/CreateSpendingLimit/CreateSpendingLimit.test.tsx
+++ b/apps/web/src/features/spending-limits/components/CreateSpendingLimit/CreateSpendingLimit.test.tsx
@@ -54,7 +54,7 @@ const mockBalances = (items: Balances['items']) => {
   })
 }
 
-const buildForm = (data?: Partial<NewSpendingLimitFlowProps>) => {
+const renderForm = (data?: Partial<NewSpendingLimitFlowProps>) => {
   const onNext = jest.fn()
   const context: TxFlowContextType<NewSpendingLimitFlowProps> = {
     ...initialContext,
@@ -68,19 +68,13 @@ const buildForm = (data?: Partial<NewSpendingLimitFlowProps>) => {
     onNext,
   }
 
-  // A fresh element per render call, so `rerender` cannot bail out on an identical element.
-  const buildUi = () => (
+  const ui = (
     <TxFlowContext.Provider value={context as TxFlowContextType}>
       <CreateSpendingLimit />
     </TxFlowContext.Provider>
   )
 
-  return { buildUi, onNext }
-}
-
-const renderForm = (data?: Partial<NewSpendingLimitFlowProps>) => {
-  const { buildUi, onNext } = buildForm(data)
-  return { ...render(buildUi()), buildUi, onNext }
+  return { ...render(ui), onNext }
 }
 
 const fillForm = async (amount: string) => {
@@ -164,24 +158,6 @@ describe('CreateSpendingLimit', () => {
           expect.anything(),
         ),
       )
-    })
-
-    it('re-validates a prefilled amount once the selected token becomes available', async () => {
-      mockBalances([])
-
-      const { rerender, buildUi } = renderForm({
-        [SpendingLimitFields.beneficiary]: BENEFICIARY,
-        [SpendingLimitFields.amount]: '1.5',
-      })
-
-      expect(await screen.findByText(NO_TOKEN_SELECTED_ERROR)).toBeInTheDocument()
-      expect(screen.getByTestId('next-btn')).toBeDisabled()
-
-      mockBalances([nativeBalance])
-      rerender(buildUi())
-
-      await waitFor(() => expect(screen.getByTestId('next-btn')).toBeEnabled())
-      expect(screen.queryByText(NO_TOKEN_SELECTED_ERROR)).not.toBeInTheDocument()
     })
   })
 })

--- a/apps/web/src/features/spending-limits/components/CreateSpendingLimit/CreateSpendingLimit.test.tsx
+++ b/apps/web/src/features/spending-limits/components/CreateSpendingLimit/CreateSpendingLimit.test.tsx
@@ -54,7 +54,7 @@ const mockBalances = (items: Balances['items']) => {
   })
 }
 
-const renderForm = (data?: Partial<NewSpendingLimitFlowProps>) => {
+const buildForm = (data?: Partial<NewSpendingLimitFlowProps>) => {
   const onNext = jest.fn()
   const context: TxFlowContextType<NewSpendingLimitFlowProps> = {
     ...initialContext,
@@ -68,13 +68,19 @@ const renderForm = (data?: Partial<NewSpendingLimitFlowProps>) => {
     onNext,
   }
 
-  const ui = (
+  // A fresh element per render call, so `rerender` cannot bail out on an identical element.
+  const buildUi = () => (
     <TxFlowContext.Provider value={context as TxFlowContextType}>
       <CreateSpendingLimit />
     </TxFlowContext.Provider>
   )
 
-  return { ...render(ui), onNext }
+  return { buildUi, onNext }
+}
+
+const renderForm = (data?: Partial<NewSpendingLimitFlowProps>) => {
+  const { buildUi, onNext } = buildForm(data)
+  return { ...render(buildUi()), buildUi, onNext }
 }
 
 const fillForm = async (amount: string) => {
@@ -158,6 +164,24 @@ describe('CreateSpendingLimit', () => {
           expect.anything(),
         ),
       )
+    })
+
+    it('re-validates a prefilled amount once the selected token becomes available', async () => {
+      mockBalances([])
+
+      const { rerender, buildUi } = renderForm({
+        [SpendingLimitFields.beneficiary]: BENEFICIARY,
+        [SpendingLimitFields.amount]: '1.5',
+      })
+
+      expect(await screen.findByText(NO_TOKEN_SELECTED_ERROR)).toBeInTheDocument()
+      expect(screen.getByTestId('next-btn')).toBeDisabled()
+
+      mockBalances([nativeBalance])
+      rerender(buildUi())
+
+      await waitFor(() => expect(screen.getByTestId('next-btn')).toBeEnabled())
+      expect(screen.queryByText(NO_TOKEN_SELECTED_ERROR)).not.toBeInTheDocument()
     })
   })
 })

--- a/apps/web/src/features/spending-limits/components/CreateSpendingLimit/index.tsx
+++ b/apps/web/src/features/spending-limits/components/CreateSpendingLimit/index.tsx
@@ -22,11 +22,11 @@ import SpendingLimitNotSupported from './SpendingLimitNotSupported'
 export const NO_TOKEN_SELECTED_ERROR = 'Select a token'
 
 export const _validateSpendingLimit = (val: string, decimals?: number | null) => {
-  // Without a selected token we don't know the decimals, so the amount can't be range-checked yet.
-  if (decimals == null) return
+  // Without a selected token the decimals are unknown, so the amount cannot be valid yet.
+  if (decimals == null) return NO_TOKEN_SELECTED_ERROR
   // Allowance amount is uint96 https://github.com/safe-global/safe-modules/blob/main/modules/allowances/contracts/AllowanceModule.sol#L52
   try {
-    const amount = parseUnits(val, decimals ?? 'Gwei')
+    const amount = parseUnits(val, decimals)
     AbiCoder.defaultAbiCoder().encode(['int96'], [amount])
   } catch (e) {
     return Number(val) > 1 ? 'Amount is too big' : 'Amount is too small'
@@ -60,15 +60,10 @@ const CreateSpendingLimit = () => {
   const tokenDecimals = selectedToken?.tokenInfo.decimals
 
   const validateSpendingLimit = useCallback(
-    (value: string) => {
-      if (tokenDecimals == null) return NO_TOKEN_SELECTED_ERROR
-
-      return (
-        validateAmount(value) ||
-        validateDecimalLength(value, tokenDecimals) ||
-        _validateSpendingLimit(value, tokenDecimals)
-      )
-    },
+    (value: string) =>
+      validateAmount(value) ||
+      validateDecimalLength(value, tokenDecimals) ||
+      _validateSpendingLimit(value, tokenDecimals),
     [tokenDecimals],
   )
 

--- a/apps/web/src/features/spending-limits/components/CreateSpendingLimit/index.tsx
+++ b/apps/web/src/features/spending-limits/components/CreateSpendingLimit/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useMemo } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import { Controller, FormProvider, useForm } from 'react-hook-form'
 import { Button } from '@/components/ui/button'
 import { Typography } from '@/components/ui/typography'
@@ -46,7 +46,7 @@ const CreateSpendingLimit = () => {
     mode: 'onChange',
   })
 
-  const { handleSubmit, watch, control, formState, getValues, trigger } = formMethods
+  const { handleSubmit, watch, control, formState } = formMethods
 
   const tokenAddress = watch(SpendingLimitFields.tokenAddress)
   const beneficiary = watch(SpendingLimitFields.beneficiary)
@@ -66,14 +66,6 @@ const CreateSpendingLimit = () => {
       _validateSpendingLimit(value, tokenDecimals),
     [tokenDecimals],
   )
-
-  // react-hook-form only evaluates `isValid` on mount, so a prefilled amount must be re-checked
-  // once the selected token (and therefore its decimals) becomes known or is lost.
-  useEffect(() => {
-    if (getValues(SpendingLimitFields.amount)) {
-      trigger(SpendingLimitFields.amount)
-    }
-  }, [tokenDecimals, getValues, trigger])
 
   if (!isSupported) {
     return <SpendingLimitNotSupported />

--- a/apps/web/src/features/spending-limits/components/CreateSpendingLimit/index.tsx
+++ b/apps/web/src/features/spending-limits/components/CreateSpendingLimit/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useMemo } from 'react'
+import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { Controller, FormProvider, useForm } from 'react-hook-form'
 import { Button } from '@/components/ui/button'
 import { Typography } from '@/components/ui/typography'
@@ -18,6 +18,8 @@ import { TxFlowContext, type TxFlowContextType } from '@/components/tx-flow/TxFl
 import { SpendingLimitFields, type NewSpendingLimitFlowProps } from '../../types'
 import useIsSpendingLimitSupported from '../../hooks/useIsSpendingLimitSupported'
 import SpendingLimitNotSupported from './SpendingLimitNotSupported'
+
+export const NO_TOKEN_SELECTED_ERROR = 'Select a token'
 
 export const _validateSpendingLimit = (val: string, decimals?: number | null) => {
   // Without a selected token we don't know the decimals, so the amount can't be range-checked yet.
@@ -44,7 +46,7 @@ const CreateSpendingLimit = () => {
     mode: 'onChange',
   })
 
-  const { handleSubmit, watch, control } = formMethods
+  const { handleSubmit, watch, control, formState, getValues, trigger } = formMethods
 
   const tokenAddress = watch(SpendingLimitFields.tokenAddress)
   const beneficiary = watch(SpendingLimitFields.beneficiary)
@@ -55,16 +57,28 @@ const CreateSpendingLimit = () => {
     ? balances.items.find((item) => item.tokenInfo.address === tokenAddress)
     : undefined
 
+  const tokenDecimals = selectedToken?.tokenInfo.decimals
+
   const validateSpendingLimit = useCallback(
     (value: string) => {
+      if (tokenDecimals == null) return NO_TOKEN_SELECTED_ERROR
+
       return (
         validateAmount(value) ||
-        validateDecimalLength(value, selectedToken?.tokenInfo.decimals) ||
-        _validateSpendingLimit(value, selectedToken?.tokenInfo.decimals)
+        validateDecimalLength(value, tokenDecimals) ||
+        _validateSpendingLimit(value, tokenDecimals)
       )
     },
-    [selectedToken?.tokenInfo.decimals],
+    [tokenDecimals],
   )
+
+  // react-hook-form only evaluates `isValid` on mount, so a prefilled amount must be re-checked
+  // once the selected token (and therefore its decimals) becomes known or is lost.
+  useEffect(() => {
+    if (getValues(SpendingLimitFields.amount)) {
+      trigger(SpendingLimitFields.amount)
+    }
+  }, [tokenDecimals, getValues, trigger])
 
   if (!isSupported) {
     return <SpendingLimitNotSupported />
@@ -114,7 +128,7 @@ const CreateSpendingLimit = () => {
           </div>
 
           <TxCardActions>
-            <Button data-testid="next-btn" type="submit">
+            <Button data-testid="next-btn" type="submit" disabled={!formState.isValid}>
               Next
             </Button>
           </TxCardActions>

--- a/apps/web/src/features/spending-limits/components/CreateSpendingLimit/index.tsx
+++ b/apps/web/src/features/spending-limits/components/CreateSpendingLimit/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useMemo } from 'react'
+import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { Controller, FormProvider, useForm } from 'react-hook-form'
 import { Button } from '@/components/ui/button'
 import { Typography } from '@/components/ui/typography'
@@ -46,7 +46,7 @@ const CreateSpendingLimit = () => {
     mode: 'onChange',
   })
 
-  const { handleSubmit, watch, control, formState } = formMethods
+  const { handleSubmit, watch, control, formState, getValues, trigger } = formMethods
 
   const tokenAddress = watch(SpendingLimitFields.tokenAddress)
   const beneficiary = watch(SpendingLimitFields.beneficiary)
@@ -66,6 +66,14 @@ const CreateSpendingLimit = () => {
       _validateSpendingLimit(value, tokenDecimals),
     [tokenDecimals],
   )
+
+  // react-hook-form only evaluates `isValid` on mount, so a prefilled amount must be re-checked
+  // once the selected token (and therefore its decimals) becomes known or is lost.
+  useEffect(() => {
+    if (getValues(SpendingLimitFields.amount)) {
+      trigger(SpendingLimitFields.amount)
+    }
+  }, [tokenDecimals, getValues, trigger])
 
   if (!isSupported) {
     return <SpendingLimitNotSupported />


### PR DESCRIPTION
Fixes WA-3435

## What it solves

Prevents users from submitting an incomplete or invalid spending limit form by disabling the Next button until all required fields are valid. Specifically:
- Requires a token to be selected before an amount can be considered valid
- Validates that the amount is within the uint96 range supported by the AllowanceModule
- Blocks form submission when validation fails

## How this PR fixes it

**Component changes (`CreateSpendingLimit/index.tsx`):**
- Updated `_validateSpendingLimit` to return an error message (`NO_TOKEN_SELECTED_ERROR`) when token decimals are unknown, instead of silently passing validation
- Added `formState.isValid` check to disable the Next button until the form passes all validations
- Simplified the validation callback to use the extracted `tokenDecimals` variable

**Test coverage (`CreateSpendingLimit.test.tsx`):**
- Added comprehensive test suite for the Next button behavior:
  - Disabled while form is empty
  - Stays disabled when amount is entered without a selectable token (shows error)
  - Stays disabled when amount exceeds uint96 range
  - Enabled and submits when all fields are valid
- Mocked `AddressBookInput` to isolate token/amount validation logic
- Enhanced test utilities to capture and verify `onNext` callback invocation

**Unit test updates (`SpendingLimitForm.test.ts`):**
- Updated validation tests to expect `NO_TOKEN_SELECTED_ERROR` when decimals are unknown
- Clarified test intent from "no error" to "returns an error"

## How to test it

The changes are covered by the new test suite in `CreateSpendingLimit.test.tsx`:
- Run `npm test -- CreateSpendingLimit.test.tsx` to verify all button state transitions
- Run `npm test -- SpendingLimitForm.test.ts` to verify validation logic

Manual testing:
1. Navigate to create a spending limit
2. Verify the Next button is disabled initially
3. Enter an amount without selecting a token → button stays disabled, error shown
4. Select a token and enter a valid amount → button becomes enabled
5. Click Next → form submits with correct data

## Affected flows

- Owner creates a new spending limit from Settings > Spending Limits

## Blast radius

- `CreateSpendingLimit` component: Form validation and submission behavior
- `_validateSpendingLimit` utility: Now returns error string instead of undefined for missing token
- No impact on other components or shared dependencies

## Risks / not checked

- Did not verify behavior with feature flag for spending limits disabled
- Did not test on mobile (form interaction should be identical)
- Did not verify with non-native tokens (test uses ETH; logic is token-agnostic)

## Checklist

- [x] I've written unit tests for the validation and button state logic
- [x] I've listed affected flows and blast radius

https://claude.ai/code/session_01AaeBjVfdAwqfjyaq5ZB9oh