### PR TITLE
feat(policies): explain the spending limit before the flow starts

### DIFF
--- a/apps/web/src/features/spaces/components/Policies/Policies.stories.tsx
+++ b/apps/web/src/features/spaces/components/Policies/Policies.stories.tsx
@@ -1,9 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { Button } from '@/components/ui/button'
+import useLocalStorage from '@/services/local-storage/useLocalStorage'
+import { withMockProvider } from '@/storybook/preview'
+import { SPENDING_LIMIT_INTRO_SEEN_KEY } from './SpendingLimitIntroDialog/constants'
 import Policies from './index'
 
 const meta = {
   title: 'Features/Spaces/Policies',
   component: Policies,
+  // The page renders inside a `.shadcn-scope` wrapper in the app; the dialog it opens is
+  // portalled into that same scope, so the story needs the provider to match.
+  decorators: [withMockProvider({ shadcn: true })],
   tags: ['autodocs'],
   parameters: {
     layout: 'padded',
@@ -14,3 +21,27 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
+
+/**
+ * The spending limit intro opens on the first entry only, and "seen" lives in localStorage — so
+ * the behaviour is only demoable with a way to forget it again.
+ *
+ * Click the Spending limit tile: the intro opens. Dismiss it, click the tile again, and nothing
+ * opens — the flow behind the intro lands in WA-3150, so proceeding is a no-op for now. Forget
+ * that it was seen, and the intro is back.
+ */
+export const SpendingLimitIntro: Story = {
+  render: function SpendingLimitIntroStory() {
+    const [, setHasSeenIntro] = useLocalStorage<boolean>(SPENDING_LIMIT_INTRO_SEEN_KEY)
+
+    return (
+      <div className="flex flex-col items-start gap-6">
+        <Button variant="outline" onClick={() => setHasSeenIntro(false)}>
+          Forget that the intro was seen
+        </Button>
+
+        <Policies />
+      </div>
+    )
+  },
+}

--- a/apps/web/src/features/spaces/components/Policies/Policies.stories.tsx
+++ b/apps/web/src/features/spaces/components/Policies/Policies.stories.tsx
@@ -8,8 +8,7 @@ import Policies from './index'
 const meta = {
   title: 'Features/Spaces/Policies',
   component: Policies,
-  // The page renders inside a `.shadcn-scope` wrapper in the app; the dialog it opens is
-  // portalled into that same scope, so the story needs the provider to match.
+  // The dialog is portalled into `.shadcn-scope`, which only the provider sets up.
   decorators: [withMockProvider({ shadcn: true })],
   tags: ['autodocs'],
   parameters: {
@@ -23,12 +22,8 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {}
 
 /**
- * The spending limit intro opens on the first entry only, and "seen" lives in localStorage — so
- * the behaviour is only demoable with a way to forget it again.
- *
- * Click the Spending limit tile: the intro opens. Dismiss it, click the tile again, and nothing
- * opens — the flow behind the intro lands in WA-3150, so proceeding is a no-op for now. Forget
- * that it was seen, and the intro is back.
+ * Click the Spending limit tile: the intro opens. Dismiss it and click again: nothing opens, since
+ * the flow behind it lands in WA-3150. Forget that it was seen, and the intro is back.
  */
 export const SpendingLimitIntro: Story = {
   render: function SpendingLimitIntroStory() {

--- a/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/__tests__/PolicyCatalogue.test.tsx
+++ b/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/__tests__/PolicyCatalogue.test.tsx
@@ -51,8 +51,8 @@ describe('PolicyCatalogue', () => {
   it('renders the mechanisms not yet shipped as unavailable rather than absent', () => {
     render(<PolicyCatalogue />)
 
-    expect(screen.getByRole('button', { name: /Spending limit/ })).toHaveAttribute('aria-disabled', 'true')
     expect(screen.getByRole('button', { name: /Account recovery/ })).toHaveAttribute('aria-disabled', 'true')
+    expect(screen.getByRole('button', { name: /Spending limit/ })).not.toHaveAttribute('aria-disabled')
     expect(screen.getByRole('button', { name: /Proposer/ })).not.toHaveAttribute('aria-disabled')
     expect(screen.getByRole('button', { name: /Something missing\?/ })).not.toHaveAttribute('aria-disabled')
   })
@@ -74,12 +74,12 @@ describe('PolicyCatalogue', () => {
   it('tracks a click on an unavailable tile', async () => {
     const { user } = renderWithUserEvent(<PolicyCatalogue />)
 
-    await user.click(screen.getByRole('button', { name: /Spending limit/ }))
+    await user.click(screen.getByRole('button', { name: /Account recovery/ }))
 
     expect(mockTrackEvent).toHaveBeenCalledWith(
-      { ...POLICY_EVENTS.POLICY_CATALOGUE_TILE_CLICKED, label: 'spending-limit' },
+      { ...POLICY_EVENTS.POLICY_CATALOGUE_TILE_CLICKED, label: 'account-recovery' },
       {
-        [MixpanelEventParams.POLICY_TYPE]: 'spending-limit',
+        [MixpanelEventParams.POLICY_TYPE]: 'account-recovery',
         [MixpanelEventParams.IS_AVAILABLE]: false,
       },
     )

--- a/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/catalogue.ts
+++ b/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/catalogue.ts
@@ -16,7 +16,7 @@ export const POLICY_CATALOGUE: PolicyCatalogueEntry[] = [
     title: 'Spending limit',
     description: 'Let spenders access assets without collecting signatures.',
     Icon: WalletCards,
-    isAvailable: false,
+    isAvailable: true,
   },
   {
     id: 'proposer',

--- a/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/SpendingLimitIntroDialog.stories.tsx
+++ b/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/SpendingLimitIntroDialog.stories.tsx
@@ -26,11 +26,7 @@ type Story = StoryObj<typeof meta>
 /** The intro as designed: the end-result preview, the three things to know, and the way in. */
 export const Default: Story = {}
 
-/**
- * Open state held by the story, so dismissal is exercisable: the close button, Escape and a click
- * outside all close the dialog and leave `onProceed` uncalled — the "nothing started" guarantee.
- * Proceeding closes it too, as it does on the Policies page.
- */
+/** Dismissal is exercisable here: close, Escape and click-outside all leave `onProceed` uncalled. */
 export const Dismissible: Story = {
   render: function DismissibleStory(args) {
     const [open, setOpen] = useState(true)

--- a/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/SpendingLimitIntroDialog.stories.tsx
+++ b/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/SpendingLimitIntroDialog.stories.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react'
+import { fn } from 'storybook/test'
+import { Button } from '@/components/ui/button'
+import { withMockProvider } from '@/storybook/preview'
+import SpendingLimitIntroDialog from './index'
+
+const meta = {
+  title: 'Features/Spaces/Policies/SpendingLimitIntroDialog',
+  component: SpendingLimitIntroDialog,
+  decorators: [withMockProvider({ shadcn: true })],
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  args: {
+    open: true,
+    onOpenChange: fn(),
+    onProceed: fn(),
+  },
+} satisfies Meta<typeof SpendingLimitIntroDialog>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** The intro as designed: the end-result preview, the three things to know, and the way in. */
+export const Default: Story = {}
+
+/**
+ * Open state held by the story, so dismissal is exercisable: the close button, Escape and a click
+ * outside all close the dialog and leave `onProceed` uncalled — the "nothing started" guarantee.
+ * Proceeding closes it too, as it does on the Policies page.
+ */
+export const Dismissible: Story = {
+  render: function DismissibleStory(args) {
+    const [open, setOpen] = useState(true)
+
+    return (
+      <>
+        <Button variant="outline" onClick={() => setOpen(true)}>
+          Open the intro
+        </Button>
+
+        <SpendingLimitIntroDialog
+          {...args}
+          open={open}
+          onOpenChange={setOpen}
+          onProceed={() => {
+            args.onProceed()
+            setOpen(false)
+          }}
+        />
+      </>
+    )
+  },
+}

--- a/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/SpendingLimitPreview.tsx
+++ b/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/SpendingLimitPreview.tsx
@@ -4,12 +4,7 @@ import TokenIcon from '@/components/common/TokenIcon'
 import { Progress, ProgressIndicator, ProgressTrack } from '@/components/ui/progress'
 import { Typography } from '@/components/ui/typography'
 
-/**
- * Illustrative values, not live data: the intro is shown before any limit exists, so there is
- * nothing real to read — these mirror the design so the preview reads as a finished limit
- * rather than an empty state. Two distinct spenders keep the identicons from looking like the
- * same row rendered twice.
- */
+/** Illustrative values: the intro is shown before any limit exists, so nothing here is real. */
 const PREVIEW_SPENDERS = ['0x8674ff2cC41CE1A26D0A1B4b8f6c8B58F7bca19b', '0x2F4b9a1Cd3e5F70a8b6c4D2E1a9F8c7B6E5d4c3b']
 
 const PREVIEW_TOKEN = {
@@ -17,20 +12,15 @@ const PREVIEW_TOKEN = {
   logoUri: 'https://safe-transaction-assets.safe.global/tokens/logos/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.png',
   allowance: '1,500/Month',
   remaining: '500 USDC remaining',
-  /** 500 of the 1,500 monthly allowance is still available. */
   remainingPercentage: 33,
 }
 
-/**
- * The cards recede: each one sits lower, wider and less transparent than the one behind it. The
- * offsets and widths are the illustration's designed geometry, not a layout that should reflow.
- */
+/** Fixed geometry from the design frame, not a layout that should reflow. */
 const SPENDER_CARDS = [
   { address: PREVIEW_SPENDERS[0], position: 'top-[14px] w-[245px] opacity-50' },
   { address: PREVIEW_SPENDERS[1], position: 'top-[46px] w-[279px] opacity-80' },
 ]
 
-/** `0x` and the ellipsis stay muted; the head and tail that identify the account are bold. */
 const PreviewAddress = ({ address }: { address: string }): ReactElement => (
   <Typography variant="paragraph-mini" color="muted" className="font-mono">
     0x
@@ -54,13 +44,11 @@ const SpenderCard = ({ address, position }: { address: string; position: string 
   </div>
 )
 
-/**
- * The end result of the flow, as an illustration: who may spend, how much per period, and how
- * much of the current period is left. Plain elements rather than the Card primitives — this is
- * a picture of a limit, not a card the user can act on.
- */
+/** Plain elements, not the Card primitives: a picture of a limit, not a card to act on. */
 const SpendingLimitPreview = (): ReactElement => (
+  // Hidden from assistive tech: the values are invented and the copy already explains the limit.
   <div
+    aria-hidden
     data-testid="spending-limit-preview"
     className="relative h-[200px] w-full overflow-hidden rounded-xl bg-surface-sunken"
   >
@@ -80,8 +68,7 @@ const SpendingLimitPreview = (): ReactElement => (
       </div>
 
       <div className="flex flex-col gap-1">
-        {/* Hidden from assistive tech: an illustrated limit has no progress worth announcing. */}
-        <Progress value={PREVIEW_TOKEN.remainingPercentage} aria-hidden>
+        <Progress value={PREVIEW_TOKEN.remainingPercentage}>
           <ProgressTrack className="bg-border">
             <ProgressIndicator className="bg-badge-dot-success" />
           </ProgressTrack>

--- a/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/SpendingLimitPreview.tsx
+++ b/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/SpendingLimitPreview.tsx
@@ -1,0 +1,98 @@
+import type { ReactElement } from 'react'
+import Identicon from '@/components/common/Identicon'
+import TokenIcon from '@/components/common/TokenIcon'
+import { Progress, ProgressIndicator, ProgressTrack } from '@/components/ui/progress'
+import { Typography } from '@/components/ui/typography'
+
+/**
+ * Illustrative values, not live data: the intro is shown before any limit exists, so there is
+ * nothing real to read — these mirror the design so the preview reads as a finished limit
+ * rather than an empty state. Two distinct spenders keep the identicons from looking like the
+ * same row rendered twice.
+ */
+const PREVIEW_SPENDERS = ['0x8674ff2cC41CE1A26D0A1B4b8f6c8B58F7bca19b', '0x2F4b9a1Cd3e5F70a8b6c4D2E1a9F8c7B6E5d4c3b']
+
+const PREVIEW_TOKEN = {
+  symbol: 'USDC',
+  logoUri: 'https://safe-transaction-assets.safe.global/tokens/logos/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.png',
+  allowance: '1,500/Month',
+  remaining: '500 USDC remaining',
+  /** 500 of the 1,500 monthly allowance is still available. */
+  remainingPercentage: 33,
+}
+
+/**
+ * The cards recede: each one sits lower, wider and less transparent than the one behind it. The
+ * offsets and widths are the illustration's designed geometry, not a layout that should reflow.
+ */
+const SPENDER_CARDS = [
+  { address: PREVIEW_SPENDERS[0], position: 'top-[14px] w-[245px] opacity-50' },
+  { address: PREVIEW_SPENDERS[1], position: 'top-[46px] w-[279px] opacity-80' },
+]
+
+/** `0x` and the ellipsis stay muted; the head and tail that identify the account are bold. */
+const PreviewAddress = ({ address }: { address: string }): ReactElement => (
+  <Typography variant="paragraph-mini" color="muted" className="font-mono">
+    0x
+    <span className="font-semibold text-foreground">{address.slice(2, 5)}</span>
+    ...
+    <span className="font-semibold text-foreground">{address.slice(-6)}</span>
+  </Typography>
+)
+
+const SpenderCard = ({ address, position }: { address: string; position: string }): ReactElement => (
+  <div
+    className={`absolute left-1/2 flex h-10 -translate-x-1/2 items-center gap-2 rounded-md bg-card px-3 py-2 shadow-md ${position}`}
+  >
+    <Typography variant="paragraph-mini-medium" className="flex-1">
+      Spender
+    </Typography>
+
+    <Identicon address={address} size={24} />
+
+    <PreviewAddress address={address} />
+  </div>
+)
+
+/**
+ * The end result of the flow, as an illustration: who may spend, how much per period, and how
+ * much of the current period is left. Plain elements rather than the Card primitives — this is
+ * a picture of a limit, not a card the user can act on.
+ */
+const SpendingLimitPreview = (): ReactElement => (
+  <div
+    data-testid="spending-limit-preview"
+    className="relative h-[200px] w-full overflow-hidden rounded-xl bg-surface-sunken"
+  >
+    {SPENDER_CARDS.map(({ address, position }) => (
+      <SpenderCard key={address} address={address} position={position} />
+    ))}
+
+    <div className="absolute left-1/2 top-[98px] flex w-[319px] -translate-x-1/2 flex-col gap-2 rounded-md bg-card p-2 shadow-lg">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <TokenIcon logoUri={PREVIEW_TOKEN.logoUri} tokenSymbol={PREVIEW_TOKEN.symbol} size={24} />
+
+          <Typography variant="paragraph-mini">{PREVIEW_TOKEN.symbol}</Typography>
+        </div>
+
+        <Typography variant="paragraph-mini-medium">{PREVIEW_TOKEN.allowance}</Typography>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        {/* Hidden from assistive tech: an illustrated limit has no progress worth announcing. */}
+        <Progress value={PREVIEW_TOKEN.remainingPercentage} aria-hidden>
+          <ProgressTrack className="bg-border">
+            <ProgressIndicator className="bg-badge-dot-success" />
+          </ProgressTrack>
+        </Progress>
+
+        <Typography variant="paragraph-mini" color="muted">
+          {PREVIEW_TOKEN.remaining}
+        </Typography>
+      </div>
+    </div>
+  </div>
+)
+
+export default SpendingLimitPreview

--- a/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/__tests__/SpendingLimitIntroDialog.test.tsx
+++ b/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/__tests__/SpendingLimitIntroDialog.test.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react'
+import { HelpCenterArticle } from '@safe-global/utils/config/constants'
+import { render, renderWithUserEvent, screen, waitFor } from '@/tests/test-utils'
+import SpendingLimitIntroDialog from '../index'
+
+/** Holds the open state the way the Policies page does, so dismissal is observable. */
+const StatefulIntro = ({ onProceed }: { onProceed: () => void }) => {
+  const [open, setOpen] = useState(true)
+
+  return <SpendingLimitIntroDialog open={open} onOpenChange={setOpen} onProceed={onProceed} />
+}
+
+describe('SpendingLimitIntroDialog', () => {
+  it('names the policy and what it does', () => {
+    render(<SpendingLimitIntroDialog open onOpenChange={jest.fn()} onProceed={jest.fn()} />)
+
+    expect(screen.getByRole('heading', { name: /Spending limit/ })).toBeInTheDocument()
+    expect(screen.getByText('Let spenders access assets without collecting signatures.')).toBeInTheDocument()
+  })
+
+  // The three things someone must understand before signing, per the design copy.
+  it('explains that a spender need not be a signer', () => {
+    render(<SpendingLimitIntroDialog open onOpenChange={jest.fn()} onProceed={jest.fn()} />)
+
+    expect(
+      screen.getByText("Anyone can be a spender, they don't need to be signers of this Safe account."),
+    ).toBeInTheDocument()
+  })
+
+  it('explains the token, the amount, the period and the automatic reset', () => {
+    render(<SpendingLimitIntroDialog open onOpenChange={jest.fn()} onProceed={jest.fn()} />)
+
+    expect(
+      screen.getByText(
+        'Choose a token and an amount per day, week, or month. When the period ends, the limit resets automatically.',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('explains that creating the limit costs a transaction but spending within it does not', () => {
+    render(<SpendingLimitIntroDialog open onOpenChange={jest.fn()} onProceed={jest.fn()} />)
+
+    expect(
+      screen.getByText(
+        "Creating the limit requires a transaction. Once it's active, spending within the limit needs no further approvals.",
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('previews the end result: spenders, a token limit and the remaining balance', () => {
+    render(<SpendingLimitIntroDialog open onOpenChange={jest.fn()} onProceed={jest.fn()} />)
+
+    const preview = screen.getByTestId('spending-limit-preview')
+
+    expect(preview).toBeInTheDocument()
+    expect(screen.getAllByText('Spender')).toHaveLength(2)
+    expect(screen.getByText('USDC')).toBeInTheDocument()
+    expect(screen.getByText('1,500/Month')).toBeInTheDocument()
+    expect(screen.getByText('500 USDC remaining')).toBeInTheDocument()
+  })
+
+  it('links the title icon to the spending limits article', () => {
+    render(<SpendingLimitIntroDialog open onOpenChange={jest.fn()} onProceed={jest.fn()} />)
+
+    expect(screen.getByRole('link', { name: 'Learn more about spending limits' })).toHaveAttribute(
+      'href',
+      HelpCenterArticle.SPENDING_LIMITS,
+    )
+  })
+
+  it('proceeds to the flow on the primary action', async () => {
+    const onProceed = jest.fn()
+    const { user } = renderWithUserEvent(
+      <SpendingLimitIntroDialog open onOpenChange={jest.fn()} onProceed={onProceed} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Set up spending limit' }))
+
+    expect(onProceed).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes without proceeding when dismissed', async () => {
+    const onProceed = jest.fn()
+    const { user } = renderWithUserEvent(<StatefulIntro onProceed={onProceed} />)
+
+    await user.click(screen.getByRole('button', { name: 'Close' }))
+
+    await waitFor(() => expect(screen.queryByTestId('spending-limit-intro-dialog')).not.toBeInTheDocument())
+    expect(onProceed).not.toHaveBeenCalled()
+  })
+
+  it('renders nothing while closed', () => {
+    render(<SpendingLimitIntroDialog open={false} onOpenChange={jest.fn()} onProceed={jest.fn()} />)
+
+    expect(screen.queryByTestId('spending-limit-intro-dialog')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/__tests__/SpendingLimitIntroDialog.test.tsx
+++ b/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/__tests__/SpendingLimitIntroDialog.test.tsx
@@ -18,7 +18,6 @@ describe('SpendingLimitIntroDialog', () => {
     expect(screen.getByText('Let spenders access assets without collecting signatures.')).toBeInTheDocument()
   })
 
-  // The three things someone must understand before signing, per the design copy.
   it('explains that a spender need not be a signer', () => {
     render(<SpendingLimitIntroDialog open onOpenChange={jest.fn()} onProceed={jest.fn()} />)
 

--- a/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/constants.ts
+++ b/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * localStorage flag recording that the spending limit intro has been shown.
+ *
+ * The intro explains the concept, not a particular Safe account, so one browser-wide key is
+ * right — keying it per space or per Safe would replay the same explanation on every new
+ * account. It follows that a different browser, cleared site data or a private window shows the
+ * intro again: there is no server-side "already read" store to hang this on.
+ */
+export const SPENDING_LIMIT_INTRO_SEEN_KEY = 'spendingLimitIntroSeen'

--- a/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/constants.ts
+++ b/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/constants.ts
@@ -1,9 +1,2 @@
-/**
- * localStorage flag recording that the spending limit intro has been shown.
- *
- * The intro explains the concept, not a particular Safe account, so one browser-wide key is
- * right — keying it per space or per Safe would replay the same explanation on every new
- * account. It follows that a different browser, cleared site data or a private window shows the
- * intro again: there is no server-side "already read" store to hang this on.
- */
+/** Browser-wide by design: the intro explains the concept, not a Safe, so one key covers all of them. */
 export const SPENDING_LIMIT_INTRO_SEEN_KEY = 'spendingLimitIntroSeen'

--- a/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/index.tsx
+++ b/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/index.tsx
@@ -7,11 +7,7 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { Typography } from '@/components/ui/typography'
 import SpendingLimitPreview from './SpendingLimitPreview'
 
-/**
- * The three things someone must understand before signing: a spender is not a signer, a limit is
- * a token/amount/period that resets, and only creating it costs a transaction. Copy is verbatim
- * from the design.
- */
+/** Copy is verbatim from the design. */
 const EXPLAINERS: { Icon: LucideIcon; text: string }[] = [
   {
     Icon: UsersRound,
@@ -31,17 +27,11 @@ export interface SpendingLimitIntroDialogProps {
   open: boolean
   /** Called with `false` on every dismissal — the close button, Escape and a click outside. */
   onOpenChange: (open: boolean) => void
-  /** Called when the user chooses to continue into the spending limit flow. */
   onProceed: () => void
 }
 
-/**
- * Explains what a spending limit is before the flow starts, so the consequences are not
- * discovered after signing. Dismissing it starts nothing.
- */
 const SpendingLimitIntroDialog = ({ open, onOpenChange, onProceed }: SpendingLimitIntroDialogProps): ReactElement => {
-  // Without this the dialog opens with the title's help link focused, which both rings a 16px
-  // icon and puts "open a new tab" one Enter away from someone who only wants to read on.
+  // Without this, focus opens on the title's help link, where Enter opens a new tab.
   const proceedRef = useRef<HTMLButtonElement>(null)
 
   return (
@@ -85,7 +75,7 @@ const SpendingLimitIntroDialog = ({ open, onOpenChange, onProceed }: SpendingLim
 
             <Button ref={proceedRef} className="w-full gap-2" onClick={onProceed}>
               Set up spending limit
-              {/* Brand green on the light button; the dark button is already green, so its icon stays black. */}
+              {/* The dark button is already green, so its icon stays black. */}
               <ArrowRight className="text-[var(--color-static-text-brand)] dark:text-black" aria-hidden />
             </Button>
           </div>

--- a/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/index.tsx
+++ b/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/index.tsx
@@ -1,0 +1,98 @@
+import { useRef, type ReactElement } from 'react'
+import { ArrowRight, CalendarClock, HandCoins, Info, UsersRound, type LucideIcon } from 'lucide-react'
+import { HelpCenterArticle } from '@safe-global/utils/config/constants'
+import ExternalLink from '@/components/common/ExternalLink'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Typography } from '@/components/ui/typography'
+import SpendingLimitPreview from './SpendingLimitPreview'
+
+/**
+ * The three things someone must understand before signing: a spender is not a signer, a limit is
+ * a token/amount/period that resets, and only creating it costs a transaction. Copy is verbatim
+ * from the design.
+ */
+const EXPLAINERS: { Icon: LucideIcon; text: string }[] = [
+  {
+    Icon: UsersRound,
+    text: "Anyone can be a spender, they don't need to be signers of this Safe account.",
+  },
+  {
+    Icon: CalendarClock,
+    text: 'Choose a token and an amount per day, week, or month. When the period ends, the limit resets automatically.',
+  },
+  {
+    Icon: HandCoins,
+    text: "Creating the limit requires a transaction. Once it's active, spending within the limit needs no further approvals.",
+  },
+]
+
+export interface SpendingLimitIntroDialogProps {
+  open: boolean
+  /** Called with `false` on every dismissal — the close button, Escape and a click outside. */
+  onOpenChange: (open: boolean) => void
+  /** Called when the user chooses to continue into the spending limit flow. */
+  onProceed: () => void
+}
+
+/**
+ * Explains what a spending limit is before the flow starts, so the consequences are not
+ * discovered after signing. Dismissing it starts nothing.
+ */
+const SpendingLimitIntroDialog = ({ open, onOpenChange, onProceed }: SpendingLimitIntroDialogProps): ReactElement => {
+  // Without this the dialog opens with the title's help link focused, which both rings a 16px
+  // icon and puts "open a new tab" one Enter away from someone who only wants to read on.
+  const proceedRef = useRef<HTMLButtonElement>(null)
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="xs" initialFocus={proceedRef} data-testid="spending-limit-intro-dialog">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2.5 text-xl leading-6 font-semibold">
+            Spending limit
+            <ExternalLink
+              href={HelpCenterArticle.SPENDING_LIMITS}
+              noIcon
+              aria-label="Learn more about spending limits"
+              className="text-muted-foreground no-underline hover:text-foreground"
+            >
+              <Info className="size-4" aria-hidden />
+            </ExternalLink>
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-5 px-5 pb-5">
+          <DialogDescription className="text-base leading-6 text-secondary-foreground">
+            Let spenders access assets without collecting signatures.
+          </DialogDescription>
+
+          <SpendingLimitPreview />
+
+          <div className="flex flex-col gap-8">
+            <ul className="flex flex-col gap-8">
+              {EXPLAINERS.map(({ Icon, text }) => (
+                <li key={text} className="flex items-center gap-4">
+                  <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-[var(--color-background-light-hover)]">
+                    <Icon className="size-4 text-badge-dot-success" aria-hidden />
+                  </div>
+
+                  <Typography variant="paragraph-small" color="muted">
+                    {text}
+                  </Typography>
+                </li>
+              ))}
+            </ul>
+
+            <Button ref={proceedRef} className="w-full gap-2" onClick={onProceed}>
+              Set up spending limit
+              {/* Brand green on the light button; the dark button is already green, so its icon stays black. */}
+              <ArrowRight className="text-[var(--color-static-text-brand)] dark:text-black" aria-hidden />
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default SpendingLimitIntroDialog

--- a/apps/web/src/features/spaces/components/Policies/__tests__/Policies.test.tsx
+++ b/apps/web/src/features/spaces/components/Policies/__tests__/Policies.test.tsx
@@ -1,6 +1,14 @@
-import { render, screen } from '@/tests/test-utils'
+import { render, renderWithUserEvent, screen, waitFor } from '@/tests/test-utils'
 import { HelpCenterArticle } from '@safe-global/utils/config/constants'
 import Policies from '../index'
+
+let mockHasSeenSpendingLimitIntro: boolean | undefined = false
+const mockSetHasSeenSpendingLimitIntro = jest.fn()
+
+jest.mock('@/services/local-storage/useLocalStorage', () => ({
+  __esModule: true,
+  default: jest.fn(() => [mockHasSeenSpendingLimitIntro, mockSetHasSeenSpendingLimitIntro]),
+}))
 
 /**
  * The page must render a title, a one-line description and a `Learn more` link to documentation,
@@ -8,6 +16,11 @@ import Policies from '../index'
  * Proposer grant is off-chain — a product decision, not an oversight.
  */
 describe('Policies', () => {
+  beforeEach(() => {
+    mockHasSeenSpendingLimitIntro = false
+    jest.clearAllMocks()
+  })
+
   it('renders the page title', () => {
     render(<Policies />)
 
@@ -56,5 +69,42 @@ describe('Policies', () => {
     expect(screen.queryByRole('table')).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /Create policy/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('searchbox')).not.toBeInTheDocument()
+  })
+  describe('the spending limit intro', () => {
+    it('explains a spending limit before the flow starts', async () => {
+      const { user } = renderWithUserEvent(<Policies />)
+
+      await user.click(screen.getByRole('button', { name: /Spending limit/ }))
+
+      expect(screen.getByTestId('spending-limit-intro-dialog')).toBeInTheDocument()
+    })
+
+    it('returns to the catalogue with nothing started when dismissed', async () => {
+      const { user } = renderWithUserEvent(<Policies />)
+
+      await user.click(screen.getByRole('button', { name: /Spending limit/ }))
+      await user.click(screen.getByRole('button', { name: 'Close' }))
+
+      await waitFor(() => expect(screen.queryByTestId('spending-limit-intro-dialog')).not.toBeInTheDocument())
+      expect(screen.getByTestId('policy-catalogue')).toBeInTheDocument()
+    })
+
+    it('records that it has been shown', async () => {
+      const { user } = renderWithUserEvent(<Policies />)
+
+      await user.click(screen.getByRole('button', { name: /Spending limit/ }))
+      await user.click(screen.getByRole('button', { name: 'Close' }))
+
+      expect(mockSetHasSeenSpendingLimitIntro).toHaveBeenCalledWith(true)
+    })
+
+    it('does not explain again once it has been shown', async () => {
+      mockHasSeenSpendingLimitIntro = true
+      const { user } = renderWithUserEvent(<Policies />)
+
+      await user.click(screen.getByRole('button', { name: /Spending limit/ }))
+
+      expect(screen.queryByTestId('spending-limit-intro-dialog')).not.toBeInTheDocument()
+    })
   })
 })

--- a/apps/web/src/features/spaces/components/Policies/index.tsx
+++ b/apps/web/src/features/spaces/components/Policies/index.tsx
@@ -1,10 +1,51 @@
-import { type ReactElement } from 'react'
-import { Typography } from '@/components/ui/typography'
-import ExternalLink from '@/components/common/ExternalLink'
+import { useCallback, useState, type ReactElement } from 'react'
 import { HelpCenterArticle } from '@safe-global/utils/config/constants'
+import ExternalLink from '@/components/common/ExternalLink'
+import { Typography } from '@/components/ui/typography'
+import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import PolicyCatalogue from './PolicyCatalogue'
+import type { PolicyCatalogueId } from './PolicyCatalogue/catalogue'
+import SpendingLimitIntroDialog from './SpendingLimitIntroDialog'
+import { SPENDING_LIMIT_INTRO_SEEN_KEY } from './SpendingLimitIntroDialog/constants'
 
 const Policies = (): ReactElement => {
+  const [hasSeenSpendingLimitIntro = false, setHasSeenSpendingLimitIntro] =
+    useLocalStorage<boolean>(SPENDING_LIMIT_INTRO_SEEN_KEY)
+  const [isSpendingLimitIntroOpen, setIsSpendingLimitIntroOpen] = useState(false)
+
+  const startSpendingLimitFlow = useCallback(() => {
+    // TODO(WA-3150): open the spending limit create form.
+  }, [])
+
+  const handleSelect = useCallback(
+    (id: PolicyCatalogueId) => {
+      // TODO(WA-3138, WA-3160): open the proposer form and the Suggest a policy dialog.
+      if (id !== 'spending-limit') return
+
+      // The intro explains what a spending limit is, so it is worth reading once: later entries
+      // go straight to the flow.
+      if (hasSeenSpendingLimitIntro) {
+        startSpendingLimitFlow()
+        return
+      }
+
+      setIsSpendingLimitIntroOpen(true)
+    },
+    [hasSeenSpendingLimitIntro, startSpendingLimitFlow],
+  )
+
+  // Any dismissal counts as shown — an explainer that returns after the user closed it reads as
+  // a bug, and the help link in its title is there for a second look.
+  const closeSpendingLimitIntro = useCallback(() => {
+    setIsSpendingLimitIntroOpen(false)
+    setHasSeenSpendingLimitIntro(true)
+  }, [setHasSeenSpendingLimitIntro])
+
+  const proceedToSpendingLimitFlow = useCallback(() => {
+    closeSpendingLimitIntro()
+    startSpendingLimitFlow()
+  }, [closeSpendingLimitIntro, startSpendingLimitFlow])
+
   return (
     <div data-testid="policies">
       <div className="mb-6 flex flex-col gap-6">
@@ -21,8 +62,15 @@ const Policies = (): ReactElement => {
         </Typography>
       </div>
 
-      {/* TODO(WA-3138, WA-3160): pass onSelect to open the proposer form and the Suggest a policy dialog */}
-      <PolicyCatalogue />
+      <PolicyCatalogue onSelect={handleSelect} />
+
+      <SpendingLimitIntroDialog
+        open={isSpendingLimitIntroOpen}
+        onOpenChange={(open) => {
+          if (!open) closeSpendingLimitIntro()
+        }}
+        onProceed={proceedToSpendingLimitFlow}
+      />
     </div>
   )
 }

--- a/apps/web/src/features/spaces/components/Policies/index.tsx
+++ b/apps/web/src/features/spaces/components/Policies/index.tsx
@@ -22,8 +22,6 @@ const Policies = (): ReactElement => {
       // TODO(WA-3138, WA-3160): open the proposer form and the Suggest a policy dialog.
       if (id !== 'spending-limit') return
 
-      // The intro explains what a spending limit is, so it is worth reading once: later entries
-      // go straight to the flow.
       if (hasSeenSpendingLimitIntro) {
         startSpendingLimitFlow()
         return
@@ -34,8 +32,7 @@ const Policies = (): ReactElement => {
     [hasSeenSpendingLimitIntro, startSpendingLimitFlow],
   )
 
-  // Any dismissal counts as shown — an explainer that returns after the user closed it reads as
-  // a bug, and the help link in its title is there for a second look.
+  // Any dismissal counts as shown: an explainer that returns after you closed it reads as a bug.
   const closeSpendingLimitIntro = useCallback(() => {
     setIsSpendingLimitIntroOpen(false)
     setHasSeenSpendingLimitIntro(true)


### PR DESCRIPTION

## What it solves

Resolves: [WA-3148](https://linear.app/safe-global/issue/WA-3148/build-the-spending-limit-intro-dialog)

Opening the Spending limit tile used to do nothing — the tile was marked `Soon` — and once the flow lands, someone would meet a token/amount/period form with no explanation of what a spending limit actually is, discovering the consequences (a spender is not a signer; creating the limit costs a transaction) only after signing.

## How this PR fixes it

The tile now opens an explanatory dialog that states the three things someone must understand before signing, and previews the end result — spenders, a token limit, the balance left in the period — so the shape of what they are about to create is visible before any form appears.

Decisions worth a reviewer's attention:

- **Frequency (ticket Q25, was open).** The intro is shown **on the first entry only**: it explains the concept, not a particular Safe account, so a single browser-wide `localStorage` flag records that it has been shown and later entries go straight to the flow ([`Policies/index.tsx#L12-L47`](https://github.com/safe-global/safe-wallet-monorepo/blob/97ae7fc44ed573cc177b5fe27d7858bf4564b06d/apps/web/src/features/spaces/components/Policies/index.tsx#L12-L47), key at [`constants.ts#L9`](https://github.com/safe-global/safe-wallet-monorepo/blob/97ae7fc44ed573cc177b5fe27d7858bf4564b06d/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/constants.ts#L9)). Consequences, stated plainly: a different browser, cleared site data or a private window shows it again, and it does not sync across devices — there is no server-side "already read" store to hang this on. Keying it per space or per Safe would replay the same explanation on every new account, hence one global key.
- **Any dismissal counts as shown** ([`index.tsx#L39-L42`](https://github.com/safe-global/safe-wallet-monorepo/blob/97ae7fc44ed573cc177b5fe27d7858bf4564b06d/apps/web/src/features/spaces/components/Policies/index.tsx#L39-L42)) — an explainer that comes back after you closed it reads as a bug, and the ⓘ link in the title is there for a second look. If Design would rather re-explain to anyone who never started the flow, moving `setHasSeenSpendingLimitIntro(true)` into `proceedToSpendingLimitFlow` is the whole change.
- **The flow behind the CTA is WA-3150**, so `startSpendingLimitFlow()` is a documented no-op for now ([`index.tsx#L16-L18`](https://github.com/safe-global/safe-wallet-monorepo/blob/97ae7fc44ed573cc177b5fe27d7858bf4564b06d/apps/web/src/features/spaces/components/Policies/index.tsx#L16-L18)). The semantics are already correct, which means that in this PR a second entry to the tile does nothing visible; that is the intended intermediate state rather than an oversight.
- **The dialog lives under `Policies/`, not in the `spending-limits` feature.** It is pure explanatory UI with no chain logic, and `spending-limits` is a lazily-loaded feature whose components are stubbed to `null` when `FEATURES.SPENDING_LIMIT` is off — routing the intro through it would make the tile silently do nothing on such a chain.
- **Focus opens on the CTA** ([`SpendingLimitIntroDialog/index.tsx#L49`](https://github.com/safe-global/safe-wallet-monorepo/blob/97ae7fc44ed573cc177b5fe27d7858bf4564b06d/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/index.tsx#L49)). Base UI's default lands on the first tabbable element — the title's help link — which rings a 16px icon and puts "open a new tab" one Enter away from someone who only meant to read.
- **Design-system token drift, flagged rather than papered over.** The chip fill and icon green come from repo variables whose values match the design frame exactly: `--color-background-light-hover` (#e7fff2) and `--badge-dot-success` (#22c55e) ([`index.tsx#L75-L76`](https://github.com/safe-global/safe-wallet-monorepo/blob/97ae7fc44ed573cc177b5fe27d7858bf4564b06d/apps/web/src/features/spaces/components/Policies/SpendingLimitIntroDialog/index.tsx#L75-L76)). The semantically right tokens, shadcn's `--accent` (#f0fdf4) and `--accent-success` (#16a34a), have drifted from the design system's values. No hex is hard-coded, but the names read oddly — aligning those two tokens is the real fix and belongs outside this feature.

Copy is verbatim from the design; the AC's examples ("a bot, a teammate or an external wallet") are not in the Figma copy and were left out. Geometry follows the frame's measured values — a 200px well holding a receding stack of cards (245/279/319px wide, 50%/80%/100% opaque), points 32px apart behind 36px chips, and the brand-green arrow on the CTA. The dialog uses the design system's `size="xs"` (444px) rather than the frame's 430px, since overriding a dialog width means bypassing the DS width scale.

## How to test it

Two surfaces; Storybook needs no chain or wallet.

**Storybook** — `yarn workspace @safe-global/web storybook`

1. `Features/Spaces/Policies/SpendingLimitIntroDialog → Default` — the design, open. Toggle the theme globals to check dark.
2. `… → Dismissible` — close button, Escape and click-outside all dismiss it; the Actions panel shows `onProceed` was never called.
3. `Features/Spaces/Policies → Spending Limit Intro` — the page with a `Forget that the intro was seen` button, since first-entry-only is not otherwise demoable:
   - click the **Spending limit** tile → the intro opens
   - dismiss it, click the tile again → nothing opens (the flow is WA-3150)
   - reload the page, click the tile → still nothing (the flag is in `localStorage`)
   - click **Forget that the intro was seen**, click the tile → the intro is back

**The live page** — a Space on a chain with `FEATURES.POLICIES` enabled, at `/spaces/policies`. Clear `SAFE_v2__spendingLimitIntroSeen` from `localStorage` first to see the first-entry behaviour. Expect: the **Spending limit** tile no longer carries the `Soon` badge and is clickable; **Account recovery** still does.

## Affected flows

- Space → Policies → clicking the **Spending limit** tile: previously inert (`Soon`), now opens the intro on the first entry and is a no-op on later entries until WA-3150.
- Space → Policies → clicking **Account recovery**: unchanged (still `Soon`, still inert).

## Blast radius

- **`POLICY_CATALOGUE`** ([`catalogue.ts#L19`](https://github.com/safe-global/safe-wallet-monorepo/blob/97ae7fc44ed573cc177b5fe27d7858bf4564b06d/apps/web/src/features/spaces/components/Policies/PolicyCatalogue/catalogue.ts#L19)) — `spending-limit` flips to `isAvailable: true`. Consumers are `PolicyCatalogue/index.tsx`, `PolicyCatalogueTile.tsx` and `Policies/index.tsx` (type only), all inside this folder. No other feature, no mobile.
- **`Policies`** — reached only through `Policies/Page.tsx` → the `spaces` feature contract (`SpacePoliciesPage`) → `apps/web/src/pages/spaces/policies.tsx`, which `apps/web-tanstack/src/routes/spaces/policies.tsx` lazily renders too. Both shells get the change; the page itself keeps its props and its `FEATURES.POLICIES` redirect.
- **Analytics (payload change, no new events).** `POLICY_CATALOGUE_TILE_CLICKED` / Mixpanel `Policy Catalogue Tile Clicked` now reports `is_available: true` for `policy_type: spending-limit`, where it reported `false` before. Anyone counting "clicks on unshipped policies" will see spending-limit leave that bucket. No event was added for the intro's CTA or dismissal — the tile click already counts intro opens, and conversion is only meaningful once WA-3150 provides something to convert into.
- **Persistence.** One new browser-scoped key, `SAFE_v2__spendingLimitIntroSeen` (`localStorage`, via `useLocalStorage`). Not a Redux slice, so it is outside `persistedSlices`, needs no migration, and does not cross-tab-sync through `broadcast.ts` — though `useLocalStorage`'s own `storage` listener does keep open tabs in step.
- **Feature flags.** The intro rides on `FEATURES.POLICIES` (the page's own gate) and deliberately does **not** consult `FEATURES.SPENDING_LIMIT`; see the placement note above.
- **Design system.** No `components/ui/*` primitive was touched. `Progress` is used composed, with `aria-hidden` so an illustrated limit is not announced as a real progressbar.
- **Stories.** `Features/Spaces/Policies` gains `withMockProvider({ shadcn: true })` so the portalled dialog renders inside `.shadcn-scope` — the previous story rendered outside the scope where the CSS variables are defined.

## Risks / not checked

- **Not verified on the live page.** Everything was exercised in Storybook and in unit tests; the app's Policies page needs `FEATURES.POLICIES` enabled for the chain in the config service, which I did not turn on.
- **Not tested on mobile** (📱 unchecked). Spaces → Policies is web-only, and no shared package was touched, so there is nothing for `apps/mobile` to pick up — but I did not run it.
- **No small-viewport check.** The dialog is 444px wide and the illustration is a fixed 200px-tall stack of absolutely positioned cards; behaviour below ~480px wide is unverified.
- **No E2E test.** Per the repo's testability contract this belongs at the unit + story level, which is where the coverage is; nothing exercises tile → dialog in Playwright.
- **`localStorage` unavailable** (private windows, blocked site data) was not exercised. `useLocalStorage` is the repo's normal path for this and degrades to "always show", but I did not test it.
- **Argos snapshots did not run** (the workflow is `workflow_dispatch`-only), so the visual check is the screenshots below rather than a diff against `dev`.
- **The Mixpanel `is_available: true` payload was not observed in a real environment** — only in the updated unit test.
- **Open for Design:** the 430px vs `size="xs"` 444px dialog width; the two drifted green tokens; the frame's 4px stagger between the title (16px inset) and everything below it (20px inset), which I implemented as specified but which looks like a layout artifact.

## Visual summary

Both UI and logic changed, so both are included.

**The dialog** — `Features/Spaces/Policies/SpendingLimitIntroDialog → Default`, in both themes:

| Light | Dark |
| --- | --- |
| <img width="498" alt="Spending limit intro dialog, light theme" src="https://github.com/user-attachments/assets/09b9396b-4cd2-4e66-880e-d5788e6d0284" /> | <img width="480" alt="Spending limit intro dialog, dark theme" src="https://github.com/user-attachments/assets/44559540-3de9-4aa3-8c00-ab398a6b89e3" /> |

**Over the Policies page**, after clicking the Spending limit tile:

<img width="1493" alt="The intro over the Policies catalogue" src="https://github.com/user-attachments/assets/de34d5c8-1a02-4d7f-b3ab-d03fe221e671" />

**First-entry-only logic:**

```mermaid
flowchart TD
    A[Click the Spending limit tile] --> B{spendingLimitIntroSeen<br/>in localStorage?}
    B -- no --> C[Open the intro dialog]
    B -- yes --> D["startSpendingLimitFlow()<br/>TODO WA-3150: no-op today"]
    C --> E[Set up spending limit]
    C --> F[Close button, Escape,<br/>click outside]
    E --> G[Mark as seen] --> D
    F --> H[Mark as seen] --> I[Back on the Policies page,<br/>nothing started]
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — not applicable and not run: Spaces → Policies is web-only and no shared package changed
- [x] I've documented how it affects the analytics (if at all) 📊 — see Blast radius: `is_available` flips to `true` for `spending-limit`; no new events
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — 9 dialog tests plus 4 page-level tests covering first entry, dismissal, the recorded flag and the second entry
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).