### PR TITLE
fix: fetch in-flight queries again after a replayed step-up mutation

### DIFF
--- a/apps/web/src/features/oidc-auth/utils/__tests__/stepUpReplay.test.ts
+++ b/apps/web/src/features/oidc-auth/utils/__tests__/stepUpReplay.test.ts
@@ -1,5 +1,14 @@
 import { faker } from '@faker-js/faker'
-import { getReplayableAction, saveStepUpTrip, takeStepUpTrip } from '../stepUpReplay'
+import { http, HttpResponse } from 'msw'
+import { cgwApi } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { cgwApi as usersApi } from '@safe-global/store/gateway/AUTO_GENERATED/users'
+import { GATEWAY_URL } from '@/config/gateway'
+import { makeStore } from '@/store'
+import { selectNotifications } from '@/store/notificationsSlice'
+import { server } from '@/tests/server'
+import { STEP_UP_FAILED_MESSAGE } from '../../constants'
+import { stepUpReturning } from '../../store'
+import { getReplayableAction, replayStepUpAction, saveStepUpTrip, takeStepUpTrip } from '../stepUpReplay'
 
 const rejectedMutation = (endpointName: string, originalArgs: unknown) => ({
   type: 'cgwClient/executeMutation/rejected',
@@ -115,5 +124,198 @@ describe('step-up trip storage', () => {
     )
 
     expect(takeStepUpTrip()).toEqual({})
+  })
+})
+
+describe('replayStepUpAction', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('should, when the list query is still in flight with two subscribers while the replay completes, fetch the list again so it shows the added Safe', async () => {
+    const spaceId = faker.string.uuid()
+    const existingSafe = faker.finance.ethereumAddress()
+    const addedSafe = faker.finance.ethereumAddress()
+    const listRequests: string[] = []
+    let releaseFirstList: () => void = () => {}
+    const firstListReleased = new Promise<void>((resolve) => (releaseFirstList = resolve))
+    let mutationReceived: () => void = () => {}
+    const mutationArrived = new Promise<void>((resolve) => (mutationReceived = resolve))
+
+    server.use(
+      http.get(`${GATEWAY_URL}/v1/spaces/${spaceId}/safes`, async () => {
+        listRequests.push('GET')
+        if (listRequests.length === 1) {
+          await firstListReleased
+          return HttpResponse.json({ safes: { '1': [existingSafe] } })
+        }
+        return HttpResponse.json({ safes: { '1': [existingSafe, addedSafe] } })
+      }),
+      http.post(`${GATEWAY_URL}/v1/spaces/${spaceId}/safes`, () => {
+        mutationReceived()
+        return HttpResponse.json({}, { status: 201 })
+      }),
+    )
+
+    const store = makeStore(undefined, { skipBroadcast: true })
+    store.dispatch(cgwApi.endpoints.spaceSafesGetV1.initiate({ spaceId }))
+    store.dispatch(cgwApi.endpoints.spaceSafesGetV1.initiate({ spaceId }))
+
+    const replay = replayStepUpAction(store.dispatch, {
+      endpoint: 'spaceSafesCreateV1',
+      args: { spaceId, createSpaceSafesDto: { safes: [{ chainId: '1', address: addedSafe }] } },
+    })
+    await mutationArrived
+    await Promise.all(store.dispatch(cgwApi.util.getRunningMutationsThunk()))
+    releaseFirstList()
+    await replay
+
+    expect(listRequests).toHaveLength(2)
+    // `select` is typed against the generated API's own root state, so the cache is
+    // read through `initiate`, which resolves from the cache once the query is settled.
+    const list = await store.dispatch(cgwApi.endpoints.spaceSafesGetV1.initiate({ spaceId }))
+    expect(list.data).toEqual({ safes: { '1': [existingSafe, addedSafe] } })
+    expect(selectNotifications(store.getState())).toEqual([
+      expect.objectContaining({ message: 'Safe account added', variant: 'success' }),
+    ])
+  })
+
+  it('should, when no query is in flight while the replay completes, fetch the list after the mutation and once more before the toast', async () => {
+    const spaceId = faker.string.uuid()
+    const existingSafe = faker.finance.ethereumAddress()
+    const addedSafe = faker.finance.ethereumAddress()
+    const listRequests: string[] = []
+
+    server.use(
+      http.get(`${GATEWAY_URL}/v1/spaces/${spaceId}/safes`, () => {
+        listRequests.push('GET')
+        if (listRequests.length === 1) {
+          return HttpResponse.json({ safes: { '1': [existingSafe] } })
+        }
+        return HttpResponse.json({ safes: { '1': [existingSafe, addedSafe] } })
+      }),
+      http.post(`${GATEWAY_URL}/v1/spaces/${spaceId}/safes`, () => HttpResponse.json({}, { status: 201 })),
+    )
+
+    const store = makeStore(undefined, { skipBroadcast: true })
+    await store.dispatch(cgwApi.endpoints.spaceSafesGetV1.initiate({ spaceId }))
+
+    await replayStepUpAction(store.dispatch, {
+      endpoint: 'spaceSafesCreateV1',
+      args: { spaceId, createSpaceSafesDto: { safes: [{ chainId: '1', address: addedSafe }] } },
+    })
+
+    expect(listRequests).toHaveLength(3)
+    const list = await store.dispatch(cgwApi.endpoints.spaceSafesGetV1.initiate({ spaceId }))
+    expect(list.data).toEqual({ safes: { '1': [existingSafe, addedSafe] } })
+  })
+
+  it('should, when a list query with two subscribers starts while the replayed mutation is in flight, fetch the list again so it shows the added Safe', async () => {
+    const spaceId = faker.string.uuid()
+    const existingSafe = faker.finance.ethereumAddress()
+    const addedSafe = faker.finance.ethereumAddress()
+    const listRequests: string[] = []
+    let releaseFirstList: () => void = () => {}
+    const firstListReleased = new Promise<void>((resolve) => (releaseFirstList = resolve))
+    let releaseMutation: () => void = () => {}
+    const mutationReleased = new Promise<void>((resolve) => (releaseMutation = resolve))
+    let mutationReceived: () => void = () => {}
+    const mutationArrived = new Promise<void>((resolve) => (mutationReceived = resolve))
+
+    server.use(
+      http.get(`${GATEWAY_URL}/v1/spaces/${spaceId}/safes`, async () => {
+        listRequests.push('GET')
+        if (listRequests.length === 1) {
+          await firstListReleased
+          return HttpResponse.json({ safes: { '1': [existingSafe] } })
+        }
+        return HttpResponse.json({ safes: { '1': [existingSafe, addedSafe] } })
+      }),
+      http.post(`${GATEWAY_URL}/v1/spaces/${spaceId}/safes`, async () => {
+        mutationReceived()
+        await mutationReleased
+        return HttpResponse.json({}, { status: 201 })
+      }),
+    )
+
+    const store = makeStore(undefined, { skipBroadcast: true })
+    const replay = replayStepUpAction(store.dispatch, {
+      endpoint: 'spaceSafesCreateV1',
+      args: { spaceId, createSpaceSafesDto: { safes: [{ chainId: '1', address: addedSafe }] } },
+    })
+    await mutationArrived
+    store.dispatch(cgwApi.endpoints.spaceSafesGetV1.initiate({ spaceId }))
+    store.dispatch(cgwApi.endpoints.spaceSafesGetV1.initiate({ spaceId }))
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    releaseMutation()
+    await Promise.all(store.dispatch(cgwApi.util.getRunningMutationsThunk()))
+    releaseFirstList()
+    await replay
+
+    expect(listRequests).toHaveLength(2)
+    const list = await store.dispatch(cgwApi.endpoints.spaceSafesGetV1.initiate({ spaceId }))
+    expect(list.data).toEqual({ safes: { '1': [existingSafe, addedSafe] } })
+  })
+
+  it('should, when a query the mutation does not invalidate is in flight while the replay completes, not fetch it again', async () => {
+    const spaceId = faker.string.uuid()
+    const userRequests: string[] = []
+    let releaseUser: () => void = () => {}
+    const userReleased = new Promise<void>((resolve) => (releaseUser = resolve))
+    let mutationReceived: () => void = () => {}
+    const mutationArrived = new Promise<void>((resolve) => (mutationReceived = resolve))
+
+    server.use(
+      http.get(`${GATEWAY_URL}/v1/users`, async () => {
+        userRequests.push('GET')
+        await userReleased
+        return HttpResponse.json({ id: 1, status: 'ACTIVE', wallets: [] })
+      }),
+      http.post(`${GATEWAY_URL}/v1/spaces/${spaceId}/safes`, () => {
+        mutationReceived()
+        return HttpResponse.json({}, { status: 201 })
+      }),
+    )
+
+    const store = makeStore(undefined, { skipBroadcast: true })
+    store.dispatch(usersApi.endpoints.usersGetWithWalletsV1.initiate())
+    store.dispatch(usersApi.endpoints.usersGetWithWalletsV1.initiate())
+
+    const replay = replayStepUpAction(store.dispatch, {
+      endpoint: 'spaceSafesCreateV1',
+      args: { spaceId, createSpaceSafesDto: { safes: [{ chainId: '1', address: faker.finance.ethereumAddress() }] } },
+    })
+    await mutationArrived
+    await Promise.all(store.dispatch(cgwApi.util.getRunningMutationsThunk()))
+    releaseUser()
+    await replay
+
+    expect(userRequests).toHaveLength(1)
+    expect(selectNotifications(store.getState())).toEqual([
+      expect.objectContaining({ message: 'Safe account added', variant: 'success' }),
+    ])
+  })
+
+  it('should, when the replayed mutation is rejected because the session is not elevated, show the step-up failed message without saving another trip', async () => {
+    const spaceId = faker.string.uuid()
+
+    server.use(
+      http.post(`${GATEWAY_URL}/v1/spaces/${spaceId}/safes`, () =>
+        HttpResponse.json({ message: 'elevation_required', statusCode: 403 }, { status: 403 }),
+      ),
+    )
+
+    const store = makeStore(undefined, { skipBroadcast: true })
+    store.dispatch(stepUpReturning())
+
+    await replayStepUpAction(store.dispatch, {
+      endpoint: 'spaceSafesCreateV1',
+      args: { spaceId, createSpaceSafesDto: { safes: [{ chainId: '1', address: faker.finance.ethereumAddress() }] } },
+    })
+
+    expect(sessionStorage.getItem('oidc_step_up')).toBeNull()
+    expect(selectNotifications(store.getState())).toEqual([
+      expect.objectContaining({ message: STEP_UP_FAILED_MESSAGE, variant: 'error' }),
+    ])
   })
 })

