### PR TITLE
fix: name the minimum on a low gas limit, and keep transaction errors out of the notification center

### DIFF
--- a/apps/web/src/components/common/Header/Topbar/NotificationsPopover.test.tsx
+++ b/apps/web/src/components/common/Header/Topbar/NotificationsPopover.test.tsx
@@ -115,6 +115,17 @@ describe('NotificationsPopover', () => {
     expect(screen.getByText('2')).toBeInTheDocument()
   })
 
+  it('does not show errors in the unread count', () => {
+    const initialReduxState: Partial<RootState> = {
+      notifications: [createNotification(), createNotification({ variant: 'error' })],
+    }
+
+    render(<PopoverOpener />, { initialReduxState })
+    fireEvent.click(screen.getByTestId('open-trigger'))
+
+    expect(screen.getByText('1')).toBeInTheDocument()
+  })
+
   it('does not show unread count when all notifications are read', () => {
     const initialReduxState: Partial<RootState> = {
       notifications: [createNotification({ isRead: true })],

--- a/apps/web/src/components/common/Header/Topbar/hooks/useNotificationsPopover.test.ts
+++ b/apps/web/src/components/common/Header/Topbar/hooks/useNotificationsPopover.test.ts
@@ -59,6 +59,18 @@ describe('useNotificationsPopover', () => {
     expect(result.current.unreadCount).toBe(2)
   })
 
+  it('leaves errors out of the list and the unread count', () => {
+    const initialReduxState = stateWithNotifications([
+      createNotification({ message: 'queued' }),
+      createNotification({ message: 'failed', variant: 'error' }),
+    ])
+
+    const { result } = renderHook(() => useNotificationsPopover(), { initialReduxState })
+
+    expect(result.current.notifications.map(({ message }) => message)).toEqual(['queued'])
+    expect(result.current.unreadCount).toBe(1)
+  })
+
   it('sorts notifications chronologically (newest first)', () => {
     const initialReduxState = stateWithNotifications([
       createNotification({ message: 'older', timestamp: 1000 }),

--- a/apps/web/src/components/common/Header/Topbar/hooks/useNotificationsPopover.ts
+++ b/apps/web/src/components/common/Header/Topbar/hooks/useNotificationsPopover.ts
@@ -2,6 +2,7 @@ import { useMemo, useState, type MouseEvent } from 'react'
 
 import { useAppDispatch, useAppSelector } from '@/store'
 import {
+  selectCenterNotifications,
   selectNotifications,
   readNotification,
   closeNotification,
@@ -15,7 +16,10 @@ export const NOTIFICATION_CENTER_LIMIT = 4
 const useNotificationsPopover = () => {
   useShowNotificationsRenewalMessage()
   const dispatch = useAppDispatch()
-  const notifications = useAppSelector(selectNotifications)
+  const notifications = useAppSelector(selectCenterNotifications)
+  // Opening the bell dismisses every visible toast, errors included — so that sweep needs the
+  // unfiltered list.
+  const allNotifications = useAppSelector(selectNotifications)
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
   const [showAll, setShowAll] = useState<boolean>(false)
   const open = Boolean(anchorEl)
@@ -44,7 +48,7 @@ const useNotificationsPopover = () => {
     if (!open) {
       trackEvent(OVERVIEW_EVENTS.NOTIFICATION_CENTER)
 
-      notifications.forEach(({ isDismissed, id }) => {
+      allNotifications.forEach(({ isDismissed, id }) => {
         if (!isDismissed) {
           dispatch(closeNotification({ id }))
         }

--- a/apps/web/src/components/common/Header/Topbar/index.test.tsx
+++ b/apps/web/src/components/common/Header/Topbar/index.test.tsx
@@ -175,6 +175,16 @@ describe('Topbar', () => {
     expect(screen.queryByLabelText(/unread messages/)).not.toBeInTheDocument()
   })
 
+  it('does not count errors in the badge', () => {
+    const initialReduxState: Partial<RootState> = {
+      notifications: [createNotification(), createNotification({ variant: 'error' })],
+    }
+
+    render(<Topbar />, { initialReduxState })
+
+    expect(screen.getByLabelText('1 unread messages')).toBeInTheDocument()
+  })
+
   it('does not count read notifications in the badge', () => {
     const initialReduxState: Partial<RootState> = {
       notifications: [createNotification({ isRead: true }), createNotification()],

--- a/apps/web/src/components/common/Header/Topbar/index.tsx
+++ b/apps/web/src/components/common/Header/Topbar/index.tsx
@@ -12,7 +12,7 @@ import { WalletConnectFeature } from '@/features/walletconnect'
 import { useDraftBatch } from '@/features/batching'
 import { useIsBelowMd } from '@/hooks/useMediaQuery'
 import { useAppDispatch, useAppSelector } from '@/store'
-import { selectNotifications } from '@/store/notificationsSlice'
+import { selectCenterNotifications } from '@/store/notificationsSlice'
 import { openGlobalSearch } from '@/features/global-search/store'
 import { useWalletName } from '@/hooks/wallets/useWalletName'
 import useSafeAddress from '@/hooks/useSafeAddress'
@@ -77,7 +77,7 @@ const Topbar = ({ onMenuToggle, onBatchToggle }: TopbarProps): ReactElement => {
   const { GlobalSearchModal, GlobalSearchInput } = useLoadFeature(GlobalSearchFeature)
   const { WalletConnectWidget } = useLoadFeature(WalletConnectFeature)
   const notificationsRef = useRef<NotificationsPopoverRef>(null)
-  const notifications = useAppSelector(selectNotifications)
+  const notifications = useAppSelector(selectCenterNotifications)
   const spaceId = useCurrentSpaceId()
   const isSpaceRoute = useIsSpaceRoute()
   const pathname = usePathname()

--- a/apps/web/src/components/notification-center/NotificationCenter/index.tsx
+++ b/apps/web/src/components/notification-center/NotificationCenter/index.tsx
@@ -7,6 +7,7 @@ import BellIcon from '@/public/images/common/notifications.svg'
 import { ChevronDown, ChevronUp } from 'lucide-react'
 import { useAppDispatch, useAppSelector } from '@/store'
 import {
+  selectCenterNotifications,
   selectNotifications,
   readNotification,
   closeNotification,
@@ -38,7 +39,10 @@ const NotificationCenter = (): ReactElement => {
   // This hook is used to show the notification renewal message when the app is opened
   useShowNotificationsRenewalMessage()
 
-  const notifications = useAppSelector(selectNotifications)
+  const notifications = useAppSelector(selectCenterNotifications)
+  // Opening the bell dismisses every visible toast, errors included — so that sweep needs the
+  // unfiltered list.
+  const allNotifications = useAppSelector(selectNotifications)
   const chronologicalNotifications = useMemo(() => {
     // Clone as Redux returns read-only array
     return notifications.slice().sort((a, b) => b.timestamp - a.timestamp)
@@ -65,7 +69,7 @@ const NotificationCenter = (): ReactElement => {
     if (!open) {
       trackEvent(OVERVIEW_EVENTS.NOTIFICATION_CENTER)
 
-      notifications.forEach(({ isDismissed, id }) => {
+      allNotifications.forEach(({ isDismissed, id }) => {
         if (!isDismissed) {
           dispatch(closeNotification({ id }))
         }

--- a/apps/web/src/components/safe-messages/SingleMsg/SingleMsg.test.tsx
+++ b/apps/web/src/components/safe-messages/SingleMsg/SingleMsg.test.tsx
@@ -1,5 +1,5 @@
 import { extendedSafeInfoBuilder } from '@/tests/builders/safe'
-import { fireEvent, render, waitFor } from '@/tests/test-utils'
+import { render, waitFor } from '@/tests/test-utils'
 import * as useSafeInfo from '@/hooks/useSafeInfo'
 import * as syncSafeMessageSigner from '@/hooks/messages/useSyncSafeMessageSigner'
 
@@ -59,9 +59,8 @@ describe('SingleMsg', () => {
       expect(screen.getByText('Failed to load message')).toBeInTheDocument()
     })
 
-    await waitFor(() => {
-      fireEvent.click(screen.getByText('Details'))
-      expect(screen.getByText('Server error')).toBeInTheDocument()
-    })
+    // The raw error is never offered to the user — there is no Details toggle to open.
+    expect(screen.queryByText('Details')).not.toBeInTheDocument()
+    expect(screen.queryByText('Server error')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/transactions/SingleTx/SingleTx.test.tsx
+++ b/apps/web/src/components/transactions/SingleTx/SingleTx.test.tsx
@@ -91,10 +91,10 @@ describe('SingleTx', () => {
       expect(screen.getByText('Failed to load transaction')).toBeInTheDocument()
     })
 
-    // A known CGW response state shows the code-only support reference instead
-    // of a Details toggle revealing the raw response (WA-3252).
-    expect(screen.getByTestId('error-details')).toBeInTheDocument()
-    expect(screen.getByText('CGW-500')).toBeInTheDocument()
+    // A known CGW response state shows its message alone — no code reference, and no Details
+    // toggle revealing the raw response (WA-3252).
+    expect(screen.queryByTestId('error-details')).not.toBeInTheDocument()
+    expect(screen.queryByText('CGW-500')).not.toBeInTheDocument()
     expect(screen.queryByText('Details')).not.toBeInTheDocument()
     expect(screen.queryByText('Server error')).not.toBeInTheDocument()
   })

--- a/apps/web/src/components/transactions/SingleTx/SingleTx.test.tsx
+++ b/apps/web/src/components/transactions/SingleTx/SingleTx.test.tsx
@@ -1,6 +1,6 @@
 import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { extendedSafeInfoBuilder } from '@/tests/builders/safe'
-import { fireEvent, render } from '@/tests/test-utils'
+import { render } from '@/tests/test-utils'
 import SingleTx from '@/pages/transactions/tx'
 import * as useSafeInfo from '@/hooks/useSafeInfo'
 import { waitFor } from '@testing-library/react'
@@ -115,10 +115,8 @@ describe('SingleTx', () => {
       expect(screen.getByText('Failed to load transaction')).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByText('Details'))
-
-    await waitFor(() => {
-      expect(screen.getByText('Transaction with this id was not found in this Safe account')).toBeInTheDocument()
-    })
+    // The raw gateway response is never offered to the user — there is no Details toggle to open.
+    expect(screen.queryByText('Details')).not.toBeInTheDocument()
+    expect(screen.queryByText('Transaction with this id was not found in this Safe account')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/tx-flow/__tests__/useIsTxFlowOpen.test.tsx
+++ b/apps/web/src/components/tx-flow/__tests__/useIsTxFlowOpen.test.tsx
@@ -1,0 +1,35 @@
+import { act, useContext, type RefObject } from 'react'
+import { render, waitFor } from '@/tests/test-utils'
+import { TxModalContext, type TxModalContextType, TxModalProvider } from '..'
+import { useIsTxFlowOpenRef } from '../useIsTxFlowOpen'
+
+jest.mock('@/hooks/useTopbarElevation', () => ({
+  useTopbarElevation: jest.fn(),
+}))
+
+describe('useIsTxFlowOpenRef', () => {
+  it('tracks whether a flow is on screen', async () => {
+    let isTxFlowOpenRef: RefObject<boolean> | undefined
+    let setTxFlow: TxModalContextType['setTxFlow'] | undefined
+
+    const Subscriber = () => {
+      isTxFlowOpenRef = useIsTxFlowOpenRef()
+      setTxFlow = useContext(TxModalContext).setTxFlow
+      return null
+    }
+
+    render(
+      <TxModalProvider>
+        <Subscriber />
+      </TxModalProvider>,
+    )
+
+    expect(isTxFlowOpenRef?.current).toBe(false)
+
+    act(() => setTxFlow?.(<div>Flow content</div>, undefined, false))
+    await waitFor(() => expect(isTxFlowOpenRef?.current).toBe(true))
+
+    act(() => setTxFlow?.(undefined))
+    await waitFor(() => expect(isTxFlowOpenRef?.current).toBe(false))
+  })
+})

--- a/apps/web/src/components/tx-flow/flows/SignMessage/SignMessage.test.tsx
+++ b/apps/web/src/components/tx-flow/flows/SignMessage/SignMessage.test.tsx
@@ -938,17 +938,16 @@ describe('SignMessage', () => {
       [429, CGW_ERROR_FALLBACK],
       [422, CGW_ERROR_FALLBACK],
       [451, CGW_SAFE_UNAVAILABLE],
-    ])('renders the agreed copy and the CGW-%s support code', async (status, copy) => {
+    ])('renders the agreed copy for a %s, with no support code', async (status, copy) => {
       mockConfirmationResponse(() => HttpResponse.json({ message: 'Example error' }, { status }))
 
-      const { getByText, getByTestId } = renderPendingConfirmation()
+      const { getByText, queryByTestId } = renderPendingConfirmation()
 
       fireEvent.click(getByText('Sign'))
 
-      await waitFor(() => {
-        expect(getByText(copy)).toBeInTheDocument()
-        expect(getByTestId('error-details')).toHaveTextContent(`CGW-${status}`)
-      })
+      await waitFor(() => expect(getByText(copy)).toBeInTheDocument())
+
+      expect(queryByTestId('error-details')).not.toBeInTheDocument()
     })
 
     it('never renders a stringified error object', async () => {

--- a/apps/web/src/components/tx-flow/useIsTxFlowOpen.ts
+++ b/apps/web/src/components/tx-flow/useIsTxFlowOpen.ts
@@ -1,4 +1,4 @@
-import { useContext, useRef, type RefObject } from 'react'
+import { useContext, useEffect, useRef, type RefObject } from 'react'
 import { TxModalContext } from '.'
 
 /**
@@ -8,7 +8,12 @@ import { TxModalContext } from '.'
 export const useIsTxFlowOpenRef = (): RefObject<boolean> => {
   const { txFlow } = useContext(TxModalContext)
   const isTxFlowOpen = useRef(false)
-  isTxFlowOpen.current = !!txFlow
+
+  // Written after commit, not during render: a render React throws away would otherwise leave
+  // the ref claiming a flow is on screen when none is.
+  useEffect(() => {
+    isTxFlowOpen.current = !!txFlow
+  }, [txFlow])
 
   return isTxFlowOpen
 }

--- a/apps/web/src/components/tx-flow/useIsTxFlowOpen.ts
+++ b/apps/web/src/components/tx-flow/useIsTxFlowOpen.ts
@@ -1,0 +1,14 @@
+import { useContext, useRef, type RefObject } from 'react'
+import { TxModalContext } from '.'
+
+/**
+ * Whether a tx flow is on screen, as a ref so event subscribers can read it when an event
+ * arrives instead of resubscribing every time a flow opens or closes.
+ */
+export const useIsTxFlowOpenRef = (): RefObject<boolean> => {
+  const { txFlow } = useContext(TxModalContext)
+  const isTxFlowOpen = useRef(false)
+  isTxFlowOpen.current = !!txFlow
+
+  return isTxFlowOpen
+}

--- a/apps/web/src/components/tx/ErrorMessage/ContractErrorMessages.stories.tsx
+++ b/apps/web/src/components/tx/ErrorMessage/ContractErrorMessages.stories.tsx
@@ -19,9 +19,8 @@ import CONTRACT_ERRORS, {
  * - `MessageCatalog` lists every GS code with its user-facing copy and handling.
  * - `RenderedInErrorMessage` shows the copy in the real `ErrorMessage` component.
  *   Each error is fed a realistic raw payload (provider URLs, request bodies,
- *   library versions); a GS error shows an always-visible, code-only reference
- *   with a copy button — never the raw payload. (Non-GS errors keep their raw
- *   Details toggle, unchanged.)
+ *   library versions); no alert renders it. A GS error shows an always-visible,
+ *   code-only reference with a copy button.
  */
 
 const PARAMS = { nativeAsset: 'ETH', token: 'USDC' }
@@ -73,10 +72,9 @@ const Catalog = () => (
 )
 
 /**
- * Representative raw payloads as they arrive from ethers/viem/RPC today. These
- * are the strings currently dumped into the "Details" panel — provider URLs,
- * request bodies, library versions, calldata. Topic 2 replaces them with a
- * support reference (code, tx hash, network, timestamp, copy button).
+ * Representative raw payloads as they arrive from ethers/viem/RPC today —
+ * provider URLs, request bodies, library versions, calldata. None of this
+ * reaches the user: a GS error carries a code-only support reference instead.
  */
 const RAW_PAYLOADS: Partial<Record<GsCode, string>> = {
   GS201: `execution reverted: GS201 (action="estimateGas", data="0x08c379a0...4753323031", reason="GS201", code=CALL_EXCEPTION, version=6.13.2)`,
@@ -99,8 +97,9 @@ const InErrorMessage = () => {
       <Alert variant="info" outlined>
         <AlertDescription>
           The message you see is the new copy. Each error is fed a realistic raw payload (provider URLs, request bodies,
-          library versions), but a GS error shows only an inline <strong>error code</strong> with a copy button — never
-          the raw payload. The full support reference is meant to live in the support tool.
+          library versions), but none of it reaches the alert: a GS error shows only an inline{' '}
+          <strong>error code</strong> with a copy button. The full support reference is meant to live in the support
+          tool.
         </AlertDescription>
       </Alert>
       {samples.map(({ code, label }) => {

--- a/apps/web/src/components/tx/ErrorMessage/__tests__/ErrorMessage.test.tsx
+++ b/apps/web/src/components/tx/ErrorMessage/__tests__/ErrorMessage.test.tsx
@@ -36,6 +36,19 @@ describe('ErrorMessage', () => {
     expect(queryByText(/rpc\.example\.org/)).toBeInTheDocument()
   })
 
+  it('shows a known CGW response state with no code and no raw response body', () => {
+    const error = Object.assign(new Error('<html><title>502 Bad Gateway</title></html>'), { status: 502 })
+
+    const { getByText, queryByText, queryByTestId } = render(
+      <ErrorMessage error={error}>Something went wrong on our end. Try again.</ErrorMessage>,
+    )
+
+    expect(getByText('Something went wrong on our end. Try again.')).toBeInTheDocument()
+    expect(queryByTestId('error-details')).not.toBeInTheDocument()
+    expect(queryByText('Details')).not.toBeInTheDocument()
+    expect(queryByText(/Bad Gateway/)).not.toBeInTheDocument()
+  })
+
   it('withholds the raw message of a Ledger device failure, mapped or not', () => {
     const cause = mapLedgerError({
       _tag: 'DeviceLockedError',

--- a/apps/web/src/components/tx/ErrorMessage/__tests__/ErrorMessage.test.tsx
+++ b/apps/web/src/components/tx/ErrorMessage/__tests__/ErrorMessage.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@/tests/test-utils'
+import { render } from '@/tests/test-utils'
 import type { DmkError } from '@ledgerhq/device-management-kit'
 import { mapLedgerError } from '@/services/onboard/ledger-errors'
 import ErrorMessage from '..'
@@ -25,15 +25,17 @@ describe('ErrorMessage', () => {
     expect(queryByText(/eth_call/)).not.toBeInTheDocument()
   })
 
-  it('shows the raw message for a non-GS error (on-chain-scoped ticket)', () => {
+  it('offers no way to reach the raw message of an error with no code at all', () => {
     const raw = 'Request failed at https://rpc.example.org using viem@2.0.0'
 
-    const { getByText, queryByText } = render(<ErrorMessage error={new Error(raw)}>Something failed.</ErrorMessage>)
+    const { getByText, queryByText, queryByTestId, container } = render(
+      <ErrorMessage error={new Error(raw)}>Something failed.</ErrorMessage>,
+    )
 
-    fireEvent.click(getByText('Details'))
-
-    // No GS code → the original raw-message Details is kept (unchanged by this ticket).
-    expect(queryByText(/rpc\.example\.org/)).toBeInTheDocument()
+    expect(getByText('Something failed.')).toBeInTheDocument()
+    expect(queryByText('Details')).not.toBeInTheDocument()
+    expect(queryByTestId('error-details')).not.toBeInTheDocument()
+    expect(container.textContent).not.toContain('rpc.example.org')
   })
 
   it('shows a known CGW response state with no code and no raw response body', () => {

--- a/apps/web/src/components/tx/ErrorMessage/index.tsx
+++ b/apps/web/src/components/tx/ErrorMessage/index.tsx
@@ -62,10 +62,10 @@ const ErrorMessage = ({
     error && (gsCode === 'GS013' || (!gsCode && isRevertError(error))) ? decodeCustomError(error) : undefined
   const effectiveGsCode = gsCode ?? (customError ? 'GS013' : undefined)
 
-  // A known CGW response state (429/422/451/5xx) gets the same code-only
-  // support reference, so the raw response body — which can be a gateway's HTML
-  // error page — is never rendered in Details (WA-3252).
-  const supportCode = effectiveGsCode ?? (error ? getCgwSupportCode(error) : undefined)
+  // A known CGW response state (429/422/451/5xx) shows its agreed message and nothing else: no
+  // code reference, and no Details either — the raw response body can be a gateway's HTML error
+  // page (WA-3252).
+  const isCgwError = !effectiveGsCode && !!error && !!getCgwSupportCode(error)
 
   // Check if this is a Guard error that should get special treatment
   const guardErrorName = error && context ? getGuardErrorInfo(error) : undefined
@@ -107,7 +107,7 @@ const ErrorMessage = ({
             </span>
           )}
 
-          {error && !supportCode && !ledgerError && (
+          {error && !effectiveGsCode && !isCgwError && !ledgerError && (
             <Link
               render={<button type="button" />}
               onClick={onDetailsToggle}
@@ -118,12 +118,13 @@ const ErrorMessage = ({
           )}
         </span>
 
-        {supportCode ? (
-          <ErrorDetails code={supportCode} customError={customError} />
+        {effectiveGsCode ? (
+          <ErrorDetails code={effectiveGsCode} customError={customError} />
         ) : ledgerError ? (
           ledgerReference && <ErrorDetails code={ledgerReference} />
         ) : (
           error &&
+          !isCgwError &&
           showDetails && (
             <Typography variant="paragraph-small" color="muted" className="mt-2 block break-words">
               {error.message.replace(ETHERS_PREFIX, '').trim().slice(0, 500)}

--- a/apps/web/src/components/tx/ErrorMessage/index.tsx
+++ b/apps/web/src/components/tx/ErrorMessage/index.tsx
@@ -1,7 +1,6 @@
-import { type ReactElement, type ReactNode, type SyntheticEvent, useState } from 'react'
+import { type ReactElement, type ReactNode } from 'react'
 import { getGsCodeFromError } from '@safe-global/utils/services/exceptions/contractErrors'
 import { getGuardErrorInfo, isRevertError } from '@/utils/transaction-errors'
-import { getCgwSupportCode } from '@/utils/cgw-errors'
 import { decodeCustomError } from '@/utils/customErrorRegistry'
 import { getBlockExplorerLink } from '@/utils/chains'
 import useSafeInfo from '@/hooks/useSafeInfo'
@@ -10,11 +9,7 @@ import ExternalLink from '@/components/common/ExternalLink'
 import ErrorDetails from '@/components/common/ErrorDetails'
 import { getLedgerDeviceError, getLedgerSupportReference } from '@/services/onboard/ledger-errors'
 import { Alert, AlertDescription, AlertTitle, AlertSeverityIcon } from '@/components/ui/alert'
-import { Typography } from '@/components/ui/typography'
-import { Link } from '@/components/ui/link'
 import { cn } from '@/utils/cn'
-
-const ETHERS_PREFIX = 'could not coalesce error'
 
 const alertVariant: Record<'error' | 'warning' | 'info', 'destructive' | 'warning' | 'info'> = {
   error: 'destructive',
@@ -37,20 +32,14 @@ const ErrorMessage = ({
   title?: string
   context?: 'estimation' | 'execution'
 }): ReactElement => {
-  const [showDetails, setShowDetails] = useState<boolean>(false)
   const { safe } = useSafeInfo()
   const chain = useCurrentChain()
 
-  // On-chain (GS) errors show an always-visible, code-only support reference;
-  // every other error keeps its raw message behind the Details toggle, as
-  // before (WA-3005 is on-chain-scoped).
+  // No alert ever shows the raw payload: it is a dump of provider URLs, calldata, library
+  // versions and class names, and it goes to Sentry instead. An on-chain (GS) error and an
+  // unmapped Ledger state carry a code-only support reference (WA-3005 / WA-3243).
   const gsCode = error ? getGsCodeFromError(error) : undefined
 
-  // A Ledger device failure carries its own translated sentence, so the raw
-  // message must never be offered: by the time it reaches us it has been
-  // re-wrapped by ethers and viem and reads as a dump of class names, codes and
-  // library versions (WA-3243). An unmapped device state gets a support
-  // reference instead — the device's own words stay in telemetry.
   const ledgerError = error ? getLedgerDeviceError(error) : undefined
   const ledgerReference = ledgerError?.reason === 'unknown' ? getLedgerSupportReference(ledgerError) : undefined
 
@@ -62,20 +51,10 @@ const ErrorMessage = ({
     error && (gsCode === 'GS013' || (!gsCode && isRevertError(error))) ? decodeCustomError(error) : undefined
   const effectiveGsCode = gsCode ?? (customError ? 'GS013' : undefined)
 
-  // A known CGW response state (429/422/451/5xx) shows its agreed message and nothing else: no
-  // code reference, and no Details either — the raw response body can be a gateway's HTML error
-  // page (WA-3252).
-  const isCgwError = !effectiveGsCode && !!error && !!getCgwSupportCode(error)
-
   // Check if this is a Guard error that should get special treatment
   const guardErrorName = error && context ? getGuardErrorInfo(error) : undefined
   const guardExplorerLink =
     guardErrorName && safe.guard && chain ? getBlockExplorerLink(chain, safe.guard.value) : undefined
-
-  const onDetailsToggle = (e: SyntheticEvent) => {
-    e.preventDefault()
-    setShowDetails((prev) => !prev)
-  }
 
   return (
     <Alert
@@ -106,30 +85,12 @@ const ErrorMessage = ({
               </strong>
             </span>
           )}
-
-          {error && !effectiveGsCode && !isCgwError && !ledgerError && (
-            <Link
-              render={<button type="button" />}
-              onClick={onDetailsToggle}
-              className={cn('block', guardErrorName && 'mt-1')}
-            >
-              Details
-            </Link>
-          )}
         </span>
 
         {effectiveGsCode ? (
           <ErrorDetails code={effectiveGsCode} customError={customError} />
-        ) : ledgerError ? (
-          ledgerReference && <ErrorDetails code={ledgerReference} />
         ) : (
-          error &&
-          !isCgwError &&
-          showDetails && (
-            <Typography variant="paragraph-small" color="muted" className="mt-2 block break-words">
-              {error.message.replace(ETHERS_PREFIX, '').trim().slice(0, 500)}
-            </Typography>
-          )
+          ledgerReference && <ErrorDetails code={ledgerReference} />
         )}
       </AlertDescription>
     </Alert>

--- a/apps/web/src/components/tx/TxCheckError/__tests__/TxCheckError.test.tsx
+++ b/apps/web/src/components/tx/TxCheckError/__tests__/TxCheckError.test.tsx
@@ -44,6 +44,18 @@ describe('TxCheckError', () => {
     expect(queryByText(/Could not check/)).not.toBeInTheDocument()
   })
 
+  it('tells the user to raise a gas limit below the intrinsic minimum, not to reject (WA-3523)', () => {
+    const error = new Error('intrinsic gas too low: gas 21000, minimum needed 25484')
+
+    const { getByText, queryByText } = render(<TxCheckError error={error} context="estimation" />)
+
+    expect(
+      getByText('Gas limit too low. Minimum needed: 25,484. Increase the gas limit and try again.'),
+    ).toBeInTheDocument()
+    expect(queryByText(/most likely fail/)).not.toBeInTheDocument()
+    expect(queryByText(/reject this transaction/)).not.toBeInTheDocument()
+  })
+
   it('shows the Hypernative approval message when the HN guard blocks execution', () => {
     mockAssessmentUrl.mockReturnValue(DEEP_LINK)
 

--- a/apps/web/src/components/tx/TxCheckError/__tests__/TxCheckError.test.tsx
+++ b/apps/web/src/components/tx/TxCheckError/__tests__/TxCheckError.test.tsx
@@ -1,6 +1,8 @@
 import { render } from '@/tests/test-utils'
+import { chainBuilder } from '@/tests/builders/chains'
 import { GUARD_ERROR_CODES, HYPERNATIVE_APPROVAL_REQUIRED_MESSAGE } from '@/utils/transaction-errors'
 import { useSafeShieldAssessmentUrl } from '@/features/hypernative'
+import { useCurrentChain } from '@/hooks/useChains'
 import TxCheckError from '..'
 
 jest.mock('@/features/hypernative', () => ({
@@ -8,7 +10,19 @@ jest.mock('@/features/hypernative', () => ({
   useSafeShieldAssessmentUrl: jest.fn(),
 }))
 
+jest.mock('@/hooks/useChains', () => ({
+  __esModule: true,
+  useCurrentChain: jest.fn(),
+  useHasFeature: jest.fn(),
+  default: jest.fn(),
+}))
+
 const mockAssessmentUrl = useSafeShieldAssessmentUrl as jest.MockedFunction<typeof useSafeShieldAssessmentUrl>
+const mockCurrentChain = useCurrentChain as jest.MockedFunction<typeof useCurrentChain>
+
+/** An ethers CALL_EXCEPTION: the code reaches us in `reason` and inside `message`. */
+const gsRevert = (code: string) =>
+  Object.assign(new Error(`execution reverted: "${code}" (action="call")`), { reason: code, code: 'CALL_EXCEPTION' })
 
 const DEEP_LINK = 'https://app.hypernative.xyz/guardian/alert?chain=evm%3A1&safe=0x123&tx=0xabc&referrer=safe'
 
@@ -18,6 +32,10 @@ const hypernativeRevert = () =>
   )
 
 describe('TxCheckError', () => {
+  beforeEach(() => {
+    mockCurrentChain.mockReturnValue(undefined)
+  })
+
   it('warns the transaction will fail for a genuine on-chain revert', () => {
     const revert = Object.assign(new Error('execution reverted'), { reason: 'GS013' })
     const { getByText, queryByText } = render(<TxCheckError error={revert} />)
@@ -74,5 +92,38 @@ describe('TxCheckError', () => {
     expect(getByText(/Nothing was signed/)).toBeInTheDocument()
     // Must NOT claim the transaction will fail when we simply could not reach the node.
     expect(queryByText(/most likely fail/)).not.toBeInTheDocument()
+  })
+
+  it('names the cause for a GS code we have copy for, instead of predicting a failure', () => {
+    const { getByText, queryByText } = render(<TxCheckError error={gsRevert('GS025')} context="estimation" />)
+
+    expect(getByText('This transaction needs more confirmations before it can be executed.')).toBeInTheDocument()
+    expect(queryByText(/most likely fail/)).not.toBeInTheDocument()
+    // The raw code stays a support reference only.
+    expect(getByText(/GS025/)).toBeInTheDocument()
+  })
+
+  it('interpolates the native asset into the cause', () => {
+    const chain = chainBuilder().build()
+    mockCurrentChain.mockReturnValue({ ...chain, nativeCurrency: { ...chain.nativeCurrency, symbol: 'ETH' } })
+
+    const { getByText } = render(<TxCheckError error={gsRevert('GS011')} context="estimation" />)
+
+    expect(getByText('Not enough ETH in this Safe Account to cover the network fee.')).toBeInTheDocument()
+  })
+
+  it('keeps the prediction rather than showing an unresolved placeholder', () => {
+    // GS012 names the ERC-20 gas token, which this surface cannot resolve.
+    const { getByText, queryByText } = render(<TxCheckError error={gsRevert('GS012')} context="estimation" />)
+
+    expect(getByText(/most likely fail/)).toBeInTheDocument()
+    expect(queryByText(/\{token\}/)).not.toBeInTheDocument()
+  })
+
+  it('keeps the prediction for a code whose only copy is the shared fallback', () => {
+    const { getByText, queryByText } = render(<TxCheckError error={gsRevert('GS013')} context="estimation" />)
+
+    expect(getByText(/most likely fail/)).toBeInTheDocument()
+    expect(queryByText(/contact support with the reference below/)).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/tx/TxCheckError/index.tsx
+++ b/apps/web/src/components/tx/TxCheckError/index.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react'
 import { useCurrentChain } from '@/hooks/useChains'
 import {
+  getGasLimitTooLowMessage,
   HYPERNATIVE_APPROVAL_REQUIRED_MESSAGE,
   isHypernativeGuardRevert,
   isRateLimitError,
@@ -75,6 +76,18 @@ const TxCheckError = ({ error, context }: { error: Error; context?: 'estimation'
     return (
       <ErrorMessage error={error} level="warning" context={context}>
         {RATE_LIMIT_USER_MESSAGE}
+      </ErrorMessage>
+    )
+  }
+
+  // `useIsValidExecution` simulates with the gas limit the user set, so a node that rejects the
+  // simulation on intrinsic gas answers here. That is a setting to fix, not a transaction that
+  // will fail, so it must never reach the "reject this transaction" advice below.
+  const gasLimitTooLow = getGasLimitTooLowMessage(error)
+  if (gasLimitTooLow) {
+    return (
+      <ErrorMessage error={error} level="warning" context={context}>
+        {gasLimitTooLow}
       </ErrorMessage>
     )
   }

--- a/apps/web/src/components/tx/TxCheckError/index.tsx
+++ b/apps/web/src/components/tx/TxCheckError/index.tsx
@@ -7,6 +7,7 @@ import {
   isRevertError,
   RATE_LIMIT_USER_MESSAGE,
 } from '@/utils/transaction-errors'
+import { getSpecificContractErrorMessage } from '@safe-global/utils/services/exceptions/contractErrors'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import { ExternalLink as ExternalLinkIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -60,7 +61,8 @@ export const getCouldNotCheckMessage = (network?: string): string =>
  * reverts) warns the transaction will fail so the user can avoid wasting gas;
  * an infrastructure failure (we could not reach the node) only says we could
  * not check — never a prediction about the transaction. A transient rate-limit
- * keeps its own dedicated copy.
+ * keeps its own dedicated copy. A revert carrying a GS code we have specific copy for
+ * shows that cause instead of the prediction.
  */
 const TxCheckError = ({ error, context }: { error: Error; context?: 'estimation' | 'execution' }): ReactElement => {
   const chain = useCurrentChain()
@@ -78,10 +80,13 @@ const TxCheckError = ({ error, context }: { error: Error; context?: 'estimation'
   }
 
   const willRevert = isRevertError(error)
+  // The chain named the cause, so say it instead of predicting a failure. Codes with no copy
+  // of their own keep the prediction — it is more useful than the shared fallback here.
+  const contractErrorMessage = getSpecificContractErrorMessage(error, { nativeAsset: chain?.nativeCurrency.symbol })
 
   return (
     <ErrorMessage error={error} level={willRevert ? 'error' : 'warning'} context={context}>
-      {willRevert ? TX_WILL_FAIL_MESSAGE : getCouldNotCheckMessage(chain?.chainName)}
+      {contractErrorMessage ?? (willRevert ? TX_WILL_FAIL_MESSAGE : getCouldNotCheckMessage(chain?.chainName))}
     </ErrorMessage>
   )
 }

--- a/apps/web/src/components/tx/TxSubmitError/__tests__/TxSubmitError.test.tsx
+++ b/apps/web/src/components/tx/TxSubmitError/__tests__/TxSubmitError.test.tsx
@@ -115,6 +115,33 @@ describe('TxSubmitError', () => {
     expect(getByText('Could not submit the transaction. Try again.')).toBeInTheDocument()
   })
 
+  describe('a gas limit below the intrinsic minimum (WA-3523)', () => {
+    /** The pool rejection as viem re-wraps it: a contract revert it never was. */
+    const intrinsicGasError = () =>
+      new Error(
+        'The contract function "execTransaction" reverted with the following reason:\nintrinsic gas too low: gas 21000, minimum needed 25484',
+      )
+
+    it('names the setting to change and the minimum needed', () => {
+      const { getByText, queryByText } = render(<TxSubmitError error={intrinsicGasError()} />)
+
+      expect(
+        getByText('Gas limit too low. Minimum needed: 25,484. Increase the gas limit and try again.'),
+      ).toBeInTheDocument()
+      expect(queryByText(/Could not submit/)).not.toBeInTheDocument()
+    })
+
+    it('never claims the contract reverted, and shows no ABI or raw arguments', () => {
+      const { container, queryByText, queryByTestId } = render(<TxSubmitError error={intrinsicGasError()} />)
+
+      for (const forbidden of ['execTransaction', 'reverted', 'intrinsic gas', '21000']) {
+        expect(container.textContent).not.toContain(forbidden)
+      }
+      expect(queryByText('Details')).not.toBeInTheDocument()
+      expect(queryByTestId('error-details')).not.toBeInTheDocument()
+    })
+  })
+
   describe('CGW response states (WA-3252)', () => {
     it.each([429, 502, 500, 503, 422])('renders the agreed copy for a %s from CGW', (status) => {
       const error = asError({ status, data: {} })

--- a/apps/web/src/components/tx/TxSubmitError/__tests__/TxSubmitError.test.tsx
+++ b/apps/web/src/components/tx/TxSubmitError/__tests__/TxSubmitError.test.tsx
@@ -149,7 +149,7 @@ describe('TxSubmitError', () => {
       expect(getByText('This Safe Account is not available.')).toBeInTheDocument()
     })
 
-    it('shows a code-only support reference instead of a raw Details payload', () => {
+    it('shows the message alone — no code reference and no raw Details payload', () => {
       const error = asError({
         status: 'PARSING_ERROR',
         originalStatus: 502,
@@ -157,10 +157,10 @@ describe('TxSubmitError', () => {
         error: "SyntaxError: Unexpected token '<'",
       })
 
-      const { getByTestId, getByText, queryByText } = render(<TxSubmitError error={error} />)
+      const { queryByTestId, queryByText } = render(<TxSubmitError error={error} />)
 
-      expect(getByTestId('error-details')).toBeInTheDocument()
-      expect(getByText('CGW-502')).toBeInTheDocument()
+      expect(queryByTestId('error-details')).not.toBeInTheDocument()
+      expect(queryByText('CGW-502')).not.toBeInTheDocument()
       expect(queryByText('Details')).not.toBeInTheDocument()
     })
 

--- a/apps/web/src/components/tx/TxSubmitError/index.tsx
+++ b/apps/web/src/components/tx/TxSubmitError/index.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react'
 import { useCurrentChain } from '@/hooks/useChains'
 import { getGs026Message } from '@safe-global/utils/services/exceptions/contractErrors'
 import {
+  getGasLimitTooLowMessage,
   isNonceTooLowError,
   isRateLimitError,
   isRevertError,
@@ -67,6 +68,18 @@ const TxSubmitError = ({
     return (
       <ErrorMessage error={error} level="error" context={context}>
         {getGs026Message('STALE_NONCE')}
+      </ErrorMessage>
+    )
+  }
+
+  // The gas limit set in Advanced parameters is below the transaction's intrinsic cost, so the
+  // node refused it pre-broadcast. Name the value to raise it to. Checked before the revert
+  // classification for the same reason as the nonce above: viem wraps this rejection as a revert.
+  const gasLimitTooLow = getGasLimitTooLowMessage(error)
+  if (gasLimitTooLow) {
+    return (
+      <ErrorMessage error={error} level="error" context={context}>
+        {gasLimitTooLow}
       </ErrorMessage>
     )
   }

--- a/apps/web/src/hooks/__tests__/useTxNotifications.test.ts
+++ b/apps/web/src/hooks/__tests__/useTxNotifications.test.ts
@@ -265,6 +265,39 @@ describe('useTxNotifications — CGW response states (WA-3252)', () => {
   })
 })
 
+describe('useTxNotifications — a gas limit below the intrinsic minimum (WA-3523)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsTxFlowOpen = false
+  })
+
+  it('names the minimum needed and keeps the raw payload out of the toast', async () => {
+    renderHook(() => useTxNotifications())
+
+    act(() => {
+      txDispatch(TxEvent.FAILED, {
+        txId: '0x1',
+        nonce: 1,
+        chainId: '1',
+        safeAddress: '0x0000000000000000000000000000000000000001',
+        error: new Error(
+          'The contract function "execTransaction" reverted with the following reason:\nintrinsic gas too low: gas 21000, minimum needed 25484',
+        ),
+      })
+    })
+
+    await waitFor(() => expect(showNotification).toHaveBeenCalled())
+
+    const notification = lastNotification()
+    expect(notification.message).toBe(
+      'Gas limit too low. Minimum needed: 25,484. Increase the gas limit and try again.',
+    )
+    expect(notification.detailedMessage).toBeUndefined()
+    expect(JSON.stringify(notification)).not.toContain('execTransaction')
+    expect(JSON.stringify(notification)).not.toContain('intrinsic gas')
+  })
+})
+
 describe('useTxNotifications — errors the tx flow already shows inline', () => {
   beforeEach(() => {
     jest.clearAllMocks()

--- a/apps/web/src/hooks/__tests__/useTxNotifications.test.ts
+++ b/apps/web/src/hooks/__tests__/useTxNotifications.test.ts
@@ -16,6 +16,12 @@ import {
 import { CGW_ERROR_FALLBACK } from '@safe-global/utils/services/exceptions/gatewayErrors'
 import useTxNotifications from '../useTxNotifications'
 
+let mockIsTxFlowOpen = false
+
+jest.mock('@/components/tx-flow/useIsTxFlowOpen', () => ({
+  useIsTxFlowOpenRef: () => ({ current: mockIsTxFlowOpen }),
+}))
+
 jest.mock('@/store/notificationsSlice', () => {
   const original = jest.requireActual('@/store/notificationsSlice')
   return {
@@ -212,7 +218,7 @@ describe('useTxNotifications — CGW response states (WA-3252)', () => {
 
     const notification = lastNotification()
     expect(notification.message).toBe('Something went wrong on our end. Try again.')
-    expect(notification.detailedMessage).toBe('Error code CGW-502')
+    expect(notification.detailedMessage).toBeUndefined()
     expect(JSON.stringify(notification)).not.toContain('nginx')
     expect(JSON.stringify(notification)).not.toContain('Bad Gateway')
     expect(JSON.stringify(notification)).not.toContain('<html')
@@ -255,6 +261,45 @@ describe('useTxNotifications — CGW response states (WA-3252)', () => {
     expect(notification.message).not.toBe(CGW_ERROR_FALLBACK)
     // The support reference still carries the status, exactly as the inline
     // alert's code-only reference does.
-    expect(notification.detailedMessage).toBe('Error code CGW-429')
+    expect(notification.detailedMessage).toBeUndefined()
+  })
+})
+
+describe('useTxNotifications — errors the tx flow already shows inline', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsTxFlowOpen = false
+  })
+
+  it('raises nothing at all for a failure while a flow is on screen', async () => {
+    mockIsTxFlowOpen = true
+    renderHook(() => useTxNotifications())
+
+    await act(async () => {
+      txDispatch(TxEvent.PROPOSE_FAILED, { error: asError({ status: 502, data: {} }) })
+    })
+
+    expect(showNotification).not.toHaveBeenCalled()
+  })
+
+  it('toasts a failure that arrives with no flow on screen', async () => {
+    renderHook(() => useTxNotifications())
+
+    act(() => {
+      txDispatch(TxEvent.PROPOSE_FAILED, { error: new Error('boom') })
+    })
+
+    await waitFor(() => expect(lastNotification()).toMatchObject({ variant: 'error' }))
+  })
+
+  it('still toasts a success raised from inside the flow', async () => {
+    mockIsTxFlowOpen = true
+    renderHook(() => useTxNotifications())
+
+    act(() => {
+      txDispatch(TxEvent.PROPOSED, { txId: '0x1', nonce: 1 })
+    })
+
+    await waitFor(() => expect(lastNotification()).toMatchObject({ variant: 'success' }))
   })
 })

--- a/apps/web/src/hooks/useTxNotifications.ts
+++ b/apps/web/src/hooks/useTxNotifications.ts
@@ -26,6 +26,7 @@ import {
 import { getGs026Message } from '@safe-global/utils/services/exceptions/contractErrors'
 import { getLedgerDeviceError, getLedgerUserMessage } from '@/services/onboard/ledger-errors'
 import { getCgwErrorInfo } from '@/utils/cgw-errors'
+import { useIsTxFlowOpenRef } from '@/components/tx-flow/useIsTxFlowOpen'
 
 const TxNotifications = {
   [TxEvent.SIGN_FAILED]: 'Failed to sign. Please try again.',
@@ -58,6 +59,7 @@ const useTxNotifications = (): void => {
   const chain = useCurrentChain()
   const safeAddress = useSafeAddress()
   const [trigger] = useLazyTransactionsGetTransactionByIdV1Query()
+  const isTxFlowOpenRef = useIsTxFlowOpenRef()
 
   /**
    * Show notifications of a transaction's lifecycle
@@ -72,6 +74,9 @@ const useTxNotifications = (): void => {
       txSubscribe(event, async (detail) => {
         const isError = 'error' in detail
         if (isError && isWalletRejection(detail.error)) return
+        // The flow on screen already shows the failure inline, and errors are never listed in the
+        // notification center — a toast would only repeat what the flow says.
+        if (isError && isTxFlowOpenRef.current) return
         const isSuccess = successEvents.includes(event)
 
         // Check if this is a Guard error
@@ -132,13 +137,7 @@ const useTxNotifications = (): void => {
             title: humanDescription,
             message,
             detailedMessage:
-              ledgerError || hnApprovalRequired
-                ? undefined
-                : cgwError
-                  ? `Error code ${cgwError.code}`
-                  : isError
-                    ? detail.error.message
-                    : undefined,
+              ledgerError || hnApprovalRequired || cgwError ? undefined : isError ? detail.error.message : undefined,
             groupKey,
             variant: isError ? Variant.ERROR : isSuccess ? Variant.SUCCESS : Variant.INFO,
             link: txId
@@ -154,7 +153,7 @@ const useTxNotifications = (): void => {
     return () => {
       unsubFns.forEach((unsub) => unsub())
     }
-  }, [dispatch, safeAddress, chain, trigger])
+  }, [dispatch, safeAddress, chain, trigger, isTxFlowOpenRef])
 
   /**
    * If there's at least one transaction awaiting confirmations, show a notification for it

--- a/apps/web/src/hooks/useTxNotifications.ts
+++ b/apps/web/src/hooks/useTxNotifications.ts
@@ -16,6 +16,7 @@ import { getTxLink } from '@/utils/tx-link'
 import { useLazyTransactionsGetTransactionByIdV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { getExplorerLink } from '@safe-global/utils/utils/gateway'
 import {
+  getGasLimitTooLowMessage,
   getGuardErrorInfo,
   HYPERNATIVE_APPROVAL_REQUIRED_MESSAGE,
   isHypernativeGuardRevert,
@@ -90,6 +91,10 @@ const useTxNotifications = (): void => {
         // A known CGW response state replaces both the copy and the details:
         // the response body can be a gateway HTML error page (WA-3252).
         const cgwError = isError ? getCgwErrorInfo(detail.error) : undefined
+        // A gas limit below the transaction's intrinsic cost: refused pre-broadcast, and fixable
+        // by raising the limit, so the toast names the value instead of the raw payload.
+        const gasLimitTooLowMessage = isError ? getGasLimitTooLowMessage(detail.error) : undefined
+
         let message = isError ? `${baseMessage} ${formatError(detail.error)}` : baseMessage
 
         // Override message for Guard errors
@@ -100,6 +105,8 @@ const useTxNotifications = (): void => {
           message = HYPERNATIVE_APPROVAL_REQUIRED_MESSAGE
         } else if (guardErrorName) {
           message = `Guard reverted the transaction (${guardErrorName}).`
+        } else if (gasLimitTooLowMessage) {
+          message = gasLimitTooLowMessage
         } else if (isError && isNonceTooLowError(detail.error)) {
           // The signer wallet's Ethereum nonce advanced before broadcast — the
           // RPC rejected it pre-mining (no gas spent). Same user story as a
@@ -137,7 +144,11 @@ const useTxNotifications = (): void => {
             title: humanDescription,
             message,
             detailedMessage:
-              ledgerError || hnApprovalRequired || cgwError ? undefined : isError ? detail.error.message : undefined,
+              ledgerError || hnApprovalRequired || cgwError || gasLimitTooLowMessage
+                ? undefined
+                : isError
+                  ? detail.error.message
+                  : undefined,
             groupKey,
             variant: isError ? Variant.ERROR : isSuccess ? Variant.SUCCESS : Variant.INFO,
             link: txId

--- a/apps/web/src/services/safe-messages/__tests__/safeMsgSender.test.ts
+++ b/apps/web/src/services/safe-messages/__tests__/safeMsgSender.test.ts
@@ -338,7 +338,7 @@ describe('safeMsgSender', () => {
 
       const error = await rejection(propose)
 
-      expect(getCgwErrorInfo(error)).toEqual(expect.objectContaining({ status, code: `CGW-${status}`, message: copy }))
+      expect(getCgwErrorInfo(error)).toEqual(expect.objectContaining({ status, message: copy }))
     })
 
     it.each([
@@ -351,7 +351,7 @@ describe('safeMsgSender', () => {
 
       const error = await rejection(confirm)
 
-      expect(getCgwErrorInfo(error)).toEqual(expect.objectContaining({ status, code: `CGW-${status}`, message: copy }))
+      expect(getCgwErrorInfo(error)).toEqual(expect.objectContaining({ status, message: copy }))
     })
 
     it('never throws a stringified error object', async () => {

--- a/apps/web/src/store/__tests__/notificationsSlice.test.ts
+++ b/apps/web/src/store/__tests__/notificationsSlice.test.ts
@@ -5,6 +5,7 @@ import {
   readNotification,
   showNotification,
   selectNotifications,
+  selectCenterNotifications,
   type Notification,
 } from '../notificationsSlice'
 import { makeStore } from '@/store'
@@ -97,6 +98,31 @@ describe('notificationsSlice', () => {
       const state = reducer([notification], readNotification({ id: '1' }))
 
       expect(state[0].isRead).toBe(true)
+    })
+  })
+
+  describe('selectCenterNotifications', () => {
+    it('leaves errors out of the notification center', () => {
+      const store = makeStore()
+
+      store.dispatch(showNotification({ message: 'Queued', groupKey: 'a', variant: 'success' }))
+      store.dispatch(showNotification({ message: 'Failed to sign', groupKey: 'b', variant: 'error' }))
+      store.dispatch(showNotification({ message: 'Needs confirmation', groupKey: 'c', variant: 'info' }))
+
+      expect(selectNotifications(store.getState())).toHaveLength(3)
+      expect(selectCenterNotifications(store.getState()).map(({ message }) => message)).toEqual([
+        'Queued',
+        'Needs confirmation',
+      ])
+    })
+
+    it('keeps the same reference until the notifications change', () => {
+      const store = makeStore()
+      store.dispatch(showNotification({ message: 'Queued', groupKey: 'a', variant: 'success' }))
+
+      const first = selectCenterNotifications(store.getState())
+
+      expect(selectCenterNotifications(store.getState())).toBe(first)
     })
   })
 

--- a/apps/web/src/store/notificationsSlice.ts
+++ b/apps/web/src/store/notificationsSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import type { AppThunk, RootState } from '@/store'
 import type { LinkProps } from 'next/link'
 import type { ReactNode } from 'react'
@@ -80,3 +80,11 @@ export const showNotification = (payload: Omit<Notification, 'id' | 'timestamp'>
 export const selectNotifications = (state: RootState): NotificationState => {
   return state[notificationsSlice.name]
 }
+
+/**
+ * What the notification center lists. Failures are transient: they are shown as a toast and,
+ * when a tx flow is on screen, inline in the flow — they are never kept as a record here.
+ */
+export const selectCenterNotifications = createSelector(selectNotifications, (notifications) =>
+  notifications.filter(({ variant }) => variant !== 'error'),
+)

--- a/apps/web/src/utils/__tests__/transaction-errors.test.ts
+++ b/apps/web/src/utils/__tests__/transaction-errors.test.ts
@@ -9,6 +9,7 @@ import {
   isHypernativeGuardRevert,
   isNonceTooLowError,
   isRateLimitError,
+  getGasLimitTooLowMessage,
   isRevertError,
   isExpectedEstimationError,
   GUARD_ERROR_CODES,
@@ -71,6 +72,40 @@ describe('transaction-errors', () => {
       expect(isNonceTooLowError(new Error('execution reverted: GS026'))).toBe(false)
       expect(isNonceTooLowError(null)).toBe(false)
       expect(isNonceTooLowError(undefined)).toBe(false)
+    })
+  })
+
+  describe('getGasLimitTooLowMessage', () => {
+    it('names the minimum the node quoted, even wrapped as a viem revert (WA-3523)', () => {
+      // Real shape: the gas limit set in Advanced parameters is below the tx's
+      // intrinsic cost, and viem wraps the pool rejection as a contract revert.
+      const viemWrapped = new Error(
+        'The contract function "execTransaction" reverted with the following reason:\nintrinsic gas too low: gas 21000, minimum needed 25484',
+      )
+
+      expect(getGasLimitTooLowMessage(viemWrapped)).toBe(
+        'Gas limit too low. Minimum needed: 25,484. Increase the gas limit and try again.',
+      )
+    })
+
+    it('reads the "want" phrasing some clients use', () => {
+      expect(getGasLimitTooLowMessage(new Error('intrinsic gas too low: have 21000, want 25484'))).toBe(
+        'Gas limit too low. Minimum needed: 25,484. Increase the gas limit and try again.',
+      )
+    })
+
+    it('drops the minimum when the node quoted none', () => {
+      // Besu's phrasing carries no numbers.
+      expect(getGasLimitTooLowMessage(new Error('Intrinsic gas exceeds gas limit'))).toBe(
+        'Gas limit too low. Increase the gas limit and try again.',
+      )
+    })
+
+    it('returns undefined for unrelated errors, including a real revert', () => {
+      expect(getGasLimitTooLowMessage(new Error('execution reverted: GS013'))).toBeUndefined()
+      expect(getGasLimitTooLowMessage(new Error('out of gas'))).toBeUndefined()
+      expect(getGasLimitTooLowMessage(null)).toBeUndefined()
+      expect(getGasLimitTooLowMessage(undefined)).toBeUndefined()
     })
   })
 

--- a/apps/web/src/utils/cgw-errors.test.ts
+++ b/apps/web/src/utils/cgw-errors.test.ts
@@ -1,5 +1,5 @@
 import { asError } from '@safe-global/utils/services/exceptions/utils'
-import { getCgwErrorInfo, getCgwSupportCode } from './cgw-errors'
+import { getCgwErrorInfo } from './cgw-errors'
 
 const HTML_502 =
   '<html><head><title>502 Bad Gateway</title></head><body><center><h1>502 Bad Gateway</h1></center><hr><center>nginx</center></body></html>'
@@ -9,14 +9,14 @@ describe('getCgwErrorInfo', () => {
     const info = getCgwErrorInfo(Object.assign(new Error('boom'), { status }))
 
     expect(info?.message).toBe('Something went wrong on our end. Try again.')
-    expect(info?.code).toBe(`CGW-${status}`)
+    expect(info?.status).toBe(status)
   })
 
   it('classifies a 451 as an unavailable Safe Account', () => {
     const info = getCgwErrorInfo(Object.assign(new Error('boom'), { status: 451 }))
 
     expect(info?.message).toBe('This Safe Account is not available.')
-    expect(info?.code).toBe('CGW-451')
+    expect(info?.status).toBe(451)
   })
 
   it('classifies the original 502 defect: an HTML body from a failed CGW request', () => {
@@ -43,12 +43,5 @@ describe('getCgwErrorInfo', () => {
   it('returns undefined for an error with no HTTP status', () => {
     expect(getCgwErrorInfo(new Error('execution reverted'))).toBeUndefined()
     expect(getCgwErrorInfo(undefined)).toBeUndefined()
-  })
-})
-
-describe('getCgwSupportCode', () => {
-  it('returns the support reference for a known state and nothing otherwise', () => {
-    expect(getCgwSupportCode(Object.assign(new Error('boom'), { status: 502 }))).toBe('CGW-502')
-    expect(getCgwSupportCode(new Error('boom'))).toBeUndefined()
   })
 })

--- a/apps/web/src/utils/cgw-errors.ts
+++ b/apps/web/src/utils/cgw-errors.ts
@@ -1,8 +1,8 @@
 /**
  * Classifies a failed CGW request against the shared response-state contract
  * (`@safe-global/utils/services/exceptions/gatewayErrors`) so every surface —
- * inline submit errors, notification toasts — renders the same copy and the
- * same code-only support reference.
+ * inline submit errors, notification toasts — renders the same copy. The code
+ * classifies the response state; it is never shown to the user.
  */
 import {
   getCgwErrorCode,
@@ -13,14 +13,13 @@ import { getHttpStatusFromError } from '@safe-global/utils/services/exceptions/u
 
 export interface CgwErrorInfo extends CgwErrorMeta {
   status: number
-  /** Support reference for the Details panel — never part of the message. */
+  /** Classifies the response state for telemetry and tests — never shown to the user. */
   code: string
 }
 
 /**
- * Returns the agreed copy and support reference for a known CGW response
- * state, or `undefined` when the error is not one we have agreed copy for (the
- * caller then keeps its existing behaviour).
+ * Returns the agreed copy for a known CGW response state, or `undefined` when the error is not
+ * one we have agreed copy for (the caller then keeps its existing behaviour).
  */
 export const getCgwErrorInfo = (error: unknown): CgwErrorInfo | undefined => {
   const status = getHttpStatusFromError(error)
@@ -29,5 +28,5 @@ export const getCgwErrorInfo = (error: unknown): CgwErrorInfo | undefined => {
   return status === undefined || !meta ? undefined : { ...meta, status, code: getCgwErrorCode(status) }
 }
 
-/** Support reference code for a known CGW response state. */
+/** Classification code for a known CGW response state. */
 export const getCgwSupportCode = (error: unknown): string | undefined => getCgwErrorInfo(error)?.code

--- a/apps/web/src/utils/cgw-errors.ts
+++ b/apps/web/src/utils/cgw-errors.ts
@@ -1,20 +1,14 @@
 /**
  * Classifies a failed CGW request against the shared response-state contract
  * (`@safe-global/utils/services/exceptions/gatewayErrors`) so every surface —
- * inline submit errors, notification toasts — renders the same copy. The code
- * classifies the response state; it is never shown to the user.
+ * inline submit errors, notification toasts — renders the same copy. The status
+ * is never shown to the user.
  */
-import {
-  getCgwErrorCode,
-  getCgwErrorMeta,
-  type CgwErrorMeta,
-} from '@safe-global/utils/services/exceptions/gatewayErrors'
+import { getCgwErrorMeta, type CgwErrorMeta } from '@safe-global/utils/services/exceptions/gatewayErrors'
 import { getHttpStatusFromError } from '@safe-global/utils/services/exceptions/utils'
 
 export interface CgwErrorInfo extends CgwErrorMeta {
   status: number
-  /** Classifies the response state for telemetry and tests — never shown to the user. */
-  code: string
 }
 
 /**
@@ -25,8 +19,5 @@ export const getCgwErrorInfo = (error: unknown): CgwErrorInfo | undefined => {
   const status = getHttpStatusFromError(error)
   const meta = getCgwErrorMeta(status)
 
-  return status === undefined || !meta ? undefined : { ...meta, status, code: getCgwErrorCode(status) }
+  return status === undefined || !meta ? undefined : { ...meta, status }
 }
-
-/** Classification code for a known CGW response state. */
-export const getCgwSupportCode = (error: unknown): string | undefined => getCgwErrorInfo(error)?.code

--- a/apps/web/src/utils/transaction-errors.ts
+++ b/apps/web/src/utils/transaction-errors.ts
@@ -153,6 +153,30 @@ export const isNonceTooLowError = (error: unknown): boolean => {
   )
 }
 
+/**
+ * A gas limit below the transaction's intrinsic cost (21000 base + calldata) is rejected by the
+ * node before anything is broadcast: nothing reverted and no gas was spent. viem wraps that
+ * rejection as a contract revert, so this must be resolved before the revert classification —
+ * otherwise a fixable setting reads as a transaction that will fail.
+ *
+ * geth-family clients quote the minimum back ("intrinsic gas too low: gas 21000, minimum needed
+ * 25484"); Besu ("Intrinsic gas exceeds gas limit") quotes nothing, so the value is optional.
+ */
+const INTRINSIC_GAS_MESSAGE = /intrinsic gas (?:too low|exceeds)/i
+const MINIMUM_GAS = /(?:minimum needed|want)[:\s]+(\d+)/i
+
+export const getGasLimitTooLowMessage = (error: unknown): string | undefined => {
+  const message = (error as { message?: unknown } | null | undefined)?.message
+
+  if (typeof message !== 'string' || !INTRINSIC_GAS_MESSAGE.test(message)) return undefined
+
+  const minimumGas = Number(MINIMUM_GAS.exec(message)?.[1])
+
+  return Number.isSafeInteger(minimumGas) && minimumGas > 0
+    ? `Gas limit too low. Minimum needed: ${minimumGas.toLocaleString()}. Increase the gas limit and try again.`
+    : 'Gas limit too low. Increase the gas limit and try again.'
+}
+
 export { isRevertError }
 
 /**

--- a/packages/utils/src/services/exceptions/__tests__/contractErrors.test.ts
+++ b/packages/utils/src/services/exceptions/__tests__/contractErrors.test.ts
@@ -5,6 +5,7 @@ import CONTRACT_ERRORS, {
   getContractErrorMessage,
   getGs026Message,
   getGsCodeFromError,
+  getSpecificContractErrorMessage,
   isGsCode,
   isRevertError,
   type GsCode,
@@ -133,6 +134,41 @@ describe('contractErrors', () => {
       expect(getGsCodeFromError({ message: 'GS999 is not a real code' })).toBeUndefined()
       expect(getGsCodeFromError(undefined)).toBeUndefined()
       expect(getGsCodeFromError(null)).toBeUndefined()
+    })
+  })
+
+  describe('getSpecificContractErrorMessage', () => {
+    it('resolves a code that has copy of its own', () => {
+      expect(getSpecificContractErrorMessage({ reason: 'GS025' })).toBe(
+        'This transaction needs more confirmations before it can be executed.',
+      )
+    })
+
+    it('interpolates the params it is given', () => {
+      expect(getSpecificContractErrorMessage({ reason: 'GS011' }, { nativeAsset: 'ETH' })).toBe(
+        'Not enough ETH in this Safe Account to cover the network fee.',
+      )
+      expect(getSpecificContractErrorMessage({ reason: 'GS012' }, { token: 'USDC', nativeAsset: 'ETH' })).toBe(
+        'Not enough USDC to cover the network fee. Pay with ETH instead.',
+      )
+    })
+
+    it('says nothing for a code whose only copy is the shared fallback', () => {
+      // The caller's own wording beats a generic sentence, so these must not resolve.
+      expect(getSpecificContractErrorMessage({ reason: 'GS013' })).toBeUndefined()
+      expect(getSpecificContractErrorMessage({ reason: 'GS026' })).toBeUndefined()
+      expect(getSpecificContractErrorMessage({ reason: 'GS100' })).toBeUndefined()
+    })
+
+    it('says nothing rather than leaking an unfilled placeholder', () => {
+      expect(getSpecificContractErrorMessage({ reason: 'GS011' })).toBeUndefined()
+      expect(getSpecificContractErrorMessage({ reason: 'GS012' }, { nativeAsset: 'ETH' })).toBeUndefined()
+    })
+
+    it('says nothing for an error carrying no GS code', () => {
+      expect(getSpecificContractErrorMessage({ message: 'HTTP request failed. Status: 500' })).toBeUndefined()
+      expect(getSpecificContractErrorMessage(undefined)).toBeUndefined()
+      expect(getSpecificContractErrorMessage(null)).toBeUndefined()
     })
   })
 

--- a/packages/utils/src/services/exceptions/__tests__/gatewayErrors.test.ts
+++ b/packages/utils/src/services/exceptions/__tests__/gatewayErrors.test.ts
@@ -4,7 +4,6 @@ import {
   CGW_TOO_MANY_REQUESTS,
   CGW_UNAVAILABLE_FOR_LEGAL_REASONS,
   CGW_UNPROCESSABLE_ENTITY,
-  getCgwErrorCode,
   getCgwErrorMeta,
   shouldAlertOnCgwStatus,
 } from '../gatewayErrors'
@@ -47,12 +46,6 @@ describe('gatewayErrors', () => {
       expect(shouldAlertOnCgwStatus(CGW_UNAVAILABLE_FOR_LEGAL_REASONS)).toBe(false)
       expect(shouldAlertOnCgwStatus(404)).toBe(false)
       expect(shouldAlertOnCgwStatus(undefined)).toBe(false)
-    })
-  })
-
-  describe('getCgwErrorCode', () => {
-    it('builds a support reference that carries the status', () => {
-      expect(getCgwErrorCode(502)).toBe('CGW-502')
     })
   })
 

--- a/packages/utils/src/services/exceptions/contractErrors.ts
+++ b/packages/utils/src/services/exceptions/contractErrors.ts
@@ -179,6 +179,28 @@ export const getContractErrorMessage = (code: GsCode, params?: ContractErrorPara
 /** How the given code should be handled in the product. */
 export const getContractErrorHandling = (code: GsCode): ContractErrorHandling => CONTRACT_ERRORS[code].handling
 
+const PLACEHOLDER_RE = /\{\w+\}/
+
+/**
+ * The message for an error's GS code when we have copy specific to that code, so a caller
+ * showing its own generic wording can replace it with the real cause.
+ *
+ * `undefined` means keep your own wording: either the code shares
+ * `CONTRACT_ERROR_FALLBACK` (nothing specific to say) or a placeholder could not be filled
+ * from `params` — a raw `{token}` must never reach the user.
+ */
+export const getSpecificContractErrorMessage = (
+  error?: { message?: string; reason?: string; code?: unknown } | null,
+  params?: ContractErrorParams,
+): string | undefined => {
+  const code = getGsCodeFromError(error)
+  if (!code) return undefined
+
+  const message = getContractErrorMessage(code, params)
+
+  return message === CONTRACT_ERROR_FALLBACK || PLACEHOLDER_RE.test(message) ? undefined : message
+}
+
 /** Resolve a specific GS026 cause to its message. */
 export const getGs026Message = (reason: Gs026Reason): string => GS026_MESSAGES[reason]
 

--- a/packages/utils/src/services/exceptions/gatewayErrors.ts
+++ b/packages/utils/src/services/exceptions/gatewayErrors.ts
@@ -6,7 +6,7 @@
  *
  * The raw response body is never part of the copy: a gateway can answer with an
  * HTML error page, and rendering that verbatim is what this module exists to
- * prevent. The status is a support reference only (see `getCgwErrorCode`).
+ * prevent, and the status itself is never shown to the user.
  */
 
 /** Shown for every response state we cannot act on: transient, or our own bug. */
@@ -52,12 +52,6 @@ export const getCgwErrorMeta = (status: number | undefined): CgwErrorMeta | unde
   if (status === undefined) return undefined
   return CGW_ERRORS[status] ?? (isServerErrorStatus(status) ? CGW_SERVER_ERROR : undefined)
 }
-
-/**
- * Support reference for the Details panel. Carries the status so support can
- * correlate the report with gateway logs — it never appears in the message.
- */
-export const getCgwErrorCode = (status: number): string => `CGW-${status}`
 
 /** Whether this state should raise an internal alert (a bug on our side). */
 export const shouldAlertOnCgwStatus = (status: number | undefined): boolean =>


### PR DESCRIPTION
## What it solves

Resolves: [WA-3523](https://linear.app/safe-global/issue/WA-3523), plus a cherry-pick of [#8684](https://github.com/safe-global/safe-wallet-monorepo/pull/8684) onto `release` (no ticket — product follow-up to WA-3005 / WA-3252).

Three ways the same failure was mis-told to the user, all on the Execute surface.

A transaction failure was being recorded three times over: inline in the tx flow that raised it, as a toast, and as a permanent entry in the notification center that also incremented the bell's unread badge. The badge kept counting failures the user had already read and dismissed inside the flow. On top of that, every alert for a known gateway response state ended with an `Error code CGW-502` chip, which means nothing to a user, and the `Details` toggle revealed the raw ethers/viem payload — provider URLs, calldata, library versions.

**WA-3523:** setting a gas limit below the transaction's intrinsic cost was reported as a contract revert. The node refuses that broadcast before it reaches the chain, but viem wraps the rejection as `The contract function "execTransaction" reverted with the following reason: intrinsic gas too low: gas 21000, minimum needed 25484`, so it read as a failing transaction — and the alert withheld a retry, because a revert is treated as deterministic.

## How this PR fixes it

Errors are treated as transient. They surface where the user is looking — inline in the flow, or as a toast — and are never kept as a record:

- [`selectCenterNotifications`](https://github.com/safe-global/safe-wallet-monorepo/blob/dc473b3846f3c838f1f532a77180665fdd35a118/apps/web/src/store/notificationsSlice.ts#L88-L90) (memoised via `createSelector`) filters `variant: 'error'` out of the notification center list, its unread badge and its expander. The bell's "dismiss every visible toast" sweep deliberately keeps reading the **unfiltered** `selectNotifications`, so opening the bell still clears error toasts.
- [`useTxNotifications` returns early](https://github.com/safe-global/safe-wallet-monorepo/blob/dc473b3846f3c838f1f532a77180665fdd35a118/apps/web/src/hooks/useTxNotifications.ts#L76-L79) for a failure raised while a tx flow is on screen — the flow already shows it inline, so there is nothing left to toast and nothing to record. [`useIsTxFlowOpenRef`](https://github.com/safe-global/safe-wallet-monorepo/blob/dc473b3846f3c838f1f532a77180665fdd35a118/apps/web/src/components/tx-flow/useIsTxFlowOpen.ts#L8-L19) reads the flow state as a ref so the event subscribers do not have to resubscribe every time a flow opens or closes.
- The `Details` toggle is [gone from `ErrorMessage`](https://github.com/safe-global/safe-wallet-monorepo/blob/dc473b3846f3c838f1f532a77180665fdd35a118/apps/web/src/components/tx/ErrorMessage/index.tsx#L88-L94), and so is the `Error code CGW-XXX` reference. An on-chain (GS) error and an unmapped Ledger state keep their code-only support reference; every other error is now its message alone. The raw error still reaches Sentry.
- Separately, a revert carrying a GS code we have specific copy for now shows that cause ([`getSpecificContractErrorMessage`](https://github.com/safe-global/safe-wallet-monorepo/blob/dc473b3846f3c838f1f532a77180665fdd35a118/packages/utils/src/services/exceptions/contractErrors.ts#L192-L202)) instead of the generic "will most likely fail" prediction. Codes whose only copy is the shared fallback, or whose copy has a placeholder we cannot fill on that surface, keep the prediction.

### A gas limit below the intrinsic minimum (WA-3523)

The rejection is now its own condition, resolved **before** the revert classification — for the same reason [`isNonceTooLowError`](<https://github.com/safe-global/safe-wallet-monorepo/blob/f43a672c20eb8ebeee8f289a9cf57c192822d597/apps/web/src/utils/transaction-errors.ts#L143-L156>) already is: viem misreads both as contract reverts. [`getGasLimitTooLowMessage`](<https://github.com/safe-global/safe-wallet-monorepo/blob/f43a672c20eb8ebeee8f289a9cf57c192822d597/apps/web/src/utils/transaction-errors.ts#L157-L178>) quotes back the minimum the node named:

> Gas limit too low. Minimum needed: 25,484. Increase the gas limit and try again.

Clients that name no minimum (Besu says only `Intrinsic gas exceeds gas limit`) get the sentence without the number. Nothing claims the contract reverted, and the raw payload is withheld from the toast's `detailedMessage` the way a Ledger/CGW failure already is.

It is applied at **all three** surfaces that classify this error, so the inline alert, the pre-execution check and the toast cannot disagree: [`TxSubmitError`](<https://github.com/safe-global/safe-wallet-monorepo/blob/f43a672c20eb8ebeee8f289a9cf57c192822d597/apps/web/src/components/tx/TxSubmitError/index.tsx#L75-L85>), [`TxCheckError`](<https://github.com/safe-global/safe-wallet-monorepo/blob/f43a672c20eb8ebeee8f289a9cf57c192822d597/apps/web/src/components/tx/TxCheckError/index.tsx#L83-L93>) and [`useTxNotifications`](<https://github.com/safe-global/safe-wallet-monorepo/blob/f43a672c20eb8ebeee8f289a9cf57c192822d597/apps/web/src/hooks/useTxNotifications.ts#L108-L109>). `TxCheckError` matters more than it looks: [`useIsValidExecution` simulates with the user's own gas limit](<https://github.com/safe-global/safe-wallet-monorepo/blob/f43a672c20eb8ebeee8f289a9cf57c192822d597/apps/web/src/components/tx-flow/actions/Execute/ExecuteForm.tsx#L154-L157>), and its fallback advice is *"To save gas costs, reject this transaction"* — the exact opposite of the fix.

### Differences from #8684

Two deliberate deviations, both driven by what `release` already carries:

1. **`useSafeMessageNotifications` is untouched here.** `release` already has [WA-3502 (#8675)](https://github.com/safe-global/safe-wallet-monorepo/pull/8675), which removed error handling from that hook entirely — there are no `*_FAILED` message events left to suppress, so #8684's changes to it are moot. I kept the release version rather than reintroducing the error path.
2. **[`SignMessage.test.tsx`](https://github.com/safe-global/safe-wallet-monorepo/blob/dc473b3846f3c838f1f532a77180665fdd35a118/apps/web/src/components/tx-flow/flows/SignMessage/SignMessage.test.tsx#L935-L950)** asserted `error-details` shows `CGW-502`, which these commits remove. #8684 fixed this inside its merge commit [`14124d65`](https://github.com/safe-global/safe-wallet-monorepo/commit/14124d655); the same resolution is folded into the first commit here so the series doesn't break mid-way.

### Review follow-up ([`dc473b38`](https://github.com/safe-global/safe-wallet-monorepo/commit/dc473b3846f3c838f1f532a77180665fdd35a118))

Addresses the automated review on #8684:

- Nothing renders the CGW support reference any more, so the surface that built it was dead: `getCgwSupportCode` had no caller left, `CgwErrorInfo.code` no reader, and `getCgwErrorCode` in `packages/utils` no consumer on either platform. All three are gone, along with the "for telemetry and tests" comment that no sink backed up. [`CgwErrorInfo`](https://github.com/safe-global/safe-wallet-monorepo/blob/dc473b3846f3c838f1f532a77180665fdd35a118/apps/web/src/utils/cgw-errors.ts#L10-L12) now carries only `status` + the shared copy.
- [`useIsTxFlowOpenRef`](https://github.com/safe-global/safe-wallet-monorepo/blob/dc473b3846f3c838f1f532a77180665fdd35a118/apps/web/src/components/tx-flow/useIsTxFlowOpen.ts#L12-L16) wrote its ref during render, so a render React discards could leave it claiming a flow is on screen when none is. It now writes in an effect, after commit.

Three review items were **not** applied, with reasoning:

- **NotificationCenter duplication / missing toggle / Topbar double-derivation.** [`NotificationCenter/index.tsx`](https://github.com/safe-global/safe-wallet-monorepo/blob/dc473b3846f3c838f1f532a77180665fdd35a118/apps/web/src/components/notification-center/NotificationCenter/index.tsx#L31-L93) is not rendered anywhere — its only referrer is its own `index.stories.tsx`. The live bell is [`Topbar/NotificationsPopover.tsx`](https://github.com/safe-global/safe-wallet-monorepo/blob/dc473b3846f3c838f1f532a77180665fdd35a118/apps/web/src/components/common/Header/Topbar/NotificationsPopover.tsx#L40). The duplication and the `handleClick` toggle bug both predate #8684, and the right fix is deleting the dead component — dev work, not a release hotfix.
- **Re-check the ref after the `await`.** The [check at event-arrival time](https://github.com/safe-global/safe-wallet-monorepo/blob/dc473b3846f3c838f1f532a77180665fdd35a118/apps/web/src/hooks/useTxNotifications.ts#L79) answers "was the flow on screen when the failure happened", which is what decides whether the flow showed it inline. Re-checking after the CGW round-trip would swallow the toast for an error that a later-opened, unrelated flow never displayed.
- **Coverage for the awaiting-confirmation effect.** `isTxFlowOpenRef` is only in the [subscriber effect's deps](https://github.com/safe-global/safe-wallet-monorepo/blob/dc473b3846f3c838f1f532a77180665fdd35a118/apps/web/src/hooks/useTxNotifications.ts#L156), not [that one](https://github.com/safe-global/safe-wallet-monorepo/blob/dc473b3846f3c838f1f532a77180665fdd35a118/apps/web/src/hooks/useTxNotifications.ts#L204), and `useRef` is stable, so it cannot re-fire. The coverage drop the review cited is in `ErrorMessage`, a different file.

## How to test it

Any Safe on Sepolia, connected with a signer wallet.

1. **Error inside a flow raises nothing:** start Send tokens, set an amount above the balance so estimation reverts, and submit. The inline alert explains the failure; no toast appears, and the bell shows no new unread count.
2. **Error outside a flow still toasts:** with DevTools throttling set to Offline, trigger a queue action from the transaction list. A toast appears; open the bell — the failure is **not** listed, and the badge did not increment.
3. **Toasts still clear from the bell:** with an error toast on screen, click the bell. The toast is dismissed even though the error is not in the list.
4. **Success/info unchanged:** propose a transaction. "Successfully added to queue" toasts *and* is listed in the center, with the badge incrementing.
5. **No CGW code, no raw payload:** block `safe-client.safe.global` in DevTools and open a transaction's details. The alert reads "Something went wrong on our end. Try again." with no `Error code CGW-500` chip and no `Details` toggle.
6. **GS/Ledger references kept:** execute a transaction that reverts with a GS code — the alert still shows `Error code GS013 · …` with its copy button.
7. **Specific GS copy:** a transaction below threshold shows "This transaction needs more confirmations before it can be executed." instead of "will most likely fail".
8. **Gas limit too low (WA-3523):** open a queued transaction ready to execute, expand **Advanced parameters**, set **Gas limit = 21000**, press **Execute** and confirm in the wallet. The alert reads "Gas limit too low. Minimum needed: 25,484. Increase the gas limit and try again." — no claim that the contract reverted, no `execTransaction` ABI or raw arguments anywhere, and the toast (if one appears) says the same thing. Raise the limit and the transaction executes.

## Affected flows

- Any tx flow that surfaces a failure inline (send tokens, execute, sign, replace/reject, batch, recovery) — the failure no longer also toasts or lands in the notification center
- Failures raised outside a flow (queue list actions, transaction details) — still toast, but are no longer recorded in the center
- Notification center / bell badge — lists and counts successes and info only
- Every alert rendered by `ErrorMessage` — the `Details` toggle is gone across all of them
- Every alert for a known CGW response state (429/422/451/5xx) across submit errors, estimation errors and failed single-tx loads
- Estimation/execution warnings for on-chain reverts with specific GS copy
- Execute with a manually lowered gas limit — both the pre-execution check and the submit error now name the minimum instead of blaming the contract

## Blast radius

- **`store/notificationsSlice`** — new `selectCenterNotifications` selector. Consumers switched to it: `Header/Topbar/hooks/useNotificationsPopover`, `Header/Topbar`, and the unrendered `notification-center/NotificationCenter`. Deliberately **not** switched: the toast host `common/Notifications`, `useShowNotificationsRenewalMessage`, and the awaiting-confirmation effects — they need the full list. `createSelector` keeps the filtered array referentially stable, so the switch does not add re-renders.
- **`components/tx/ErrorMessage`** — the shared alert behind `TxCheckError`, `TxSubmitError`, `SingleTx`, `SingleMsg` and every feature that renders an error. The `Details` toggle is removed for **all** error classes; the GS and Ledger code-only references are unchanged.
- **`hooks/useTxNotifications`** — gained a dependency on `TxModalContext` through `useIsTxFlowOpenRef`. Mounted app-wide from `_app.tsx`, inside the tx-flow provider.
- **`components/tx-flow/useIsTxFlowOpen`** — new, and the only consumer of `TxModalContext.txFlow` outside the flow itself.
- **`utils/cgw-errors`** — `getCgwSupportCode` and `CgwErrorInfo.code` deleted (no readers). `getCgwErrorInfo` is still read by `TxSubmitError`, `SignMessage` and `useTxNotifications`, and still returns `status` + the shared copy.
- **Mobile:** `packages/utils/services/exceptions/contractErrors` gains `getSpecificContractErrorMessage` (additive); `gatewayErrors` loses the unused `getCgwErrorCode` export. Mobile does not import `gatewayErrors` at all — verified by grep — and its full suite passes 353/353. No mobile behaviour change.
- **`utils/transaction-errors`** — new `getGasLimitTooLowMessage`, alongside the existing `isNonceTooLowError` / `isRateLimitError` classifiers. Pure function over the error text; no existing classifier changed.
- **`components/tx/TxCheckError`** — the pre-execution check behind `ExecuteForm`, `SignForm` and the recovery/batch flows. One branch added ahead of `willRevert`; the Hypernative, rate-limit, specific-GS and fallback branches are untouched.
- **Ordering is load-bearing in three places.** The new branch sits before the revert classification in `TxSubmitError`, before `willRevert` in `TxCheckError`, and after `guardErrorName` in the `useTxNotifications` chain. A genuine revert must still reach `COULD_NOT_SUBMIT_MESSAGE` with no retry offered — pinned by the existing tests at each surface.
- **No** feature flag, chain config, RTK Query endpoint, route or persisted-state change. `notifications` is not a persisted slice.

## Risks / not checked

- **Errors are now purely transient.** A user who misses a toast has no way back to it in the UI. This is the requested behaviour, but it is a real loss of a recovery path — worth a second opinion from product before merge.
- **Targeting `release`, not `dev`.** This change will need to land on `dev` separately (#8684 is still open there); until then the two branches diverge on this behaviour.
- Did not run E2E. The tx-flow suppression is unit-tested with `TxModalContext` mocked; the real provider wiring is covered only by `useIsTxFlowOpen.test.tsx`.
- Did not exercise a live failing transaction on every surface; no visual/Argos check (Argos does not auto-run).
- Did not test on mobile devices (no mobile behaviour change, but not exercised on-device).
- The decoded custom-error label (`UnapprovedHash (Hypernative guard)`) still renders inside the GS reference — unchanged here, but it means `customErrorRegistry` is still load-bearing for UI copy even though CGW codes are gone.
- No analytics change; `OVERVIEW_EVENTS.NOTIFICATION_CENTER` still fires on bell open regardless of what the list contains.
- The dead `NotificationCenter` component is left in place (see reasoning above) — it still carries the duplicated bell logic and its own latent toggle bug.
- **WA-3523 is matched on the RPC error text**, since neither viem nor ethers gives this rejection a distinctive code. Only phrasings containing "intrinsic gas too low" (geth/erigon/reth/Nethermind) or "intrinsic gas exceeds" (Besu) are recognised; another client's wording would fall through to the old copy rather than break.
- **Did not execute a live low-gas transaction against a node.** The classifier and all three surfaces are unit-tested against the real geth phrasing, but the end-to-end path was not exercised.
- **The formatted minimum follows the viewer's locale** — `25,484` is the en-US rendering; a German locale shows `25.484`. Consistent with the rest of the app, but it means the number is not byte-identical to the ticket everywhere.
- **Out-of-gas is out of scope.** A gas limit high enough to pass intrinsic validation but too low to complete execution still reads as "will most likely fail… reject this transaction". Same wrong advice, different condition — not addressed here.

## Visual summary

Where a failure ends up, before and after:

```mermaid
flowchart LR
  E["Tx error<br/>(TxEvent.*_FAILED)"]

  subgraph before["Before"]
    direction TB
    B1{"Wallet<br/>rejection?"}
    B2["showNotification<br/>variant: error"]
    B3["Toast"]
    B4["Notification center<br/>+ unread badge"]
    B5["Inline alert in flow<br/>+ Error code CGW-502"]
    B1 -->|no| B2
    B2 --> B3
    B2 --> B4
    B1 -.-> B5
  end

  subgraph after["After"]
    direction TB
    A1{"Wallet<br/>rejection?"}
    A2{"Tx flow<br/>on screen?"}
    A3["Inline alert in flow<br/>message only"]
    A4["showNotification<br/>variant: error"]
    A5["Toast"]
    A6["Notification center<br/>filtered out by<br/>selectCenterNotifications"]
    A1 -->|no| A2
    A2 -->|"yes: return, nothing raised"| A3
    A2 -->|no| A4
    A4 --> A5
    A4 -.->|never listed| A6
  end

  E --> B1
  E --> A1
```

What each error class shows in an alert now:

```mermaid
flowchart TD
  ERR["error passed to ErrorMessage"] --> GS{"GS code, or<br/>custom-error revert?"}
  GS -->|yes| GSOUT["message<br/>+ Error code GS013 · CustomError"]
  GS -->|no| LED{"Ledger device<br/>failure?"}
  LED -->|"mapped state"| LEDA["message only"]
  LED -->|"unknown state"| LEDB["message<br/>+ Error code LEDGER-UNKNOWN"]
  LED -->|no| GASLIM{"Gas limit below<br/>intrinsic cost?"}
  GASLIM -->|yes| GASOUT["Gas limit too low.<br/>Minimum needed: 25,484.<br/>Increase the gas limit and try again.<br/>NEW (WA-3523): was a revert claim"]
  GASLIM -->|no| RAW["message only<br/>CHANGED: was message<br/>+ Details toggle with raw payload"]

  style RAW stroke-width:3px
  style GASOUT stroke-width:3px
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — not tested on-device; no mobile behaviour change (`contractErrors` addition is additive, `gatewayErrors` loses an export mobile never imported), and the mobile suite passes 353/353
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics change; noted under Risks
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — `notificationsSlice` (filter + stable reference), `useNotificationsPopover`, `Topbar`, `NotificationsPopover`, `ErrorMessage`, `TxCheckError`, `TxSubmitError`, `SingleTx`, `SingleMsg`, `SignMessage`, `useTxNotifications`, `useIsTxFlowOpen`, `cgw-errors`, `safeMsgSender`, `gatewayErrors`, `contractErrors`, and for WA-3523: `transaction-errors` (geth phrasing, Besu phrasing with no quoted minimum, the `have/want` variant, and unrelated errors including a real revert) plus a case at each of the three surfaces
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

### Verification run

- `yarn verify:changed` — exit 0: prettier clean, lint 0 errors (19 pre-existing warnings, none in touched files), **8391/8391** web tests pass (8 added for WA-3523)
- `yarn turbo run type-check test --filter=@safe-global/utils` — pass, **1415/1415**
- `apps/mobile` full suite — **353/353** suites, 2930 passed / 1 skipped

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
