### PR TITLE
refactor: capitalise Workspace throughout the UI copy

### DIFF
--- a/apps/web/cypress/e2e/pages/spaces.page.js
+++ b/apps/web/cypress/e2e/pages/spaces.page.js
@@ -162,7 +162,7 @@ export const zeroBalanceRegex = /\$[\u200a\s]*0(?:\.00)?/
 export const txDetailsLabel = 'Transaction details'
 export const pendingTxName = 'Send'
 export const pendingTxStatus = 'Needs confirmation'
-export const deleteSpaceConfirmationMsg = (name) => `Deleted workspace ${name}`
+export const deleteSpaceConfirmationMsg = (name) => `Deleted Workspace ${name}`
 export const acceptInviteConfirmationMsg = (spaceName) => `Accepted invite to ${spaceName}`
 
 // ===========================================

--- a/apps/web/cypress/e2e/visual/welcome.cy.js
+++ b/apps/web/cypress/e2e/visual/welcome.cy.js
@@ -16,7 +16,7 @@ describe('[VISUAL] Welcome page screenshots', { defaultCommandTimeout: 60000, ..
 
   it('[VISUAL] Screenshot spaces welcome signed-out page', () => {
     cy.visit(constants.spacesUrl)
-    cy.contains('Sign in to your workspace').should('be.visible')
+    cy.contains('Sign in to your Workspace').should('be.visible')
     main.awaitVisualStability()
   })
 })

