### PR TITLE
fix: fetch recovery events in windows within the RPC getLogs block limit

### DIFF
--- a/apps/web/src/features/recovery/services/__tests__/recovery-state.test.ts
+++ b/apps/web/src/features/recovery/services/__tests__/recovery-state.test.ts
@@ -10,8 +10,10 @@ import {
   _getRecoveryQueueItemTimestamps,
   _getSafeCreationReceipt,
   _isMaliciousRecovery,
+  getRecoveryState,
 } from '../recovery-state'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
+import { Errors, logError } from '@/services/exceptions'
 import { encodeMultiSendData } from '@safe-global/protocol-kit'
 import { getMultiSendCallOnlyDeployment, getSafeSingletonDeployment } from '@safe-global/safe-deployments'
 import { Interface } from 'ethers'
@@ -22,6 +24,13 @@ import { createMockWeb3Provider } from '@safe-global/utils/tests/web3Provider'
 import { SENTINEL_ADDRESS } from '@safe-global/utils/utils/constants'
 
 jest.mock('@/hooks/wallets/web3')
+
+jest.mock('@/services/exceptions', () => ({
+  ...jest.requireActual('@/services/exceptions'),
+  logError: jest.fn(),
+}))
+
+const mockedLogError = logError as jest.MockedFunction<typeof logError>
 
 const mockUseWeb3ReadOnly = useWeb3ReadOnly as jest.MockedFunction<typeof useWeb3ReadOnly>
 
