### PR TITLE
feat: report mobile execution failures to RUM with the error taxonomy

### DIFF
--- a/apps/mobile/src/features/ExecuteTx/hooks/useTransactionExecution.test.tsx
+++ b/apps/mobile/src/features/ExecuteTx/hooks/useTransactionExecution.test.tsx
@@ -2,6 +2,7 @@ import { renderHook, act, waitFor } from '@testing-library/react-native'
 import { Provider } from 'react-redux'
 import React from 'react'
 import { RelaySimulationError } from '@safe-global/utils/services/relayErrors'
+import { DdRum, ErrorSource } from 'expo-datadog'
 
 const mockExecuteRelayTx = jest.fn()
 const mockRelayMutation = jest.fn()
@@ -120,5 +121,51 @@ describe('useTransactionExecution', () => {
     })
 
     expect(mockExecuteRelayTx).toHaveBeenCalledWith(expect.objectContaining({ acceptUnverifiedSimulation: true }))
+  })
+
+  it('reports an execution failure to RUM with the shared error taxonomy', async () => {
+    mockExecuteRelayTx.mockRejectedValue(new Error('method not supported: eth_sendRawTransaction'))
+
+    const { result } = renderExecution()
+
+    await act(async () => {
+      await expect(result.current.execute()).rejects.toThrow('method not supported')
+    })
+
+    expect(DdRum.addError).toHaveBeenCalledWith(
+      'method not supported: eth_sendRawTransaction',
+      ErrorSource.CUSTOM,
+      expect.any(String),
+      expect.objectContaining({
+        error_domain: 'tx_execution',
+        error_type: 'tx_execution_failed',
+        error_layer: 'off_chain',
+        execution_method: ExecutionMethod.WITH_RELAY,
+        chain_id: '137',
+      }),
+    )
+  })
+
+  it('does not report a user rejection to RUM', async () => {
+    mockExecuteRelayTx.mockRejectedValue(new Error('User rejected the request'))
+
+    const { result } = renderExecution()
+
+    await act(async () => {
+      await expect(result.current.execute()).rejects.toThrow('User rejected')
+    })
+
+    expect(DdRum.addError).not.toHaveBeenCalled()
+    expect(result.current.status).toBe(ExecutionStatus.ERROR)
+  })
+
+  it('does not report a successful execution to RUM', async () => {
+    const { result } = renderExecution()
+
+    await act(async () => {
+      await result.current.execute()
+    })
+
+    expect(DdRum.addError).not.toHaveBeenCalled()
   })
 })

--- a/apps/mobile/src/features/ExecuteTx/hooks/useTransactionExecution.test.tsx
+++ b/apps/mobile/src/features/ExecuteTx/hooks/useTransactionExecution.test.tsx
@@ -2,10 +2,14 @@ import { renderHook, act, waitFor } from '@testing-library/react-native'
 import { Provider } from 'react-redux'
 import React from 'react'
 import { RelaySimulationError } from '@safe-global/utils/services/relayErrors'
-import { DdRum, ErrorSource } from 'expo-datadog'
 
 const mockExecuteRelayTx = jest.fn()
 const mockRelayMutation = jest.fn()
