### PR TITLE
chore: derive web app version from release tags instead of package.json

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -6,6 +6,9 @@ inputs:
   prod: # id of input
     description: 'Production build flag'
     required: false
+  app-version:
+    description: 'App version from the release tag; defaults to the latest published release'
+    required: false
 
 runs:
   using: 'composite'
@@ -28,6 +31,7 @@ runs:
         NEXT_PUBLIC_IS_PRODUCTION: ${{ inputs.prod }}
         PROD: ${{ inputs.prod }}
         COMMIT_SHA: ${{ github.sha }}
+        APP_VERSION: ${{ inputs.app-version }}
 
     - name: Upload source maps to Datadog
       shell: bash
@@ -54,6 +58,7 @@ runs:
       env:
         PROD: ${{ inputs.prod }}
         COMMIT_SHA: ${{ github.sha }}
+        APP_VERSION: ${{ inputs.app-version }}
     - name: Generate SRI for static scripts
       shell: bash
       # Skip SRI for Cypress test builds (NODE_ENV=cypress)

--- a/.github/workflows/web-linear-release.yml
+++ b/.github/workflows/web-linear-release.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (e.g. 1.92.0) - defaults to apps/web/package.json'
+        description: 'Release version (e.g. 1.92.0) - defaults to the latest web-v* tag'
         required: false
         type: string
       command:
@@ -63,7 +63,7 @@ jobs:
           if [ -n "$INPUT_VERSION" ]; then
             VERSION="$INPUT_VERSION"
           else
-            VERSION=$(node -p "require('./apps/web/package.json').version")
+            VERSION=$(git tag -l 'web-v*' --sort=-v:refname | head -n 1 | sed 's/^web-v//')
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Linear release version: $VERSION"

--- a/.github/workflows/web-release-start.yml
+++ b/.github/workflows/web-release-start.yml
@@ -80,12 +80,11 @@ jobs:
             echo "✅ Using provided version: $VERSION"
           else
             # Auto-increment version based on release type
-            cd apps/web
-            CURRENT_VERSION=$(node -p "require('./package.json').version" || echo "")
+            CURRENT_VERSION=$(git tag -l 'web-v*' --sort=-v:refname | head -n 1 | sed 's/^web-v//')
 
             # Validate extraction succeeded
             if [ -z "$CURRENT_VERSION" ]; then
-              echo "❌ Error: Could not extract version from package.json"
+              echo "❌ Error: Could not find a previous web-v* release tag"
               exit 1
             fi
 
@@ -126,48 +125,29 @@ jobs:
           echo "✅ Version is new"
 
       - name: Check for concurrent release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_BRANCH: release/${{ steps.version.outputs.version }}
         run: |
-          RELEASE_COMMIT=$(git ls-remote origin refs/heads/release | cut -f1)
-          if [ -n "$RELEASE_COMMIT" ]; then
-            # Release branch exists, check if it differs from base
-            BASE_COMMIT=$(git ls-remote origin "refs/heads/${{ steps.base.outputs.branch }}" | cut -f1)
-            if [ "$RELEASE_COMMIT" != "$BASE_COMMIT" ]; then
-              echo "⚠️  Warning: The 'release' branch already exists and differs from ${{ steps.base.outputs.branch }}"
-              echo "This may indicate a concurrent or in-progress release."
-              echo ""
-              echo "If you're sure you want to overwrite it, re-run this workflow."
-              echo "Otherwise, check for open release PRs first."
-              exit 1
-            fi
+          OPEN_RELEASES=$(gh pr list --base main --state open --json headRefName \
+            --jq '.[] | select(.headRefName | startswith("release/")) | .headRefName' \
+            | grep -vx "$RELEASE_BRANCH" || true)
+          if [ -n "$OPEN_RELEASES" ]; then
+            echo "⚠️  Warning: Another release is already in progress:"
+            echo "$OPEN_RELEASES"
+            echo ""
+            echo "Finish or close that release PR before starting a new one."
+            exit 1
           fi
           echo "✅ Safe to create/update release branch"
 
       - name: Create/update release branch
