### PR TITLE
feat: do not show the logout toast outside of Spaces

### DIFF
--- a/apps/web/src/services/sessionExpiry/__tests__/useSessionExpiryGuard.test.tsx
+++ b/apps/web/src/services/sessionExpiry/__tests__/useSessionExpiryGuard.test.tsx
@@ -1,12 +1,7 @@
 import { useStore } from 'react-redux'
 import { act, renderHook, waitFor } from '@/tests/test-utils'
 import type { AppStore, RootState } from '@/store'
-import {
-  useSessionExpiryGuard,
-  SESSION_EXPIRED_GROUP_KEY,
-  SESSION_EXPIRED_MESSAGE,
-  SESSION_EXPIRED_SIGN_IN_LABEL,
-} from '../useSessionExpiryGuard'
+import { useSessionExpiryGuard, SESSION_EXPIRED_GROUP_KEY, SESSION_EXPIRED_MESSAGE } from '../useSessionExpiryGuard'
 import { setAuthenticated } from '@/store/authSlice'
 import { LOGGING_OUT_KEY } from '@/hooks/useLogoutCallback'
 import { AppRoutes } from '@/config/routes'
@@ -301,14 +296,13 @@ describe('useSessionExpiryGuard', () => {
     expect(findNotification(store)?.isDismissed).toBe(true)
   })
 
