### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Code owners for safe-wallet-monorepo
+
+*                   @safe-global/safe-web
+
+# Mobile app and its native plugins
+/apps/mobile/       @safe-global/safe-mobile
+/expo-plugins/      @safe-global/safe-mobile
+
+# CI, deploy, dependency resolution and anything that executes on dev machines or in builds
+/.github/           @safe-global/infrasec @compojoom @PooyaRaki
+/Dockerfile         @safe-global/infrasec @compojoom @PooyaRaki
+/.devcontainer/     @safe-global/infrasec @compojoom @PooyaRaki
+/.yarnrc.yml        @safe-global/infrasec @compojoom @PooyaRaki
+/.yarn/             @safe-global/infrasec @compojoom @PooyaRaki
+/.husky/            @safe-global/infrasec @compojoom @PooyaRaki

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,12 +2,16 @@
 
 *                   @safe-global/safe-web
 
+# Shared by web and mobile. Both teams are requested; either approval satisfies the gate.
+/packages/          @safe-global/safe-web @safe-global/safe-mobile
+
 # Mobile app and its native plugins
 /apps/mobile/       @safe-global/safe-mobile
 /expo-plugins/      @safe-global/safe-mobile
 
 # CI, deploy, dependency resolution and anything that executes on dev machines or in builds
 /.github/           @safe-global/infrasec @compojoom @PooyaRaki
+/package.json       @safe-global/infrasec @compojoom @PooyaRaki
 /Dockerfile         @safe-global/infrasec @compojoom @PooyaRaki
 /.devcontainer/     @safe-global/infrasec @compojoom @PooyaRaki
 /.yarnrc.yml        @safe-global/infrasec @compojoom @PooyaRaki


### PR DESCRIPTION
## What it solves

Adds a CODEOWNERS file so PRs are routed to the right team for review. The default-branches ruleset already requires a code-owner review, so this makes that rule effective.

## Blast radius

- Every PR to `dev`: at least one approval from a listed owner is now required.

## Visual summary

```mermaid
flowchart LR
  A["any path"] --> W["safe-web"]
  M["apps/mobile, expo-plugins"] --> MO["safe-mobile"]
  C[".github, Dockerfile, .devcontainer, .yarnrc.yml, .yarn, .husky"] --> I["infrasec + compojoom + PooyaRaki"]
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (not applicable)
- [ ] I've documented how it affects the analytics (if at all) 📊 (not applicable)
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 (not applicable)
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