+const mockReportExecutionFailure = jest.fn()
+
+jest.mock('@/src/services/tx-execution/reportExecutionFailure', () => ({
+  reportExecutionFailure: (...args: unknown[]) => mockReportExecutionFailure(...args),
+}))
 
 jest.mock('@/src/services/tx-execution/relayExecutor', () => ({
   executeRelayTx: (...args: unknown[]) => mockExecuteRelayTx(...args),
@@ -123,49 +127,27 @@ describe('useTransactionExecution', () => {
     expect(mockExecuteRelayTx).toHaveBeenCalledWith(expect.objectContaining({ acceptUnverifiedSimulation: true }))
   })
 
-  it('reports an execution failure to RUM with the shared error taxonomy', async () => {
-    mockExecuteRelayTx.mockRejectedValue(new Error('method not supported: eth_sendRawTransaction'))
+  it('reports an execution failure with the execution method and chain', async () => {
+    const failure = new Error('method not supported: eth_sendRawTransaction')
+    mockExecuteRelayTx.mockRejectedValue(failure)
 
     const { result } = renderExecution()
 
     await act(async () => {
-      await expect(result.current.execute()).rejects.toThrow('method not supported')
+      await expect(result.current.execute()).rejects.toBe(failure)
     })
 
-    expect(DdRum.addError).toHaveBeenCalledWith(
-      'method not supported: eth_sendRawTransaction',
-      ErrorSource.CUSTOM,
-      expect.any(String),
-      expect.objectContaining({
-        error_domain: 'tx_execution',
-        error_type: 'tx_execution_failed',
-        error_layer: 'off_chain',
-        execution_method: ExecutionMethod.WITH_RELAY,
-        chain_id: '137',
-      }),
-    )
-  })
-
-  it('does not report a user rejection to RUM', async () => {
-    mockExecuteRelayTx.mockRejectedValue(new Error('User rejected the request'))
-
-    const { result } = renderExecution()
-
-    await act(async () => {
-      await expect(result.current.execute()).rejects.toThrow('User rejected')
-    })
-
-    expect(DdRum.addError).not.toHaveBeenCalled()
+    expect(mockReportExecutionFailure).toHaveBeenCalledWith(failure, ExecutionMethod.WITH_RELAY, '137')
     expect(result.current.status).toBe(ExecutionStatus.ERROR)
   })
 
-  it('does not report a successful execution to RUM', async () => {
+  it('does not report a successful execution', async () => {
     const { result } = renderExecution()
 
     await act(async () => {
       await result.current.execute()
     })
 
-    expect(DdRum.addError).not.toHaveBeenCalled()
+    expect(mockReportExecutionFailure).not.toHaveBeenCalled()
   })
 })

--- a/apps/mobile/src/features/ExecuteTx/hooks/useTransactionExecution.ts
+++ b/apps/mobile/src/features/ExecuteTx/hooks/useTransactionExecution.ts
@@ -15,6 +15,8 @@ import { executeRelayTx } from '@/src/services/tx-execution/relayExecutor'
 import { executeLedgerTx } from '@/src/services/tx-execution/ledgerExecutor'
 import { executeWalletConnectTx } from '@/src/services/tx-execution/walletConnectExecutor'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
+import { matchUserOutcome, normalizeError } from '@safe-global/utils/services/exceptions/normalizeError'
+import { DdRum, ErrorSource } from 'expo-datadog'
 import type { Provider } from '@reown/appkit-common-react-native'
 
 export enum ExecutionStatus {
@@ -31,6 +33,27 @@ interface UseTransactionExecutionProps {
   feeParams: EstimatedFeeValues | null
   executionMethod: ExecutionMethod
   wcProvider?: Provider
+}
+
+// 804 is the web's "Error executing a transaction" code; reusing it keeps one error taxonomy across both apps.
+const TX_EXECUTION_ERROR_CODE = 804
+
+const reportExecutionFailure = (error: Error, executionMethod: ExecutionMethod, chainId: string): void => {
+  if (matchUserOutcome(error.message)) {
+    return
+  }
+  const { domain, type, layer } = normalizeError({
+    code: TX_EXECUTION_ERROR_CODE,
+    message: error.message,
+    isUserFacing: true,
+  })
+  DdRum.addError(error.message, ErrorSource.CUSTOM, error.stack ?? '', {
+    error_domain: domain,
+    error_type: type,
+    error_layer: layer,
+    execution_method: executionMethod,
+    chain_id: chainId,
+  })
 }
 
 export function useTransactionExecution({
@@ -114,6 +137,7 @@ export function useTransactionExecution({
         setStatus(ExecutionStatus.PROCESSING)
       } catch (error) {
         logger.error('Error executing transaction:', error)
+        reportExecutionFailure(asError(error), executionMethod, activeChain.chainId)
         setStatus(ExecutionStatus.ERROR)
         dispatch(setExecutingError({ txId, error: asError(error).message }))
 

--- a/apps/mobile/src/features/ExecuteTx/hooks/useTransactionExecution.ts
+++ b/apps/mobile/src/features/ExecuteTx/hooks/useTransactionExecution.ts
@@ -15,8 +15,7 @@ import { executeRelayTx } from '@/src/services/tx-execution/relayExecutor'
 import { executeLedgerTx } from '@/src/services/tx-execution/ledgerExecutor'
 import { executeWalletConnectTx } from '@/src/services/tx-execution/walletConnectExecutor'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
-import { matchUserOutcome, normalizeError } from '@safe-global/utils/services/exceptions/normalizeError'
-import { DdRum, ErrorSource } from 'expo-datadog'
+import { reportExecutionFailure } from '@/src/services/tx-execution/reportExecutionFailure'
 import type { Provider } from '@reown/appkit-common-react-native'
 
 export enum ExecutionStatus {
@@ -33,27 +32,6 @@ interface UseTransactionExecutionProps {
   feeParams: EstimatedFeeValues | null
   executionMethod: ExecutionMethod
   wcProvider?: Provider
-}
-
-// 804 is the web's "Error executing a transaction" code; reusing it keeps one error taxonomy across both apps.
-const TX_EXECUTION_ERROR_CODE = 804
-
-const reportExecutionFailure = (error: Error, executionMethod: ExecutionMethod, chainId: string): void => {
-  if (matchUserOutcome(error.message)) {
-    return
-  }
-  const { domain, type, layer } = normalizeError({
-    code: TX_EXECUTION_ERROR_CODE,
-    message: error.message,
-    isUserFacing: true,
-  })
-  DdRum.addError(error.message, ErrorSource.CUSTOM, error.stack ?? '', {
-    error_domain: domain,
-    error_type: type,
-    error_layer: layer,
-    execution_method: executionMethod,
-    chain_id: chainId,
-  })
 }
 
 export function useTransactionExecution({

--- a/apps/mobile/src/services/tx-execution/errors.ts
+++ b/apps/mobile/src/services/tx-execution/errors.ts
@@ -1,0 +1,6 @@
+export class PrivateKeyUnavailableError extends Error {
+  constructor() {
+    super('Private key not found')
+    this.name = 'PrivateKeyUnavailableError'
+  }
+}

--- a/apps/mobile/src/services/tx-execution/ledgerExecutor.test.ts
+++ b/apps/mobile/src/services/tx-execution/ledgerExecutor.test.ts
@@ -183,28 +183,28 @@ describe('executeLedgerTx', () => {
 
       await expect(executeLedgerTx(defaultParams)).rejects.toThrow('Ledger execution failed')
 
-      expect(mockGetUserNonce).not.toHaveBeenCalled()
+      expect(mockGetUserNonce).toHaveBeenCalled()
       expect(mockDisconnect).not.toHaveBeenCalled()
     })
 
-    it('should propagate error from getUserNonce', async () => {
+    it('should propagate error from getUserNonce without broadcasting', async () => {
       mockSelectSignerByAddress.mockReturnValue(mockLedgerSigner)
       const nonceError = new Error('Failed to get nonce')
       mockGetUserNonce.mockRejectedValue(nonceError)
 
       await expect(executeLedgerTx(defaultParams)).rejects.toThrow('Failed to get nonce')
 
-      expect(mockExecuteTransaction).toHaveBeenCalled()
+      expect(mockExecuteTransaction).not.toHaveBeenCalled()
       expect(mockDisconnect).not.toHaveBeenCalled()
     })
 
-    it('should propagate error from disconnect', async () => {
+    it('should still return the result when disconnect fails after broadcast', async () => {
       mockSelectSignerByAddress.mockReturnValue(mockLedgerSigner)
-      const disconnectError = new Error('Failed to disconnect')
-      mockDisconnect.mockRejectedValue(disconnectError)
+      mockDisconnect.mockRejectedValue(new Error('Failed to disconnect'))
 
-      await expect(executeLedgerTx(defaultParams)).rejects.toThrow('Failed to disconnect')
+      const result = await executeLedgerTx(defaultParams)
 
+      expect(result.txHash).toBe('0xTransactionHash')
       expect(mockExecuteTransaction).toHaveBeenCalled()
       expect(mockGetUserNonce).toHaveBeenCalled()
     })
@@ -233,7 +233,7 @@ describe('executeLedgerTx', () => {
 
       await executeLedgerTx(defaultParams)
 
-      expect(callOrder).toEqual(['selectSignerByAddress', 'executeTransaction', 'getUserNonce', 'disconnect'])
+      expect(callOrder).toEqual(['selectSignerByAddress', 'getUserNonce', 'executeTransaction', 'disconnect'])
     })
   })
 })

--- a/apps/mobile/src/services/tx-execution/ledgerExecutor.ts
+++ b/apps/mobile/src/services/tx-execution/ledgerExecutor.ts
@@ -2,6 +2,7 @@ import { getUserNonce } from '@/src/services/web3'
 import { ExecutionMethod } from '@/src/features/HowToExecuteSheet/types'
 import { ledgerExecutionService } from '@/src/services/ledger/ledger-execution.service'
 import { ledgerDMKService } from '@/src/services/ledger/ledger-dmk.service'
+import logger from '@/src/utils/logger'
 import { store } from '@/src/store'
 import { selectSignerByAddress } from '@/src/store/signersSlice'
 import type { EstimatedFeeValues } from '@/src/store/estimatedFeeSlice'
@@ -47,7 +48,9 @@ export const executeLedgerTx = async ({
     throw new Error('Ledger signer missing derivation path')
   }
 
-  // Execute with Ledger
+  // Pre-broadcast nonce, like the other executors: the pending-tx watcher tracks the wallet nonce from here.
+  const walletNonce = await getUserNonce(chain, signerAddress)
+
   const { hash } = await ledgerExecutionService.executeTransaction({
     chain,
     activeSafe,
@@ -57,11 +60,12 @@ export const executeLedgerTx = async ({
     feeParams,
   })
 
-  // Get wallet nonce for tracking
-  const walletNonce = await getUserNonce(chain, signerAddress)
-
-  // Disconnect to prevent DMK background pinger from continuing after execution
-  await ledgerDMKService.disconnect()
+  // The transaction is already broadcast; a failed disconnect must not surface as an execution failure.
+  try {
+    await ledgerDMKService.disconnect()
+  } catch (error) {
+    logger.warn('Ledger disconnect after execution failed:', error)
+  }
 
   return {
     // From here on, the transaction tracking in the app assumes the execution was done with a private key

--- a/apps/mobile/src/services/tx-execution/privateKeyExecutor.test.ts
+++ b/apps/mobile/src/services/tx-execution/privateKeyExecutor.test.ts
@@ -3,6 +3,7 @@ import type { EstimatedFeeValues } from '@/src/store/estimatedFeeSlice'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import type { SafeInfo } from '@/src/types/address'
 import { executePrivateKeyTx } from './privateKeyExecutor'
+import { PrivateKeyUnavailableError } from './errors'
 import { createMockChain, createMockSafeInfo } from '@safe-global/test'
 
 const mockExecuteTx = jest.fn()
@@ -121,6 +122,7 @@ describe('executePrivateKeyTx', () => {
       mockGetPrivateKey.mockResolvedValue(undefined)
 
       await expect(executePrivateKeyTx(defaultParams)).rejects.toThrow('Private key not found')
+      await expect(executePrivateKeyTx(defaultParams)).rejects.toBeInstanceOf(PrivateKeyUnavailableError)
 
       expect(mockExecuteTx).not.toHaveBeenCalled()
     })

--- a/apps/mobile/src/services/tx-execution/privateKeyExecutor.ts
+++ b/apps/mobile/src/services/tx-execution/privateKeyExecutor.ts
@@ -6,6 +6,7 @@ import logger from '@/src/utils/logger'
 import type { EstimatedFeeValues } from '@/src/store/estimatedFeeSlice'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import type { SafeInfo } from '@/src/types/address'
+import { PrivateKeyUnavailableError } from './errors'
 
 interface ExecutePrivateKeyTxParams {
   chain: Chain
@@ -41,7 +42,7 @@ export const executePrivateKeyTx = async ({
   }
 
   if (!privateKey) {
-    throw new Error('Private key not found')
+    throw new PrivateKeyUnavailableError()
   }
 
   const walletNonce = await getUserNonce(chain, signerAddress)

--- a/apps/mobile/src/services/tx-execution/reportExecutionFailure.test.ts
+++ b/apps/mobile/src/services/tx-execution/reportExecutionFailure.test.ts
@@ -1,0 +1,62 @@
+import { DdRum, ErrorSource } from 'expo-datadog'
+import { BiometryInvalidationError } from '@/src/services/key-storage/errors'
+import { ExecutionMethod } from '@/src/features/HowToExecuteSheet/types'
+import { PrivateKeyUnavailableError } from './errors'
+import { reportExecutionFailure } from './reportExecutionFailure'
+
+describe('reportExecutionFailure', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('reports a failure with the shared error taxonomy and execution context', () => {
+    const error = new Error('method not supported: eth_sendRawTransaction')
+
+    reportExecutionFailure(error, ExecutionMethod.WITH_PK, '1')
+
+    expect(DdRum.addError).toHaveBeenCalledWith(
+      'method not supported: eth_sendRawTransaction',
+      ErrorSource.CUSTOM,
+      expect.any(String),
+      {
+        error_domain: 'tx_execution',
+        error_type: 'tx_execution_failed',
+        error_layer: 'off_chain',
+        execution_method: ExecutionMethod.WITH_PK,
+        chain_id: '1',
+      },
+    )
+  })
+
+  it('redacts addresses and hex blobs from the message and stack', () => {
+    const address = '0x' + 'ab'.repeat(20)
+    const error = new Error(`WalletConnect returned an invalid transaction hash: ${address}`)
+
+    reportExecutionFailure(error, ExecutionMethod.WITH_WC, '137')
+
+    const [message, , stack] = (DdRum.addError as jest.Mock).mock.calls[0]
+    expect(message).toBe('WalletConnect returned an invalid transaction hash: [redacted]')
+    expect(stack).not.toContain(address)
+  })
+
+  it('classifies GS revert codes as on-chain reverts', () => {
+    reportExecutionFailure(new Error('execution reverted: GS013'), ExecutionMethod.WITH_LEDGER, '1')
+
+    expect(DdRum.addError).toHaveBeenCalledWith(
+      expect.any(String),
+      ErrorSource.CUSTOM,
+      expect.any(String),
+      expect.objectContaining({ error_type: 'on_chain_revert', error_layer: 'on_chain' }),
+    )
+  })
+
+  it.each([
+    ['a user rejection', new Error('User rejected the request')],
+    ['a cancelled or missing private key', new PrivateKeyUnavailableError()],
+    ['an invalidated biometry key', new BiometryInvalidationError(new Error('cause'))],
+  ])('does not report %s', (_label, error) => {
+    reportExecutionFailure(error, ExecutionMethod.WITH_PK, '1')
+
+    expect(DdRum.addError).not.toHaveBeenCalled()
+  })
+})

--- a/apps/mobile/src/services/tx-execution/reportExecutionFailure.ts
+++ b/apps/mobile/src/services/tx-execution/reportExecutionFailure.ts
@@ -1,0 +1,34 @@
+import { DdRum, ErrorSource } from 'expo-datadog'
+import {
+  matchUserOutcome,
+  normalizeError,
+  sanitizeErrorMessage,
+} from '@safe-global/utils/services/exceptions/normalizeError'
+import { BiometryInvalidationError } from '@/src/services/key-storage/errors'
+import type { ExecutionMethod } from '@/src/features/HowToExecuteSheet/types'
+import { PrivateKeyUnavailableError } from './errors'
+
+// 804 is the web's "Error executing a transaction" code; reusing it keeps one error taxonomy across both apps.
+const TX_EXECUTION_ERROR_CODE = 804
+
+// Thrown before signing starts (prompt cancelled, key missing or invalidated), so no execution was attempted.
+const isKeyAccessFailure = (error: Error): boolean =>
+  error instanceof PrivateKeyUnavailableError || error instanceof BiometryInvalidationError
+
+export const reportExecutionFailure = (error: Error, executionMethod: ExecutionMethod, chainId: string): void => {
+  if (isKeyAccessFailure(error) || matchUserOutcome(error.message)) {
+    return
+  }
+  const { domain, type, layer, sanitizedMessage } = normalizeError({
+    code: TX_EXECUTION_ERROR_CODE,
+    message: error.message,
+    isUserFacing: true,
+  })
+  DdRum.addError(sanitizedMessage, ErrorSource.CUSTOM, sanitizeErrorMessage(error.stack ?? ''), {
+    error_domain: domain,
+    error_type: type,
+    error_layer: layer,
+    execution_method: executionMethod,
+    chain_id: chainId,
+  })
+}


### PR DESCRIPTION
## What it solves

Resolves: -

Mobile transaction execution failures were only visible as unstructured console errors, so a spike in failing users could not be detected or attributed to an execution method or chain.

## How this PR fixes it

The execution hook reports each failure to RUM with the error taxonomy already used by web (`error_domain` / `error_type` / `error_layer`), plus `execution_method` and `chain_id`. User outcomes (rejected or expired approvals) are not reported.

## How to test it

1. Open a Safe with a queued, fully-signed transaction on mobile.
2. Execute it with a signer that cannot broadcast (e.g. no funds) and confirm the failure appears in RUM with `error_domain:tx_execution`.
3. Cancel the biometric prompt or reject in WalletConnect and confirm nothing is reported.

## Affected flows

- Execute transaction (private key, Ledger, WalletConnect, relay) – failure path only

## Blast radius

- `useTransactionExecution` catch block; consumers are the review-and-execute and Ledger review screens
- Read-only reuse of `normalizeError` / `matchUserOutcome` from `@safe-global/utils`

## Risks / not checked

- Not exercised on a device; covered by unit tests only
- Success path and the relay simulation rethrow are unchanged

## Visual summary

```mermaid
flowchart LR
  E[executor throws] --> U{user outcome?}
  U -- yes --> S[status ERROR]
  U -- no --> N[normalizeError] --> R[DdRum.addError + context] --> S
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