-  it('shows a Spaces sign-in link in the toast that points at /welcome/spaces', async () => {
+  it('shows the toast without a CTA link', async () => {
     const { store } = renderGuardWithStore(Date.now() - 1_000)
     await flushMicrotasks()
 
-    expect(findNotification(store)).toMatchObject({
-      message: SESSION_EXPIRED_MESSAGE,
-      link: { href: '/welcome/spaces', title: SESSION_EXPIRED_SIGN_IN_LABEL },
-    })
+    const notification = findNotification(store)
+    expect(notification).toMatchObject({ message: SESSION_EXPIRED_MESSAGE })
+    expect(notification?.link).toBeUndefined()
     expect(SESSION_EXPIRED_MESSAGE).toBe('Your session has expired. Please sign in to workspaces again.')
   })
 

--- a/apps/web/src/services/sessionExpiry/__tests__/useSessionExpiryGuard.test.tsx
+++ b/apps/web/src/services/sessionExpiry/__tests__/useSessionExpiryGuard.test.tsx
@@ -9,6 +9,7 @@ import {
 } from '../useSessionExpiryGuard'
 import { setAuthenticated } from '@/store/authSlice'
 import { LOGGING_OUT_KEY } from '@/hooks/useLogoutCallback'
+import { AppRoutes } from '@/config/routes'
 
 const mockUnwrap = jest.fn()
 const mockUnsubscribe = jest.fn()
@@ -42,14 +43,14 @@ const findNotification = (store: AppStore) =>
 
 const flushMicrotasks = () => act(async () => Promise.resolve())
 
-const renderGuardWithStore = (sessionExpiresAt: number | null) => {
+const renderGuardWithStore = (sessionExpiresAt: number | null, pathname = AppRoutes.welcome.spaces) => {
   let capturedStore: AppStore | undefined
   const result = renderHook(
     () => {
       capturedStore = useStore() as AppStore
       useSessionExpiryGuard()
     },
-    { initialReduxState: buildState(sessionExpiresAt) },
+    { initialReduxState: buildState(sessionExpiresAt), routerProps: { pathname } },
   )
   if (!capturedStore) throw new Error('store not captured')
   return { ...result, store: capturedStore }
@@ -91,7 +92,8 @@ describe('useSessionExpiryGuard', () => {
     expect(store.getState().auth.sessionExpiresAt).toBeNull()
     expect(findNotification(store)).toMatchObject({
       message: SESSION_EXPIRED_MESSAGE,
-      variant: 'error',
+      variant: 'info',
+      autoHideDuration: null,
       groupKey: SESSION_EXPIRED_GROUP_KEY,
     })
   })
@@ -128,7 +130,7 @@ describe('useSessionExpiryGuard', () => {
     expect(store.getState().auth.sessionExpiresAt).toBeNull()
     expect(findNotification(store)).toMatchObject({
       message: SESSION_EXPIRED_MESSAGE,
-      variant: 'error',
+      variant: 'info',
       groupKey: SESSION_EXPIRED_GROUP_KEY,
     })
   })
@@ -308,6 +310,40 @@ describe('useSessionExpiryGuard', () => {
       link: { href: '/welcome/spaces', title: SESSION_EXPIRED_SIGN_IN_LABEL },
     })
     expect(SESSION_EXPIRED_MESSAGE).toBe('Your session has expired. Please sign in to workspaces again.')
+  })
+
+  it('clears auth but shows no toast when the session expires outside /welcome/spaces', async () => {
+    const { store } = renderGuardWithStore(Date.now() - 1_000, AppRoutes.welcome.accounts)
+    await flushMicrotasks()
+
+    expect(store.getState().auth.sessionExpiresAt).toBeNull()
+    expect(findNotification(store)).toBeUndefined()
+  })
+
+  it('shows the toast when the session expires on an in-space route (/spaces)', async () => {
+    const { store } = renderGuardWithStore(Date.now() - 1_000, AppRoutes.spaces.index)
+    await flushMicrotasks()
+
+    expect(store.getState().auth.sessionExpiresAt).toBeNull()
+    expect(findNotification(store)).toMatchObject({
+      message: SESSION_EXPIRED_MESSAGE,
+      variant: 'info',
+      groupKey: SESSION_EXPIRED_GROUP_KEY,
+    })
+  })
+
+  it('shows no toast when the mid-tab timer fires outside a workspaces route', async () => {
+    mockUnwrap.mockResolvedValue({ id: 'user-1' })
+    const { store } = renderGuardWithStore(Date.now() + 60_000, AppRoutes.welcome.accounts)
+    await flushMicrotasks()
+
+    await act(async () => {
+      jest.advanceTimersByTime(60_001)
+      await Promise.resolve()
+    })
+
+    expect(store.getState().auth.sessionExpiresAt).toBeNull()
+    expect(findNotification(store)).toBeUndefined()
   })
 
   it('runs once after the store hydrates from a partial preloaded state', async () => {

--- a/apps/web/src/services/sessionExpiry/useSessionExpiryGuard.ts
+++ b/apps/web/src/services/sessionExpiry/useSessionExpiryGuard.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { useRouter } from 'next/router'
 import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import { cgwApi as authApi } from '@safe-global/store/gateway/AUTO_GENERATED/auth'
 import { useAppDispatch, useAppSelector } from '@/store'
@@ -18,6 +19,9 @@ export const SESSION_EXPIRED_SIGN_IN_LABEL = 'Sign in to workspaces'
 
 const isForbidden = (error: unknown): error is FetchBaseQueryError =>
   typeof error === 'object' && error !== null && 'status' in error && error.status === 403
+
+const isSpacesRoute = (pathname: string): boolean =>
+  pathname === AppRoutes.welcome.spaces || pathname === AppRoutes.spaces.index || pathname.startsWith('/spaces/')
 
 /**
  * Detects an expired session and clears Redux auth state so components stop
@@ -39,11 +43,18 @@ const isForbidden = (error: unknown): error is FetchBaseQueryError =>
  * processing — those hooks already call /me themselves. The local timer is
  * **not** suppressed: we still want sessionExpiresAt enforced even if the
  * surrounding flow finishes silently without dispatching an auth-state change.
+ *
+ * Auth is cleared on every route; the toast is shown only on workspaces routes.
  */
 export const useSessionExpiryGuard = (): void => {
   const dispatch = useAppDispatch()
+  const router = useRouter()
   const isHydrated = useAppSelector(selectIsStoreHydrated)
   const sessionExpiresAt = useAppSelector((state) => state.auth.sessionExpiresAt)
+
+  // Ref so expiry reads the pathname at fire-time without re-arming the effect.
+  const pathnameRef = useRef(router.pathname)
+  pathnameRef.current = router.pathname
 
   // Track which sessionExpiresAt value we've already processed so that
   // unrelated re-renders (e.g. dispatch identity churn under React Strict Mode)
@@ -65,10 +76,13 @@ export const useSessionExpiryGuard = (): void => {
 
     const expireNow = () => {
       dispatch(setUnauthenticated())
+      if (!isSpacesRoute(pathnameRef.current)) return
       dispatch(
         showNotification({
           message: SESSION_EXPIRED_MESSAGE,
-          variant: 'error',
+          variant: 'info',
+          // Keep until dismissed — info toasts otherwise auto-hide after 5s.
+          autoHideDuration: null,
           groupKey: SESSION_EXPIRED_GROUP_KEY,
           link: { href: AppRoutes.welcome.spaces, title: SESSION_EXPIRED_SIGN_IN_LABEL },
         }),

--- a/apps/web/src/services/sessionExpiry/useSessionExpiryGuard.ts
+++ b/apps/web/src/services/sessionExpiry/useSessionExpiryGuard.ts
@@ -15,7 +15,6 @@ const OIDC_AUTH_PENDING_KEY = 'oidc_auth_pending'
 
 export const SESSION_EXPIRED_GROUP_KEY = 'session-expired'
 export const SESSION_EXPIRED_MESSAGE = 'Your session has expired. Please sign in to workspaces again.'
-export const SESSION_EXPIRED_SIGN_IN_LABEL = 'Sign in to workspaces'
 
 const isForbidden = (error: unknown): error is FetchBaseQueryError =>
   typeof error === 'object' && error !== null && 'status' in error && error.status === 403
@@ -84,7 +83,6 @@ export const useSessionExpiryGuard = (): void => {
           // Keep until dismissed — info toasts otherwise auto-hide after 5s.
           autoHideDuration: null,
           groupKey: SESSION_EXPIRED_GROUP_KEY,
-          link: { href: AppRoutes.welcome.spaces, title: SESSION_EXPIRED_SIGN_IN_LABEL },
         }),
       )
     }


### PR DESCRIPTION
## What it solves

Resolves: [WA-3251](https://linear.app/safe-global/issue/WA-3251/show-workspace-session-expiry-prompt-only-on-spaces)

The session-expiry toast fired on every route (incl. Safe-level), and when the session expired **inside a space** the user was redirected to `/welcome/spaces` with **no toast**.

## How this PR fixes it

- Scope the toast to **workspaces routes only** (`/welcome/spaces` + `/spaces/*`); auth is still cleared silently everywhere else.
- Toast is dispatched at expiry fire-time on the `/spaces/*` route and **survives the redirect** to `/welcome/spaces` (Redux-backed, not cleared on nav).
- Variant `error` → `info`, `autoHideDuration: null` so the "logged out" message stays until dismissed (info toasts otherwise auto-hide after 5s).

## How to test it

Force a session expiry from the browser console (expires 5s after reload):

```js
const KEY = 'SAFE_v2__auth'
const auth = JSON.parse(localStorage.getItem(KEY) ?? '{}')
auth.sessionExpiresAt = Date.now() + 5_000
localStorage.setItem(KEY, JSON.stringify(auth))
location.reload()
```

1. Inside a space (`/spaces/...`), run the script → redirected to `/welcome/spaces` **with** toast.
2. On the Safe level, run the script → auth cleared, **no** toast.

## Affected flows

- Session expiry inside a space — redirect + toast
- Session expiry on `/accounts` / other routes — silent, no toast

## Blast radius

- `useSessionExpiryGuard` (global in `_app.tsx`) — only the toast dispatch is route-gated; `setUnauthenticated()` unchanged.
- Notification `session-expired` — variant/auto-hide changed.
- No API / flag / persistence / mobile changes.

## Risks / not checked

- Copy unchanged (differs slightly from ticket wording).

## Visual summary

```mermaid
flowchart TD
  E[Session expires] --> C[setUnauthenticated - every route]
  C --> Q{isSpacesRoute?}
  Q -->|/welcome/spaces or /spaces/*| T[Show info toast - sticky]
  Q -->|/accounts, other| S[Silent, no toast]
  T --> R[AuthState redirect to /welcome/spaces]
  R --> V[Toast survives navigation]
```

<img width="373" height="212" alt="image" src="https://github.com/user-attachments/assets/b2a0bfde-d349-4f5d-82b0-93c67fb3d14d" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