--- a/apps/web/src/features/oidc-auth/utils/stepUpReplay.ts
+++ b/apps/web/src/features/oidc-auth/utils/stepUpReplay.ts
@@ -85,6 +85,9 @@ export const takeStepUpTrip = (): StepUpTrip | undefined => {
   }
 }
 
+/** Every endpoint in `REPLAYABLE_ENDPOINTS` invalidates this tag and no other. */
+const REPLAY_INVALIDATED_TAGS = ['spaces'] as const
+
 type ReplayOutcome = { error?: FetchBaseQueryError | SerializedError }
 
 /**
@@ -121,6 +124,17 @@ export const replayStepUpAction = async (dispatch: AppDispatch, pending: Pending
 
   // The success message must not appear while the lists still show the old data.
   // This thunk returns one promise per running query, not a single promise.
+  await Promise.all(dispatch(cgwApi.util.getRunningQueriesThunk()))
+
+  // The replay runs during page load, so a query it invalidates can still be in
+  // flight when the mutation completes. RTK Query does not start a second fetch
+  // for such a query, and its `delayed` invalidation does not wait for it either:
+  // the pending counter behind it is also decremented by the rejection that a
+  // duplicate `initiate` of the same in-flight query produces, so the counter is
+  // zero while the first request is still open. The query then keeps the response
+  // it gets, which may have been produced before the write. Invalidating again
+  // once nothing is in flight fetches every affected query with the written data.
+  dispatch(cgwApi.util.invalidateTags([...REPLAY_INVALIDATED_TAGS]))
   await Promise.all(dispatch(cgwApi.util.getRunningQueriesThunk()))
 
   dispatch(


### PR DESCRIPTION
## What it solves

Resolves: Fixes WA-3484

After a step-up round trip (the user is sent to verify a second factor and comes back), the interrupted action is replayed automatically. The replay succeeded, but the list on the page kept its old content until a reload. Seen when adding or removing a Safe account in a workspace. The same replay path serves all step-up actions, so members and address book were affected in the same way.

## How this PR fixes it

In plain terms. When the page loads after the round trip, two things start at almost the same time: the request that loads the list, and the replayed action, for example "add this Safe". The list request can be answered by the gateway before the add has happened, while its answer is still on the way to the browser. When the add completes, RTK Query marks the list as out of date, but it does not start a second request for a list that is already being fetched. It expects the running request to bring fresh data. Here the running request brings the old data. RTK Query stores it as current and never asks again.

RTK Query has a setting meant to prevent this (`invalidationBehavior: 'delayed'`, the default). It does not hold here: the counter it uses to know whether requests are in flight is also decremented when a duplicate `initiate` of an in-flight query is rejected, so it reads zero while the real request is still open.

The change is in `replayStepUpAction`. After the replayed mutation succeeds it waits for the running queries to settle, then invalidates the `spaces` tag once more and waits again before showing the toast. Every workspace query is fetched with the written data whenever it started, and queries outside that tag are left alone. The cost is one extra fetch of the workspace lists on the page load after a step-up.

## How to test it

1. Sign in to a workspace with an OIDC session (email or Google, not a wallet) and wait until the elevation window has lapsed.
2. Safe accounts → Add accounts → pick a Safe → Add. Complete the one-time code.
3. Back on the page the list shows the new Safe, then the "Safe account added" toast appears.
4. Repeat with "Remove from workspace" on the same Safe.

Unit tests cover five cases: the list query still in flight while the replay completes, a list query that starts while the mutation is in flight, no query in flight, a query outside the tag in flight that must not be fetched again, and a replay rejected because the session is not elevated.

## Affected flows

- Every replayed step-up action on return from the second-factor check: add and remove Safe account, rename and delete workspace, invite member, change role, remove member, address book add, edit, delete and approve.

## Blast radius

- One function, `replayStepUpAction` in `apps/web/src/features/oidc-auth/utils/stepUpReplay.ts`. Its only caller is `useStepUpCallback`.
- No change to the store, the listener, the generated API or any endpoint.
- Normal mutations outside the replay path are untouched.
- No mobile impact.

## Risks / not checked

- Exercised in the browser with Safe accounts only. The other replayed actions go through the same code but were not clicked through again.
- The same race can in theory happen outside the replay path, whenever a mutation completes while a list refetch is in flight. Not covered by this change.
- The workspace lists are fetched one extra time on the page load after a step-up, also when nothing was in flight. That is intended.

## Visual summary

```mermaid
sequenceDiagram
  participant App
  participant CGW
  App->>CGW: GET list (page load)
  App->>CGW: replayed mutation
  CGW-->>App: mutation OK
  Note over App: invalidation skips the list, it is still in flight
  CGW-->>App: list response (produced before the write)
  Note over App: fix: list was running before and after the mutation
  App->>CGW: GET list again
  CGW-->>App: list response (after the write)
  App->>App: success toast
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
