### PR TITLE
fix: allow non-owner executors to confirm speed-ups

### DIFF
--- a/apps/web/src/features/speedup/components/SpeedUpModal/index.tsx
+++ b/apps/web/src/features/speedup/components/SpeedUpModal/index.tsx
@@ -200,7 +200,7 @@ const SpeedUpModal = ({ open, handleClose, pendingTx, txId, txHash, signerAddres
           <Button onClick={onCancel}>Cancel</Button>
 
           <Tooltip title="Speed up transaction">
-            <CheckWallet checkNetwork={!isDisabled}>
+            <CheckWallet allowNonOwner checkNetwork={!isDisabled}>
               {(isOk) => (
                 <Button
                   color="primary"


### PR DESCRIPTION
## What it solves

A non-owner wallet can execute a fully signed Safe transaction, but the speed-up confirmation is blocked by the wallet membership check.

Ticket: to be linked by Rudy.

## How this PR fixes it

Passes the existing `allowNonOwner` option to `CheckWallet` in `SpeedUpModal`, allowing the original non-owner executor to confirm a replacement. The existing original-sender eligibility check and wallet/network checks remain in place.

## How to test it

1. On a supported test chain, execute a fully signed Safe transaction using a non-owner EOA and keep the transaction pending long enough for Speed up to appear.
2. With the same wallet connected, open Speed up from the queue or processing screen. Confirm should no longer show the owner restriction.
3. Confirm the replacement and verify it uses the original wallet nonce and completes successfully.
4. Check that another wallet cannot speed up that transaction, an owner executor still can, and the wrong-network flow still requires switching networks.

Validation performed: reviewed the main-branch sender checks; formatting and `git diff --check` passed.

## Affected flows

- Speed-up confirmation for a pending transaction submitted by a non-owner EOA, through the queue and processing screen.

## Blast radius

One prop at the web speed-up modal call site. Shared `CheckWallet`, transaction dispatch, backend APIs, persistence, and mobile code are unchanged. Existing speed-up analytics are reused.

## Risks / not checked

- Successful non-owner replacement has not been verified end to end.
- Automated tests, full type-check, and lint have not been run; validation remains outstanding.
- Batch replacement tracking, smart-contract-wallet handling, and fee-bump edge cases are outside this change and have not been validated.

## Visual summary

```mermaid
flowchart LR
    A[Original non-owner executor opens Speed up] --> B[Existing wallet and network checks]
    B --> C[Before: membership check blocks Confirm]
    B --> D[After: allowNonOwner permits Confirm]
    D --> E[Existing replacement submission]
```

To capture the UI result, take a screenshot of the speed-up modal in step 2 with the original non-owner executor connected.

## Checklist

- [ ] I've tested the branch on mobile — web-only change.
- [x] I've documented how it affects the analytics — existing events are reused.
- [ ] I've written a unit/e2e test — deferred.
- [x] I've listed affected flows and blast radius, and named what I did not verify.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
