### PR TITLE
feat(safe-pro): track banner clicks in Mixpanel

### DIFF
--- a/apps/web/src/features/safe-pro-announcement/components/SafeProAnnouncement/SafeProAnnouncement.stories.tsx
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProAnnouncement/SafeProAnnouncement.stories.tsx
@@ -7,6 +7,9 @@ const meta = {
   title: 'Features/SafePro/SafeProAnnouncement',
   tags: ['autodocs'],
   decorators: [withMockProvider({ shadcn: true })],
+  args: {
+    location: 'plans_page',
+  },
 } satisfies Meta<typeof SafeProAnnouncement>
 
 export default meta

--- a/apps/web/src/features/safe-pro-announcement/components/SafeProAnnouncement/index.tsx
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProAnnouncement/index.tsx
@@ -5,9 +5,10 @@ import { Typography } from '@/components/ui/typography'
 import { cn } from '@/utils/cn'
 import { SAFE_PRO_ANNOUNCEMENT_URL } from '@/config/constants'
 import { useDarkMode } from '@/hooks/useDarkMode'
+import { trackSafeProBannerClick, type SafeProBannerLocation } from '../../utils/trackSafeProBannerClick'
 import css from './styles.module.css'
 
-const SafeProAnnouncement = ({ onDismiss }: { onDismiss?: () => void }) => {
+const SafeProAnnouncement = ({ location, onDismiss }: { location: SafeProBannerLocation; onDismiss?: () => void }) => {
   const isDarkMode = useDarkMode()
 
   return (
@@ -41,7 +42,17 @@ const SafeProAnnouncement = ({ onDismiss }: { onDismiss?: () => void }) => {
             </Button>
           )}
 
-          <Button size="lg" render={<a href={SAFE_PRO_ANNOUNCEMENT_URL} target="_blank" rel="noopener noreferrer" />}>
+          <Button
+            size="lg"
+            render={
+              <a
+                onClick={() => trackSafeProBannerClick(location)}
+                href={SAFE_PRO_ANNOUNCEMENT_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              />
+            }
+          >
             Learn more
             <ArrowUpRight data-icon="inline-end" className={cn('text-green-400', css.arrow)} />
           </Button>

--- a/apps/web/src/features/safe-pro-announcement/components/SafeProAnnouncementModal/index.tsx
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProAnnouncementModal/index.tsx
@@ -13,7 +13,7 @@ const SafeProAnnouncementModal = ({
       <DialogTitle className="sr-only" render={<div />}>
         Your Workspace moves to Pro on Oct 6, 2026
       </DialogTitle>
-      <SafeProAnnouncement onDismiss={() => onOpenChange?.(false)} />
+      <SafeProAnnouncement location="announcement_modal" onDismiss={() => onOpenChange?.(false)} />
     </DialogContent>
   </Dialog>
 )

--- a/apps/web/src/features/safe-pro-announcement/components/SafeProBanner/index.tsx
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProBanner/index.tsx
@@ -4,11 +4,13 @@ import { ICON_STROKE } from '@/components/common/iconStroke'
 import { Typography } from '@/components/ui/typography'
 import { cn } from '@/utils/cn'
 import { SAFE_PRO_ANNOUNCEMENT_URL } from '@/config/constants'
+import { trackSafeProBannerClick } from '../../utils/trackSafeProBannerClick'
 import css from './styles.module.css'
 
 const SafeProBanner = ({ className }: { className?: string }) => (
   <a
     href={SAFE_PRO_ANNOUNCEMENT_URL}
+    onClick={() => trackSafeProBannerClick('workspaces_sign_in')}
     target="_blank"
     rel="noopener noreferrer"
     className={cn(

--- a/apps/web/src/features/safe-pro-announcement/components/SafeProSidebarBanner/index.tsx
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProSidebarBanner/index.tsx
@@ -4,6 +4,7 @@ import { Typography } from '@/components/ui/typography'
 import { cn } from '@/utils/cn'
 import { SAFE_PRO_ANNOUNCEMENT_URL } from '@/config/constants'
 import ProWordmark from '@/public/images/safe-pro/pro-wordmark.svg'
+import { trackSafeProBannerClick } from '../../utils/trackSafeProBannerClick'
 import css from './styles.module.css'
 
 const SafeProSidebarBanner = ({ className }: { className?: string }) => (
@@ -30,7 +31,14 @@ const SafeProSidebarBanner = ({ className }: { className?: string }) => (
 
     <Button
       size="xs"
-      render={<a href={SAFE_PRO_ANNOUNCEMENT_URL} target="_blank" rel="noopener noreferrer" />}
+      render={
+        <a
+          onClick={() => trackSafeProBannerClick('sidebar')}
+          href={SAFE_PRO_ANNOUNCEMENT_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        />
+      }
       className={css.learnMore}
     >
       Learn more

--- a/apps/web/src/features/safe-pro-announcement/components/SafeProWorkspacesBanner/index.tsx
+++ b/apps/web/src/features/safe-pro-announcement/components/SafeProWorkspacesBanner/index.tsx
@@ -7,6 +7,7 @@ import { ShadcnProvider } from '@/components/ui/ShadcnProvider'
 import { useDarkMode } from '@/hooks/useDarkMode'
 import { SAFE_PRO_ANNOUNCEMENT_URL } from '@/config/constants'
 import ProWordmark from '@/public/images/safe-pro/pro-wordmark.svg'
+import { trackSafeProBannerClick } from '../../utils/trackSafeProBannerClick'
 import css from './styles.module.css'
 
 const SafeProWorkspacesBanner = ({ className }: { className?: string }) => {
@@ -29,7 +30,14 @@ const SafeProWorkspacesBanner = ({ className }: { className?: string }) => {
             </div>
 
             <Button
-              render={<a href={SAFE_PRO_ANNOUNCEMENT_URL} target="_blank" rel="noopener noreferrer" />}
+              render={
+                <a
+                  onClick={() => trackSafeProBannerClick('workspaces_list')}
+                  href={SAFE_PRO_ANNOUNCEMENT_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />
+              }
               className={cn('shrink-0', css.learnMore)}
             >
               Learn more

--- a/apps/web/src/features/safe-pro-announcement/utils/__tests__/trackSafeProBannerClick.test.ts
+++ b/apps/web/src/features/safe-pro-announcement/utils/__tests__/trackSafeProBannerClick.test.ts
@@ -1,0 +1,17 @@
+import { MixpanelEvent, MixpanelEventParams, trackMixpanelEvent } from '@/services/analytics'
+import { trackSafeProBannerClick } from '../trackSafeProBannerClick'
+
+jest.mock('@/services/analytics', () => ({
+  ...jest.requireActual('@/services/analytics'),
+  trackMixpanelEvent: jest.fn(),
+}))
+
+describe('trackSafeProBannerClick', () => {
+  it('sends the banner location as the Mixpanel Location property', () => {
+    trackSafeProBannerClick('sidebar')
+
+    expect(trackMixpanelEvent).toHaveBeenCalledWith(MixpanelEvent.SAFE_PRO_BANNER_CLICKED, {
+      [MixpanelEventParams.LOCATION]: 'sidebar',
+    })
+  })
+})

--- a/apps/web/src/features/safe-pro-announcement/utils/trackSafeProBannerClick.ts
+++ b/apps/web/src/features/safe-pro-announcement/utils/trackSafeProBannerClick.ts
@@ -1,0 +1,11 @@
+import { MixpanelEvent, MixpanelEventParams, trackMixpanelEvent } from '@/services/analytics'
+
+export type SafeProBannerLocation =
+  | 'sidebar'
+  | 'workspaces_list'
+  | 'workspaces_sign_in'
+  | 'announcement_modal'
+  | 'plans_page'
+
+export const trackSafeProBannerClick = (location: SafeProBannerLocation) =>
+  trackMixpanelEvent(MixpanelEvent.SAFE_PRO_BANNER_CLICKED, { [MixpanelEventParams.LOCATION]: location })

--- a/apps/web/src/features/spaces/components/Plans/Page.tsx
+++ b/apps/web/src/features/spaces/components/Plans/Page.tsx
@@ -18,7 +18,7 @@ export default function SpacePlansPage({ spaceId }: { spaceId: string }) {
         </Typography>
 
         <Card className="w-full gap-0 py-0">
-          <SafeProAnnouncement />
+          <SafeProAnnouncement location="plans_page" />
         </Card>
       </div>
     </AuthState>

--- a/apps/web/src/services/analytics/mixpanel-events.ts
+++ b/apps/web/src/services/analytics/mixpanel-events.ts
@@ -24,6 +24,7 @@ export enum MixpanelEvent {
   EURCV_BOOST_EXPLORE_CLICKED = 'EURCV Boost Explore Clicked',
   EURCV_BOOST_BANNER_CLICKED = 'EURCV Boost Banner Clicked',
   EURCV_BOOST_BANNER_DISMISSED = 'EURCV Boost Banner Dismissed',
+  SAFE_PRO_BANNER_CLICKED = 'Safe Pro Banner Clicked',
   TRANSACTION_STARTED = 'Transaction Started',
   TRANSACTION_RECIPIENT_DECODED = 'Transaction Recipient Decoded',
   TRANSACTION_CONTRACT_DECODED = 'Transaction Contract Decoded',


### PR DESCRIPTION
## What it solves

Marketing needs to attribute Safe Pro applications to the in-app banner they came from, so every Learn more link reports which banner was clicked.

Resolves: https://linear.app/safe-global/issue/PLA-1946/add-tracking-to-safe-pro-banners

## How this PR fixes it

Every Safe Pro "Learn more" link now sends a Mixpanel event Safe Pro Banner Clicked with a Location property naming the banner: sidebar, workspaces_list, workspaces_sign_in, announcement_modal or plans_page. 

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