@@ -362,6 +371,7 @@ describe('recovery-state', () => {
       const safeCreationReceipt = {
         blockNumber: faker.number.int(),
       } as TransactionReceipt
+      const latestBlock = safeCreationReceipt.blockNumber + faker.number.int({ min: 1, max: 9_999 })
       const transactionAddedReceipt = {
         from: faker.finance.ethereumAddress(),
       } as TransactionReceipt
@@ -443,6 +453,9 @@ describe('recovery-state', () => {
       ;(mockProvider.getTransactionReceipt as jest.MockedFunction<JsonRpcProvider['getTransactionReceipt']>)
         .mockResolvedValueOnce(safeCreationReceipt)
         .mockResolvedValue(transactionAddedReceipt)
+      ;(mockProvider as unknown as { getBlockNumber: jest.Mock }).getBlockNumber = jest
+        .fn()
+        .mockResolvedValue(latestBlock)
 
       const mockDelayModifierAddress = faker.finance.ethereumAddress()
 
@@ -503,8 +516,225 @@ describe('recovery-state', () => {
       expect(queryFilterMock).toHaveBeenCalledWith(
         [...topics, [zeroPadValue('0x02', 32), zeroPadValue('0x03', 32)]],
         safeCreationReceipt.blockNumber,
-        'latest',
+        latestBlock,
       )
+    })
+
+    it('should query the block range in windows if it exceeds the eth_getLogs limit', async () => {
+      const safeAddress = faker.finance.ethereumAddress()
+      const version = '1.3.0'
+      const transactionService = faker.internet.url({ appendSlash: false })
+      const transactionHash = `0x${faker.string.hexadecimal()}`
+      const safeCreationReceipt = {
+        blockNumber: 100,
+      } as TransactionReceipt
+      const latestBlock = 20_500
+      const transactionAddedReceipt = {
+        from: faker.finance.ethereumAddress(),
+      } as TransactionReceipt
+
+      global.fetch = jest.fn().mockImplementation(() => {
+        return Promise.resolve({
+          json: () => Promise.resolve({ transactionHash }),
+          status: 200,
+          ok: true,
+        })
+      })
+
+      const recoverers = [faker.finance.ethereumAddress()]
+      const expiry = 0n
+      const delay = 69420n
+      const txNonce = 2n
+      const queueNonce = 4n
+
+      const makeTransactionAdded = (queueNonce: bigint, to: string) => ({
+        args: {
+          queueNonce,
+          to,
+          value: 0n,
+          data: '0x',
+        },
+      })
+
+      const topics = [id('TransactionAdded(uint256,bytes32,address,uint256,bytes,uint8)')]
+      const queryNonces = [zeroPadValue('0x02', 32), zeroPadValue('0x03', 32)]
+
+      // The most recent window only holds the newest queued tx, so a second window is queried
+      const queryFilterMock = jest
+        .fn()
+        .mockResolvedValueOnce([makeTransactionAdded(3n, safeAddress)])
+        .mockResolvedValueOnce([makeTransactionAdded(2n, safeAddress)])
+      const defaultTransactionAddedFilter = {
+        getTopicFilter: jest.fn().mockResolvedValue([...topics]),
+      }
+
+      const mockProvider = createMockWeb3Provider([
+        {
+          signature: DELAY_INTERFACE.getFunction('getModulesPaginated')?.selector!,
+          returnType: 'raw',
+          returnValue: DELAY_INTERFACE.encodeFunctionResult('getModulesPaginated', [recoverers, SENTINEL_ADDRESS]),
+        },
+        {
+          signature: DELAY_INTERFACE.getFunction('txExpiration')?.selector!,
+          returnType: 'uint256',
+          returnValue: expiry,
+        },
+        {
+          signature: DELAY_INTERFACE.getFunction('txCooldown')?.selector!,
+          returnType: 'uint256',
+          returnValue: delay,
+        },
+        {
+          signature: DELAY_INTERFACE.getFunction('txNonce')?.selector!,
+          returnType: 'uint256',
+          returnValue: txNonce,
+        },
+        {
+          signature: DELAY_INTERFACE.getFunction('queueNonce')?.selector!,
+          returnType: 'uint256',
+          returnValue: queueNonce,
+        },
+      ])
+      ;(mockProvider.getTransactionReceipt as jest.MockedFunction<JsonRpcProvider['getTransactionReceipt']>)
+        .mockResolvedValueOnce(safeCreationReceipt)
+        .mockResolvedValue(transactionAddedReceipt)
+      ;(mockProvider as unknown as { getBlockNumber: jest.Mock }).getBlockNumber = jest
+        .fn()
+        .mockResolvedValue(latestBlock)
+
+      const patchedDelayModifier = {
+        ...getModuleInstance(KnownContracts.DELAY, faker.finance.ethereumAddress(), mockProvider),
+        filters: {
+          TransactionAdded: () => cloneDeep(defaultTransactionAddedFilter),
+        },
+        getAddress: jest.fn().mockResolvedValue(faker.finance.ethereumAddress()),
+        txCreatedAt: jest.fn().mockResolvedValueOnce(420n).mockResolvedValueOnce(69420n),
+        queryFilter: queryFilterMock,
+      }
+
+      const recoveryState = await _getRecoveryStateItem({
+        delayModifier: patchedDelayModifier as unknown as Delay,
+        safeAddress,
+        transactionService,
+        provider: mockProvider,
+        chainId,
+        version,
+      })
+
+      // Stops querying once all queued txs are found
+      expect(queryFilterMock).toHaveBeenCalledTimes(2)
+      expect(queryFilterMock).toHaveBeenNthCalledWith(1, [...topics, queryNonces], 10_501, 20_500)
+      expect(queryFilterMock).toHaveBeenNthCalledWith(2, [...topics, queryNonces], 501, 10_500)
+
+      // Events are ordered chronologically across windows
+      expect(recoveryState.queue.map((item) => item.args.queueNonce)).toEqual([2n, 3n])
+    })
+
+    it('should not blank the recovery state of working Delay Modifiers if another one fails', async () => {
+      const safeAddress = faker.finance.ethereumAddress()
+      const version = '1.3.0'
+      const transactionService = faker.internet.url({ appendSlash: false })
+      const transactionHash = `0x${faker.string.hexadecimal()}`
+      const safeCreationReceipt = {
+        blockNumber: faker.number.int(),
+      } as TransactionReceipt
+      const latestBlock = safeCreationReceipt.blockNumber + faker.number.int({ min: 1, max: 9_999 })
+      const transactionAddedReceipt = {
+        from: faker.finance.ethereumAddress(),
+      } as TransactionReceipt
+
+      global.fetch = jest.fn().mockImplementation(() => {
+        return Promise.resolve({
+          json: () => Promise.resolve({ transactionHash }),
+          status: 200,
+          ok: true,
+        })
+      })
+
+      const recoverers = [faker.finance.ethereumAddress()]
+      const expiry = 0n
+      const delay = 69420n
+      const txNonce = 2n
+      const queueNonce = 4n
+      const transactionsAdded = [
+        {
+          args: {
+            queueNonce: 2n,
+            to: safeAddress,
+            value: 0n,
+            data: '0x',
+          },
+        },
+      ] as unknown as Array<TransactionAddedEvent.InputTuple>
+
+      const topics = [id('TransactionAdded(uint256,bytes32,address,uint256,bytes,uint8)')]
+      const queryFilterMock = jest.fn().mockImplementation(() => Promise.resolve(transactionsAdded))
+      const defaultTransactionAddedFilter = {
+        getTopicFilter: jest.fn().mockResolvedValue([...topics]),
+      }
+
+      const mockProvider = createMockWeb3Provider([
+        {
+          signature: DELAY_INTERFACE.getFunction('getModulesPaginated')?.selector!,
+          returnType: 'raw',
+          returnValue: DELAY_INTERFACE.encodeFunctionResult('getModulesPaginated', [recoverers, SENTINEL_ADDRESS]),
+        },
+        {
+          signature: DELAY_INTERFACE.getFunction('txExpiration')?.selector!,
+          returnType: 'uint256',
+          returnValue: expiry,
+        },
+        {
+          signature: DELAY_INTERFACE.getFunction('txCooldown')?.selector!,
+          returnType: 'uint256',
+          returnValue: delay,
+        },
+        {
+          signature: DELAY_INTERFACE.getFunction('txNonce')?.selector!,
+          returnType: 'uint256',
+          returnValue: txNonce,
+        },
+        {
+          signature: DELAY_INTERFACE.getFunction('queueNonce')?.selector!,
+          returnType: 'uint256',
+          returnValue: queueNonce,
+        },
+      ])
+      ;(mockProvider.getTransactionReceipt as jest.MockedFunction<JsonRpcProvider['getTransactionReceipt']>)
+        .mockResolvedValueOnce(safeCreationReceipt)
+        .mockResolvedValue(transactionAddedReceipt)
+      ;(mockProvider as unknown as { getBlockNumber: jest.Mock }).getBlockNumber = jest
+        .fn()
+        .mockResolvedValue(latestBlock)
+
+      const mockDelayModifierAddress = faker.finance.ethereumAddress()
+
+      const workingDelayModifier = {
+        ...getModuleInstance(KnownContracts.DELAY, mockDelayModifierAddress, mockProvider),
+        filters: {
+          TransactionAdded: () => cloneDeep(defaultTransactionAddedFilter),
+        },
+        getAddress: jest.fn().mockResolvedValue(mockDelayModifierAddress),
+        txCreatedAt: jest.fn().mockResolvedValueOnce(420n),
+        queryFilter: queryFilterMock,
+      }
+
+      const failingDelayModifier = {
+        getAddress: jest.fn().mockRejectedValue(new Error('Failed to fetch recovery state')),
+      } as unknown as Delay
+
+      const recoveryState = await getRecoveryState({
+        delayModifiers: [workingDelayModifier as unknown as Delay, failingDelayModifier],
+        safeAddress,
+        transactionService,
+        provider: mockProvider,
+        chainId,
+        version,
+      })
+
+      expect(recoveryState).toHaveLength(1)
+      expect(recoveryState[0].address).toBe(mockDelayModifierAddress)
+      expect(mockedLogError).toHaveBeenCalledWith(Errors._823, expect.any(Error))
     })
 
     it('should not query data if the queueNonce equals the txNonce', async () => {

--- a/apps/web/src/features/recovery/services/recovery-state.ts
+++ b/apps/web/src/features/recovery/services/recovery-state.ts
@@ -1,4 +1,5 @@
 import { SENTINEL_ADDRESS } from '@safe-global/utils/utils/constants'
+import { logError, Errors } from '@/services/exceptions'
 import memoize from 'lodash/memoize'
 import { getMultiSendCallOnlyDeployments } from '@safe-global/safe-deployments'
 import { getChainAgnosticAddress } from '@safe-global/utils/services/contracts/deployments'
@@ -13,6 +14,9 @@ import { decodeMultiSendData } from '@safe-global/protocol-kit'
 import { multicall } from '@safe-global/utils/utils/multicall'
 
 export const MAX_RECOVERER_PAGE_SIZE = 100
+
+// Most providers cap the eth_getLogs block range (e.g. Infura at 10 000 blocks)
+const MAX_QUERY_BLOCK_RANGE = 10_000
 
 type AddedEvent = TransactionAddedEvent.Log
 export type RecoveryQueueItem = AddedEvent & {
@@ -154,8 +158,28 @@ const queryAddedTransactions = async (
     throw new Error(`Could not fetch creation receipt for Safe ${safeAddress}`)
   }
 
-  // @ts-expect-error
-  return await delayModifier.queryFilter(topics, creationReceipt.blockNumber, 'latest')
+  // The block range is queried in windows within the provider's eth_getLogs limit,
+  // walking backwards from the latest block and stopping once all queued txs are found.
+  const latestBlock = await provider.getBlockNumber()
+
+  const addedTransactions: AddedEvent[] = []
+
+  for (let toBlock = latestBlock; toBlock >= creationReceipt.blockNumber; toBlock -= MAX_QUERY_BLOCK_RANGE) {
+    const fromBlock = Math.max(toBlock - MAX_QUERY_BLOCK_RANGE + 1, creationReceipt.blockNumber)
+
+    // @ts-expect-error
+    const events = await delayModifier.queryFilter(topics, fromBlock, toBlock)
+    addedTransactions.unshift(...events)
+
+    // Reorged logs do not count towards the expected amount of queued txs
+    const found = addedTransactions.filter((event) => !event.removed).length
+
+    if (found >= Number(diff)) {
+      break
+    }
+  }
+
+  return addedTransactions
 }
 
 const getRecoveryQueueItem = async ({
@@ -306,5 +330,15 @@ export function getRecoveryState({
   chainId: string
   version: SafeState['version']
 }): Promise<RecoveryState> {
-  return Promise.all(delayModifiers.map((delayModifier) => _getRecoveryStateItem({ delayModifier, ...rest })))
+  // One failing Delay Modifier must not blank the recovery state of the others
+  return Promise.all(
+    delayModifiers.map(async (delayModifier) => {
+      try {
+        return await _getRecoveryStateItem({ delayModifier, ...rest })
+      } catch (error) {
+        logError(Errors._823, error)
+        return null
+      }
+    }),
+  ).then((state) => state.filter((item) => item !== null))
 }

--- a/packages/utils/src/services/exceptions/ErrorCodes.ts
+++ b/packages/utils/src/services/exceptions/ErrorCodes.ts
@@ -85,6 +85,7 @@ enum ErrorCodes {
   _820 = '820: Error signing or submitting delegation',
   _821 = '821: Untrusted gas-fee refundReceiver returned by CGW',
   _822 = '822: Safe SDK singleton used while a SafeScope is active',
+  _823 = '823: Error fetching the recovery state',
 
   _900 = '900: Error loading Safe App',
   _901 = '901: Error processing Safe Apps SDK request',


### PR DESCRIPTION
## What it solves

Resolves #8642

A queued recovery never appears in the UI for Safes older than ~10 000 blocks: `queryAddedTransactions` fetches `TransactionAdded` logs from the Safe creation block to `latest` in a single `eth_getLogs` request, which providers such as Infura reject once the range exceeds their cap (10 000 blocks). The rejection propagates out of `getRecoveryState`, so the queue, the pending recovery card and the Cancel button all disappear exactly when a recovery is queued.

## How this PR fixes it

The block range is now queried in windows within the RPC getLogs limit (10 000 blocks), walking backwards from the latest block and stopping once all queued transactions (`queueNonce - txNonce`) have been found. Walking backwards keeps the common case at a single request, and reorged (`removed`) logs do not count towards the stop condition.

`getRecoveryState` also no longer lets one failing Delay Modifier blank the recovery state of the others: a failing modifier is skipped and logged as error `823` instead of rejecting the whole `Promise.all`.

The cooldown + expiration window proposed in #2792 was deliberately not used as the only bound, since a modifier with `txExpiration = 0` can hold an arbitrarily old queued transaction (as noted in the issue).

## How to test it

1. On Ethereum mainnet, open any Safe older than ~10 000 blocks with Account recovery enabled (e.g. a Safe created a few days ago).
2. As the Recoverer, propose a recovery.
3. Open the transaction queue or Settings -> Security & Login: the queued recovery now appears with its remaining delay and a Cancel button, instead of rendering nothing.
4. In the network tab, `eth_getLogs` requests are now sent in windows of at most 10 000 blocks.

Unit tests: `apps/web/src/features/recovery/services/__tests__/recovery-state.test.ts` covers a multi-window range with early stop and the failure isolation between Delay Modifiers.

## Affected flows

- Recoverer or owner views the queued recovery state (transaction queue, dashboard, Settings -> Security & Login) on Safes whose age exceeds the RPC getLogs range limit.

## Blast radius

- `getRecoveryState` consumers: `useRecoveryState` (RecoveryContext) and everything reading recovery state from it. The return shape is unchanged; a previously-throwing call now resolves with the successful modifiers only.
- `packages/utils` ErrorCodes: additive `_823` entry only.
- No changes to contracts, chain configs, RTK Query endpoints or shared components. Mobile does not consume these web app services.

## Risks / not checked

- Not verified on a live Safe with a real queued recovery (unit tests mock the provider); the window and early-stop logic is covered by unit tests.
- Providers with a getLogs cap below 10 000 blocks would still fail; the constant matches the cap named in the issue (Infura).
- Did not run the mobile workspace tests.

## Visual summary

```mermaid
flowchart TD
    A[queryAddedTransactions] --> B{queueNonce == txNonce?}
    B -- yes --> C[return empty queue]
    B -- no --> D[get latest block and creation block]
    D --> E[query window of max 10k blocks ending at toBlock]
    E --> F{all queued txs found?}
    F -- no --> G{reached creation block?}
    G -- yes --> H[return events]
    G -- no --> I[toBlock = fromBlock - 1] --> E
    F -- yes --> H
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (not applicable: apps/web-only change, no shared mobile code touched)
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics impact)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
