### PR TITLE
fix(web): say co-signer address when sending to a Safe owner

### DIFF
--- a/apps/web/src/components/common/AddressBookInput/index.test.tsx
+++ b/apps/web/src/components/common/AddressBookInput/index.test.tsx
@@ -12,6 +12,7 @@ import { checksumAddress } from '@safe-global/utils/utils/addresses'
 import type { AddressBook } from '@/store/addressBookSlice'
 import type { SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useGetSpaceAddressBook } from '@/features/spaces'
+import { extendedSafeInfoBuilder, addressExBuilder } from '@/tests/builders/safe'
 
 jest.mock('@/features/spaces/hooks/useGetSpaceAddressBook', () => ({
   __esModule: true,
@@ -348,6 +349,34 @@ describe('AddressBookInput', () => {
     })
 
     await waitFor(() => expect(utils.queryByText('add it to your address book', { exact: false })).toBeNull())
+  })
+
+  it('should label a Safe co-signer as a co-signer address instead of unknown', async () => {
+    const coSigner = checksumAddress(faker.finance.ethereumAddress())
+    const safe = extendedSafeInfoBuilder()
+      .with({ owners: [addressExBuilder().with({ value: coSigner }).build()] })
+      .build()
+
+    const name = 'recipient'
+    const Form = () => {
+      const methods = useForm<{ [name]: string }>({ defaultValues: { [name]: coSigner }, mode: 'all' })
+      return (
+        <FormProvider {...methods}>
+          <AddressBookInput data-testid={testId} name={name} label="Recipient address" canAdd />
+        </FormProvider>
+      )
+    }
+
+    const utils = render(<Form />, {
+      initialReduxState: {
+        addressBook: { [mockChain.chainId]: {} },
+        safeInfo: { loading: false, error: undefined, data: safe, loaded: true },
+      },
+    })
+
+    await waitFor(() => expect(utils.getByText('This is a co-signer address', { exact: false })).toBeDefined())
+    expect(utils.queryByText('This is an unknown address', { exact: false })).toBeNull()
+    expect(utils.getByText('add it to your address book', { exact: false })).toBeDefined()
   })
 
   it('should group a server-stored (space) contact under the workspace header with the workspace icon', async () => {

--- a/apps/web/src/components/common/AddressBookInput/index.tsx
+++ b/apps/web/src/components/common/AddressBookInput/index.tsx
@@ -13,6 +13,8 @@ import type { ContactSource } from '@/hooks/useAllAddressBooks'
 import { useMergedAddressBooks, useSafeNameResolver, type ExtendedContact } from '@/hooks/useAllAddressBooks'
 import { useCurrentChain } from '@/hooks/useChains'
 import useChainId from '@/hooks/useChainId'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { isOwner } from '@/utils/transaction-guards'
 import { useMemberNameResolver } from '@/features/spaces'
 import RecipientOption from './RecipientOption'
 import RecipientGroupHeader from './RecipientGroupHeader'
@@ -90,6 +92,9 @@ const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canA
     () => allAddressBookEntries.some((entry) => sameAddress(entry.label, addressValue)),
     [allAddressBookEntries, addressValue],
   )
+
+  const { safe } = useSafeInfo()
+  const isCoSigner = useMemo(() => isOwner(safe.owners, addressValue), [safe.owners, addressValue])
 
   const wrapperRef = useRef<HTMLDivElement>(null)
   // The portalled list is not inside wrapperRef, so dismissal has to check it separately or a
@@ -287,7 +292,7 @@ const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canA
         <Typography variant="paragraph-small" className={css.unknownAddress}>
           <InfoIcon className="size-4" />
           <span>
-            This is an unknown address. You can{' '}
+            {isCoSigner ? 'This is a co-signer address' : 'This is an unknown address'}. You can{' '}
             <a role="button" onClick={onAddressBookClick}>
               add it to your address book
             </a>


### PR DESCRIPTION
## What it solves

Fixes #8672

When composing a send and the recipient is one of the Safe's owners (co-signers), but that address is not in the address book, the UI still shows:

> This is an unknown address. You can add it to your address book.

That reads as if the address is a stranger. It is not - it is already a signer on this Safe. The reporter's wording is clearer: label it as a co-signer instead.

## How this PR fixes it

In `AddressBookInput`, if the entered address is in `safe.owners` (via the existing `isOwner` helper) and is not already in the address book, the hint now says:

> This is a co-signer address. You can add it to your address book.

Everyone else keeps the previous "unknown address" copy. The add-to-address-book CTA is unchanged either way, so you can still name a co-signer if you want.

No new APIs, flags, or shared-package changes - just a copy branch next to the existing unknown-address hint.

## How to test it

1. Open a Safe with at least one co-signer who is **not** in your address book.
2. Start a send / token transfer and paste that co-signer's address as the recipient.
3. Confirm the hint under the field says **This is a co-signer address**, and that "add it to your address book" still works.
4. Paste a random unused address (also not in the book). Confirm it still says **This is an unknown address**.
5. Add the co-signer to the address book and re-enter the address - the hint should disappear, same as today.

Unit coverage: `AddressBookInput` test that seeds `safeInfo.owners` and asserts the co-signer wording (and that "unknown" is not shown).

```bash
yarn workspace @safe-global/web test -- src/components/common/AddressBookInput/index.test.tsx
```

## Affected flows

- Send / token transfer recipient field when `canAdd` is true and the address is a Safe owner not yet in the address book.

## Blast radius

- `AddressBookInput` only (`apps/web`). Used by the token transfer recipient row and any other caller that passes `canAdd`.
- Reads `safe.owners` through `useSafeInfo` + `isOwner`. No RTK Query, flags, persistence, or mobile shared-package changes.

## Risks / not checked

- Did not run the full web suite locally (deps not installed in this environment); relying on the new unit test + CI.
- Did not verify mobile UI (web-only change).
- Did not check Storybook visual snapshots for `UnknownAddress` (that story uses a non-owner address, so copy there should be unchanged).

## Checklist

- [ ] I've tested the branch on mobile - n/a, web-only
- [x] I've documented how it affects the analytics (if at all) - no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) - unit test added
- [x] I've listed affected flows and blast radius, and named what I did not verify

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).