+        env:
+          RELEASE_BRANCH: release/${{ steps.version.outputs.version }}
         run: |
-          git checkout -B release origin/${{ steps.base.outputs.branch }}
-          git push origin release
-          echo "✅ Release branch created from ${{ steps.base.outputs.branch }}"
-
-      - name: Bump version in package.json
-        run: |
-          cd apps/web
-          # Update version using Node.js
-          node -e "
-            const fs = require('fs');
-            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            pkg.version = '${{ steps.version.outputs.version }}';
-            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-          "
-          echo "✅ Version bumped to ${{ steps.version.outputs.version }}"
-
-      - name: Commit version bump
-        run: |
-          git config user.name "GH Signer Bot"
-          git config user.email "gh-signer-bot@safe.global"
-          git add apps/web/package.json
-          git commit -S -m "${{ steps.version.outputs.version }}"
-          git push origin release
-          echo "✅ Version committed"
+          git checkout -B "$RELEASE_BRANCH" origin/${{ steps.base.outputs.branch }}
+          git push origin "$RELEASE_BRANCH"
+          echo "✅ Release branch $RELEASE_BRANCH created from ${{ steps.base.outputs.branch }}"
 
       - name: Generate changelog
         id: changelog
@@ -227,7 +207,7 @@ jobs:
           Merge commits are disabled in this repo. Use the command line:
 
           \`\`\`bash
-          git push origin release:main
+          git push origin release/${{ steps.version.outputs.version }}:main
           \`\`\`
 
           ---
@@ -242,7 +222,7 @@ jobs:
           # Create the PR
           PR_URL=$(gh pr create \
             --base main \
-            --head release \
+            --head release/${{ steps.version.outputs.version }} \
             --title "Release web-v${{ steps.version.outputs.version }}" \
             --body "$PR_BODY" \
             --label "release" \

--- a/.github/workflows/web-tag-release.yml
+++ b/.github/workflows/web-tag-release.yml
@@ -17,7 +17,7 @@ jobs:
     if: >-
       github.event.pull_request.merged == true ||
       (github.event.action == 'closed' &&
-       startsWith(github.event.pull_request.head.ref, 'release') &&
+       startsWith(github.event.pull_request.head.ref, 'release/') &&
        github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       actions: write
@@ -59,10 +59,17 @@ jobs:
             exit 1
           fi
 
-      - name: Extract version
+      - name: Extract version from release branch name
         id: version
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          NEW_VERSION=$(node -p 'require("./apps/web/package.json").version')
+          if [[ "$HEAD_REF" =~ ^release/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            NEW_VERSION="${BASH_REMATCH[1]}"
+          else
+            echo "::error::PR branch '$HEAD_REF' is not a release branch (expected 'release/X.Y.Z')"
+            exit 1
+          fi
           echo "version=web-v$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "version_number=$NEW_VERSION" >> $GITHUB_OUTPUT
 
@@ -142,6 +149,12 @@ jobs:
 
       - uses: ./.github/actions/yarn
 
+      - name: Extract app version from release tag
+        id: app_version
+        env:
+          RELEASE_TAG: ${{ needs.tag.outputs.version }}
+        run: echo "version=${RELEASE_TAG#web-v}" >> $GITHUB_OUTPUT
+
       - uses: ./.github/actions/build
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
@@ -204,6 +217,7 @@ jobs:
           NEXT_PUBLIC_ZODIAC_SECURITY_CHECK_URL: ${{ secrets.NEXT_PUBLIC_ZODIAC_SECURITY_CHECK_URL }}
         with:
           prod: ${{ true }}
+          app-version: ${{ steps.app_version.outputs.version }}
 
       - name: Add SRI to scripts
         run: node ./scripts/integrity-hashes.cjs

--- a/apps/web-tanstack/vite.config.ts
+++ b/apps/web-tanstack/vite.config.ts
@@ -13,6 +13,7 @@ import { execSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { swAssets } from './plugins/vite-plugin-sw-assets'
 import { importMapIntegrity } from './plugins/vite-plugin-import-map-integrity'
+import { resolveAppVersion } from '../web/scripts/resolve-app-version.cjs'
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname)
 const webRoot = path.resolve(__dirname, '../web')
@@ -27,7 +28,7 @@ if (!commitHash) {
   }
 }
 
-const appVersion = process.env.VISUAL_REGRESSION_BUILD === 'true' ? 'vistest' : pkg.version
+const appVersion = process.env.VISUAL_REGRESSION_BUILD === 'true' ? 'vistest' : resolveAppVersion()
 if (process.env.VISUAL_REGRESSION_BUILD === 'true') commitHash = 'vistest'
 
 // See decisions.md: env vars are renamed to VITE_* but a transitional shim

--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -4,6 +4,7 @@ import type { StorybookConfig } from '@storybook/nextjs'
 import path from 'path'
 import { readFileSync } from 'fs'
 import { fileURLToPath } from 'url'
+import { resolveAppVersion } from '../scripts/resolve-app-version.cjs'
 
 const require = createRequire(import.meta.url)
 
@@ -12,7 +13,8 @@ const __dirname = path.dirname(__filename)
 const packageJsonPath = path.join(__dirname, '../package.json')
 const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
 
-process.env.NEXT_PUBLIC_APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION || packageJson.version
+const appVersion = resolveAppVersion()
+process.env.NEXT_PUBLIC_APP_VERSION = appVersion
 process.env.NEXT_PUBLIC_APP_HOMEPAGE = process.env.NEXT_PUBLIC_APP_HOMEPAGE || packageJson.homepage
 
 const config: StorybookConfig = {
@@ -168,7 +170,7 @@ const config: StorybookConfig = {
   env: (config) => ({
     ...config,
     NEXT_PUBLIC_HUBSPOT_CONFIG: process.env.NEXT_PUBLIC_HUBSPOT_CONFIG ?? '',
-    NEXT_PUBLIC_APP_VERSION: process.env.NEXT_PUBLIC_APP_VERSION || packageJson.version,
+    NEXT_PUBLIC_APP_VERSION: appVersion,
     NEXT_PUBLIC_APP_HOMEPAGE: process.env.NEXT_PUBLIC_APP_HOMEPAGE || packageJson.homepage,
     // Enable official host features (logo, branding) in Storybook
     NEXT_PUBLIC_IS_OFFICIAL_HOST: 'true',

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/github/license/safe-global/safe-wallet-web)](https://github.com/safe-global/safe-wallet-web/blob/main/LICENSE)
 ![Tests](https://img.shields.io/github/actions/workflow/status/safe-global/safe-wallet-web/test.yml?branch=main&label=tests)
-![GitHub package.json version (branch)](https://img.shields.io/github/package-json/v/safe-global/safe-wallet-web)
+![GitHub release](https://img.shields.io/github/v/release/safe-global/safe-wallet-web?filter=web-v*&label=version)
 [![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/safe-global/safe-wallet-web/badge)](https://www.gitpoap.io/gh/safe-global/safe-wallet-web)
 
 # Safe{Wallet} web app

--- a/apps/web/docs/release-procedure-automated.md
+++ b/apps/web/docs/release-procedure-automated.md
@@ -34,10 +34,10 @@ GitHub → Actions → "🚀 Start Web Release"
 
 **What happens automatically:**
 
-- ✅ Creates/updates `release` branch
-- ✅ Bumps version in `package.json`
+- ✅ Creates the `release/X.Y.Z` branch
+- ✅ Derives the next version from the latest `web-v*` tag
 - ✅ Generates changelog with grouped changes
-- ✅ Creates PR from `release` to `main`
+- ✅ Creates PR from `release/X.Y.Z` to `main`
 - ✅ Sends Slack notification (if configured)
 
 **Result:** Pull Request ready for QA (~2-3 minutes)
@@ -47,7 +47,7 @@ GitHub → Actions → "🚀 Start Web Release"
 1. Find the release PR (has `release` label)
 2. Test the changes thoroughly
 3. If bugs found:
-   - Create PRs targeting `release` branch
+   - Create PRs targeting the `release/X.Y.Z` branch
    - Merge fixes
    - Continue testing
 4. When all tests pass → Approve the PR
@@ -66,7 +66,7 @@ GitHub → Actions → "🚀 Start Web Release"
    **Do not use GitHub's merge button!** Use the command line:
 
    ```bash
