### PR TITLE
tests: Fix failing regression tests

### DIFF
--- a/apps/web/e2e/docs/AI_TEST_OUTPUT_FORMAT.md
+++ b/apps/web/e2e/docs/AI_TEST_OUTPUT_FORMAT.md
@@ -191,7 +191,7 @@ Use web-first assertions only. Never extract text manually and assert on the raw
 
 ```typescript
 // ✅ Good — web-first, auto-retrying, role-based
-await expect(page.getByRole('alert')).toContainText('Email is required')
+await expect(page.getByRole('alert').filter({ hasText: 'Email is required' })).toBeVisible()
 await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled()
 await expect(page.getByRole('heading', { name: user.name })).toBeVisible()
 

--- a/apps/web/e2e/docs/README.md
+++ b/apps/web/e2e/docs/README.md
@@ -129,13 +129,15 @@ Use web-first assertions (auto-retrying). Never extract text and assert on it ma
 
 ```typescript
 // ✅ Good — web-first, role-based, user-visible
-await expect(page.getByRole('alert')).toContainText('Email is required')
+await expect(page.getByRole('alert').filter({ hasText: 'Email is required' })).toBeVisible()
 await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled()
 await expect(page.getByRole('heading', { name: user.name })).toBeVisible()
 
 // ❌ Avoid — non-retrying, implementation-coupled
 expect(await locator.textContent()).toBe('Saved')
 ```
+
+Always narrow `getByRole('alert')` with `.filter({ hasText })`: Next.js renders its route announcer as a `role="alert"` element on every page, so a bare `getByRole('alert')` resolves to two elements the moment a toast appears and fails strict mode.
 
 ### Locator Priority
 

--- a/apps/web/e2e/tests/regression/step-up-auth.spec.ts
+++ b/apps/web/e2e/tests/regression/step-up-auth.spec.ts
@@ -96,6 +96,9 @@ async function openRemoveDialog(page: Page): Promise<void> {
 
 const readStepUpRecord = (page: Page) => page.evaluate((key) => window.sessionStorage.getItem(key), STEP_UP_KEY)
 
+// Next.js renders its route announcer with role="alert" too, so a bare getByRole('alert') trips strict mode once a toast shows.
+const toast = (page: Page, text: string) => page.getByRole('alert').filter({ hasText: text })
+
 test.describe('Step-up auth round-trip', { tag: '@regression' }, () => {
   test.beforeEach(async ({ safePage }) => {
     await seedWorkspaceSession(safePage)
@@ -146,7 +149,7 @@ test.describe('Step-up auth round-trip', { tag: '@regression' }, () => {
 
     await safePage.goto(`/spaces/safe-accounts?spaceId=${SPACE_ID}`)
 
-    await expect(safePage.getByRole('alert')).toContainText('Verification was not completed')
+    await expect(toast(safePage, 'Verification was not completed')).toBeVisible()
     await expect.poll(() => readStepUpRecord(safePage)).toBeNull()
   })
 
@@ -194,7 +197,7 @@ test.describe('Step-up auth round-trip', { tag: '@regression' }, () => {
     await openRemoveDialog(safePage)
     await safePage.getByRole('button', { name: 'Remove' }).click()
 
-    await expect(safePage.getByRole('alert')).toContainText('Safe account removed')
+    await expect(toast(safePage, 'Safe account removed')).toBeVisible()
     expect(removalCalls).toBe(2)
     await expect.poll(() => readStepUpRecord(safePage)).toBeNull()
   })
@@ -215,7 +218,7 @@ test.describe('Step-up auth round-trip', { tag: '@regression' }, () => {
     await openRemoveDialog(safePage)
     await safePage.getByRole('button', { name: 'Remove' }).click()
 
-    await expect(safePage.getByRole('alert')).toBeVisible()
+    await expect(toast(safePage, 'Internal error')).toBeVisible()
     await expect.poll(() => readStepUpRecord(safePage)).toBeNull()
   })
 })


### PR DESCRIPTION
Fixes regression tests for playwright step up auth e2e tests

Error was
```
Error: strict mode violation: getByRole('alert') resolved to 2 elements:
    1) <div role="alert" data-slot="alert" ...>  aka getByRole('alert').filter({ hasText: 'Verification was not' })
    2) <p role="alert" aria-live="assertive" id="__next-route-announcer__"></p>
```