### PR TITLE
fix: allow non-owner submitter to speed up own transaction

### DIFF
--- a/apps/web/src/features/speedup/components/SpeedUpModal/index.test.tsx
+++ b/apps/web/src/features/speedup/components/SpeedUpModal/index.test.tsx
@@ -5,12 +5,10 @@ import { extendedSafeInfoBuilder, addressExBuilder } from '@/tests/builders/safe
 import { chainBuilder } from '@/tests/builders/chains'
 import { PendingStatus, PendingTxType, type PendingProcessingTx } from '@/store/pendingTxsSlice'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import useWallet, { useSigner } from '@/hooks/wallets/useWallet'
-import { useNestedSafeOwners } from '@/hooks/useNestedSafeOwners'
-import { useSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
+import useWallet from '@/hooks/wallets/useWallet'
+import useIsWrongChain from '@/hooks/useIsWrongChain'
 import * as useChains from '@/hooks/useChains'
 import { createExistingTx } from '@/services/tx/tx-sender'
-import type Safe from '@safe-global/protocol-kit'
 import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import SpeedUpModal from '.'
 
@@ -20,7 +18,6 @@ const SAFE_ADDRESS = fakerChecksummedAddress()
 jest.mock('@/hooks/wallets/useWallet', () => ({
   __esModule: true,
   default: jest.fn(),
-  useSigner: jest.fn(),
 }))
 
 jest.mock('@/hooks/wallets/useOnboard', () => ({
@@ -34,10 +31,6 @@ jest.mock('@/hooks/useSafeAddress', () => ({
 }))
 
 jest.mock('@/hooks/useSafeInfo')
-
-jest.mock('@/hooks/useNestedSafeOwners')
-
-jest.mock('@/hooks/coreSDK/safeCoreSDK')
 
 jest.mock('@/hooks/useIsWrongChain', () => ({
   __esModule: true,
@@ -60,11 +53,9 @@ jest.mock('@safe-global/store/gateway/AUTO_GENERATED/transactions', () => ({
 }))
 
 const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>
-const mockUseSigner = useSigner as jest.MockedFunction<typeof useSigner>
 const mockUseSafeInfo = useSafeInfo as jest.MockedFunction<typeof useSafeInfo>
-const mockUseNestedSafeOwners = useNestedSafeOwners as jest.MockedFunction<typeof useNestedSafeOwners>
-const mockUseSafeSdk = useSafeSDK as jest.MockedFunction<typeof useSafeSDK>
 const mockCreateExistingTx = createExistingTx as jest.MockedFunction<typeof createExistingTx>
+const mockUseIsWrongChain = useIsWrongChain as jest.MockedFunction<typeof useIsWrongChain>
 
 const pendingTx: PendingProcessingTx = {
   chainId: '1',
@@ -113,10 +104,8 @@ describe('SpeedUpModal', () => {
     jest.clearAllMocks()
     jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(chainBuilder().with({ chainId: '1' }).build())
     jest.spyOn(useChains, 'useHasFeature').mockReturnValue(true)
-    mockUseSafeSdk.mockReturnValue({} as unknown as Safe)
-    mockUseNestedSafeOwners.mockReturnValue([])
+    mockUseIsWrongChain.mockReturnValue(false)
     mockUseWallet.mockReturnValue({ address: SIGNER_ADDRESS, provider: {} } as unknown as ConnectedWallet)
-    mockUseSigner.mockReturnValue({ address: SIGNER_ADDRESS } as unknown as ReturnType<typeof useSigner>)
     mockCreateExistingTx.mockResolvedValue({
       data: { nonce: 5 },
       signatures: new Map([[SIGNER_ADDRESS, {}]]),
@@ -139,9 +128,25 @@ describe('SpeedUpModal', () => {
     expect(queryByLabelText('Your connected wallet is not a signer of this Safe account')).not.toBeInTheDocument()
   })
 
+  it('disables Confirm and explains why when connected to the wrong chain', async () => {
+    mockUseIsWrongChain.mockReturnValue(true)
+
+    const { findByText, getByText } = renderModal()
+
+    expect(await findByText('Confirm')).toBeDisabled()
+    expect(getByText('Change your wallet network')).toBeInTheDocument()
+    expect(getByText(/trying to speed up a transaction/)).toBeInTheDocument()
+  })
+
+  it('shows no network warning when Confirm is enabled', async () => {
+    const { findByText, queryByText } = renderModal()
+
+    expect(await findByText('Confirm')).not.toBeDisabled()
+    expect(queryByText('Change your wallet network')).not.toBeInTheDocument()
+  })
+
   it('renders nothing when no wallet is connected', async () => {
     mockUseWallet.mockReturnValue(null)
-    mockUseSigner.mockReturnValue(null)
 
     const { queryByTestId } = renderModal()
     await waitFor(() => expect(mockCreateExistingTx).toHaveBeenCalled())

--- a/apps/web/src/features/speedup/components/SpeedUpModal/index.test.tsx
+++ b/apps/web/src/features/speedup/components/SpeedUpModal/index.test.tsx
@@ -1,0 +1,163 @@
+import { faker } from '@faker-js/faker'
+import { waitFor } from '@testing-library/react'
+import { render, fakerChecksummedAddress } from '@/tests/test-utils'
+import { extendedSafeInfoBuilder, addressExBuilder } from '@/tests/builders/safe'
+import { chainBuilder } from '@/tests/builders/chains'
+import { PendingStatus, PendingTxType, type PendingProcessingTx } from '@/store/pendingTxsSlice'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import useWallet, { useSigner } from '@/hooks/wallets/useWallet'
+import { useNestedSafeOwners } from '@/hooks/useNestedSafeOwners'
+import { useSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
+import * as useChains from '@/hooks/useChains'
+import { createExistingTx } from '@/services/tx/tx-sender'
+import type Safe from '@safe-global/protocol-kit'
+import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
+import SpeedUpModal from '.'
+
+const SIGNER_ADDRESS = fakerChecksummedAddress()
+const SAFE_ADDRESS = fakerChecksummedAddress()
+
+jest.mock('@/hooks/wallets/useWallet', () => ({
+  __esModule: true,
+  default: jest.fn(),
+  useSigner: jest.fn(),
+}))
+
+jest.mock('@/hooks/wallets/useOnboard', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({})),
+}))
+
+jest.mock('@/hooks/useSafeAddress', () => ({
+  __esModule: true,
+  default: jest.fn(() => SAFE_ADDRESS),
+}))
+
+jest.mock('@/hooks/useSafeInfo')
+
+jest.mock('@/hooks/useNestedSafeOwners')
+
+jest.mock('@/hooks/coreSDK/safeCoreSDK')
+
+jest.mock('@/hooks/useIsWrongChain', () => ({
+  __esModule: true,
+  default: jest.fn(() => false),
+}))
+
+jest.mock('@/hooks/useGasPrice', () => ({
+  __esModule: true,
+  default: jest.fn(() => [{ maxFeePerGas: BigInt(1e9), maxPriorityFeePerGas: BigInt(1e8) }, undefined, false]),
+}))
+
+jest.mock('@/services/tx/tx-sender', () => ({
+  createExistingTx: jest.fn(),
+  dispatchSafeTxSpeedUp: jest.fn(),
+  dispatchCustomTxSpeedUp: jest.fn(),
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/transactions', () => ({
+  useLazyTransactionsGetTransactionByIdV1Query: jest.fn(() => [jest.fn(() => Promise.resolve({ data: undefined }))]),
+}))
+
+const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>
+const mockUseSigner = useSigner as jest.MockedFunction<typeof useSigner>
+const mockUseSafeInfo = useSafeInfo as jest.MockedFunction<typeof useSafeInfo>
+const mockUseNestedSafeOwners = useNestedSafeOwners as jest.MockedFunction<typeof useNestedSafeOwners>
+const mockUseSafeSdk = useSafeSDK as jest.MockedFunction<typeof useSafeSDK>
+const mockCreateExistingTx = createExistingTx as jest.MockedFunction<typeof createExistingTx>
+
+const pendingTx: PendingProcessingTx = {
+  chainId: '1',
+  safeAddress: SAFE_ADDRESS,
+  nonce: 5,
+  txHash: faker.string.hexadecimal({ length: 64 }),
+  submittedAt: Date.now(),
+  signerNonce: 7,
+  signerAddress: SIGNER_ADDRESS,
+  gasLimit: '150000',
+  status: PendingStatus.PROCESSING,
+  txType: PendingTxType.SAFE_TX,
+}
+
+const setSafeOwners = (owners: string[]) => {
+  mockUseSafeInfo.mockReturnValue({
+    safeAddress: SAFE_ADDRESS,
+    safe: extendedSafeInfoBuilder()
+      .with({ address: { value: SAFE_ADDRESS } })
+      .with({ chainId: '1' })
+      .with({ deployed: true })
+      .with({ owners: owners.map((value) => addressExBuilder().with({ value }).build()) })
+      .build(),
+    safeLoaded: true,
+    safeLoading: false,
+    safeError: undefined,
+  } as unknown as ReturnType<typeof useSafeInfo>)
+}
+
+const renderModal = () =>
+  render(
+    <SpeedUpModal
+      open
+      handleClose={jest.fn()}
+      pendingTx={pendingTx}
+      txId={`multisig_${SAFE_ADDRESS}_0xabc`}
+      txHash={pendingTx.txHash}
+      signerAddress={SIGNER_ADDRESS}
+      signerNonce={pendingTx.signerNonce}
+      gasLimit={pendingTx.gasLimit}
+    />,
+  )
+
+describe('SpeedUpModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(chainBuilder().with({ chainId: '1' }).build())
+    jest.spyOn(useChains, 'useHasFeature').mockReturnValue(true)
+    mockUseSafeSdk.mockReturnValue({} as unknown as Safe)
+    mockUseNestedSafeOwners.mockReturnValue([])
+    mockUseWallet.mockReturnValue({ address: SIGNER_ADDRESS, provider: {} } as unknown as ConnectedWallet)
+    mockUseSigner.mockReturnValue({ address: SIGNER_ADDRESS } as unknown as ReturnType<typeof useSigner>)
+    mockCreateExistingTx.mockResolvedValue({
+      data: { nonce: 5 },
+      signatures: new Map([[SIGNER_ADDRESS, {}]]),
+    } as unknown as Awaited<ReturnType<typeof createExistingTx>>)
+    setSafeOwners([SIGNER_ADDRESS])
+  })
+
+  it('enables Confirm for an owner who submitted the transaction', async () => {
+    const { findByText } = renderModal()
+
+    expect(await findByText('Confirm')).not.toBeDisabled()
+  })
+
+  it('enables Confirm for a non-owner who submitted the transaction', async () => {
+    setSafeOwners([fakerChecksummedAddress(), fakerChecksummedAddress()])
+
+    const { findByText, queryByLabelText } = renderModal()
+
+    expect(await findByText('Confirm')).not.toBeDisabled()
+    expect(queryByLabelText('Your connected wallet is not a signer of this Safe account')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when no wallet is connected', async () => {
+    mockUseWallet.mockReturnValue(null)
+    mockUseSigner.mockReturnValue(null)
+
+    const { queryByTestId } = renderModal()
+    await waitFor(() => expect(mockCreateExistingTx).toHaveBeenCalled())
+
+    expect(queryByTestId('speedup-summary')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when the connected wallet did not submit the transaction', async () => {
+    mockUseWallet.mockReturnValue({
+      address: fakerChecksummedAddress(),
+      provider: {},
+    } as unknown as ConnectedWallet)
+
+    const { queryByTestId } = renderModal()
+    await waitFor(() => expect(mockCreateExistingTx).toHaveBeenCalled())
+
+    expect(queryByTestId('speedup-summary')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/speedup/components/SpeedUpModal/index.tsx
+++ b/apps/web/src/features/speedup/components/SpeedUpModal/index.tsx
@@ -2,7 +2,6 @@ import useGasPrice from '@/hooks/useGasPrice'
 import ModalDialog from '@/components/common/ModalDialog'
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Typography } from '@/components/ui/typography'
 import RocketSpeedup from '@/public/images/common/ic-rocket-speedup.svg'
 import useWallet from '@/hooks/wallets/useWallet'
@@ -27,7 +26,7 @@ import { getTransactionTrackingType } from '@/services/analytics/tx-tracking'
 import { isGtfSafePaid } from '@safe-global/utils/utils/isGtfSafePaid'
 import { trackError } from '@/services/exceptions'
 import ErrorCodes from '@safe-global/utils/services/exceptions/ErrorCodes'
-import CheckWallet from '@/components/common/CheckWallet'
+import useIsWrongChain from '@/hooks/useIsWrongChain'
 import { useLazyTransactionsGetTransactionByIdV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import NetworkWarning from '@/components/new-safe/create/NetworkWarning'
 import { FEATURES } from '@safe-global/utils/utils/chains'
@@ -52,6 +51,8 @@ const SpeedUpModal = ({ open, handleClose, pendingTx, txId, txHash, signerAddres
   const onboard = useOnboard()
   const chainInfo = useCurrentChain()
   const safeAddress = useSafeAddress()
+  const isWrongChain = useIsWrongChain()
+  // Sole authorization: a replacement needs the original (from, nonce), so only the submitter can send one
   const hasActions = signerAddress && signerAddress === wallet?.address
   const dispatch = useAppDispatch()
   const [trigger] = useLazyTransactionsGetTransactionByIdV1Query()
@@ -194,7 +195,7 @@ const SpeedUpModal = ({ open, handleClose, pendingTx, txId, txHash, signerAddres
             )}
           </div>
           <div className="[&:not(:empty)]:mt-6">
-            <NetworkWarning />
+            <NetworkWarning action="speed up a transaction" />
           </div>
         </div>
 
@@ -203,19 +204,9 @@ const SpeedUpModal = ({ open, handleClose, pendingTx, txId, txHash, signerAddres
             Cancel
           </Button>
 
-          <Tooltip>
-            <TooltipTrigger render={<span className="inline-flex" />}>
-              {/* Only the wallet that broadcast the tx can replace it by nonce, owner or not */}
-              <CheckWallet allowNonOwner checkNetwork={!isDisabled}>
-                {(isOk) => (
-                  <Button disabled={!isOk || isDisabled} onClick={onSubmit}>
-                    {isDisabled ? <Spinner className="size-5" /> : 'Confirm'}
-                  </Button>
-                )}
-              </CheckWallet>
-            </TooltipTrigger>
-            <TooltipContent>Speed up transaction</TooltipContent>
-          </Tooltip>
+          <Button disabled={isDisabled || isWrongChain} onClick={onSubmit}>
+            {isDisabled ? <Spinner className="size-5" /> : 'Confirm'}
+          </Button>
         </div>
       </ModalDialog>
     )

--- a/apps/web/src/features/speedup/components/SpeedUpModal/index.tsx
+++ b/apps/web/src/features/speedup/components/SpeedUpModal/index.tsx
@@ -144,6 +144,7 @@ const SpeedUpModal = ({ open, handleClose, pendingTx, txId, txHash, signerAddres
     dispatch,
     gasLimit,
     handleClose,
+    isGtfChain,
     onboard,
     pendingTx,
     safeAddress,
@@ -170,7 +171,7 @@ const SpeedUpModal = ({ open, handleClose, pendingTx, txId, txHash, signerAddres
 
           <Typography data-testid="speedup-summary">
             This will speed up the pending transaction by{' '}
-            <Typography variant="paragraph-bold" className="inline">
+            <Typography as="span" variant="paragraph-bold" className="inline">
               replacing
             </Typography>{' '}
             the original gas parameters with new ones.
@@ -204,7 +205,8 @@ const SpeedUpModal = ({ open, handleClose, pendingTx, txId, txHash, signerAddres
 
           <Tooltip>
             <TooltipTrigger render={<span className="inline-flex" />}>
-              <CheckWallet checkNetwork={!isDisabled}>
+              {/* Only the wallet that broadcast the tx can replace it by nonce, owner or not */}
+              <CheckWallet allowNonOwner checkNetwork={!isDisabled}>
                 {(isOk) => (
                   <Button disabled={!isOk || isDisabled} onClick={onSubmit}>
                     {isDisabled ? <Spinner className="size-5" /> : 'Confirm'}


### PR DESCRIPTION
## What it solves

Resolves https://linear.app/safe-global/issue/WA-3491/allow-non-owner-signers-to-speed-up-safe-transactions

Speed up's **Confirm** was disabled with _"Your connected wallet is not a signer of this Safe account"_ — shown to the only account that can act, the one that broadcast the tx.

## How this PR fixes it

A speed-up is a replacement tx: same `(from, nonce)`, higher gas. Only the original submitter's key can produce one, and `isSpeedableTx`/`hasActions` already require exactly that — stricter than ownership, since another owner can't speed up your tx either. So the owner check only ever blocked the right person. The state is reachable because `ExecuteForm` deliberately lets a non-owner execute a fully-signed tx.

Commit 1 adds `allowNonOwner`. Commit 2 then drops `CheckWallet` from this modal: its remaining conditions can't fire here (`hasActions` guarantees a connected wallet; no SDK ⇒ no `safeTx` ⇒ no button; `PROCESSING` implies a deployed Safe). Only the wrong-chain check did anything — and it's the sole chain guard in this path, since `assertWalletChain` has no callers — so it's now an explicit `useIsWrongChain()`.

`NetworkWarning` gets `action="speed up a transaction"`; it already rendered on the same condition, just with generic copy.

Two drive-bys in the touched file: `<p>` nested in `<p>`, and `isGtfChain` missing from the `onSubmit` deps.

## How to test it

1. Fully sign a tx on a Safe, then execute it from a **non-owner** wallet.
2. While pending (>15s), click **Speed up** → Confirm is enabled, submitting replaces the tx.
3. Switch your wallet's network → Confirm greys out, "Change your wallet network" appears.

## Affected flows

- Non-owner speeds up a tx they executed — was blocked, now works
- Owner speeds up own tx — unchanged
- Wrong network — still blocked

## Blast radius

- `SpeedUpModal` only; `CheckWallet` and `NetworkWarning` themselves untouched
- Reaches users via `QueueActions` and `SuccessScreen/ProcessingStatus`
- No dispatcher, slice, endpoint, flag or shared-package changes — no mobile impact

## Risks / not checked

- No E2E — needs a live mempool race
- Broadcast path unchanged, not re-verified on-chain
- The dropped SDK/undeployed checks are unreachable by code reading, not by forcing those states at runtime
- `CUSTOM_TX` (batch execute) branch not exercised manually

## Visual summary

```mermaid
flowchart LR
    A[Confirm button] --> B{"wallet == submitter?<br/>isSpeedableTx + hasActions"}
    B -->|no| C[no button at all]
    B -->|yes| D{isWrongChain?}
    D -->|yes| E["disabled + NetworkWarning"]
    D -->|no| F[enabled]
    G["is Safe owner?<br/>REMOVED — blocked the submitter"] -.-> D

    style G fill:#ffdddd,stroke:#cc0000
    style F fill:#ddffdd,stroke:#00aa00
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — _n/a, web-only_
- [x] I've documented how it affects the analytics (if at all) 📊 — _no new events; the `isGtfChain` dep fix stops `gas_payment_source` reporting a stale value_
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — _6 cases; each new guard reverted in turn to confirm only its own test fails_
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