-   git push origin release:main
+   git push origin release/X.Y.Z:main
    ```
 
 **What happens automatically:**
@@ -201,7 +201,7 @@ Notifications will be sent for:
 ### What's Automated
 
 - Creating release branches
-- Bumping versions
+- Deriving versions from release tags
 - Generating changelogs
 - Creating and merging PRs
 - Syncing branches

--- a/apps/web/docs/release-procedure.md
+++ b/apps/web/docs/release-procedure.md
@@ -16,10 +16,9 @@ When it's time to make a release, we "freeze" the code by creating a release bra
 
 ### Preparing a release branch
 
-- Create a code-freeze branch named `release`
+- Create a code-freeze branch named `release/X.Y.Z`, where `X.Y.Z` is the new version. The git tag and the app version are taken from this name
   - If it's a regular release, this branch is typically based off of `dev`
   - For hot fixes, it would be `main` + cherry-picked commits
-- Bump the version in the `package.json` as a separate commit with the commit message equal to the exact version
 - Create a PR with the list of changes
 
   > 💡 To generate a quick changelog:
@@ -35,21 +34,13 @@ When it's time to make a release, we "freeze" the code by creating a release bra
   > ```
 
 ```bash
-git checkout release # switch to the release branch
+git checkout -B release/1.54.0 # where 1.54.0 is the new version
 git fetch --all; git reset --hard origin/dev # sync it with dev
-```
-
-Change the version in `app/web/package.json` to the new version.
-
-```bash
-git add .
-git commit -m '1.54.0' # where 1.54.0 is the new version
-git push
 ```
 
 Once pushed:
 