--- a/apps/web/e2e/tests/regression/step-up-auth.spec.ts
+++ b/apps/web/e2e/tests/regression/step-up-auth.spec.ts
@@ -91,7 +91,7 @@ function captureAuthorizeRequest(page: Page) {
 async function openRemoveDialog(page: Page): Promise<void> {
   await page.goto(`/spaces/safe-accounts?spaceId=${SPACE_ID}`)
   await page.getByRole('button', { name: 'Safe Account actions' }).first().click()
-  await page.getByRole('menuitem', { name: 'Remove from workspace' }).click()
+  await page.getByRole('menuitem', { name: 'Remove from Workspace' }).click()
 }
 
 const readStepUpRecord = (page: Page) => page.evaluate((key) => window.sessionStorage.getItem(key), STEP_UP_KEY)

--- a/apps/web/src/components/address-book/AddressBookHeader/index.tsx
+++ b/apps/web/src/components/address-book/AddressBookHeader/index.tsx
@@ -30,7 +30,7 @@ const SpaceAddressBookCTA = () => {
 
   return (
     <Typography className="max-w-[500px] text-sm">
-      This data is stored in your local storage. Do you want to manage your <b>{space?.name}</b> workspace address book
+      This data is stored in your local storage. Do you want to manage your <b>{space?.name}</b> Workspace address book
       instead?{' '}
       <ShadcnLink render={<Link href={{ pathname: AppRoutes.spaces.addressBook, query: { spaceId } }} passHref />}>
         Click here

--- a/apps/web/src/components/common/AddressBookInput/RecipientGroupHeader.tsx
+++ b/apps/web/src/components/common/AddressBookInput/RecipientGroupHeader.tsx
@@ -42,8 +42,8 @@ const RecipientGroupHeader = ({
         <TooltipTrigger render={<Info size={14} className={css.groupInfoIcon} />} />
         <TooltipContent>
           {isSpace
-            ? `Shared with everyone in ${workspaceName ?? 'your workspace'}. Only Workspace admins can add or change these contacts.`
-            : 'Saved only in this browser, from your old address book. Not shared with your workspace.'}
+            ? `Shared with everyone in ${workspaceName ?? 'your Workspace'}. Only Workspace admins can add or change these contacts.`
+            : 'Saved only in this browser, from your old address book. Not shared with your Workspace.'}
         </TooltipContent>
       </Tooltip>
 

--- a/apps/web/src/components/common/DialogActions/DialogActions.stories.tsx
+++ b/apps/web/src/components/common/DialogActions/DialogActions.stories.tsx
@@ -25,11 +25,11 @@ export const AllVariants: Story = {
       </div>
       <div>
         <h3 className="mb-4 text-lg font-semibold">Destructive</h3>
-        <DialogActions confirmLabel="Delete workspace" onConfirm={() => {}} onCancel={() => {}} confirmDestructive />
+        <DialogActions confirmLabel="Delete Workspace" onConfirm={() => {}} onCancel={() => {}} confirmDestructive />
       </div>
       <div>
         <h3 className="mb-4 text-lg font-semibold">Loading</h3>
-        <DialogActions confirmLabel="Create workspace" onConfirm={() => {}} onCancel={() => {}} confirmLoading />
+        <DialogActions confirmLabel="Create Workspace" onConfirm={() => {}} onCancel={() => {}} confirmLoading />
       </div>
       <div>
         <h3 className="mb-4 text-lg font-semibold">Confirm-only</h3>

--- a/apps/web/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
+++ b/apps/web/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
@@ -120,7 +120,7 @@ const SrcEthHashInfo = ({
                       )}
                     </TooltipTrigger>
                     <TooltipContent>
-                      From your {addressBookNameSource === ContactSource.space ? 'workspace' : 'local'} address book
+                      From your {addressBookNameSource === ContactSource.space ? 'Workspace' : 'local'} address book
                     </TooltipContent>
                   </Tooltip>
                 )}

--- a/apps/web/src/components/common/SpaceSafeBar/index.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.test.tsx
@@ -341,7 +341,7 @@ describe('SpaceSafeBar', () => {
     expect(connect).toHaveBeenCalledTimes(1)
   })
 
-  it('does not render a footer on the Workspace tab (default in a space context)', () => {
+  it('does not render a footer on the workspace tab (default in a space context)', () => {
     mockUseIsQualifiedSafe.mockReturnValue(true)
     mockUseSpaceSafeSelectorItems.mockReturnValue({
       workspaceItems: mockItems,
@@ -359,18 +359,18 @@ describe('SpaceSafeBar', () => {
     expect(getByTestId('safe-selector-dropdown').getAttribute('data-has-footer')).toBe('false')
   })
 
-  it('renders Workspace and Local tabs in the dropdown', () => {
+  it('renders workspace and Local tabs in the dropdown', () => {
     const { getByTestId } = render(<SpaceSafeBar />)
     expect(getByTestId('dropdown-tab-workspace')).toBeInTheDocument()
     expect(getByTestId('dropdown-tab-local')).toBeInTheDocument()
   })
 
-  it('labels the Workspace tab "Workspace" off the Spaces level', () => {
+  it('labels the workspace tab "Workspace" off the Spaces level', () => {
     const { getByTestId } = render(<SpaceSafeBar />)
     expect(getByTestId('dropdown-tab-workspace').textContent).toBe('Workspace')
   })
 
-  it('labels the Workspace tab "Workspace" when a fallback space is loaded but the safe is not part of it', () => {
+  it('labels the workspace tab "Workspace" when a fallback space is loaded but the safe is not part of it', () => {
     // `useCurrentSpaceId` resolves a fallback space (last-used / first in the list) even when the
     // current safe belongs to no workspace, so `space` is populated while isInSpaceContext is false.
     mockUseSpaceBackLink.mockReturnValue({ space: { id: 1, name: 'Daniel Test space' }, handleBackToSpace: jest.fn() })
@@ -379,7 +379,7 @@ describe('SpaceSafeBar', () => {
     expect(getByTestId('dropdown-tab-workspace').textContent).toBe('Workspace')
   })
 
-  it('labels the Workspace tab with the space name in a space context', () => {
+  it('labels the workspace tab with the space name in a space context', () => {
     mockUseIsQualifiedSafe.mockReturnValue(true)
     mockUseSpaceSafeSelectorItems.mockReturnValue({
       workspaceItems: mockItems,

--- a/apps/web/src/components/common/SpaceSafeBar/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.tsx
@@ -91,7 +91,7 @@ function SignInWorkspaceCta({ label, onSignIn }: { label: string; onSignIn: () =
   return (
     <div className="flex flex-col items-center gap-3 px-4 py-8 text-center" data-testid="dropdown-signin-cta">
       <p className="text-sm text-muted-foreground">
-        Sign in to a workspace to collaborate on Safe accounts with your team.
+        Sign in to a Workspace to collaborate on Safe accounts with your team.
       </p>
       <Button variant="secondary" size="sm" onClick={onSignIn} data-testid="dropdown-signin-btn">
         {label}
@@ -262,7 +262,7 @@ function SpaceSafeBar() {
   const emptyStateOverride =
     activeTab === 'workspace' && !isInSpaceContext ? (
       <SignInWorkspaceCta
-        label={isSignedIn ? 'View workspaces' : 'Sign in'}
+        label={isSignedIn ? 'View Workspaces' : 'Sign in'}
         onSignIn={() => router.push({ pathname: AppRoutes.welcome.spaces })}
       />
     ) : activeTab === 'local' && !hasWallet ? (

--- a/apps/web/src/components/common/SubmitButton/SubmitButton.stories.tsx
+++ b/apps/web/src/components/common/SubmitButton/SubmitButton.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
     disabled: { control: 'boolean' },
     children: { control: 'text' },
   },
-  args: { children: 'Create workspace' },
+  args: { children: 'Create Workspace' },
 } satisfies Meta<typeof SubmitButton>
 
 export default meta
@@ -27,9 +27,9 @@ export const AllVariants: Story = {
       <div>
         <h3 className="mb-4 text-lg font-semibold">States</h3>
         <div className="flex flex-wrap items-center gap-4">
-          <SubmitButton>Create workspace</SubmitButton>
-          <SubmitButton loading>Create workspace</SubmitButton>
-          <SubmitButton disabled>Create workspace</SubmitButton>
+          <SubmitButton>Create Workspace</SubmitButton>
+          <SubmitButton loading>Create Workspace</SubmitButton>
+          <SubmitButton disabled>Create Workspace</SubmitButton>
         </div>
         <p className="mt-2 text-sm text-muted-foreground">
           The label swaps to a spinner while <code>loading</code> without the button resizing (the <code>submit</code>{' '}

--- a/apps/web/src/components/ui/stories/design-system.stories.tsx
+++ b/apps/web/src/components/ui/stories/design-system.stories.tsx
@@ -375,7 +375,7 @@ export const Buttons: Story = {
             Cancel
           </Button>
         </Swatch>
-        <Swatch label="destructive" to="Pages/Spaces/Settings" toLabel="Delete workspace">
+        <Swatch label="destructive" to="Pages/Spaces/Settings" toLabel="Delete Workspace">
           <Button variant="destructive">Delete</Button>
         </Swatch>
         <Swatch label="ghost" to="Components/Settings/OwnerList" toLabel="Signers">

--- a/apps/web/src/components/ui/stories/dropdown-menu.stories.tsx
+++ b/apps/web/src/components/ui/stories/dropdown-menu.stories.tsx
@@ -87,7 +87,7 @@ export const NarrowTrigger: Story = {
           </DropdownMenuItem>
           <DropdownMenuItem variant="destructive">
             <Trash2 />
-            Remove from workspace
+            Remove from Workspace
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/web/src/components/welcome/WelcomeLogin/hooks/__tests__/useSignInRedirect.test.ts
+++ b/apps/web/src/components/welcome/WelcomeLogin/hooks/__tests__/useSignInRedirect.test.ts
@@ -86,7 +86,7 @@ describe('useSignInRedirect', () => {
   // -----------------------------------------------------------------------
 
   describe('when user is new (no spaces)', () => {
-    it('does not redirect after sign-in (they stay on the Workspaces tab)', async () => {
+    it('does not redirect after sign-in (they stay on the workspaces tab)', async () => {
       setupMocks()
 
       const { result } = renderHook(() => useSignInRedirect(defaultProps))

--- a/apps/web/src/features/counterfactual/services/persistCounterfactualSafe.ts
+++ b/apps/web/src/features/counterfactual/services/persistCounterfactualSafe.ts
@@ -119,7 +119,7 @@ export const persistCounterfactualSafe = async ({
           showNotification({
             variant: 'info',
             groupKey: 'cf-safe-space-skipped',
-            message: 'Safe added to your accounts — ask an admin to add it to the workspace',
+            message: 'Safe added to your accounts — ask an admin to add it to the Workspace',
           }),
         )
       } else if (spaceSafeCount !== undefined && spaceSafeCount >= SAFE_ACCOUNTS_LIMIT) {
@@ -130,7 +130,7 @@ export const persistCounterfactualSafe = async ({
           showNotification({
             variant: 'info',
             groupKey: 'cf-safe-space-limit',
-            message: `Safe created. This workspace is full (${SAFE_ACCOUNTS_LIMIT} Safes), so it wasn't added — switch to another workspace to add it there`,
+            message: `Safe created. This Workspace is full (${SAFE_ACCOUNTS_LIMIT} Safes), so it wasn't added — switch to another Workspace to add it there`,
           }),
         )
       } else {
@@ -235,7 +235,7 @@ function isConflict(error: unknown): boolean {
 }
 
 function toSpaceError(error: unknown): Error {
-  return new Error((error as BackendError)?.data?.message || 'Failed to add Safe account to workspace')
+  return new Error((error as BackendError)?.data?.message || 'Failed to add Safe account to Workspace')
 }
 
 /** Matches the CGW limit message, e.g. "This space only allows a maximum of 40 safe accounts...".

--- a/apps/web/src/features/myAccounts/components/SafeAccountsTable/__tests__/SafeAccountsTable.test.tsx
+++ b/apps/web/src/features/myAccounts/components/SafeAccountsTable/__tests__/SafeAccountsTable.test.tsx
@@ -358,13 +358,13 @@ describe('SafeAccountsTable — selection mode', () => {
           selectedKeys: new Set(),
           onToggle: jest.fn(),
           disabledKeys: new Set(['0xB']),
-          disabledReason: 'Already in workspace',
+          disabledReason: 'Already in Workspace',
         }}
       />,
     )
     const box = screen.getByTestId('select-0xB')
     expect(box).toHaveAttribute('data-disabled', 'true')
-    expect(box).toHaveAttribute('data-reason', 'Already in workspace')
+    expect(box).toHaveAttribute('data-reason', 'Already in Workspace')
   })
 
   it('locks a multi-chain group whose every child is in disabledKeys', () => {
@@ -375,13 +375,13 @@ describe('SafeAccountsTable — selection mode', () => {
           selectedKeys: new Set(['1:0xG', '2:0xG']),
           onToggle: jest.fn(),
           disabledKeys: new Set(['1:0xG', '2:0xG']),
-          disabledReason: 'Already in workspace',
+          disabledReason: 'Already in Workspace',
         }}
       />,
     )
     const group = screen.getByTestId('select-0xG')
     expect(group).toHaveAttribute('data-disabled', 'true')
-    expect(group).toHaveAttribute('data-reason', 'Already in workspace')
+    expect(group).toHaveAttribute('data-reason', 'Already in Workspace')
   })
 
   it('suppresses the rename action on a selection surface by default', () => {

--- a/apps/web/src/features/oidc-auth/components/SwitchAuthenticatorSection/index.tsx
+++ b/apps/web/src/features/oidc-auth/components/SwitchAuthenticatorSection/index.tsx
@@ -52,7 +52,7 @@ const SwitchAuthenticatorSection = () => {
         )}
       </div>
       <Typography variant="paragraph-small" color="muted" className="mb-4 block max-w-[560px]">
-        Required for everyone in this workspace. Signing in takes your email code and a 6-digit code from your
+        Required for everyone in this Workspace. Signing in takes your email code and a 6-digit code from your
         authenticator app.
       </Typography>
 

--- a/apps/web/src/features/spaces/components/AddAccounts/__tests__/AddAccounts.test.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/__tests__/AddAccounts.test.tsx
@@ -204,7 +204,7 @@ describe('AddAccounts — admin guard on submit', () => {
     expect(form).not.toBeNull()
     fireEvent.submit(form!)
 
-    expect(await screen.findByText('Only admins can add or remove Safe accounts in this workspace')).toBeInTheDocument()
+    expect(await screen.findByText('Only admins can add or remove Safe accounts in this Workspace')).toBeInTheDocument()
     expect(mockAddSafesToSpace).not.toHaveBeenCalled()
     expect(mockRemoveSafesFromSpace).not.toHaveBeenCalled()
   })
@@ -229,7 +229,7 @@ describe('AddAccounts — admin guard on submit', () => {
     expect(form).not.toBeNull()
     fireEvent.submit(form!)
 
-    expect(screen.queryByText('Only admins can add or remove Safe accounts in this workspace')).not.toBeInTheDocument()
+    expect(screen.queryByText('Only admins can add or remove Safe accounts in this Workspace')).not.toBeInTheDocument()
     expect(mockAddSafesToSpace).not.toHaveBeenCalled()
     expect(mockRemoveSafesFromSpace).not.toHaveBeenCalled()
   })

--- a/apps/web/src/features/spaces/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/index.tsx
@@ -211,7 +211,7 @@ const AddAccounts = ({
 
   const onSubmit = handleSubmit(async (data) => {
     if (!isAdmin) {
-      setError('Only admins can add or remove Safe accounts in this workspace')
+      setError('Only admins can add or remove Safe accounts in this Workspace')
       return
     }
 
@@ -461,7 +461,7 @@ const AddAccounts = ({
                             <Info className="size-4" />
                           </TooltipTrigger>
                           <TooltipContent>
-                            You can add up to {SAFE_ACCOUNTS_LIMIT} Safe accounts per workspace
+                            You can add up to {SAFE_ACCOUNTS_LIMIT} Safe accounts per Workspace
                           </TooltipContent>
                         </Tooltip>
                       </div>
@@ -499,7 +499,7 @@ const AddAccounts = ({
                           onToggle: handleTableToggle,
                           isAtLimit,
                           disabledKeys: spaceSafeKeys,
-                          disabledReason: 'This safe is already part of your workspace',
+                          disabledReason: 'This safe is already part of your Workspace',
                         }}
                         data-testid="add-accounts-safes-table"
                       />

--- a/apps/web/src/features/spaces/components/AddAccountsChooser/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccountsChooser/index.tsx
@@ -96,7 +96,7 @@ const AddAccountsChooser = ({
               onClick={handleCreate}
               warning={
                 isSpaceAtSafeLimit && isAdmin
-                  ? `This workspace already has ${SAFE_ACCOUNTS_LIMIT} Safes (the maximum). Your new Safe won't be added to it, but you can still create it.`
+                  ? `This Workspace already has ${SAFE_ACCOUNTS_LIMIT} Safes (the maximum). Your new Safe won't be added to it, but you can still create it.`
                   : undefined
               }
             />

--- a/apps/web/src/features/spaces/components/AddMemberModal/index.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/index.tsx
@@ -54,8 +54,8 @@ export const RoleMenuItem = ({
         <div style={{ gridArea: 'description' }}>
           <Typography variant="paragraph-small" className="max-w-[300px] break-words whitespace-normal">
             {isAdmin
-              ? 'Admins can create and delete workspaces, invite members, and more.'
-              : 'Can view the workspace data.'}
+              ? 'Admins can create and delete Workspaces, invite members, and more.'
+              : 'Can view the Workspace data.'}
           </Typography>
         </div>
       )}

--- a/apps/web/src/features/spaces/components/AddToSpacePopupModal/AddToSpacePopupModal.tsx
+++ b/apps/web/src/features/spaces/components/AddToSpacePopupModal/AddToSpacePopupModal.tsx
@@ -9,7 +9,7 @@ import { AppRoutes } from '@/config/routes'
 import { useSafeQueryParam } from '@/hooks/useSafeAddressFromUrl'
 
 const BENEFITS = [
-  'Keep all related Safes in one shared workspace',
+  'Keep all related Safes in one shared Workspace',
   'Give teams shared context around transactions and activity',
   'Streamline coordination across initiators, approvers, and executors',
 ]
@@ -23,7 +23,7 @@ export const AddToSpacePopupModal = (): ReactElement => {
     <div className="flex flex-col w-full">
       <div className="flex items-center justify-between px-5 py-5">
         <DialogTitle>
-          <Typography variant="h4">Add to workspace</Typography>
+          <Typography variant="h4">Add to Workspace</Typography>
         </DialogTitle>
         <DialogClose aria-label="Close" className="text-muted-foreground hover:text-foreground transition-colors">
           <X className="size-4" />
@@ -32,13 +32,13 @@ export const AddToSpacePopupModal = (): ReactElement => {
 
       <div className="flex flex-col gap-4 sm:gap-6 px-6 pb-6 pt-2.5">
         <Typography variant="paragraph" color="muted">
-          Bring related Safes into a shared workspace and collaborate with your team — all in one place.
+          Bring related Safes into a shared Workspace and collaborate with your team — all in one place.
         </Typography>
 
         <div className="relative h-[140px] sm:h-[200px] w-full rounded-3xl bg-secondary overflow-hidden flex items-center justify-center shrink-0">
           <Image
             src="/images/spaces/empty_dashboard.png"
-            alt="Add to workspace illustration"
+            alt="Add to Workspace illustration"
             fill
             className="object-contain"
           />
@@ -59,7 +59,7 @@ export const AddToSpacePopupModal = (): ReactElement => {
 
         <DialogClose render={<Button className="w-full gap-2" />} onClick={() => void router.push(createSpaceHref)}>
           <Plus className="size-5" />
-          Create a workspace
+          Create a Workspace
         </DialogClose>
       </div>
     </div>

--- a/apps/web/src/features/spaces/components/AddToSpacePopupModal/__tests__/AddToSpacePopupModal.test.tsx
+++ b/apps/web/src/features/spaces/components/AddToSpacePopupModal/__tests__/AddToSpacePopupModal.test.tsx
@@ -63,13 +63,13 @@ describe('AddToSpacePopupModal', () => {
   it('renders the "Add to Space" title', () => {
     render(<AddToSpacePopupModal />)
 
-    expect(screen.getByText('Add to workspace')).toBeInTheDocument()
+    expect(screen.getByText('Add to Workspace')).toBeInTheDocument()
   })
 
   it('renders all three benefit items', () => {
     render(<AddToSpacePopupModal />)
 
-    expect(screen.getByText('Keep all related Safes in one shared workspace')).toBeInTheDocument()
+    expect(screen.getByText('Keep all related Safes in one shared Workspace')).toBeInTheDocument()
     expect(screen.getByText('Give teams shared context around transactions and activity')).toBeInTheDocument()
     expect(screen.getByText('Streamline coordination across initiators, approvers, and executors')).toBeInTheDocument()
   })
@@ -84,7 +84,7 @@ describe('AddToSpacePopupModal', () => {
     mockRouterQuery = { safe: '1:0xdeadbeef' }
     render(<AddToSpacePopupModal />)
 
-    fireEvent.click(screen.getByRole('button', { name: /Create a workspace/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Create a Workspace/i }))
 
     expect(mockPush).toHaveBeenCalledWith({
       pathname: AppRoutes.spaces.createSpace,

--- a/apps/web/src/features/spaces/components/AdminOnlyWorkspaceTooltip/AdminOnlyWorkspaceTooltip.tsx
+++ b/apps/web/src/features/spaces/components/AdminOnlyWorkspaceTooltip/AdminOnlyWorkspaceTooltip.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement, ReactNode } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
-export const ADMIN_ONLY_WORKSPACE_TOOLTIP_MESSAGE = 'Only admins can add Safes to this workspace'
+export const ADMIN_ONLY_WORKSPACE_TOOLTIP_MESSAGE = 'Only admins can add Safes to this Workspace'
 
 type Side = 'top' | 'right' | 'bottom' | 'left'
 

--- a/apps/web/src/features/spaces/components/CreateSpaceOnboarding/hooks/useSpaceSubmit.ts
+++ b/apps/web/src/features/spaces/components/CreateSpaceOnboarding/hooks/useSpaceSubmit.ts
@@ -75,7 +75,7 @@ const useSpaceSubmit = (
       const errorMessage =
         error instanceof Error
           ? error.message
-          : `Failed ${isEditMode ? 'updating' : 'creating'} the workspace. Please try again.`
+          : `Failed ${isEditMode ? 'updating' : 'creating'} the Workspace. Please try again.`
       setError(errorMessage)
       setIsSubmitting(false)
     }

--- a/apps/web/src/features/spaces/components/Dashboard/AddAccountsCard.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/AddAccountsCard.tsx
@@ -21,8 +21,8 @@ const AddAccountsCard = () => {
           </Typography>
 
           <Typography variant="paragraph" color="muted" className="mb-4">
-            Start by adding Safe accounts to your workspace. Any accounts that are linked to your connected wallet can
-            be added to the workspace.
+            Start by adding Safe accounts to your Workspace. Any accounts that are linked to your connected wallet can
+            be added to the Workspace.
           </Typography>
 
           <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.space_dashboard_card}>

--- a/apps/web/src/features/spaces/components/MembersList/EditMemberDialog.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/EditMemberDialog.tsx
@@ -151,7 +151,7 @@ const EditMemberDialog = ({ member, handleClose }: { member: MemberDto; handleCl
           <form onSubmit={onSubmit}>
             <div className="p-6">
               <Typography variant="paragraph" className="mb-4">
-                Edit <b>{displayName}</b> in this workspace.
+                Edit <b>{displayName}</b> in this Workspace.
               </Typography>
 
               <MemberInfoForm

--- a/apps/web/src/features/spaces/components/SafeAccounts/SpaceSafeContextMenu.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/SpaceSafeContextMenu.tsx
@@ -68,7 +68,7 @@ const SpaceSafeContextMenu = ({ safeItem }: { safeItem: SafeItem | MultiChainSaf
               onSelect={(e) => e.stopPropagation()}
             >
               <LogOut className="size-4 text-muted-foreground" />
-              <span>Remove from workspace</span>
+              <span>Remove from Workspace</span>
             </DropdownMenuItem>
           )}
         </DropdownMenuContent>

--- a/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeAccounts.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeAccounts.test.tsx
@@ -135,7 +135,7 @@ describe('SpaceSafeAccounts', () => {
     expect(screen.getByText('Treasury')).toBeInTheDocument()
   })
 
-  it('does not render the Workspace/Trusted tabs', () => {
+  it('does not render the workspace/Trusted tabs', () => {
     render(<SpaceSafeAccounts />)
 
     expect(screen.queryByRole('tablist')).not.toBeInTheDocument()

--- a/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeContextMenu.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeContextMenu.test.tsx
@@ -128,7 +128,7 @@ describe('SpaceSafeContextMenu', () => {
     fireEvent.click(menuButton)
 
     await waitFor(() => {
-      expect(screen.getByText('Remove from workspace')).toBeInTheDocument()
+      expect(screen.getByText('Remove from Workspace')).toBeInTheDocument()
     })
   })
 
@@ -139,7 +139,7 @@ describe('SpaceSafeContextMenu', () => {
     fireEvent.click(menuButton)
 
     await waitFor(() => {
-      expect(screen.queryByText('Remove from workspace')).not.toBeInTheDocument()
+      expect(screen.queryByText('Remove from Workspace')).not.toBeInTheDocument()
     })
   })
 
@@ -167,7 +167,7 @@ describe('SpaceSafeContextMenu', () => {
     fireEvent.click(menuButton)
 
     await waitFor(() => {
-      const removeOption = screen.getByText('Remove from workspace')
+      const removeOption = screen.getByText('Remove from Workspace')
       fireEvent.click(removeOption)
     })
 

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/SafeSelectorDropdown.stories.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/SafeSelectorDropdown.stories.tsx
@@ -289,7 +289,7 @@ export const ManySafesWithFooter: Story = {
     const items = createMockItems(13)
     const header = (
       <div className="flex items-center gap-1 px-4 pt-3 pb-2">
-        <span className="text-sm font-semibold text-secondary-foreground">Safes in this workspace</span>
+        <span className="text-sm font-semibold text-secondary-foreground">Safes in this Workspace</span>
       </div>
     )
     const footer = (

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeDropdownContainer.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeDropdownContainer.test.tsx
@@ -134,7 +134,7 @@ describe('SafeDropdownContainer', () => {
           items={[]}
           onItemSelect={jest.fn()}
           closeDropdown={jest.fn()}
-          emptyStateOverride={<div data-testid="custom-empty">Sign in to a workspace</div>}
+          emptyStateOverride={<div data-testid="custom-empty">Sign in to a Workspace</div>}
         />,
       )
 
@@ -148,7 +148,7 @@ describe('SafeDropdownContainer', () => {
           items={[]}
           onItemSelect={jest.fn()}
           closeDropdown={jest.fn()}
-          emptyStateOverride={<div data-testid="custom-empty">Sign in to a workspace</div>}
+          emptyStateOverride={<div data-testid="custom-empty">Sign in to a Workspace</div>}
           searchValue="treasury"
           onSearchValueChange={jest.fn()}
         />,

--- a/apps/web/src/features/spaces/components/SecurityHub/__tests__/SecurityEmptyState.test.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/__tests__/SecurityEmptyState.test.tsx
@@ -29,7 +29,7 @@ describe('SecurityEmptyState', () => {
     expect(screen.getByText('No accounts to check yet')).toBeInTheDocument()
     expect(
       screen.getByText(
-        'Add a Safe account to this workspace to start running security checks and see its health here.',
+        'Add a Safe account to this Workspace to start running security checks and see its health here.',
       ),
     ).toBeInTheDocument()
   })

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityEmptyState/SecurityEmptyState.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityEmptyState/SecurityEmptyState.tsx
@@ -100,7 +100,7 @@ const SecurityEmptyState = (): ReactElement => {
           className="max-w-[360px] mx-auto py-16"
           icon={<ShieldCheck className="size-6 text-green-500" />}
           text="No accounts to check yet"
-          subtitle="Add a Safe account to this workspace to start running security checks and see its health here."
+          subtitle="Add a Safe account to this Workspace to start running security checks and see its health here."
           action={
             <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.security_page}>
               <AddAccounts buttonVariant="default" buttonLabel="Add account" />

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/index.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/index.tsx
@@ -118,7 +118,7 @@ const SelectSafesOnboarding = (): ReactElement => {
                 <TooltipTrigger render={<span className="inline-flex cursor-help" />}>
                   <Info className="size-4" />
                 </TooltipTrigger>
-                <TooltipContent>You can add up to {SAFE_ACCOUNTS_LIMIT} Safe accounts per workspace</TooltipContent>
+                <TooltipContent>You can add up to {SAFE_ACCOUNTS_LIMIT} Safe accounts per Workspace</TooltipContent>
               </Tooltip>
             </div>
             <SearchInput

--- a/apps/web/src/features/spaces/components/SetupWidget/__tests__/SetupWidget.test.tsx
+++ b/apps/web/src/features/spaces/components/SetupWidget/__tests__/SetupWidget.test.tsx
@@ -81,7 +81,7 @@ describe('SetupWidget', () => {
   it('renders the widget title', () => {
     render(<SetupWidget />)
 
-    expect(screen.getByText('Set up your workspace')).toBeInTheDocument()
+    expect(screen.getByText('Set up your Workspace')).toBeInTheDocument()
   })
 
   it('renders all four setup steps', () => {
@@ -90,7 +90,7 @@ describe('SetupWidget', () => {
     expect(screen.getByText('Import your address book')).toBeInTheDocument()
     expect(screen.getByText('Add your Safe accounts')).toBeInTheDocument()
     expect(screen.getByText('Invite team members')).toBeInTheDocument()
-    expect(screen.getByText('Explore workspaces')).toBeInTheDocument()
+    expect(screen.getByText('Explore Workspaces')).toBeInTheDocument()
   })
 
   it('renders the dismiss button', () => {
@@ -106,7 +106,7 @@ describe('SetupWidget', () => {
 
     await waitFor(
       () => {
-        expect(screen.queryByText('Set up your workspace')).not.toBeInTheDocument()
+        expect(screen.queryByText('Set up your Workspace')).not.toBeInTheDocument()
       },
       { timeout: 3000 },
     )
@@ -140,7 +140,7 @@ describe('SetupWidget', () => {
       'Import your address book',
       'Add your Safe accounts',
       'Invite team members',
-      'Explore workspaces',
+      'Explore Workspaces',
     ]
     const steps = screen
       .getAllByRole('button')
@@ -150,13 +150,13 @@ describe('SetupWidget', () => {
     expect(steps[0]).toHaveTextContent('Import your address book')
     expect(steps[1]).toHaveTextContent('Add your Safe accounts')
     expect(steps[2]).toHaveTextContent('Invite team members')
-    expect(steps[3]).toHaveTextContent('Explore workspaces')
+    expect(steps[3]).toHaveTextContent('Explore Workspaces')
   })
 
   it('opens the Introducing Spaces modal when Explore Spaces is clicked', () => {
     render(<SetupWidget />)
 
-    fireEvent.click(screen.getByText('Explore workspaces'))
+    fireEvent.click(screen.getByText('Explore Workspaces'))
 
     expect(screen.getByTestId('space-info-modal')).toBeInTheDocument()
   })
@@ -174,7 +174,7 @@ describe('SetupWidget', () => {
 
     render(<SetupWidget />)
 
-    fireEvent.click(screen.getByText('Explore workspaces'))
+    fireEvent.click(screen.getByText('Explore Workspaces'))
     expect(screen.getByTestId('space-info-modal')).toBeInTheDocument()
 
     fireEvent.click(screen.getByTestId('close-space-info-modal'))
@@ -189,7 +189,7 @@ describe('SetupWidget', () => {
   it('does not mark the space as completed when Explore Spaces modal is closed but steps are incomplete', () => {
     render(<SetupWidget />)
 
-    fireEvent.click(screen.getByText('Explore workspaces'))
+    fireEvent.click(screen.getByText('Explore Workspaces'))
     expect(screen.getByTestId('space-info-modal')).toBeInTheDocument()
 
     fireEvent.click(screen.getByTestId('close-space-info-modal'))
@@ -209,7 +209,7 @@ describe('SetupWidget', () => {
 
     render(<SetupWidget />)
 
-    expect(screen.queryByText('Set up your workspace')).not.toBeInTheDocument()
+    expect(screen.queryByText('Set up your Workspace')).not.toBeInTheDocument()
   })
 
   it('disables click on completed steps', () => {

--- a/apps/web/src/features/spaces/components/SetupWidget/index.tsx
+++ b/apps/web/src/features/spaces/components/SetupWidget/index.tsx
@@ -48,7 +48,7 @@ const SETUP_STEPS: SetupStep[] = [
     label: 'Invite team members',
     icon: UsersRound,
   },
-  { key: 'explore', label: 'Explore workspaces', icon: Rocket },
+  { key: 'explore', label: 'Explore Workspaces', icon: Rocket },
 ]
 
 const DISMISS_STORAGE_KEY = 'setupWidgetDismissed'
@@ -153,7 +153,7 @@ const SetupWidget = ({ onDismiss, horizontal, loading }: SetupWidgetProps): Reac
         {!dismissed && (
           <motion.div initial={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.3, ease: 'easeInOut' }}>
             <SafeWidget
-              title="Set up your workspace"
+              title="Set up your Workspace"
               testId="space-dashboard-setup-widget"
               action={
                 <Typography

--- a/apps/web/src/features/spaces/components/Sidebar/BackToSpaceButton/BackToSpaceButton.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/BackToSpaceButton/BackToSpaceButton.tsx
@@ -18,7 +18,7 @@ export const BackToSpaceButton = ({ spaceName, spaceInitial }: SafeWorkspaceHead
   return (
     <SidebarMenuButton
       size="lg"
-      tooltip="Back to workspace"
+      tooltip="Back to Workspace"
       data-testid="back-to-space-button"
       className={css.spaceSelector}
       onClick={handleBackToSpace}

--- a/apps/web/src/features/spaces/components/Sidebar/hooks/__tests__/useAddSafeToSpace.test.ts
+++ b/apps/web/src/features/spaces/components/Sidebar/hooks/__tests__/useAddSafeToSpace.test.ts
@@ -53,7 +53,7 @@ describe('useAddSafeToSpace', () => {
       expect.objectContaining({
         type: 'notifications/add',
         payload: {
-          message: 'Successfully added Safe to workspace.',
+          message: 'Successfully added Safe to Workspace.',
           variant: 'success',
           groupKey: 'add-safe-to-workspace-success',
         },
@@ -89,7 +89,7 @@ describe('useAddSafeToSpace', () => {
       expect.objectContaining({
         type: 'notifications/add',
         payload: expect.objectContaining({
-          message: 'Failed to add Safe to workspace. API error',
+          message: 'Failed to add Safe to Workspace. API error',
           variant: 'error',
           groupKey: 'add-safe-to-workspace-error',
         }),
@@ -161,7 +161,7 @@ describe('useAddSafeToSpace', () => {
       expect.objectContaining({
         type: 'notifications/add',
         payload: expect.objectContaining({
-          message: 'Failed to add Safe to workspace. Network failure',
+          message: 'Failed to add Safe to Workspace. Network failure',
           variant: 'error',
           groupKey: 'add-safe-to-workspace-error',
         }),
@@ -183,7 +183,7 @@ describe('useAddSafeToSpace', () => {
 
   it('extracts the message from a FetchBaseQueryError data payload', async () => {
     mockAddSafeToSpace.mockResolvedValue({
-      error: { status: 409, data: { message: 'Safe already exists in this workspace' } },
+      error: { status: 409, data: { message: 'Safe already exists in this Workspace' } },
     })
     const { result } = renderHook(() => useAddSafeToSpace({ spaces: [] }))
 
@@ -194,7 +194,7 @@ describe('useAddSafeToSpace', () => {
     expect(mockDispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         payload: expect.objectContaining({
-          message: 'Failed to add Safe to workspace. Safe already exists in this workspace',
+          message: 'Failed to add Safe to Workspace. Safe already exists in this Workspace',
           variant: 'error',
         }),
       }),
@@ -215,7 +215,7 @@ describe('useAddSafeToSpace', () => {
       expect.objectContaining({
         payload: expect.objectContaining({
           message:
-            "Failed to add Safe to workspace. Couldn't connect to the server. Please check your connection and try again.",
+            "Failed to add Safe to Workspace. Couldn't connect to the server. Please check your connection and try again.",
           variant: 'error',
         }),
       }),
@@ -286,7 +286,7 @@ describe('useAddSafeToSpace', () => {
         expect.objectContaining({
           type: 'notifications/add',
           payload: expect.objectContaining({
-            message: 'Failed to add Safe to workspace. ',
+            message: 'Failed to add Safe to Workspace. ',
             variant: 'error',
           }),
         }),

--- a/apps/web/src/features/spaces/components/Sidebar/hooks/useAddSafeToSpace.ts
+++ b/apps/web/src/features/spaces/components/Sidebar/hooks/useAddSafeToSpace.ts
@@ -29,7 +29,7 @@ export const useAddSafeToSpace = ({ spaces, onSpaceAdded }: UseAddSafeToSpaceOpt
   const showError = (detail: string) =>
     dispatch(
       showNotification({
-        message: `Failed to add Safe to workspace. ${detail}`,
+        message: `Failed to add Safe to Workspace. ${detail}`,
         variant: 'error',
         groupKey: 'add-safe-to-workspace-error',
       }),
@@ -49,7 +49,7 @@ export const useAddSafeToSpace = ({ spaces, onSpaceAdded }: UseAddSafeToSpaceOpt
       }
       dispatch(
         showNotification({
-          message: 'Successfully added Safe to workspace.',
+          message: 'Successfully added Safe to Workspace.',
           variant: 'success',
           groupKey: 'add-safe-to-workspace-success',
         }),

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/__tests__/SafeSidebarVariant.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/__tests__/SafeSidebarVariant.test.tsx
@@ -174,7 +174,7 @@ jest.mock('../../SpaceSelectorDropdown', () => ({
   SpaceSelectorDropdown: ({ triggerVariant }: { triggerVariant?: 'default' | 'addToWorkspace' }) =>
     triggerVariant === 'addToWorkspace' ? (
       <button type="button" data-testid="add-safe-to-workspace-button">
-        Add Safe to workspace
+        Add Safe to Workspace
       </button>
     ) : (
       <div data-testid="space-selector-default">Space selector</div>
@@ -269,7 +269,7 @@ describe('SafeSidebarVariant', () => {
     )
 
     expect(screen.queryByTestId('add-safe-to-workspace-button')).not.toBeInTheDocument()
-    expect(screen.queryByText('Add Safe to workspace')).not.toBeInTheDocument()
+    expect(screen.queryByText('Add Safe to Workspace')).not.toBeInTheDocument()
   })
 
   it('still renders backToSpace workspace header when Safe is counterfactual', () => {
@@ -449,7 +449,7 @@ describe('SafeSidebarVariant', () => {
       )
 
       expect(screen.queryByTestId('add-safe-to-workspace-button')).not.toBeInTheDocument()
-      expect(screen.queryByText('Add Safe to workspace')).not.toBeInTheDocument()
+      expect(screen.queryByText('Add Safe to Workspace')).not.toBeInTheDocument()
     })
 
     it('hides the addToWorkspace section entirely when Safe is counterfactual (undeployed)', () => {

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarWorkspaceHeader/SafeSidebarWorkspaceHeader.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarWorkspaceHeader/SafeSidebarWorkspaceHeader.tsx
@@ -53,7 +53,7 @@ export const SafeSidebarWorkspaceHeader = ({
                 size="lg"
                 className={css.addSafeToWorkspaceTrigger}
                 data-testid="add-safe-to-workspace-button"
-                aria-label="Add Safe to workspace"
+                aria-label="Add Safe to Workspace"
                 aria-haspopup="dialog"
               />
             }
@@ -61,7 +61,7 @@ export const SafeSidebarWorkspaceHeader = ({
             <span className={css.addSafeToWorkspaceRing}>
               <CircleFadingPlus className={css.addSafeToWorkspacePlusIcon} />
             </span>
-            <span className={css.addSafeToWorkspaceLabel}>Add Safe to workspace</span>
+            <span className={css.addSafeToWorkspaceLabel}>Add Safe to Workspace</span>
           </DialogTrigger>
           <DialogContent
             padding="none"

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarWorkspaceHeader/__tests__/SafeSidebarWorkspaceHeader.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarWorkspaceHeader/__tests__/SafeSidebarWorkspaceHeader.test.tsx
@@ -114,7 +114,7 @@ jest.mock('../../SpaceSelectorDropdown', () => ({
     spaceSelectorDropdownMock(props)
     return props.triggerVariant === 'addToWorkspace' ? (
       <button type="button" data-testid="add-safe-to-workspace-button">
-        Add Safe to workspace
+        Add Safe to Workspace
       </button>
     ) : (
       <div data-testid="space-selector-default">Space selector</div>
@@ -342,7 +342,7 @@ describe('SafeSidebarWorkspaceHeader', () => {
 
       expect(screen.queryByText('ChevronLeft')).not.toBeInTheDocument()
       expect(screen.getByTestId('dialog-root')).toBeInTheDocument()
-      expect(screen.getByText('Add Safe to workspace')).toBeInTheDocument()
+      expect(screen.getByText('Add Safe to Workspace')).toBeInTheDocument()
       expect(screen.getByTestId('add-to-space-popup-modal')).toBeInTheDocument()
     })
   })

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SpaceSelectorDropdown/SpaceSelectorDropdown.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SpaceSelectorDropdown/SpaceSelectorDropdown.tsx
@@ -33,7 +33,7 @@ import { AdminOnlyWorkspaceTooltip } from '../../../AdminOnlyWorkspaceTooltip'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { getDeterministicColor } from '@/utils/colors'
 
-export const SAFE_ALREADY_IN_WORKSPACE_TOOLTIP = 'Safe is already in this workspace'
+export const SAFE_ALREADY_IN_WORKSPACE_TOOLTIP = 'Safe is already in this Workspace'
 
 const MENU_ITEM_CLASS = 'cursor-pointer gap-3 min-h-9 px-2 py-2'
 
@@ -57,7 +57,7 @@ export const SpaceSelectorDropdown = ({
   const displayName = truncateSpaceName(spaceName, SPACE_SELECTOR_NAME_MAX_LENGTH)
   const initial = spaceName.charAt(0).toUpperCase()
   const selectedSpaceColor = spaceName ? getDeterministicColor(spaceName) : undefined
-  const triggerAriaLabel = triggerVariant === 'addToWorkspace' ? 'Add Safe to workspace' : 'Open workspace selector'
+  const triggerAriaLabel = triggerVariant === 'addToWorkspace' ? 'Add Safe to Workspace' : 'Open Workspace selector'
   const safe = useSafeQueryParam() || undefined
   const safeAddress = useSafeAddressFromUrl()
   const chainId = useChainId()
@@ -163,7 +163,7 @@ export const SpaceSelectorDropdown = ({
             <span className={css.addSafeToWorkspaceRing}>
               <CircleFadingPlus className={css.addSafeToWorkspacePlusIcon} />
             </span>
-            <span className={css.addSafeToWorkspaceLabel}>Add Safe to workspace</span>
+            <span className={css.addSafeToWorkspaceLabel}>Add Safe to Workspace</span>
           </>
         ) : (
           <>
@@ -217,7 +217,7 @@ export const SpaceSelectorDropdown = ({
           return (
             <Tooltip key="add-space-tooltip">
               <TooltipTrigger render={<div className="block w-full" />}>{addSpaceMenuItem}</TooltipTrigger>
-              <TooltipContent side="right">Limit of {SPACES_LIMIT} workspaces reached</TooltipContent>
+              <TooltipContent side="right">Limit of {SPACES_LIMIT} Workspaces reached</TooltipContent>
             </Tooltip>
           )
         })()}
@@ -312,7 +312,7 @@ const SpaceMenuRow = ({
     return (
       <Tooltip>
         <TooltipTrigger render={<span className="block w-full" />}>{menuItem}</TooltipTrigger>
-        <TooltipContent side="right">{`You can have up to ${SAFE_ACCOUNTS_LIMIT} Safes per workspace`}</TooltipContent>
+        <TooltipContent side="right">{`You can have up to ${SAFE_ACCOUNTS_LIMIT} Safes per Workspace`}</TooltipContent>
       </Tooltip>
     )
   }

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SpaceSelectorDropdown/SpaceSelectorDropdown.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SpaceSelectorDropdown/SpaceSelectorDropdown.tsx
@@ -208,7 +208,7 @@ export const SpaceSelectorDropdown = ({
           const addSpaceMenuItem = (
             <DropdownMenuItem onClick={handleCreateSpace} disabled={isAtSpacesLimit} className={MENU_ITEM_CLASS}>
               <Plus className={`size-5 flex-shrink-0 ${css.dropdownIcon}`} />
-              <span>Add new workspace</span>
+              <span>Add new Workspace</span>
             </DropdownMenuItem>
           )
 

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SpaceSelectorDropdown/__tests__/SpaceSelectorDropdown.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SpaceSelectorDropdown/__tests__/SpaceSelectorDropdown.test.tsx
@@ -217,7 +217,7 @@ describe('SpaceSelectorDropdown', () => {
       <SpaceSelectorDropdown selectedSpace={{ uuid: 'uuid-1', name: 'Company Space', safeCount: 0 }} spaces={[]} />,
     )
 
-    expect(screen.getByRole('button', { name: 'Open workspace selector' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Open Workspace selector' })).toBeVisible()
   })
 
   it('sets aria-expanded on the trigger based on dropdown state', () => {
@@ -225,7 +225,7 @@ describe('SpaceSelectorDropdown', () => {
       <SpaceSelectorDropdown selectedSpace={{ uuid: 'uuid-1', name: 'Company Space', safeCount: 0 }} spaces={[]} />,
     )
 
-    const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+    const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
     expect(trigger).toHaveAttribute('aria-expanded', 'false')
 
     fireEvent.click(trigger)
@@ -240,7 +240,7 @@ describe('SpaceSelectorDropdown', () => {
     ]
     render(<SpaceSelectorDropdown selectedSpace={spaces[0]} spaces={spaces} />)
 
-    const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+    const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
     fireEvent.click(trigger)
 
     const spaceItemButtons = screen
@@ -256,7 +256,7 @@ describe('SpaceSelectorDropdown', () => {
     ]
     render(<SpaceSelectorDropdown selectedSpace={spaces[0]} spaces={spaces} />)
 
-    const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+    const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
     fireEvent.click(trigger)
 
     const betaButton = screen.getAllByRole('button').find((btn) => btn.querySelector('span')?.textContent === 'Beta')
@@ -272,7 +272,7 @@ describe('SpaceSelectorDropdown', () => {
     ]
     render(<SpaceSelectorDropdown selectedSpace={spaces[0]} spaces={spaces} />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open workspace selector' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Open Workspace selector' }))
     const betaButton = screen.getAllByRole('button').find((btn) => btn.querySelector('span')?.textContent === 'Beta')
     fireEvent.click(betaButton!)
 
@@ -286,7 +286,7 @@ describe('SpaceSelectorDropdown', () => {
   it('tracks WORKSPACE_CREATE_STARTED event and navigates when "Add new space" is clicked', () => {
     render(<SpaceSelectorDropdown selectedSpace={{ uuid: 'uuid-1', name: 'Alpha', safeCount: 0 }} spaces={[]} />)
 
-    const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+    const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
     fireEvent.click(trigger)
     fireEvent.click(screen.getByText('Add new workspace'))
 
@@ -301,7 +301,7 @@ describe('SpaceSelectorDropdown', () => {
     mockRouterQuery = { spaceId: '1', safe: '1:0xdeadbeef' }
     render(<SpaceSelectorDropdown selectedSpace={{ uuid: 'uuid-1', name: 'Alpha', safeCount: 0 }} spaces={[]} />)
 
-    const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+    const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
     fireEvent.click(trigger)
     fireEvent.click(screen.getByText('Add new workspace'))
 
@@ -314,7 +314,7 @@ describe('SpaceSelectorDropdown', () => {
   it('tracks OPEN_SPACE_LIST_PAGE event and navigates when "View all" is clicked', () => {
     render(<SpaceSelectorDropdown selectedSpace={{ uuid: 'uuid-1', name: 'Alpha', safeCount: 0 }} spaces={[]} />)
 
-    const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+    const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
     fireEvent.click(trigger)
     fireEvent.click(screen.getByText('View all'))
 
@@ -340,7 +340,7 @@ describe('SpaceSelectorDropdown', () => {
     ]
     render(<SpaceSelectorDropdown selectedSpace={spaces[0]} spaces={spaces} />)
 
-    const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+    const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
     fireEvent.click(trigger)
 
     const alphaButton = screen.getAllByRole('button').find((btn) => btn.querySelector('span')?.textContent === 'Alpha')
@@ -360,7 +360,7 @@ describe('SpaceSelectorDropdown', () => {
       ]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
       const fullButton = screen
         .getAllByRole('button')
@@ -377,7 +377,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'Full Space', safeCount: LIMIT, members: adminMembersForCurrentUser }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
       expect(screen.getByText(/You can have up to /)).toBeInTheDocument()
     })
@@ -386,7 +386,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'Space', safeCount: LIMIT - 1 }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
       expect(screen.queryByText(/You can have up to /)).not.toBeInTheDocument()
     })
@@ -395,7 +395,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'Full Space', safeCount: LIMIT }]
       render(<SpaceSelectorDropdown triggerVariant="default" selectedSpace={spaces[0]} spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Open workspace selector' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Open Workspace selector' }))
 
       const fullButton = screen
         .getAllByRole('button')
@@ -407,9 +407,9 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'Full Space', safeCount: LIMIT, members: adminMembersForCurrentUser }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
-      expect(screen.getByText(`You can have up to ${LIMIT} Safes per workspace`)).toBeInTheDocument()
+      expect(screen.getByText(`You can have up to ${LIMIT} Safes per Workspace`)).toBeInTheDocument()
     })
   })
 
@@ -421,7 +421,7 @@ describe('SpaceSelectorDropdown', () => {
       ]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
       const adminBtn = screen
         .getAllByRole('button')
@@ -438,9 +438,9 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'MemberSpace', safeCount: 0, members: memberMembersForCurrentUser }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
-      expect(screen.getByText('Only admins can add Safes to this workspace')).toBeInTheDocument()
+      expect(screen.getByText('Only admins can add Safes to this Workspace')).toBeInTheDocument()
     })
 
     it('prefers the admin tooltip over the limit tooltip when both apply', () => {
@@ -448,9 +448,9 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'FullMember', safeCount: LIMIT, members: memberMembersForCurrentUser }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
-      expect(screen.getByText('Only admins can add Safes to this workspace')).toBeInTheDocument()
+      expect(screen.getByText('Only admins can add Safes to this Workspace')).toBeInTheDocument()
       expect(screen.queryByText(/You can have up to /)).not.toBeInTheDocument()
     })
 
@@ -458,13 +458,13 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'MemberSpace', safeCount: 0, members: memberMembersForCurrentUser }]
       render(<SpaceSelectorDropdown triggerVariant="default" selectedSpace={spaces[0]} spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Open workspace selector' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Open Workspace selector' }))
 
       const button = screen
         .getAllByRole('button')
         .find((btn) => btn.querySelector('span')?.textContent === 'MemberSpace')
       expect(button).not.toBeDisabled()
-      expect(screen.queryByText('Only admins can add Safes to this workspace')).not.toBeInTheDocument()
+      expect(screen.queryByText('Only admins can add Safes to this Workspace')).not.toBeInTheDocument()
     })
 
     it('does not call addToSpace when a non-admin space item is clicked', async () => {
@@ -477,7 +477,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'MemberSpace', safeCount: 0, members: memberMembersForCurrentUser }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
       const memberBtn = screen
         .getAllByRole('button')
@@ -499,7 +499,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'AdminSpace', safeCount: 0, members: adminMembersForCurrentUser }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
       const adminBtn = screen
         .getAllByRole('button')
@@ -524,7 +524,7 @@ describe('SpaceSelectorDropdown', () => {
       ]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
       const memberBtn = screen
         .getAllByRole('button')
@@ -566,7 +566,7 @@ describe('SpaceSelectorDropdown', () => {
       ]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
       const alreadyInBtn = screen
         .getAllByRole('button')
@@ -584,9 +584,9 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'AlreadyIn', safeCount: 1, members: adminMembersForCurrentUser }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
-      expect(screen.getByText('Safe is already in this workspace')).toBeInTheDocument()
+      expect(screen.getByText('Safe is already in this Workspace')).toBeInTheDocument()
     })
 
     it('matches membership by current chainId only', () => {
@@ -597,11 +597,11 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'OtherChain', safeCount: 1, members: adminMembersForCurrentUser }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
       const btn = screen.getAllByRole('button').find((b) => b.querySelector('span')?.textContent === 'OtherChain')
       expect(btn).not.toBeDisabled()
-      expect(screen.queryByText('Safe is already in this workspace')).not.toBeInTheDocument()
+      expect(screen.queryByText('Safe is already in this Workspace')).not.toBeInTheDocument()
     })
 
     it('prefers the "already in workspace" tooltip over the admin tooltip', () => {
@@ -611,10 +611,10 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'MemberAlreadyIn', safeCount: 1, members: memberMembersForCurrentUser }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
-      expect(screen.getByText('Safe is already in this workspace')).toBeInTheDocument()
-      expect(screen.queryByText('Only admins can add Safes to this workspace')).not.toBeInTheDocument()
+      expect(screen.getByText('Safe is already in this Workspace')).toBeInTheDocument()
+      expect(screen.queryByText('Only admins can add Safes to this Workspace')).not.toBeInTheDocument()
     })
 
     it('does not disable already-added spaces in the default variant', () => {
@@ -624,11 +624,11 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'AlreadyIn', safeCount: 1, members: adminMembersForCurrentUser }]
       render(<SpaceSelectorDropdown triggerVariant="default" selectedSpace={spaces[0]} spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Open workspace selector' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Open Workspace selector' }))
 
       const btn = screen.getAllByRole('button').find((b) => b.querySelector('span')?.textContent === 'AlreadyIn')
       expect(btn).not.toBeDisabled()
-      expect(screen.queryByText('Safe is already in this workspace')).not.toBeInTheDocument()
+      expect(screen.queryByText('Safe is already in this Workspace')).not.toBeInTheDocument()
     })
 
     it('does not disable any space when no Safe is in the URL', () => {
@@ -638,7 +638,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'Space', safeCount: 1, members: adminMembersForCurrentUser }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
       const btn = screen.getAllByRole('button').find((b) => b.querySelector('span')?.textContent === 'Space')
       expect(btn).not.toBeDisabled()
@@ -653,7 +653,7 @@ describe('SpaceSelectorDropdown', () => {
 
       expect(mockUseSpaceSafesGetV1Query).not.toHaveBeenCalled()
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
       expect(mockUseSpaceSafesGetV1Query).toHaveBeenCalledWith({ spaceId: 'uuid-1' }, { skip: false })
     })
@@ -666,7 +666,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'Space', safeCount: 1, members: adminMembersForCurrentUser }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
       expect(mockUseSpaceSafesGetV1Query).toHaveBeenCalledWith({ spaceId: 'uuid-1' }, { skip: true })
     })
@@ -678,11 +678,11 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'AlreadyIn', safeCount: 1, members: adminMembersForCurrentUser }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
       const btn = screen.getAllByRole('button').find((b) => b.querySelector('span')?.textContent === 'AlreadyIn')
       expect(btn).toBeDisabled()
-      expect(screen.getByText('Safe is already in this workspace')).toBeInTheDocument()
+      expect(screen.getByText('Safe is already in this Workspace')).toBeInTheDocument()
     })
   })
 
@@ -709,7 +709,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'Alpha', safeCount: 0, members: adminMembersForCurrentUser }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
       expect(screen.getByText('Alpha')).toBeInTheDocument()
 
       const alphaButton = screen
@@ -740,7 +740,7 @@ describe('SpaceSelectorDropdown', () => {
       ]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
       const alphaButton = screen
         .getAllByRole('button')
@@ -763,7 +763,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'Alpha', safeCount: 0 }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
       const alphaButton = screen
         .getAllByRole('button')
@@ -782,7 +782,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'Alpha', safeCount: 0, members: adminMembersForCurrentUser }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
       expect(screen.getByText('Alpha')).toBeInTheDocument()
 
       const alphaButton = screen
@@ -803,7 +803,7 @@ describe('SpaceSelectorDropdown', () => {
       ]
       render(<SpaceSelectorDropdown selectedSpace={spaces[0]} spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Open workspace selector' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Open Workspace selector' }))
 
       const deltaButton = screen
         .getAllByRole('button')
@@ -818,7 +818,7 @@ describe('SpaceSelectorDropdown', () => {
     it('renders correctly with no spaces', () => {
       render(<SpaceSelectorDropdown selectedSpace={{ uuid: 'uuid-1', name: 'Space', safeCount: 0 }} spaces={[]} />)
 
-      const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+      const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
       fireEvent.click(trigger)
 
       expect(screen.getByText('Add new workspace')).toBeInTheDocument()
@@ -829,7 +829,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'Alpha', safeCount: 0 }]
       render(<SpaceSelectorDropdown spaces={spaces} />)
 
-      const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+      const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
       fireEvent.click(trigger)
 
       expect(screen.getByText('Workspace')).toBeInTheDocument()
@@ -840,7 +840,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: longName, safeCount: 0 }]
       render(<SpaceSelectorDropdown selectedSpace={spaces[0]} spaces={spaces} />)
 
-      const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+      const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
       fireEvent.click(trigger)
 
       expect(trigger).toHaveTextContent(truncateSpaceName(longName, SPACE_SELECTOR_NAME_MAX_LENGTH))
@@ -858,7 +858,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'OnlySpace', safeCount: 0 }]
       render(<SpaceSelectorDropdown selectedSpace={spaces[0]} spaces={spaces} />)
 
-      const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+      const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
       fireEvent.click(trigger)
 
       const spaceButton = screen
@@ -876,7 +876,7 @@ describe('SpaceSelectorDropdown', () => {
       ]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
       const full1 = screen.getAllByRole('button').find((btn) => btn.querySelector('span')?.textContent === 'Full1')
       const full2 = screen.getAllByRole('button').find((btn) => btn.querySelector('span')?.textContent === 'Full2')
@@ -894,7 +894,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'AlmostFull', safeCount: LIMIT - 1, members: adminMembersForCurrentUser }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
       const button = screen
         .getAllByRole('button')
@@ -906,7 +906,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'Alpha', safeCount: 0 }]
       render(<SpaceSelectorDropdown selectedSpace={spaces[0]} spaces={spaces} />)
 
-      const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+      const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
 
       // First cycle
       fireEvent.click(trigger)
@@ -930,7 +930,7 @@ describe('SpaceSelectorDropdown', () => {
       ]
       const { rerender } = render(<SpaceSelectorDropdown selectedSpace={spaces[0]} spaces={spaces} />)
 
-      const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+      const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
       fireEvent.click(trigger)
 
       let alphaButton = screen.getAllByRole('button').find((btn) => btn.querySelector('span')?.textContent === 'Alpha')
@@ -954,7 +954,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ uuid: 'uuid-1', name: 'Alpha', safeCount: 0, members: adminMembersForCurrentUser }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to Workspace' }))
 
       const alphaButton = screen
         .getAllByRole('button')
@@ -977,7 +977,7 @@ describe('SpaceSelectorDropdown', () => {
       }))
       render(<SpaceSelectorDropdown selectedSpace={spaces[0]} spaces={spaces} />)
 
-      const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+      const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
       fireEvent.click(trigger)
 
       const addNewSpaceButton = screen
@@ -995,10 +995,10 @@ describe('SpaceSelectorDropdown', () => {
       }))
       render(<SpaceSelectorDropdown selectedSpace={spaces[0]} spaces={spaces} />)
 
-      const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+      const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
       fireEvent.click(trigger)
 
-      expect(screen.getByText(`Limit of ${SPACES_LIMIT} workspaces reached`)).toBeInTheDocument()
+      expect(screen.getByText(`Limit of ${SPACES_LIMIT} Workspaces reached`)).toBeInTheDocument()
     })
 
     it('does not disable "Add new space" button when spaces are below the limit', () => {
@@ -1010,7 +1010,7 @@ describe('SpaceSelectorDropdown', () => {
       }))
       render(<SpaceSelectorDropdown selectedSpace={spaces[0]} spaces={spaces} />)
 
-      const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+      const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
       fireEvent.click(trigger)
 
       const addNewSpaceButton = screen
@@ -1028,10 +1028,10 @@ describe('SpaceSelectorDropdown', () => {
       }))
       render(<SpaceSelectorDropdown selectedSpace={spaces[0]} spaces={spaces} />)
 
-      const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+      const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
       fireEvent.click(trigger)
 
-      expect(screen.queryByText(`Limit of ${SPACES_LIMIT} workspaces reached`)).not.toBeInTheDocument()
+      expect(screen.queryByText(`Limit of ${SPACES_LIMIT} Workspaces reached`)).not.toBeInTheDocument()
     })
 
     it('disables "Add new space" button when spaces exceed the limit', () => {
@@ -1043,7 +1043,7 @@ describe('SpaceSelectorDropdown', () => {
       }))
       render(<SpaceSelectorDropdown selectedSpace={spaces[0]} spaces={spaces} />)
 
-      const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+      const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
       fireEvent.click(trigger)
 
       const addNewSpaceButton = screen
@@ -1061,10 +1061,10 @@ describe('SpaceSelectorDropdown', () => {
       }))
       render(<SpaceSelectorDropdown selectedSpace={spaces[0]} spaces={spaces} />)
 
-      const trigger = screen.getByRole('button', { name: 'Open workspace selector' })
+      const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
       fireEvent.click(trigger)
 
-      expect(screen.getByText(`Limit of ${SPACES_LIMIT} workspaces reached`)).toBeInTheDocument()
+      expect(screen.getByText(`Limit of ${SPACES_LIMIT} Workspaces reached`)).toBeInTheDocument()
     })
   })
 })

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SpaceSelectorDropdown/__tests__/SpaceSelectorDropdown.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SpaceSelectorDropdown/__tests__/SpaceSelectorDropdown.test.tsx
@@ -288,7 +288,7 @@ describe('SpaceSelectorDropdown', () => {
 
     const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
     fireEvent.click(trigger)
-    fireEvent.click(screen.getByText('Add new workspace'))
+    fireEvent.click(screen.getByText('Add new Workspace'))
 
     expect(trackEvent).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'Workspace create started' }),
@@ -303,7 +303,7 @@ describe('SpaceSelectorDropdown', () => {
 
     const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
     fireEvent.click(trigger)
-    fireEvent.click(screen.getByText('Add new workspace'))
+    fireEvent.click(screen.getByText('Add new Workspace'))
 
     expect(mockPush).toHaveBeenCalledWith({
       pathname: AppRoutes.spaces.createSpace,
@@ -821,7 +821,7 @@ describe('SpaceSelectorDropdown', () => {
       const trigger = screen.getByRole('button', { name: 'Open Workspace selector' })
       fireEvent.click(trigger)
 
-      expect(screen.getByText('Add new workspace')).toBeInTheDocument()
+      expect(screen.getByText('Add new Workspace')).toBeInTheDocument()
       expect(screen.getByText('View all')).toBeInTheDocument()
     })
 
@@ -982,7 +982,7 @@ describe('SpaceSelectorDropdown', () => {
 
       const addNewSpaceButton = screen
         .getAllByRole('button')
-        .find((btn) => btn.querySelector('span')?.textContent === 'Add new workspace')
+        .find((btn) => btn.querySelector('span')?.textContent === 'Add new Workspace')
       expect(addNewSpaceButton).toBeDisabled()
     })
 
@@ -1015,7 +1015,7 @@ describe('SpaceSelectorDropdown', () => {
 
       const addNewSpaceButton = screen
         .getAllByRole('button')
-        .find((btn) => btn.querySelector('span')?.textContent === 'Add new workspace')
+        .find((btn) => btn.querySelector('span')?.textContent === 'Add new Workspace')
       expect(addNewSpaceButton).not.toBeDisabled()
     })
 
@@ -1048,7 +1048,7 @@ describe('SpaceSelectorDropdown', () => {
 
       const addNewSpaceButton = screen
         .getAllByRole('button')
-        .find((btn) => btn.querySelector('span')?.textContent === 'Add new workspace')
+        .find((btn) => btn.querySelector('span')?.textContent === 'Add new Workspace')
       expect(addNewSpaceButton).toBeDisabled()
     })
 

--- a/apps/web/src/features/spaces/components/SignInButton/SignInButton.test.tsx
+++ b/apps/web/src/features/spaces/components/SignInButton/SignInButton.test.tsx
@@ -171,7 +171,7 @@ describe('SignInButton error messages', () => {
       expect(mockDispatch).toHaveBeenCalledWith({
         type: 'notifications/show',
         payload: expect.objectContaining({
-          message: 'Safe{Wallet} for logging into workspace is not supported at the moment.',
+          message: 'Safe{Wallet} for logging into Workspace is not supported at the moment.',
           variant: 'error',
         }),
       })
@@ -190,7 +190,7 @@ describe('SignInButton error messages', () => {
       expect(mockDispatch).toHaveBeenCalledWith({
         type: 'notifications/show',
         payload: expect.objectContaining({
-          message: 'MetaMask for logging into workspace is not supported at the moment.',
+          message: 'MetaMask for logging into Workspace is not supported at the moment.',
           variant: 'error',
         }),
       })
@@ -208,7 +208,7 @@ describe('SignInButton error messages', () => {
       expect(mockDispatch).toHaveBeenCalledWith({
         type: 'notifications/show',
         payload: expect.objectContaining({
-          message: 'Ledger for logging into workspace is not supported at the moment.',
+          message: 'Ledger for logging into Workspace is not supported at the moment.',
           variant: 'error',
         }),
       })

--- a/apps/web/src/features/spaces/components/SignInButton/index.tsx
+++ b/apps/web/src/features/spaces/components/SignInButton/index.tsx
@@ -20,11 +20,11 @@ import { useEffect, useRef } from 'react'
 const getSignInErrorMessage = async (wallet: ConnectedWallet | null): Promise<string> => {
   if (wallet?.address && (await isSmartContractWallet(wallet.chainId, wallet.address))) {
     const walletName = getWalletConnectLabel(wallet) || wallet.label
-    return `${walletName} for logging into workspace is not supported at the moment.`
+    return `${walletName} for logging into Workspace is not supported at the moment.`
   }
 
   if (wallet && isLedger(wallet)) {
-    return 'Ledger for logging into workspace is not supported at the moment.'
+    return 'Ledger for logging into Workspace is not supported at the moment.'
   }
 
   return 'Something went wrong while trying to sign in'

--- a/apps/web/src/features/spaces/components/SignedOutState/index.tsx
+++ b/apps/web/src/features/spaces/components/SignedOutState/index.tsx
@@ -25,7 +25,7 @@ const SignedOutState = ({ afterSignIn, redirectLoading = false }: SignedOutState
             </Typography>
 
             <Typography color="muted" className="mb-4">
-              To view and interact with workspaces, you need to sign in with the wallet, that is a member of the
+              To view and interact with Workspaces, you need to sign in with the wallet, that is a member of the
               workspace
               {!$isDisabled && ', or sign in with email'}. Sign in to continue.
             </Typography>

--- a/apps/web/src/features/spaces/components/SignedOutState/index.tsx
+++ b/apps/web/src/features/spaces/components/SignedOutState/index.tsx
@@ -26,7 +26,7 @@ const SignedOutState = ({ afterSignIn, redirectLoading = false }: SignedOutState
 
             <Typography color="muted" className="mb-4">
               To view and interact with Workspaces, you need to sign in with the wallet, that is a member of the
-              workspace
+              Workspace
               {!$isDisabled && ', or sign in with email'}. Sign in to continue.
             </Typography>
 

--- a/apps/web/src/features/spaces/components/SpaceActivityLog/__tests__/auditEventCopy.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceActivityLog/__tests__/auditEventCopy.test.tsx
@@ -24,22 +24,22 @@ describe('getAuditEventDescription', () => {
     [
       'SPACE_CREATED',
       { eventType: 'SPACE_CREATED' as const, payload: { name: 'Treasury' } },
-      'created the workspace Treasury',
+      'created the Workspace Treasury',
     ],
     [
       'SPACE_UPDATED (rename)',
       { eventType: 'SPACE_UPDATED' as const, payload: { old: { name: 'A' }, new: { name: 'B' } } },
-      'renamed the workspace from A to B',
+      'renamed the Workspace from A to B',
     ],
     [
       'SPACE_UPDATED (no name change)',
       { eventType: 'SPACE_UPDATED' as const, payload: { old: {}, new: {} } },
-      'updated the workspace',
+      'updated the Workspace',
     ],
     [
       'SPACE_DELETED',
       { eventType: 'SPACE_DELETED' as const, payload: { name: 'Treasury' } },
-      'deleted the workspace Treasury',
+      'deleted the Workspace Treasury',
     ],
     [
       'MEMBER_INVITED',
@@ -76,12 +76,12 @@ describe('getAuditEventDescription', () => {
       'changed the role of bob from member to admin',
     ],
     ['MEMBER_ALIAS_UPDATED', { eventType: 'MEMBER_ALIAS_UPDATED' as const }, 'updated their alias'],
-    ['MEMBER_REMOVED', { eventType: 'MEMBER_REMOVED' as const, targetUser: 'bob' }, 'removed bob from the workspace'],
-    ['MEMBER_LEFT', { eventType: 'MEMBER_LEFT' as const }, 'left the workspace'],
+    ['MEMBER_REMOVED', { eventType: 'MEMBER_REMOVED' as const, targetUser: 'bob' }, 'removed bob from the Workspace'],
+    ['MEMBER_LEFT', { eventType: 'MEMBER_LEFT' as const }, 'left the Workspace'],
     [
       'MEMBER_LEFT (account deleted)',
       { eventType: 'MEMBER_LEFT' as const, payload: { targetUserId: 2, accountDeleted: true } },
-      'left the workspace (account deleted)',
+      'left the Workspace (account deleted)',
     ],
     ['SAFE_ADDED', { eventType: 'SAFE_ADDED' as const, payload: { safes: [{}, {}] } }, 'added 2 Safe accounts'],
     ['SAFE_ADDED (missing safes)', { eventType: 'SAFE_ADDED' as const, payload: {} }, 'added Safe accounts'],
@@ -177,7 +177,7 @@ describe('getAuditEventDescription', () => {
         targetUser: null,
         payload: { targetUserId: 2 },
       }),
-    ).toBe('removed a former member from the workspace')
+    ).toBe('removed a former member from the Workspace')
   })
 
   it('prefers an explicitly passed target display (member name) over the server string', () => {
@@ -187,7 +187,7 @@ describe('getAuditEventDescription', () => {
       payload: { targetUserId: 2 },
     })
     const { container } = render(<div>{getAuditEventDescription(event, 'Alice Member')}</div>)
-    expect(container.textContent).toBe('removed Alice Member from the workspace')
+    expect(container.textContent).toBe('removed Alice Member from the Workspace')
   })
 
   it('returns the server-resolved target verbatim (full address) in the default target display', () => {
@@ -212,6 +212,6 @@ describe('getAuditEventDescription', () => {
         targetUser: 'Former member',
         payload: { targetUserId: 2 },
       }),
-    ).toBe('removed Former member from the workspace')
+    ).toBe('removed Former member from the Workspace')
   })
 })

--- a/apps/web/src/features/spaces/components/SpaceActivityLog/auditEventCopy.tsx
+++ b/apps/web/src/features/spaces/components/SpaceActivityLog/auditEventCopy.tsx
@@ -61,10 +61,10 @@ export function getAuditEventDescription(
       const name = asString(payload.name)
       return name ? (
         <>
-          created the workspace <Em>{name}</Em>
+          created the Workspace <Em>{name}</Em>
         </>
       ) : (
-        'created the workspace'
+        'created the Workspace'
       )
     }
     case 'SPACE_UPDATED': {
@@ -73,20 +73,20 @@ export function getAuditEventDescription(
       if (oldName && newName) {
         return (
           <>
-            renamed the workspace from <Em>{oldName}</Em> to <Em>{newName}</Em>
+            renamed the Workspace from <Em>{oldName}</Em> to <Em>{newName}</Em>
           </>
         )
       }
-      return 'updated the workspace'
+      return 'updated the Workspace'
     }
     case 'SPACE_DELETED': {
       const name = asString(payload.name)
       return name ? (
         <>
-          deleted the workspace <Em>{name}</Em>
+          deleted the Workspace <Em>{name}</Em>
         </>
       ) : (
-        'deleted the workspace'
+        'deleted the Workspace'
       )
     }
     case 'MEMBER_INVITED': {
@@ -129,11 +129,11 @@ export function getAuditEventDescription(
     case 'MEMBER_REMOVED':
       return (
         <>
-          removed <Em>{target}</Em> from the workspace
+          removed <Em>{target}</Em> from the Workspace
         </>
       )
     case 'MEMBER_LEFT':
-      return payload.accountDeleted === true ? 'left the workspace (account deleted)' : 'left the workspace'
+      return payload.accountDeleted === true ? 'left the Workspace (account deleted)' : 'left the Workspace'
     case 'SAFE_ADDED': {
       const count = asCount(payload.safes)
       return count > 0 ? `added ${pluralize(count, 'Safe account')}` : 'added Safe accounts'

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddLocalContact.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddLocalContact.tsx
@@ -9,7 +9,7 @@ const AddLocalContact = () => {
     <AddContactDialog
       triggerLabel="Add contact"
       dialogTitle="Add contact"
-      intro="This contact is stored locally in this browser. You can propose adding it to the shared workspace address book later."
+      intro="This contact is stored locally in this browser. You can propose adding it to the shared Workspace address book later."
       successMessage="Contact added"
       successGroupKey="add-local-contact-success"
       submit={(item) => {

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddToWorkspaceButton.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddToWorkspaceButton.tsx
@@ -57,7 +57,7 @@ const AddToWorkspaceButton = ({ address, name, chainIds, isCompact }: AddToWorks
       setAdded(true)
       dispatch(
         showNotification({
-          message: 'Contact added to workspace',
+          message: 'Contact added to Workspace',
           variant: 'success',
           groupKey: 'add-to-workspace-success',
         }),
@@ -71,7 +71,7 @@ const AddToWorkspaceButton = ({ address, name, chainIds, isCompact }: AddToWorks
     }
   }
 
-  const label = added ? 'Added' : 'Add to workspace'
+  const label = added ? 'Added' : 'Add to Workspace'
   const icon = added ? <Check className="size-4" /> : <Plus className="size-4" />
 
   // Compact has no room for the label, so it moves into the accessible name and a tooltip

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/EditContactDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/EditContactDialog.tsx
@@ -130,7 +130,7 @@ const EditContactDialog = ({ entry, onClose }: EditContactDialogProps) => {
         <FormProvider {...methods}>
           <form onSubmit={onSubmit}>
             <div className="px-6 py-4">
-              <Typography className="mb-4">Edit contact details. Anyone in the workspace can see it.</Typography>
+              <Typography className="mb-4">Edit contact details. Anyone in the Workspace can see it.</Typography>
               <div className="flex flex-col gap-6">
                 <div className="pt-2">
                   <AddressInputReadOnly address={entry.address} chainId={entry.chainIds[0]} />

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/Import/__tests__/ImportAddressBookDialog.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/Import/__tests__/ImportAddressBookDialog.test.tsx
@@ -242,7 +242,7 @@ describe('ImportAddressBookDialog', () => {
 
     await userEvent.hover(screen.getByText('Bad/Name').closest('[role="button"]')?.parentElement as HTMLElement)
 
-    await waitFor(() => expect(screen.getByText(/Rename this contact to add it to the workspace/)).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText(/Rename this contact to add it to the Workspace/)).toBeInTheDocument())
   })
 
   it('filters the contact list based on the search input', async () => {

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/PendingRequestsTable.tsx
@@ -102,7 +102,7 @@ function PendingRequestsTable({ requests }: PendingRequestsTableProps) {
       trackEvent(SPACE_EVENTS.ADDRESS_REQUEST_APPROVED)
       dispatch(
         showNotification({
-          message: 'Contact added to workspace address book',
+          message: 'Contact added to Workspace address book',
           variant: 'success',
           groupKey: 'approve-success',
         }),
@@ -160,8 +160,8 @@ function PendingRequestsTable({ requests }: PendingRequestsTableProps) {
             <span className={cn('min-w-0', !isCompact && 'truncate')}>{req.name}</span>
             {spaceAddresses.has(req.address.toLowerCase()) && (
               <Tooltip>
-                <TooltipTrigger render={<Badge variant="outline">Already in workspace</Badge>} />
-                <TooltipContent>Approving replaces the existing workspace entry for this address.</TooltipContent>
+                <TooltipTrigger render={<Badge variant="outline">Already in Workspace</Badge>} />
+                <TooltipContent>Approving replaces the existing Workspace entry for this address.</TooltipContent>
               </Tooltip>
             )}
           </span>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/RequestToAddButton.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/RequestToAddButton.tsx
@@ -142,7 +142,7 @@ const RequestToAddButton = ({ address, name, chainIds, alreadyRequested, isCompa
         <div className="px-6 py-4">
           <div className="flex flex-col gap-4">
             <Typography variant="paragraph-small" color="muted">
-              An admin has to approve the request before the contact appears in the workspace address book.
+              An admin has to approve the request before the contact appears in the Workspace address book.
             </Typography>
 
             <div className="flex flex-col gap-1">
@@ -177,7 +177,7 @@ const RequestToAddButton = ({ address, name, chainIds, alreadyRequested, isCompa
             {nameError && (
               <Alert variant="warning" outlined={false}>
                 <AlertSeverityIcon variant="warning" />
-                <AlertDescription>Rename this contact to share it with the workspace. {nameError}.</AlertDescription>
+                <AlertDescription>Rename this contact to share it with the Workspace. {nameError}.</AlertDescription>
               </Alert>
             )}
           </div>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/AddLocalContact.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/AddLocalContact.test.tsx
@@ -39,7 +39,7 @@ describe('AddLocalContact', () => {
     expect(lastProps?.triggerLabel).toBe('Add contact')
     expect(lastProps?.dialogTitle).toBe('Add contact')
     expect(lastProps?.intro).toBe(
-      'This contact is stored locally in this browser. You can propose adding it to the shared workspace address book later.',
+      'This contact is stored locally in this browser. You can propose adding it to the shared Workspace address book later.',
     )
     expect(lastProps?.successMessage).toBe('Contact added')
     expect(lastProps?.successGroupKey).toBe('add-local-contact-success')

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/AddToWorkspaceButton.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/AddToWorkspaceButton.test.tsx
@@ -36,7 +36,7 @@ describe('AddToWorkspaceButton', () => {
       initialReduxState: { addressBook: { '1': { [address]: 'Alice' }, '137': { [address]: 'Alice' } } },
     })
 
-    await userEvent.click(screen.getByRole('button', { name: 'Add to workspace' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Add to Workspace' }))
 
     await waitFor(() => {
       expect(mockUpsert).toHaveBeenCalledWith({
@@ -54,7 +54,7 @@ describe('AddToWorkspaceButton', () => {
       initialReduxState: { addressBook: { '1': { [address]: ' Alice‚Bob ' } } },
     })
 
-    await userEvent.click(screen.getByRole('button', { name: 'Add to workspace' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Add to Workspace' }))
 
     await waitFor(() => {
       expect(mockUpsert).toHaveBeenCalledWith({
@@ -70,7 +70,7 @@ describe('AddToWorkspaceButton', () => {
       initialReduxState: { addressBook: { '1': { [address]: 'Alice' }, '137': { [address]: 'Alice' } } },
     })
 
-    await userEvent.click(screen.getByRole('button', { name: 'Add to workspace' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Add to Workspace' }))
 
     await waitFor(() => expect(mockUpsert).toHaveBeenCalled())
 
@@ -85,7 +85,7 @@ describe('AddToWorkspaceButton', () => {
       initialReduxState: { addressBook: { '1': { [address]: 'Alice' } } },
     })
 
-    await userEvent.click(screen.getByRole('button', { name: 'Add to workspace' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Add to Workspace' }))
 
     await waitFor(() => expect(mockUpsert).toHaveBeenCalled())
 
@@ -101,7 +101,7 @@ describe('AddToWorkspaceButton', () => {
       initialReduxState: { addressBook: { '1': { [address]: 'Alice' } } },
     })
 
-    await userEvent.click(screen.getByRole('button', { name: 'Add to workspace' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Add to Workspace' }))
 
     await waitFor(() => {
       const notifications = getStoreInstance().getState().notifications
@@ -115,7 +115,7 @@ describe('AddToWorkspaceButton', () => {
       initialReduxState: { addressBook: { '1': { [address]: 'Alice' } } },
     })
 
-    await userEvent.click(screen.getByRole('button', { name: 'Add to workspace' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Add to Workspace' }))
 
     await waitFor(() => {
       const notifications = getStoreInstance().getState().notifications
@@ -126,7 +126,7 @@ describe('AddToWorkspaceButton', () => {
   it('drops the label into the accessible name in the compact layout', () => {
     render(<AddToWorkspaceButton address={address} name="Alice" chainIds={['1']} isCompact />)
 
-    expect(screen.getByRole('button', { name: 'Add to workspace' })).toHaveTextContent('')
+    expect(screen.getByRole('button', { name: 'Add to Workspace' })).toHaveTextContent('')
   })
 
   it('disables the button and skips the mutation when the local name has invalid characters', async () => {
@@ -134,7 +134,7 @@ describe('AddToWorkspaceButton', () => {
       initialReduxState: { addressBook: { '1': { [address]: 'Bad/Name' } } },
     })
 
-    const button = screen.getByRole('button', { name: 'Add to workspace' })
+    const button = screen.getByRole('button', { name: 'Add to Workspace' })
     expect(button).toBeDisabled()
 
     await userEvent.click(button)
@@ -146,16 +146,16 @@ describe('AddToWorkspaceButton', () => {
       initialReduxState: { addressBook: { '1': { [address]: 'Bad/Name' } } },
     })
 
-    await userEvent.hover(screen.getByRole('button', { name: 'Add to workspace' }).parentElement as HTMLElement)
+    await userEvent.hover(screen.getByRole('button', { name: 'Add to Workspace' }).parentElement as HTMLElement)
 
-    await waitFor(() => expect(screen.getByText(/Rename this contact to add it to the workspace/)).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText(/Rename this contact to add it to the Workspace/)).toBeInTheDocument())
   })
 
   it('tracks the contact once it is added to the workspace', async () => {
     mockUpsert.mockResolvedValue({ data: {} })
     render(<AddToWorkspaceButton address={address} name="Alice" chainIds={['1']} />)
 
-    await userEvent.click(screen.getByRole('button', { name: 'Add to workspace' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Add to Workspace' }))
 
     await waitFor(() =>
       expect(trackEvent).toHaveBeenCalledWith(SPACE_EVENTS.LOCAL_CONTACT_ADDED, { Source: 'local_contact_row' }),
@@ -166,7 +166,7 @@ describe('AddToWorkspaceButton', () => {
     mockUpsert.mockResolvedValue({ error: { status: 500 } })
     render(<AddToWorkspaceButton address={address} name="Alice" chainIds={['1']} />)
 
-    await userEvent.click(screen.getByRole('button', { name: 'Add to workspace' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Add to Workspace' }))
 
     await waitFor(() => expect(mockUpsert).toHaveBeenCalled())
     expect(trackEvent).not.toHaveBeenCalled()

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/RequestToAddButton.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/RequestToAddButton.test.tsx
@@ -88,7 +88,7 @@ describe('RequestToAddButton', () => {
 
     await userEvent.hover(screen.getByRole('button', { name: 'Request to add' }).parentElement as HTMLElement)
 
-    await waitFor(() => expect(screen.getByText(/Rename this contact to add it to the workspace/)).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText(/Rename this contact to add it to the Workspace/)).toBeInTheDocument())
   })
 
   it('keeps the button enabled for a valid name', () => {

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/SpaceAddressBookTable.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/SpaceAddressBookTable.test.tsx
@@ -97,7 +97,7 @@ describe('SpaceAddressBookTable', () => {
       <SpaceAddressBookTable
         entries={[entryBuilder().build()]}
         showAddedBy={false}
-        renderExtraAction={() => <button>Add to workspace</button>}
+        renderExtraAction={() => <button>Add to Workspace</button>}
       />,
     )
     expect(lastHeader(withExtra.container).className).toContain('md:w-[35%]')

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/utils.test.ts
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/utils.test.ts
@@ -232,7 +232,7 @@ describe('space address book utils', () => {
   describe('getRenameContactTooltip', () => {
     it('appends the validation error to the rename prompt', () => {
       expect(getRenameContactTooltip('Invalid characters')).toBe(
-        'Rename this contact to add it to the workspace. Invalid characters',
+        'Rename this contact to add it to the Workspace. Invalid characters',
       )
     })
   })

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
@@ -117,7 +117,7 @@ const SpaceAddressBook = () => {
             <TabsTrigger value="workspace" className="cursor-pointer">
               <Tooltip>
                 <TooltipTrigger render={<span />}>Workspace contacts ({addressBookItems.length})</TooltipTrigger>
-                <TooltipContent>Shared contacts visible to everyone in this workspace</TooltipContent>
+                <TooltipContent>Shared contacts visible to everyone in this Workspace</TooltipContent>
               </Tooltip>
             </TabsTrigger>
             {isPrivateAddressBookEnabled && (
@@ -131,7 +131,7 @@ const SpaceAddressBook = () => {
                 <TabsTrigger value="pending" className="cursor-pointer">
                   <Tooltip>
                     <TooltipTrigger render={<span />}>Pending ({pendingRequests.length})</TooltipTrigger>
-                    <TooltipContent>Contacts you proposed to add to the workspace</TooltipContent>
+                    <TooltipContent>Contacts you proposed to add to the Workspace</TooltipContent>
                   </Tooltip>
                 </TabsTrigger>
               </>
@@ -170,7 +170,7 @@ const SpaceAddressBook = () => {
               {searchQuery && filteredAll.length === 0 ? (
                 <p className="text-muted-foreground mb-2 p-4 text-sm">Found 0 results</p>
               ) : addressBookItems.length === 0 ? (
-                <p className="text-muted-foreground p-4 text-sm">No contacts in this workspace yet.</p>
+                <p className="text-muted-foreground p-4 text-sm">No contacts in this Workspace yet.</p>
               ) : (
                 <SpaceAddressBookTable entries={filteredAll} />
               )}
@@ -202,7 +202,7 @@ const SpaceAddressBook = () => {
                                   <Badge variant="secondary">Already shared</Badge>
                                 )}
                               </TooltipTrigger>
-                              <TooltipContent>Already saved in your workspace address book</TooltipContent>
+                              <TooltipContent>Already saved in your Workspace address book</TooltipContent>
                             </Tooltip>
                           )
                         }

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/utils.ts
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/utils.ts
@@ -57,4 +57,4 @@ export const validateContactName = (name: string): string | undefined =>
   validateName(sanitizeName(name), { minLength: NAME_MIN_LENGTH, maxLength: ADDRESS_BOOK_NAME_MAX_LENGTH })
 
 export const getRenameContactTooltip = (nameError: string): string =>
-  `Rename this contact to add it to the workspace. ${nameError}`
+  `Rename this contact to add it to the Workspace. ${nameError}`

--- a/apps/web/src/features/spaces/components/SpaceCreationModal/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceCreationModal/index.tsx
@@ -49,7 +49,7 @@ function SpaceCreationModal({ onClose }: { onClose: () => void }): ReactElement 
 
         dispatch(
           showNotification({
-            message: `Created workspace with name ${name}.`,
+            message: `Created Workspace with name ${name}.`,
             variant: 'success',
             groupKey: 'create-space-success',
           }),
@@ -73,7 +73,7 @@ function SpaceCreationModal({ onClose }: { onClose: () => void }): ReactElement 
       dialogTitle={
         <>
           <SpaceIcon className="mr-2 size-6 fill-none" />
-          Create workspace
+          Create Workspace
         </>
       }
       hideChainIndicator
@@ -110,7 +110,7 @@ function SpaceCreationModal({ onClose }: { onClose: () => void }): ReactElement 
               className="p-4 pt-0"
               onCancel={onClose}
               cancelTestId="cancel-btn"
-              confirmLabel="Create workspace"
+              confirmLabel="Create Workspace"
               confirmType="submit"
               confirmDisabled={!formState.isValid || isSubmitting}
               confirmLoading={isSubmitting}

--- a/apps/web/src/features/spaces/components/SpaceInfoModal/__tests__/SpaceInfoModal.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceInfoModal/__tests__/SpaceInfoModal.test.tsx
@@ -5,7 +5,7 @@ describe('SpaceInfoModal', () => {
   it('renders the workspaces headline and benefits', () => {
     render(<SpaceInfoModal onClose={jest.fn()} />)
 
-    expect(screen.getByText('One workspace for your team.')).toBeInTheDocument()
+    expect(screen.getByText('One Workspace for your team.')).toBeInTheDocument()
     expect(screen.getByText('Every Safe in one view')).toBeInTheDocument()
     expect(screen.getByText('Access by role')).toBeInTheDocument()
     expect(screen.getByText('Security & audit in one view')).toBeInTheDocument()

--- a/apps/web/src/features/spaces/components/SpaceInfoModal/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceInfoModal/index.tsx
@@ -127,7 +127,7 @@ const SpaceInfoModal = ({ onClose }: { onClose: () => void }) => {
           <div className="flex flex-col justify-center gap-10 p-9 md:p-12">
             <div>
               <DialogTitle className="text-[40px] font-bold leading-[44px] tracking-[-0.04em] text-balance">
-                One workspace for your team.
+                One Workspace for your team.
               </DialogTitle>
 
               <DialogDescription className="mt-3 max-w-[420px] text-base leading-6">
@@ -152,7 +152,7 @@ const SpaceInfoModal = ({ onClose }: { onClose: () => void }) => {
             </div>
 
             <Typography variant="paragraph-small" color="muted">
-              New to workspaces?{' '}
+              New to Workspaces?{' '}
               <a
                 href={SPACE_HELP_ARTICLE_LINK}
                 target="_blank"

--- a/apps/web/src/features/spaces/components/SpaceSettings/DeleteSpaceDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/DeleteSpaceDialog.tsx
@@ -24,9 +24,9 @@ import { trackEvent } from '@/services/analytics'
 type Consequence = { variant: 'danger' | 'success'; text: string }
 
 const CONSEQUENCES: Consequence[] = [
-  { variant: 'danger', text: 'Members lose access to this workspace immediately.' },
+  { variant: 'danger', text: 'Members lose access to this Workspace immediately.' },
   { variant: 'danger', text: 'Member list and Safe account names are deleted.' },
-  { variant: 'success', text: 'Linked Safe accounts keep working — only the workspace is removed.' },
+  { variant: 'success', text: 'Linked Safe accounts keep working — only the Workspace is removed.' },
 ]
 
 const ConsequenceRow = ({ variant, text }: Consequence) => (
@@ -65,7 +65,7 @@ const DeleteSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undef
       trackEvent({ ...SPACE_EVENTS.DELETE_SPACE })
       dispatch(
         showNotification({
-          message: `Deleted workspace ${space.name}.`,
+          message: `Deleted Workspace ${space.name}.`,
           variant: 'success',
           groupKey: 'delete-space-success',
         }),
@@ -74,7 +74,7 @@ const DeleteSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undef
       router.push({ pathname: AppRoutes.welcome.spaces })
     } catch (e) {
       console.error(e)
-      setError('Error deleting the workspace. Please try again.')
+      setError('Error deleting the Workspace. Please try again.')
     }
   }
 
@@ -85,7 +85,7 @@ const DeleteSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undef
           <div className="flex items-center justify-center size-10 rounded-full bg-destructive/10 text-destructive shrink-0">
             <AlertTriangle className="size-5" />
           </div>
-          <AlertDialogTitle>Delete workspace</AlertDialogTitle>
+          <AlertDialogTitle>Delete Workspace</AlertDialogTitle>
           <AlertDialogDescription>This action is permanent and cannot be undone.</AlertDialogDescription>
         </AlertDialogHeader>
 
@@ -119,7 +119,7 @@ const DeleteSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undef
         <AlertDialogFooter>
           <DialogActions
             onCancel={onClose}
-            confirmLabel="Delete workspace"
+            confirmLabel="Delete Workspace"
             onConfirm={onDelete}
             confirmDestructive
             confirmDisabled={!canConfirm}

--- a/apps/web/src/features/spaces/components/SpaceSettings/LeaveSpaceDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/LeaveSpaceDialog.tsx
@@ -36,7 +36,7 @@ const LeaveSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undefi
       trackEvent({ ...SPACE_EVENTS.LEAVE_SPACE })
       dispatch(
         showNotification({
-          message: `Left workspace ${space.name}.`,
+          message: `Left Workspace ${space.name}.`,
           variant: 'success',
           groupKey: 'leave-space-success',
         }),
@@ -45,7 +45,7 @@ const LeaveSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undefi
       router.push({ pathname: AppRoutes.welcome.spaces })
     } catch (e) {
       console.error(e)
-      setError('Error leaving the workspace. Please try again.')
+      setError('Error leaving the Workspace. Please try again.')
     }
   }
 
@@ -56,7 +56,7 @@ const LeaveSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undefi
           <div className="flex items-center justify-center size-10 rounded-full bg-destructive/10 text-destructive shrink-0">
             <LogOut className="size-5" />
           </div>
-          <AlertDialogTitle>Leave workspace</AlertDialogTitle>
+          <AlertDialogTitle>Leave Workspace</AlertDialogTitle>
           <AlertDialogDescription>
             You&apos;ll lose access to <span className="font-semibold text-foreground">{space?.name}</span> immediately.
             An admin can re-invite you later.
@@ -77,7 +77,7 @@ const LeaveSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undefi
         <DialogActions
           onCancel={onClose}
           cancelDisabled={isLoading}
-          confirmLabel="Leave workspace"
+          confirmLabel="Leave Workspace"
           onConfirm={onLeave}
           confirmDisabled={isLoading || !space}
           confirmLoading={isLoading}

--- a/apps/web/src/features/spaces/components/SpaceSettings/UpdateSpaceDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/UpdateSpaceDialog.tsx
@@ -11,11 +11,11 @@ const UpdateSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse; onClos
   const isDarkMode = useDarkMode()
 
   return (
-    <ModalDialog dialogTitle="Update workspace" hideChainIndicator open onClose={onClose}>
+    <ModalDialog dialogTitle="Update Workspace" hideChainIndicator open onClose={onClose}>
       <div className={cn('shadcn-scope', isDarkMode && 'dark')}>
         <div className="mt-4 px-6 pb-6">
           <Typography className="mb-4">
-            The workspace name is visible in the sidebar menu, headings to all its members. Usually it&apos;s a name of
+            The Workspace name is visible in the sidebar menu, headings to all its members. Usually it&apos;s a name of
             the company or a business. <ExternalLink href={AppRoutes.privacy}>How is this data stored?</ExternalLink>
           </Typography>
           <UpdateSpaceForm space={space} onClose={onClose} />

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/DeleteSpaceDialog.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/DeleteSpaceDialog.test.tsx
@@ -123,7 +123,7 @@ describe('DeleteSpaceDialog', () => {
       const notifications = store.getState().notifications
       expect(notifications.length).toBeGreaterThan(0)
       const last = notifications[notifications.length - 1]
-      expect(last.message).toBe('Deleted workspace My Workspace.')
+      expect(last.message).toBe('Deleted Workspace My Workspace.')
       expect(last.variant).toBe('success')
     })
   })
@@ -138,7 +138,7 @@ describe('DeleteSpaceDialog', () => {
     fireEvent.click(screen.getByTestId('space-confirm-delete-button'))
 
     await waitFor(() => {
-      expect(screen.getByText('Error deleting the workspace. Please try again.')).toBeInTheDocument()
+      expect(screen.getByText('Error deleting the Workspace. Please try again.')).toBeInTheDocument()
     })
   })
 
@@ -152,7 +152,7 @@ describe('DeleteSpaceDialog', () => {
     fireEvent.click(screen.getByTestId('space-confirm-delete-button'))
 
     await waitFor(() => {
-      expect(screen.getByText('Error deleting the workspace. Please try again.')).toBeInTheDocument()
+      expect(screen.getByText('Error deleting the Workspace. Please try again.')).toBeInTheDocument()
     })
     expect(mockRouterPush).not.toHaveBeenCalled()
   })

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/LeaveSpaceDialog.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/LeaveSpaceDialog.test.tsx
@@ -94,7 +94,7 @@ describe('LeaveSpaceDialog', () => {
       const notifications = store.getState().notifications
       expect(notifications.length).toBeGreaterThan(0)
       const last = notifications[notifications.length - 1]
-      expect(last.message).toBe('Left workspace My Workspace.')
+      expect(last.message).toBe('Left Workspace My Workspace.')
       expect(last.variant).toBe('success')
     })
   })
@@ -106,7 +106,7 @@ describe('LeaveSpaceDialog', () => {
     fireEvent.click(screen.getByTestId('space-confirm-leave-button'))
 
     await waitFor(() => {
-      expect(screen.getByText('Error leaving the workspace. Please try again.')).toBeInTheDocument()
+      expect(screen.getByText('Error leaving the Workspace. Please try again.')).toBeInTheDocument()
     })
   })
 
@@ -117,7 +117,7 @@ describe('LeaveSpaceDialog', () => {
     fireEvent.click(screen.getByTestId('space-confirm-leave-button'))
 
     await waitFor(() => {
-      expect(screen.getByText('Error leaving the workspace. Please try again.')).toBeInTheDocument()
+      expect(screen.getByText('Error leaving the Workspace. Please try again.')).toBeInTheDocument()
     })
     expect(mockRouterPush).not.toHaveBeenCalled()
   })

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/UpdateSpaceForm.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/UpdateSpaceForm.test.tsx
@@ -155,7 +155,7 @@ describe('UpdateSpaceForm', () => {
       const notifications = state.notifications
       expect(notifications.length).toBeGreaterThan(0)
       const lastNotification = notifications[notifications.length - 1]
-      expect(lastNotification.message).toBe('Updated workspace name')
+      expect(lastNotification.message).toBe('Updated Workspace name')
       expect(lastNotification.variant).toBe('success')
       expect(lastNotification.groupKey).toBe('space-update-name')
     })

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/useUpdateSpace.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/useUpdateSpace.test.tsx
@@ -67,7 +67,7 @@ describe('useUpdateSpace', () => {
     const notifications = store.getState().notifications
     expect(notifications.length).toBeGreaterThan(0)
     const last = notifications[notifications.length - 1]
-    expect(last.message).toBe('Updated workspace name')
+    expect(last.message).toBe('Updated Workspace name')
     expect(last.variant).toBe('success')
     expect(last.groupKey).toBe('space-update-name')
   })

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/AccountPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/AccountPage.tsx
@@ -44,7 +44,7 @@ const AccountPage = () => {
       <SpaceSettingsSection data-testid="settings-account-page">
         <SpaceSettingsSectionTitle className="mb-2">Signed in</SpaceSettingsSectionTitle>
         <Typography variant="paragraph-small" color="muted">
-          You&apos;re not signed in to this workspace.
+          You&apos;re not signed in to this Workspace.
         </Typography>
       </SpaceSettingsSection>
     )

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/DangerZoneSection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/DangerZoneSection.tsx
@@ -19,7 +19,7 @@ const DangerZoneSection = ({ space }: { space: GetSpaceResponse | undefined }) =
 
   return (
     <SpaceSettingsSection>
-      <SpaceSettingsSectionTitle>Manage workspace</SpaceSettingsSectionTitle>
+      <SpaceSettingsSectionTitle>Manage Workspace</SpaceSettingsSectionTitle>
 
       <div
         className={cn('flex items-center justify-start gap-6 py-4 first:pt-0', isAdmin && 'border-b border-border/60')}
@@ -30,12 +30,12 @@ const DangerZoneSection = ({ space }: { space: GetSpaceResponse | undefined }) =
               render={
                 <span tabIndex={0}>
                   <Button variant="destructive" data-testid="space-leave-button" disabled>
-                    Leave workspace
+                    Leave Workspace
                   </Button>
                 </span>
               }
             />
-            <TooltipContent side="top">You are the last active admin and cannot leave the workspace.</TooltipContent>
+            <TooltipContent side="top">You are the last active admin and cannot leave the Workspace.</TooltipContent>
           </Tooltip>
         ) : (
           <Button
@@ -47,7 +47,7 @@ const DangerZoneSection = ({ space }: { space: GetSpaceResponse | undefined }) =
               trackEvent({ ...SPACE_EVENTS.LEAVE_SPACE_MODAL, label: SPACE_LABELS.space_settings })
             }}
           >
-            Leave workspace
+            Leave Workspace
           </Button>
         )}
       </div>
@@ -62,7 +62,7 @@ const DangerZoneSection = ({ space }: { space: GetSpaceResponse | undefined }) =
               trackEvent({ ...SPACE_EVENTS.DELETE_SPACE_MODAL, label: SPACE_LABELS.space_settings })
             }}
           >
-            Delete workspace
+            Delete Workspace
           </Button>
         </div>
       )}

--- a/apps/web/src/features/spaces/components/SpaceSettings/useUpdateSpace.ts
+++ b/apps/web/src/features/spaces/components/SpaceSettings/useUpdateSpace.ts
@@ -34,7 +34,7 @@ export const useUpdateSpace = (space: GetSpaceResponse | undefined, onSuccess?: 
       dispatch(
         showNotification({
           variant: 'success',
-          message: 'Updated workspace name',
+          message: 'Updated Workspace name',
           groupKey: 'space-update-name',
         }),
       )

--- a/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
@@ -194,12 +194,12 @@ describe('SpacesList — auth/expiry state rendering', () => {
 
     // The signed-out card with the "Sign in to your workspace" heading +
     // SignInOptions must render…
-    expect(screen.getByRole('heading', { name: /sign in to your workspace/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /sign in to your Workspace/i })).toBeInTheDocument()
     expect(screen.getByTestId('sign-in-options')).toBeInTheDocument()
 
     // …and the Create workspace CTA / no-workspaces empty state must NOT.
-    expect(screen.queryByText(/^create workspace$/i)).not.toBeInTheDocument()
-    expect(screen.queryByText(/create your first workspace/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/^create Workspace$/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/create your first Workspace/i)).not.toBeInTheDocument()
   })
 
   // /welcome/spaces keeps its Topbar + tabbed layout. The Accounts/Workspaces
@@ -231,7 +231,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
 
     render(<SpacesList />)
 
-    const cta = screen.getByRole('link', { name: /create your first workspace/i })
+    const cta = screen.getByRole('link', { name: /create your first Workspace/i })
     expect(cta).toHaveAttribute('href')
 
     // Sign in card must NOT render in this branch.
@@ -453,7 +453,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
 
     render(<SpacesList />)
 
-    const heading = screen.getByRole('heading', { name: /sign in to your workspace/i })
+    const heading = screen.getByRole('heading', { name: /sign in to your Workspace/i })
     expect(heading.className).toContain('text-center')
   })
 
@@ -502,7 +502,7 @@ describe('SpacesList — auth/expiry state rendering', () => {
 
     // The header button is absent; only the empty-state CTA inside the
     // No-workspaces card renders (it lives outside the spacesHeader).
-    expect(screen.getByText(/create your first workspace/i)).toBeInTheDocument()
+    expect(screen.getByText(/create your first Workspace/i)).toBeInTheDocument()
     expect(screen.getAllByTestId('create-space-button')).toHaveLength(1)
   })
 

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -44,7 +44,7 @@ const AddSpaceButton = ({
   disabled,
   size = 'lg',
   variant = 'default',
-  label = 'Create workspace',
+  label = 'Create Workspace',
   icon = 'add',
 }: {
   onClick?: () => void
@@ -84,7 +84,7 @@ const AddSpaceButton = ({
   return (
     <Tooltip>
       <TooltipTrigger render={<div className="inline-flex" />}>{button}</TooltipTrigger>
-      <TooltipContent>Limit of {SPACES_LIMIT} workspaces reached</TooltipContent>
+      <TooltipContent>Limit of {SPACES_LIMIT} Workspaces reached</TooltipContent>
     </Tooltip>
   )
 }
@@ -117,7 +117,7 @@ const SignedOutState = ({ afterSignIn, redirectLoading }: { afterSignIn: () => v
               </div>
 
               <Typography variant="h3" className="mb-6 text-center">
-                Sign in to your workspace
+                Sign in to your Workspace
               </Typography>
 
               <SignInOptions afterSignIn={afterSignIn} redirectLoading={redirectLoading} />
@@ -176,7 +176,7 @@ const NoSpacesState = ({ isAtLimit }: { isAtLimit: boolean }) => {
 
           <Image
             src={isDarkMode ? WorkspacesEmptyIllustrationDark : WorkspacesEmptyIllustration}
-            alt="Workspace dashboard showing accounts grouped by workspace"
+            alt="Workspace dashboard showing accounts grouped by Workspace"
             className="-my-8 h-auto w-full min-w-0 md:-mr-8 md:w-[60%]"
           />
         </div>
@@ -187,7 +187,7 @@ const NoSpacesState = ({ isAtLimit }: { isAtLimit: boolean }) => {
           <div className="flex flex-col items-center gap-4">
             <div className="h-12">
               <AddSpaceButton
-                label="Create your first workspace"
+                label="Create your first Workspace"
                 icon="arrow"
                 disabled={isAtLimit}
                 onClick={() =>
@@ -197,7 +197,7 @@ const NoSpacesState = ({ isAtLimit }: { isAtLimit: boolean }) => {
             </div>
 
             <Link variant="muted" className="text-sm underline" onClick={() => setIsInfoOpen(true)} href="#">
-              What are workspaces?
+              What are Workspaces?
             </Link>
           </div>
         </div>
@@ -275,7 +275,7 @@ const SpacesList = () => {
           <SignedOutState afterSignIn={afterSignIn} redirectLoading={redirectLoading} />
         ) : error && !spaces?.length ? (
           <div className="flex flex-col items-center gap-3 py-10 text-center">
-            <Typography color="muted">Couldn&apos;t load your workspaces. Try again, or contact support.</Typography>
+            <Typography color="muted">Couldn&apos;t load your Workspaces. Try again, or contact support.</Typography>
             <Button variant="outline" onClick={() => refetch()}>
               Try again
             </Button>

--- a/apps/web/src/features/spaces/components/UnauthorizedState/index.tsx
+++ b/apps/web/src/features/spaces/components/UnauthorizedState/index.tsx
@@ -19,7 +19,7 @@ const UnauthorizedState = () => {
             </Typography>
 
             <Typography color="muted" className="mb-4">
-              Sorry, you don’t have permissions to view this page, as your wallet is not a member of the workspace. Try
+              Sorry, you don’t have permissions to view this page, as your wallet is not a member of the Workspace. Try
               to sign in with a different wallet or go back to the overview.
             </Typography>
 

--- a/apps/web/src/features/spaces/constants.ts
+++ b/apps/web/src/features/spaces/constants.ts
@@ -17,4 +17,4 @@ export { SPACE_NAME_MAX_LENGTH } from '@safe-global/utils/validation/names'
 
 /** Friendly notice shown when a workspace is already at the Safe accounts cap. */
 export const safeAccountsLimitReachedText = (limit: number = SAFE_ACCOUNTS_LIMIT) =>
-  `You've reached the maximum of ${limit} Safe accounts per workspace`
+  `You've reached the maximum of ${limit} Safe accounts per Workspace`

--- a/apps/web/src/features/spaces/hooks/__tests__/useWorkspaceAddressBookLabel.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useWorkspaceAddressBookLabel.test.ts
@@ -34,6 +34,6 @@ describe('useWorkspaceAddressBookLabel', () => {
 
     const { result } = renderHook(() => useWorkspaceAddressBookLabel())
 
-    expect(result.current).toBe('the workspace address book')
+    expect(result.current).toBe('the Workspace address book')
   })
 })

--- a/apps/web/src/pages/spaces/create-space.tsx
+++ b/apps/web/src/pages/spaces/create-space.tsx
@@ -9,7 +9,7 @@ const CreateSpacePage: NextPage = () => {
   return (
     <>
       <Head>
-        <title>{`${BRAND_NAME} – Create workspace`}</title>
+        <title>{`${BRAND_NAME} – Create Workspace`}</title>
       </Head>
       <CreateSpaceOnboarding />
     </>

--- a/apps/web/src/pages/welcome/create-space.tsx
+++ b/apps/web/src/pages/welcome/create-space.tsx
@@ -9,7 +9,7 @@ const CreateSpacePage: NextPage = () => {
   return (
     <>
       <Head>
-        <title>{`${BRAND_NAME} – Create workspace`}</title>
+        <title>{`${BRAND_NAME} – Create Workspace`}</title>
       </Head>
       <CreateSpaceOnboarding />
     </>

--- a/apps/web/src/services/sessionExpiry/__tests__/useSessionExpiryGuard.test.tsx
+++ b/apps/web/src/services/sessionExpiry/__tests__/useSessionExpiryGuard.test.tsx
@@ -303,7 +303,7 @@ describe('useSessionExpiryGuard', () => {
     const notification = findNotification(store)
     expect(notification).toMatchObject({ message: SESSION_EXPIRED_MESSAGE })
     expect(notification?.link).toBeUndefined()
-    expect(SESSION_EXPIRED_MESSAGE).toBe('Your session has expired. Please sign in to workspaces again.')
+    expect(SESSION_EXPIRED_MESSAGE).toBe('Your session has expired. Please sign in to Workspaces again.')
   })
 
   it('clears auth but shows no toast when the session expires outside /welcome/spaces', async () => {

--- a/apps/web/src/services/sessionExpiry/useSessionExpiryGuard.ts
+++ b/apps/web/src/services/sessionExpiry/useSessionExpiryGuard.ts
@@ -14,7 +14,7 @@ import { AppRoutes } from '@/config/routes'
 const OIDC_AUTH_PENDING_KEY = 'oidc_auth_pending'
 
 export const SESSION_EXPIRED_GROUP_KEY = 'session-expired'
-export const SESSION_EXPIRED_MESSAGE = 'Your session has expired. Please sign in to workspaces again.'
+export const SESSION_EXPIRED_MESSAGE = 'Your session has expired. Please sign in to Workspaces again.'
 
 const isForbidden = (error: unknown): error is FetchBaseQueryError =>
   typeof error === 'object' && error !== null && 'status' in error && error.status === 403

--- a/apps/web/src/utils/addressBookNotifications.ts
+++ b/apps/web/src/utils/addressBookNotifications.ts
@@ -25,6 +25,6 @@ export const getImportSuccessMessage = ({
 
 export const PERSONAL_ADDRESS_BOOK_LABEL = 'your address book'
 
-export const WORKSPACE_ADDRESS_BOOK_FALLBACK_LABEL = 'the workspace address book'
+export const WORKSPACE_ADDRESS_BOOK_FALLBACK_LABEL = 'the Workspace address book'
 
 export const getWorkspaceAddressBookLabel = (spaceName: string): string => `${spaceName} address book`


### PR DESCRIPTION
## What it solves

Resolves: inconsistent casing of "Workspace" across the UI.

Workspace is a product name, but the UI copy referred to it in lower case in ~76 files — buttons, dialogs, tooltips, toasts, empty states and error messages. It read as a generic noun rather than the product.

This was originally part of #8587 (the Safe Pro announcement banners). It was split out of that PR because it is unrelated to the banners and made that diff twice as large.

## How this PR fixes it

Capitalises "Workspace"/"Workspaces" in user-facing copy only. Every changed line is a string literal or JSX text node — `+258 / −258` across 77 files, no logic, no structure, no props.

Deliberately **not** changed:

- identifiers, prop names, sort keys, `data-testid`s, `groupKey`s, route constants and tab values (`'workspace'` as a value stays lower case)
- code comments and the help-centre URL slug
- `apps/mobile` — no shared copy touched

## How to test it

1. `yarn workspace @safe-global/web dev`
2. Visit `/welcome/spaces` signed out → sign-in card reads "Sign in to your Workspace"
3. Sign in with no workspaces → empty state reads "Create your first Workspace" / "What are Workspaces?"
4. Space → Address book → "Add to Workspace", and the pending-requests "Already in Workspace" tooltip
5. Space → Settings → Danger zone → Leave/Delete dialogs
6. Let a session expire on a workspaces route → toast reads "…Please sign in to Workspaces again."

Or: `yarn workspace @safe-global/web test --testPathPattern 'spaces|sessionExpiry|myAccounts|AddressBook'`

## Affected flows

- Workspace sign-in and workspace list (signed-out card, empty state, limit tooltip)
- Workspace address book — add/edit contact, request-to-add, approve pending request, import
- Workspace settings — general/account, leave workspace, delete workspace
- Workspace members — invite, edit member
- Workspace creation onboarding, and adding Safe accounts to a workspace
- Security hub empty state, Setup widget, activity-log event copy
- Session-expiry toast on workspaces routes

## Blast radius

Copy-only, but the strings are asserted in tests, so the surface is wider than the visual change:

- **No shared hook, component, selector, slice, endpoint, flag or route changed.** No prop or type signature changed.
- **Test assertions**: 20 test files updated in lockstep with the copy they assert. Two assertions added on `dev` after this work began (`AddToWorkspaceButton` compact accessible name, `SESSION_EXPIRED_MESSAGE` literal) were updated here.
- **Exported constant**: `SESSION_EXPIRED_MESSAGE` in `services/sessionExpiry/useSessionExpiryGuard.ts` — value changes, name and type unchanged. Both consumers are in this diff.
- **Analytics**: no event names, properties or values touched — only display copy. Any dashboard filtering on these strings as *labels* would need updating; none do, as tracking uses `SPACE_EVENTS` constants.
- **E2E**: one Cypress visual spec asserted this copy case-sensitively (`cypress/e2e/visual/welcome.cy.js` — "Sign in to your workspace") and is updated here. Swept the rest of `e2e/` and `cypress/`: no other spec asserts workspace copy.
- **Mobile**: none — no `packages/**` copy touched.

## Risks / not checked

- **Not visually verified.** Every change is inside an existing string, so layout is unchanged except where a capital letter is marginally wider. Not checked: whether any tightly-constrained control (the compact address-book button, the workspace-limit tooltip) now wraps differently.
- **Storybook snapshots not run** — `test:storybook` fails in my worktree on an unrelated `fast-uri` resolution error. If any story snapshot contains this copy, it will need regenerating; the non-story suite (2176 tests) is green.
- **Not tested on mobile viewport.**
- No screen-reader pass on the changed `aria-label`s.
- German/other locales: not applicable, the app is English-only.

## Visual summary

Copy-only change — no architecture or layout change to diagram. The full set of changed strings:

```mermaid
flowchart LR
  subgraph Before["Before — generic noun"]
    B1["Sign in to your workspace"]
    B2["Create workspace / Create your first workspace"]
    B3["Add to workspace / Already in workspace"]
    B4["Limit of N workspaces reached"]
    B5["…sign in to workspaces again."]
  end
  subgraph After["After — product name"]
    A1["Sign in to your Workspace"]
    A2["Create Workspace / Create your first Workspace"]
    A3["Add to Workspace / Already in Workspace"]
    A4["Limit of N Workspaces reached"]
    A5["…sign in to Workspaces again."]
  end
  B1 --> A1
  B2 --> A2
  B3 --> A3
  B4 --> A4
  B5 --> A5
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no event names or properties touched, display copy only
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — no new behaviour; 20 existing test files updated in lockstep, full suite green
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
