### PR TITLE
chore: add Dependabot cooldown and run CI on lockfile changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,28 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    open-pull-requests-limit: 10
+    # Let a release age on the registry before proposing it
+    cooldown:
+      semver-patch-days: 7
+      semver-minor-days: 7
+      semver-major-days: 7
     groups:
       ledger:
         patterns:
           - '@ledgerhq/*'
+      # Catch-alls must stay last: a dependency joins the first group it matches.
+      # Majors are deliberately excluded so they arrive as individual PRs.
+      dev-minor-patch:
+        dependency-type: 'development'
+        update-types: ['minor', 'patch']
+      prod-minor-patch:
+        dependency-type: 'production'
+        update-types: ['minor', 'patch']
 
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 7

--- a/.github/workflows/mobile-checks.yml
+++ b/.github/workflows/mobile-checks.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - apps/mobile/**
       - packages/**
+      - yarn.lock
+      - package.json
+      - .yarnrc.yml
+      - .yarn/patches/**
   push:
     branches:
       - main
@@ -12,6 +16,10 @@ on:
     paths:
       - apps/mobile/**
       - packages/**
+      - yarn.lock
+      - package.json
+      - .yarnrc.yml
+      - .yarn/patches/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mobile-unit-tests.yml
+++ b/.github/workflows/mobile-unit-tests.yml
@@ -7,11 +7,19 @@ on:
     paths:
       - apps/mobile/**
       - packages/**
+      - yarn.lock
+      - package.json
+      - .yarnrc.yml
+      - .yarn/patches/**
   pull_request:
     paths:
       - apps/mobile/**
       - packages/**
       - .github/workflows/mobile-unit-tests.yml
+      - yarn.lock
+      - package.json
+      - .yarnrc.yml
+      - .yarn/patches/**
 
 jobs:
   test-and-coverage:

--- a/.github/workflows/package-utils-unit-tests.yml
+++ b/.github/workflows/package-utils-unit-tests.yml
@@ -4,11 +4,19 @@ on:
     paths:
       - packages/utils/**
       - packages/store/**
+      - yarn.lock
+      - package.json
+      - .yarnrc.yml
+      - .yarn/patches/**
   push:
     branches:
       - main
     paths:
       - packages/**
+      - yarn.lock
+      - package.json
+      - .yarnrc.yml
+      - .yarn/patches/**
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/tx-builder-checks.yml
+++ b/.github/workflows/tx-builder-checks.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - apps/tx-builder/**
       - packages/**
+      - yarn.lock
+      - package.json
+      - .yarnrc.yml
+      - .yarn/patches/**
   push:
     branches:
       - main
@@ -12,6 +16,10 @@ on:
     paths:
       - apps/tx-builder/**
       - packages/**
+      - yarn.lock
+      - package.json
+      - .yarnrc.yml
+      - .yarn/patches/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/web-checks.yml
+++ b/.github/workflows/web-checks.yml
@@ -6,6 +6,10 @@ on:
       - apps/web/**
       - apps/web-tanstack/**
       - packages/**
+      - yarn.lock
+      - package.json
+      - .yarnrc.yml
+      - .yarn/patches/**
   push:
     branches:
       - main
@@ -14,6 +18,10 @@ on:
       - apps/web/**
       - apps/web-tanstack/**
       - packages/**
+      - yarn.lock
+      - package.json
+      - .yarnrc.yml
+      - .yarn/patches/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/web-pw-smoke.yml
+++ b/.github/workflows/web-pw-smoke.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - apps/web/**
       - packages/**
+      - yarn.lock
+      - package.json
+      - .yarnrc.yml
+      - .yarn/patches/**
   push:
     branches:
       - main
@@ -12,6 +16,10 @@ on:
     paths:
       - apps/web/**
       - packages/**
+      - yarn.lock
+      - package.json
+      - .yarnrc.yml
+      - .yarn/patches/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/web-storybook-tests.yml
+++ b/.github/workflows/web-storybook-tests.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - apps/web/**
       - .github/workflows/web-storybook-tests.yml
+      - yarn.lock
+      - package.json
+      - .yarnrc.yml
+      - .yarn/patches/**
 
   push:
     branches:
@@ -15,6 +19,10 @@ on:
     paths:
       - apps/web/**
       - .github/workflows/web-storybook-tests.yml
+      - yarn.lock
+      - package.json
+      - .yarnrc.yml
+      - .yarn/patches/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/web-tanstack-checks.yml
+++ b/.github/workflows/web-tanstack-checks.yml
@@ -6,6 +6,10 @@ on:
       - apps/web-tanstack/**
       - apps/web/**
       - packages/**
+      - yarn.lock
+      - package.json
+      - .yarnrc.yml
+      - .yarn/patches/**
   push:
     branches:
       - main
@@ -14,6 +18,10 @@ on:
       - apps/web-tanstack/**
       - apps/web/**
       - packages/**
+      - yarn.lock
+      - package.json
+      - .yarnrc.yml
+      - .yarn/patches/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/web-unit-tests.yml
+++ b/.github/workflows/web-unit-tests.yml
@@ -4,6 +4,10 @@ on:
     paths:
       - apps/web/**
       - packages/**
+      - yarn.lock
+      - package.json
+      - .yarnrc.yml
+      - .yarn/patches/**
 
   push:
     branches:
@@ -12,6 +16,10 @@ on:
     paths:
       - apps/web/**
       - packages/**
+      - yarn.lock
+      - package.json
+      - .yarnrc.yml
+      - .yarn/patches/**
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## What it solves

Resolves: n/a

Two problems with our dependency update pipeline:

1. Dependabot's open-PR limit defaults to 5, and security-update PRs are exempt from it. With stale version-update PRs occupying the slots, no new updates were being proposed for the ~660 direct dependencies declared across our workspaces.
2. Root `yarn.lock`, root `package.json`, `.yarnrc.yml` and `.yarn/patches/**` matched no workflow `paths` filter. A dependency-only PR therefore ran no unit tests, lint, or type-check — green meant "nothing ran". See #8641 for an example: 4 checks, none of them functional.

## How this PR fixes it

**Dependabot** — raise `open-pull-requests-limit` to 10 and group routine `minor`/`patch` bumps into one dev PR and one prod PR, so PR count drops while coverage goes up. Majors stay individual, since those need a changelog read. Add a 7-day `cooldown` so a release ages on the registry before it is proposed; this reduces exposure to a compromised publish, and does not apply to security updates.

**CI** — add the four dependency paths to the `pull_request` and `push` triggers of the check and unit-test workflows.

`web-e2e-smoke.yml` is deliberately excluded: Cypress smoke runs 5 containers at ~16 min each and is maintenance-only, while Playwright smoke covers the same ground in one job.

## How to test it

1. On this branch, confirm `.github/workflows/*.yml` still parse and the `on:` blocks list the four new paths.
2. After merge, rebase an open dependency PR that touches only `yarn.lock` (e.g. #8641) and confirm the check and unit-test workflows now appear on it.
3. Dependabot config changes take effect on the next scheduled run; confirm subsequent PRs arrive grouped.

## Affected flows

- Dependency update proposals — cadence, grouping and PR volume change.
- CI on any PR whose diff touches root `yarn.lock`, root `package.json`, `.yarnrc.yml` or `.yarn/patches/**`, including human-authored ones.

## Blast radius

- `.github/workflows/*.yml` `paths:` filters are a shared CI surface — this affects every PR, not only Dependabot's. Adding a path can only add checks, never remove them.
- `push:` triggers on `main`/`dev` change too, so lockfile-only merges now run these suites.
- No application code, shared hooks, selectors, slices, endpoints, feature flags or persisted state touched.
- Mobile: `mobile-checks` and `mobile-unit-tests` gain triggers; no `apps/mobile` source change.
- `yarn.config.cjs` cross-workspace drift check is intentionally left report-only in this PR.

## Visual summary

```mermaid
flowchart LR
    subgraph before["Before"]
        A["PR diff:<br/>yarn.lock only"] -->|"matches no<br/>paths filter"| B["Socket + dev deploy<br/>(no tests, lint, type-check)"]
    end
    subgraph after["After"]
        C["PR diff:<br/>yarn.lock only"] -->|"matches new<br/>paths filter"| D["web/mobile/tanstack/tx-builder checks<br/>unit tests, storybook, pw-smoke"]
    end
    before --> after
```

```mermaid
flowchart TD
    E["New release on registry"] -->|"cooldown: 7 days"| F["Dependabot proposes"]
    F --> G{"Bump type"}
    G -->|"minor / patch, dev"| H["1 grouped PR"]
    G -->|"minor / patch, prod"| I["1 grouped PR"]
    G -->|"major"| J["individual PR"]
    K["Security advisory"] -->|"no cooldown, no limit"| L["individual PR, immediately"]
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — n/a, no mobile source change; `mobile-checks` and `mobile-unit-tests` triggers only
- [ ] I've documented how it affects the analytics (if at all) 📊 — n/a, no analytics surface
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — n/a, CI and bot configuration; verification is that YAML parses and triggers fire
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