-- Create a PR from `release` to `main`.
+- Create a PR from `release/1.54.0` to `main`.
 - Add the PR to the Wallet project and set the status to `Ready for QA`
 
 ### QA
@@ -73,7 +64,7 @@ git reset --hard origin/main
 - Pull from the release branch:
 
 ```
-git pull origin release
+git pull origin release/1.54.0
 ```
 
 - Push:
@@ -84,7 +75,7 @@ git push
 
 A deployment workflow will be triggered and it will do the following things:
 
-- Create a new git tag from the version in `package.json`
+- Create a new git tag from the version in the release branch name
 - Create and publish a [GitHub release](https://github.com/safe-global/safe-wallet-web/releases) linked to this tag, with a changelog taken from the release PR
 - Build production assets
 - Upload to S3

--- a/apps/web/jest.config.cjs
+++ b/apps/web/jest.config.cjs
@@ -1,12 +1,14 @@
 const path = require('path')
 const fs = require('fs')
 
+const { resolveAppVersion } = require('./scripts/resolve-app-version.cjs')
+
 // Set environment variables before modules are loaded
-if (!process.env.NEXT_PUBLIC_APP_VERSION || !process.env.NEXT_PUBLIC_APP_HOMEPAGE) {
+process.env.NEXT_PUBLIC_APP_VERSION = resolveAppVersion()
+if (!process.env.NEXT_PUBLIC_APP_HOMEPAGE) {
   const packageJsonPath = path.join(__dirname, 'package.json')
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
-  process.env.NEXT_PUBLIC_APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION || packageJson.version
-  process.env.NEXT_PUBLIC_APP_HOMEPAGE = process.env.NEXT_PUBLIC_APP_HOMEPAGE || packageJson.homepage
+  process.env.NEXT_PUBLIC_APP_HOMEPAGE = packageJson.homepage
 }
 
 const nextJest = require('next/jest')

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -10,6 +10,7 @@ import { readFile } from 'fs/promises'
 import { fileURLToPath } from 'url'
 import { execSync } from 'child_process'
 import { SriManifestWebpackPlugin } from './plugins/sri-manifest-webpack-plugin.mjs'
+import { resolveAppVersion } from './scripts/resolve-app-version.cjs'
 
 let withRspack = null
 if (process.env.USE_RSPACK === '1') {
@@ -36,6 +37,14 @@ if (!commitHash) {
   } catch {
     commitHash = ''
   }
+}
+
+let appVersion = resolveAppVersion()
+
+// Pin volatile values for visual regression builds to avoid Chromatic diffs
+if (process.env.VISUAL_REGRESSION_BUILD === 'true') {
+  commitHash = 'vistest'
+  appVersion = 'vistest'
 }
 
 const withPWA = withPWAInit({
@@ -67,19 +76,11 @@ const withPWA = withPWAInit({
     },
   ],
 
-  cacheId: pkg.version,
+  cacheId: appVersion,
 })
 
 const isProd = process.env.NODE_ENV === 'production'
 const enableExperimentalOptimizations = process.env.ENABLE_EXPERIMENTAL_OPTIMIZATIONS === '1'
-
-let appVersion = pkg.version
-
-// Pin volatile values for visual regression builds to avoid Chromatic diffs
-if (process.env.VISUAL_REGRESSION_BUILD === 'true') {
-  commitHash = 'vistest'
-  appVersion = 'istest' // UI prepends 'v' → displays 'vistest'
-}
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -92,7 +93,7 @@ const nextConfig = {
 
   env: {
     NEXT_PUBLIC_COMMIT_HASH: commitHash,
-    NEXT_PUBLIC_APP_VERSION: process.env.VISUAL_REGRESSION_BUILD === 'true' ? 'vistest' : pkg.version,
+    NEXT_PUBLIC_APP_VERSION: appVersion,
     NEXT_PUBLIC_APP_HOMEPAGE: pkg.homepage,
     VISUAL_REGRESSION_BUILD: process.env.VISUAL_REGRESSION_BUILD || '',
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,7 +2,6 @@
   "name": "@safe-global/web",
   "homepage": "https://github.com/safe-global/safe-wallet-web",
   "license": "GPL-3.0",
-  "version": "1.99.2",
   "type": "module",
   "scripts": {
     "pw:test": "npx playwright test --config=e2e/playwright.config.ts --project=chromium",

--- a/apps/web/scripts/generate-version.mjs
+++ b/apps/web/scripts/generate-version.mjs
@@ -3,11 +3,10 @@ import { execFileSync } from 'node:child_process'
 import { readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { resolveAppVersion } from './resolve-app-version.cjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const webRoot = resolve(here, '..')
-
-const pkg = JSON.parse(readFileSync(resolve(webRoot, 'package.json'), 'utf8'))
 
 const git = (...args) => {
   try {
@@ -38,7 +37,7 @@ const branch =
   headRef || (refType === 'branch' ? refName : '') || (gitBranch && gitBranch !== 'HEAD' ? gitBranch : '') || null
 
 const version = {
-  version: pkg.version,
+  version: resolveAppVersion(),
   commit,
   commitShort,
   tag,

--- a/apps/web/scripts/github/resolve-web-build-env.sh
+++ b/apps/web/scripts/github/resolve-web-build-env.sh
@@ -6,10 +6,20 @@
 # expects from them. It must be *sourced* from the same shell that invokes the
 # bundler, so the exports are not subject to `$GITHUB_ENV` precedence rules.
 #
-# Expects: PROD ("true" for production builds), COMMIT_SHA.
+# Expects: PROD ("true" for production builds), COMMIT_SHA, APP_VERSION (release builds only).
 
 SHA="${COMMIT_SHA:-}"
 export NEXT_PUBLIC_COMMIT_HASH="${NEXT_PUBLIC_COMMIT_HASH:-${SHA:0:7}}"
+
+# Release builds pass APP_VERSION from the GitHub release tag. Every other build shows
+# the latest published release; the checkout is shallow, so read the tags from the remote.
+export NEXT_PUBLIC_APP_VERSION="${NEXT_PUBLIC_APP_VERSION:-${APP_VERSION:-}}"
+if [ -z "$NEXT_PUBLIC_APP_VERSION" ]; then
+  LATEST_RELEASE=$(git ls-remote --tags --refs origin 'refs/tags/web-v*' 2>/dev/null | sed 's|.*refs/tags/web-v||' | sort -V | tail -n 1 || true)
+  if [ -n "$LATEST_RELEASE" ]; then
+    export NEXT_PUBLIC_APP_VERSION="$LATEST_RELEASE"
+  fi
+fi
 
 # Staging, dev and PR-preview builds use the devstaging Infura tokens.
 if [ "${PROD:-}" != "true" ]; then

--- a/apps/web/scripts/resolve-app-version.cjs
+++ b/apps/web/scripts/resolve-app-version.cjs
@@ -1,0 +1,23 @@
+const { execFileSync } = require('node:child_process')
+
+const TAG_PREFIX = 'web-v'
+const FALLBACK_VERSION = '0.0.0'
+
+// Release builds inject NEXT_PUBLIC_APP_VERSION from the GitHub release tag; local
+// builds use the latest release tag reachable from HEAD.
+function resolveAppVersion() {
+  if (process.env.NEXT_PUBLIC_APP_VERSION) return process.env.NEXT_PUBLIC_APP_VERSION
+  try {
+    const tag = execFileSync('git', ['describe', '--tags', '--abbrev=0', '--match', `${TAG_PREFIX}*`], {
+      cwd: __dirname,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim()
+    return tag.startsWith(TAG_PREFIX) ? tag.slice(TAG_PREFIX.length) : FALLBACK_VERSION
+  } catch {
+    return FALLBACK_VERSION
+  }
+}
+
+module.exports = { resolveAppVersion }


### PR DESCRIPTION
## What it solves

Resolves: N/A

The web app version lived in `apps/web/package.json`, so every release needed a dedicated version-bump commit on a single shared `release` branch. That commit was the only reason the branch existed as a mutable, long-lived ref, it blocked running two releases side by side, and it duplicated information the `web-v*` git tag already carries.

## How this PR fixes it

The `web-v*` tag becomes the single source of truth for the web app version. `package.json` no longer has a `version` field.

- A new `apps/web/scripts/resolve-app-version.cjs` resolves the version in one place: `NEXT_PUBLIC_APP_VERSION` if set, otherwise the nearest `web-v*` tag reachable from HEAD via `git describe`, otherwise `0.0.0`. Next.js, Vite (web-tanstack), Storybook, Jest and `generate-version.mjs` all call it instead of reading `pkg.version`.
- Release branches are now `release/X.Y.Z`. The start workflow derives the next version from the latest `web-v*` tag, and the tag workflow parses the version out of the branch name instead of `package.json`. The version-bump commit and the shared `release` branch are gone.
- Concurrent-release detection now checks for other open `release/*` PRs against `main` instead of comparing the `release` ref to its base.
- The tag workflow passes the release version into the build action as `app-version`. For every other CI build the version comes from the latest `web-v*` tag on the remote, because the checkout is shallow and has no tags locally.
- The Linear release workflow, the README badge and both release-procedure docs are updated to match.

## How to test it

1. Check out this branch and run `yarn workspace @safe-global/web dev`. The footer version should show the latest `web-v*` tag reachable from your HEAD, not a `package.json` value.
2. Run `NEXT_PUBLIC_APP_VERSION=9.9.9 yarn workspace @safe-global/web build` and confirm the built app reports `v9.9.9`, and that the PWA `cacheId` in the generated service worker is `9.9.9`.
3. Run `yarn workspace @safe-global/web storybook` and `yarn workspace @safe-global/web-tanstack dev` and check the version is populated in both.
4. Dry-run the workflows on a fork or with `act`: trigger "Start Web Release" with no version input and confirm it computes the next patch/minor from the latest tag and opens a PR from `release/X.Y.Z`. Merge that PR via `git push origin release/X.Y.Z:main` and confirm `web-tag-release.yml` tags `web-vX.Y.Z` and builds with that version.

## Affected flows

- Release manager starts a web release from the "Start Web Release" workflow.
- Release manager merges a release PR into `main` and the tag/deploy workflow publishes the GitHub release and production build.
- Release manager runs the Linear release workflow without an explicit version.
- Any user reads the app version in the footer or settings of a production, staging, PR-preview or local build.

## Blast radius

- `NEXT_PUBLIC_APP_VERSION` consumers: `apps/web/src/config/version.ts`, `apps/web-tanstack/src/config/env.ts`, the PWA `cacheId` in `next.config.mjs`, Datadog source-map upload in the build action, and `generate-version.mjs`. All now receive the same value from `resolve-app-version.cjs`.
- `apps/web/package.json` no longer has `version`. Any tooling that reads it gets `undefined`. `apps/web/.storybook-vite/main.ts` still reads `packageJson.version` and is not updated in this PR, so its Storybook build will report an empty version until it is switched to `resolveAppVersion()`.
- `web-tag-release.yml` only fires for branches matching `release/`. A PR from a bare `release` branch merged after this lands will not be tagged or deployed.
- The build action gained an optional `app-version` input. Callers that omit it fall back to the latest remote tag, so existing callers keep working.
- Mobile is untouched. The mobile release workflow still reads `apps/mobile/package.json`.

## Risks / not checked

- Did not run the GitHub workflows end to end. The shell in `web-release-start.yml`, `web-tag-release.yml` and `resolve-web-build-env.sh` was reviewed but not executed in CI.
- Did not verify `git ls-remote --tags` works under the shallow checkout used by the build action, or that it has network access at that step.
- Did not update or test `apps/web/.storybook-vite/main.ts`, see Blast radius.
- Did not add unit tests for `resolve-app-version.cjs`. It is a build-time script that shells out to git, so the fallbacks were checked manually only.
- Did not test on mobile. No shared packages are touched.
- The first release after this lands must have a `web-v*` tag reachable from `dev`, otherwise "Start Web Release" fails with "Could not find a previous web-v* release tag".

## Visual summary

```mermaid
flowchart LR
  subgraph before [Before]
    A1[package.json version] --> B1[Bump commit on shared release branch]
    B1 --> C1[Merge to main]
    C1 --> D1[Read package.json → tag web-vX.Y.Z]
  end
  subgraph after [After]
    A2[Latest web-v* tag] --> B2[Compute next version]
    B2 --> C2[Branch release/X.Y.Z, no bump commit]
    C2 --> D2[Merge to main]
    D2 --> E2[Parse version from branch name → tag web-vX.Y.Z]
    E2 --> F2[Build with APP_VERSION from tag]
  end
  subgraph resolve [resolve-app-version.cjs]
    R1{NEXT_PUBLIC_APP_VERSION set?} -- yes --> R2[use it]
    R1 -- no --> R3{git describe web-v*}
    R3 -- found --> R4[use tag]
    R3 -- none --> R5[0.0.0]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (not applicable, no shared packages touched)
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics impact)
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 (build-time script and CI workflows only, no unit test added)
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
